### PR TITLE
feat(parser): support italic and monospace quotes, as well as nested quotes

### DIFF
--- a/parser/asciidoc-grammar.peg
+++ b/parser/asciidoc-grammar.peg
@@ -13,41 +13,57 @@ Document <- lines:Line* EOF {
 	return types.NewDocument(lines.([]interface{}))
 }
 
-Line <- line:(Heading / ListItem / BlockImage / MetaElement / Inline / EmptyLine) {
-    return line, nil
-}
+Line <- Heading / ListItem / BlockImage / MetaElement / Inline / EmptyLine
 
+// ------------------------------------------
+// Headings
+// ------------------------------------------
 Heading <- level:("="+) WS+ content:Inline {
      return types.NewHeading(level, content.(*types.InlineContent))
 }
 
-// ---------------------
+// ------------------------------------------
 // Lists
-// ---------------------
+// ------------------------------------------
 //TODO: Blank lines are required before and after a list
 //TODO: Additionally, blank lines are permitted, but not required, between list items.
 ListItem <- WS* ('*' / '-') WS+ content:(Inline) {
     return types.NewListItem(content.(*types.InlineContent))
 }
 
-// ---------------------
-// Quotes
-// ---------------------
-BoldQuote <- '*' content:(BoldContent) '*' {
-    return types.NewBoldQuote(content)
+// ------------------------------------------
+// Inline content
+// ------------------------------------------
+Inline <- !NEWLINE elements:(QuotedText / ExternalLink / Word / WS)+ EOL {
+    return types.NewInlineContent(elements.([]interface{}))
+} 
+
+// ------------------------------------------
+// Quotes: bold, italic and monospace
+// ------------------------------------------
+QuotedText <- BoldText / ItalicText / MonospaceText
+
+BoldText <- '*' content:(QuotedTextContent) '*' {
+    return types.NewQuotedText(types.Bold, content.([]interface{}))
 }
 
-BoldContent <- (BoldContentWord WS+)* BoldContentWord {
-    return string(c.text), nil
+ItalicText <- '_' content:(QuotedTextContent) '_' {
+    return types.NewQuotedText(types.Italic, content.([]interface{}))
 }
 
-BoldContentWord <- (!NEWLINE !WS !'*' .)+ {
-    return string(c.text), nil
+MonospaceText <- '`' content:(QuotedTextContent) '`' {
+    return types.NewQuotedText(types.Monospace, content.([]interface{}))
 }
 
-// ---------------------
+QuotedTextContent <- QuotedTextContentElement (WS+ QuotedTextContentElement)*
+
+QuotedTextContentElement <- QuotedText / QuotedTextContentWord
+
+QuotedTextContentWord <- (!NEWLINE !WS !'*' !'_' !'`' .)+ 
+
+// ------------------------------------------
 // Links
-// ---------------------
+// ------------------------------------------
 ExternalLink <- url:(URL_SCHEME URL) text:('[' (URL_TEXT)* ']')? {
     if text != nil {
         return types.NewExternalLink(url.([]interface{}), text.([]interface{}))
@@ -55,23 +71,19 @@ ExternalLink <- url:(URL_SCHEME URL) text:('[' (URL_TEXT)* ']')? {
     return types.NewExternalLink(url.([]interface{}), nil)
 }
 
-// ---------------------
+// ------------------------------------------
 // Images
-// ---------------------
-BlockImage <- "image::" path:(URL) altText:('[' (URL_TEXT)* ']') EOL {
-    return types.NewBlockImage(path.(string), altText.([]interface{}))
+// ------------------------------------------
+BlockImage <- "image::" path:(URL) '[' altText:(URL_TEXT?) ']' EOL {
+    if altText != nil {
+        return types.NewBlockImageWithAltText(path.(string), altText.(string))
+    }
+    return types.NewBlockImage(path.(string))
 }
 
-// ---------------------
-// Inline content
-// ---------------------
-Inline <- !NEWLINE elements:(BoldQuote / ExternalLink / Word / WS)+ EOL {
-    return types.NewInlineContent(elements.([]interface{}))
-} 
-
-// ---------------------
+// ------------------------------------------
 // meta-element types
-// ---------------------
+// ------------------------------------------
 MetaElement <- meta:(ElementLink / ElementID / ElementTitle) 
 
 // a link attached to an element, such as a BlockImage
@@ -89,9 +101,9 @@ ElementTitle <- "." !WS title:(!NEWLINE .)+ EOL {
     return types.NewElementTitle(title.([]interface{}))
 }
 
-// ---------------------
+// ------------------------------------------
 // Base types
-// ---------------------
+// ------------------------------------------
 Word <- (!NEWLINE !WS .)+ {
     return string(c.text), nil
 }

--- a/parser/asciidoc_parser_test.go
+++ b/parser/asciidoc_parser_test.go
@@ -24,8 +24,8 @@ func init() {
 func compare(t *testing.T, expectedDocument *types.Document, content string) {
 	actualDocument, errs := ParseString(content)
 	require.Nil(t, errs)
-	log.Debugf("actual document: %s", actualDocument.String())
-	log.Debugf("expected document: %s", expectedDocument.String())
+	t.Log(fmt.Sprintf("actual document: %s", actualDocument.String()))
+	t.Log(fmt.Sprintf("expected document: %s", expectedDocument.String()))
 	assert.EqualValues(t, expectedDocument, actualDocument)
 }
 func TestHeadingOnly(t *testing.T) {
@@ -86,7 +86,9 @@ func TestSection2(t *testing.T) {
 
 func TestHeadingWithSection2(t *testing.T) {
 	// given a document with a heading, an empty line and a section
-	actualContent := "= a heading\n\n== section 1"
+	actualContent := "= a heading\n" +
+		"\n" +
+		"== section 1"
 	expectedDocument := &types.Document{
 		Elements: []types.DocElement{
 			&types.Heading{Level: 1, Content: &types.InlineContent{
@@ -106,7 +108,9 @@ func TestHeadingWithSection2(t *testing.T) {
 }
 func TestHeadingWithInvalidSection2(t *testing.T) {
 	// given a document with a heading, an empty line and an invalid section (extra space at beginning of line)
-	actualContent := "= a heading\n\n == section 1"
+	actualContent := "= a heading\n" +
+		"\n" +
+		" == section 1"
 	expectedDocument := &types.Document{
 		Elements: []types.DocElement{
 			&types.Heading{Level: 1, Content: &types.InlineContent{
@@ -152,121 +156,13 @@ func TestInlineSimple(t *testing.T) {
 	}
 	compare(t, expectedDocument, actualContent)
 }
-func TestBoldQuote1Word(t *testing.T) {
-	// given a bold quote of 1 word
-	actualContent := "*hello*"
-	expectedDocument := &types.Document{
-		Elements: []types.DocElement{
-			&types.InlineContent{
-				Elements: []types.DocElement{
-					&types.BoldQuote{
-						Content: "hello",
-					},
-				},
-			},
-		},
-	}
-	compare(t, expectedDocument, actualContent)
-}
-
-func TestBoldQuote2Words(t *testing.T) {
-	// given a bold quote of 2 words
-	actualContent := "*bold    content*"
-	expectedDocument := &types.Document{
-		Elements: []types.DocElement{
-			&types.InlineContent{
-				Elements: []types.DocElement{
-					&types.BoldQuote{
-						Content: "bold    content",
-					},
-				},
-			},
-		},
-	}
-	compare(t, expectedDocument, actualContent)
-}
-func TestBoldQuote3Words(t *testing.T) {
-	// given a bold quote of 3 words
-	actualContent := "*some bold content*"
-	expectedDocument := &types.Document{
-		Elements: []types.DocElement{
-			&types.InlineContent{
-				Elements: []types.DocElement{
-					&types.BoldQuote{
-						Content: "some bold content",
-					},
-				},
-			},
-		},
-	}
-	compare(t, expectedDocument, actualContent)
-}
-func TestInlineWithBoldQuote(t *testing.T) {
-	// given a sentence with a bold quote
-	actualContent := "a paragraph with *some bold content*"
-	expectedDocument := &types.Document{
-		Elements: []types.DocElement{
-			&types.InlineContent{
-				Elements: []types.DocElement{
-					&types.StringElement{Content: "a paragraph with "},
-					&types.BoldQuote{
-						Content: "some bold content",
-					},
-				},
-			},
-		},
-	}
-	compare(t, expectedDocument, actualContent)
-}
-
-func TestInlineWithInvalidBoldQuote1(t *testing.T) {
-	// given an inline with invalid bold (1)
-	actualContent := "a paragraph with *some bold content"
-	expectedDocument := &types.Document{
-		Elements: []types.DocElement{
-			&types.InlineContent{
-				Elements: []types.DocElement{
-					&types.StringElement{Content: "a paragraph with *some bold content"},
-				},
-			},
-		},
-	}
-	compare(t, expectedDocument, actualContent)
-}
-
-func TestInlineWithInvalidBoldQuote2(t *testing.T) {
-	// given an inline with invalid bold (2)
-	actualContent := "a paragraph with *some bold content *"
-	expectedDocument := &types.Document{
-		Elements: []types.DocElement{
-			&types.InlineContent{
-				Elements: []types.DocElement{
-					&types.StringElement{Content: "a paragraph with *some bold content *"},
-				},
-			},
-		},
-	}
-	compare(t, expectedDocument, actualContent)
-}
-
-func TestInlineWithInvalidBoldQuote3(t *testing.T) {
-	// given an inline with invalid bold (3)
-	actualContent := "a paragraph with * some bold content*"
-	expectedDocument := &types.Document{
-		Elements: []types.DocElement{
-			&types.InlineContent{
-				Elements: []types.DocElement{
-					&types.StringElement{Content: "a paragraph with * some bold content*"},
-				},
-			},
-		},
-	}
-	compare(t, expectedDocument, actualContent)
-}
-
 func TestHeadingSectionInlineWithBoldQuote(t *testing.T) {
 	// given
-	actualContent := "= a heading\n\n== section 1\n\na paragraph with *bold content*"
+	actualContent := "= a heading\n" +
+		"\n" +
+		"== section 1\n" +
+		"\n" +
+		"a paragraph with *bold content*"
 	expectedDocument := &types.Document{
 		Elements: []types.DocElement{
 			&types.Heading{Level: 1, Content: &types.InlineContent{
@@ -284,8 +180,10 @@ func TestHeadingSectionInlineWithBoldQuote(t *testing.T) {
 			&types.InlineContent{
 				Elements: []types.DocElement{
 					&types.StringElement{Content: "a paragraph with "},
-					&types.BoldQuote{
-						Content: "bold content",
+					&types.QuotedText{Kind: types.Bold,
+						Elements: []types.DocElement{
+							&types.StringElement{Content: "bold content"},
+						},
 					},
 				},
 			},
@@ -328,7 +226,8 @@ func TestInvalidListItem(t *testing.T) {
 
 func TestListItems(t *testing.T) {
 	// given an inline with invalid bold (3)
-	actualContent := "* a first item\n* a second item with *bold content*"
+	actualContent := "* a first item\n" +
+		"* a second item with *bold content*"
 	expectedDocument := &types.Document{
 		Elements: []types.DocElement{
 			&types.ListItem{
@@ -342,8 +241,10 @@ func TestListItems(t *testing.T) {
 				Content: &types.InlineContent{
 					Elements: []types.DocElement{
 						&types.StringElement{Content: "a second item with "},
-						&types.BoldQuote{
-							Content: "bold content",
+						&types.QuotedText{Kind: types.Bold,
+							Elements: []types.DocElement{
+								&types.StringElement{Content: "bold content"},
+							},
 						},
 					},
 				},
@@ -438,7 +339,10 @@ func TestBlockImageWithAltText(t *testing.T) {
 
 func TestBlockImageWithDimensionsAndIDLinkTitleMeta(t *testing.T) {
 	// given an inline with an external lin
-	actualContent := "[#img-foobar]\n.A title to foobar\n[link=http://foo.bar]\nimage::images/foo.png[the foo.png image,600,400]"
+	actualContent := "[#img-foobar]\n" +
+		".A title to foobar\n" +
+		"[link=http://foo.bar]\n" +
+		"image::images/foo.png[the foo.png image,600,400]"
 	altText := "the foo.png image"
 	width := "600"
 	height := "400"

--- a/parser/quotedtext_test.go
+++ b/parser/quotedtext_test.go
@@ -1,0 +1,304 @@
+package parser_test
+
+import (
+	"testing"
+
+	"github.com/bytesparadise/libasciidoc/types"
+)
+
+func TestBoldTextOf1Word(t *testing.T) {
+	// given a bold quote of 1 word
+	actualContent := "*hello*"
+	expectedDocument := &types.Document{
+		Elements: []types.DocElement{
+			&types.InlineContent{
+				Elements: []types.DocElement{
+					&types.QuotedText{
+						Kind: types.Bold,
+						Elements: []types.DocElement{
+							&types.StringElement{Content: "hello"},
+						},
+					},
+				},
+			},
+		},
+	}
+	compare(t, expectedDocument, actualContent)
+}
+
+func TestBoldTextOf2Words(t *testing.T) {
+	// given a bold quote of 2 words
+	actualContent := "*bold    content*"
+	expectedDocument := &types.Document{
+		Elements: []types.DocElement{
+			&types.InlineContent{
+				Elements: []types.DocElement{
+					&types.QuotedText{
+						Kind: types.Bold,
+						Elements: []types.DocElement{
+							&types.StringElement{Content: "bold    content"},
+						},
+					},
+				},
+			},
+		},
+	}
+	compare(t, expectedDocument, actualContent)
+}
+func TestBoldTextOf3Words(t *testing.T) {
+	// given a bold quote of 3 words
+	actualContent := "*some bold content*"
+	expectedDocument := &types.Document{
+		Elements: []types.DocElement{
+			&types.InlineContent{
+				Elements: []types.DocElement{
+					&types.QuotedText{
+						Kind: types.Bold,
+						Elements: []types.DocElement{
+							&types.StringElement{Content: "some bold content"},
+						},
+					},
+				},
+			},
+		},
+	}
+	compare(t, expectedDocument, actualContent)
+}
+
+func TestInlineWithBoldText(t *testing.T) {
+	// given a sentence with a bold quote
+	actualContent := "a paragraph with *some bold content*"
+	expectedDocument := &types.Document{
+		Elements: []types.DocElement{
+			&types.InlineContent{
+				Elements: []types.DocElement{
+					&types.StringElement{Content: "a paragraph with "},
+					&types.QuotedText{
+						Kind: types.Bold,
+						Elements: []types.DocElement{
+							&types.StringElement{Content: "some bold content"},
+						},
+					},
+				},
+			},
+		},
+	}
+	compare(t, expectedDocument, actualContent)
+}
+
+func TestInlineWithInvalidBoldText1(t *testing.T) {
+	// given an inline with invalid bold (1)
+	actualContent := "a paragraph with *some bold content"
+	expectedDocument := &types.Document{
+		Elements: []types.DocElement{
+			&types.InlineContent{
+				Elements: []types.DocElement{
+					&types.StringElement{Content: "a paragraph with *some bold content"},
+				},
+			},
+		},
+	}
+	compare(t, expectedDocument, actualContent)
+}
+
+func TestInlineWithInvalidBoldText2(t *testing.T) {
+	// given an inline with invalid bold (2)
+	actualContent := "a paragraph with *some bold content *"
+	expectedDocument := &types.Document{
+		Elements: []types.DocElement{
+			&types.InlineContent{
+				Elements: []types.DocElement{
+					&types.StringElement{Content: "a paragraph with *some bold content *"},
+				},
+			},
+		},
+	}
+	compare(t, expectedDocument, actualContent)
+}
+
+func TestInlineWithInvalidBoldText3(t *testing.T) {
+	// given an inline with invalid bold (3)
+	actualContent := "a paragraph with * some bold content*"
+	expectedDocument := &types.Document{
+		Elements: []types.DocElement{
+			&types.InlineContent{
+				Elements: []types.DocElement{
+					&types.StringElement{Content: "a paragraph with * some bold content*"},
+				},
+			},
+		},
+	}
+	compare(t, expectedDocument, actualContent)
+}
+func TestItalicTextWith3Words(t *testing.T) {
+	// given an italic quote of 3 words
+	actualContent := "_some italic content_"
+	expectedDocument := &types.Document{
+		Elements: []types.DocElement{
+			&types.InlineContent{
+				Elements: []types.DocElement{
+					&types.QuotedText{
+						Kind: types.Italic,
+						Elements: []types.DocElement{
+							&types.StringElement{Content: "some italic content"},
+						},
+					},
+				},
+			},
+		},
+	}
+	compare(t, expectedDocument, actualContent)
+}
+
+func TestMonospaceTextWith3Words(t *testing.T) {
+	// given a monospace quote of 3 words
+	actualContent := "`some monospace content`"
+	expectedDocument := &types.Document{
+		Elements: []types.DocElement{
+			&types.InlineContent{
+				Elements: []types.DocElement{
+					&types.QuotedText{
+						Kind: types.Monospace,
+						Elements: []types.DocElement{
+							&types.StringElement{Content: "some monospace content"},
+						},
+					},
+				},
+			},
+		},
+	}
+	compare(t, expectedDocument, actualContent)
+}
+
+func TestItalicTextWithinBoldText(t *testing.T) {
+	actualContent := "*some _italic_ content*"
+	expectedDocument := &types.Document{
+		Elements: []types.DocElement{
+			&types.InlineContent{
+				Elements: []types.DocElement{
+					&types.QuotedText{
+						Kind: types.Bold,
+						Elements: []types.DocElement{
+							&types.StringElement{Content: "some "},
+							&types.QuotedText{
+								Kind: types.Italic,
+								Elements: []types.DocElement{
+									&types.StringElement{Content: "italic"},
+								},
+							},
+							&types.StringElement{Content: " content"},
+						},
+					},
+				},
+			},
+		},
+	}
+	compare(t, expectedDocument, actualContent)
+}
+func TestBoldTextWithinItalicText(t *testing.T) {
+	// given a bold quote of 3 words
+	actualContent := "_some *bold* content_"
+	expectedDocument := &types.Document{
+		Elements: []types.DocElement{
+			&types.InlineContent{
+				Elements: []types.DocElement{
+					&types.QuotedText{
+						Kind: types.Italic,
+						Elements: []types.DocElement{
+							&types.StringElement{Content: "some "},
+							&types.QuotedText{
+								Kind: types.Bold,
+								Elements: []types.DocElement{
+									&types.StringElement{Content: "bold"},
+								},
+							},
+							&types.StringElement{Content: " content"},
+						},
+					},
+				},
+			},
+		},
+	}
+	compare(t, expectedDocument, actualContent)
+}
+
+func TestMonospaceTextWithinBoldTextWithinItalicQuote(t *testing.T) {
+	actualContent := "*some _italic and `monospaced content`_*"
+	expectedDocument := &types.Document{
+		Elements: []types.DocElement{
+			&types.InlineContent{
+				Elements: []types.DocElement{
+					&types.QuotedText{
+						Kind: types.Bold,
+						Elements: []types.DocElement{
+							&types.StringElement{Content: "some "},
+							&types.QuotedText{
+								Kind: types.Italic,
+								Elements: []types.DocElement{
+									&types.StringElement{Content: "italic and "},
+									&types.QuotedText{
+										Kind: types.Monospace,
+										Elements: []types.DocElement{
+											&types.StringElement{Content: "monospaced content"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	compare(t, expectedDocument, actualContent)
+}
+
+func TestItalicTextWithinItalicText(t *testing.T) {
+	// given a bold quote of 3 words
+	actualContent := "_some _very italic_ content_"
+	expectedDocument := &types.Document{
+		Elements: []types.DocElement{
+			&types.InlineContent{
+				Elements: []types.DocElement{
+					&types.QuotedText{
+						Kind: types.Italic,
+						Elements: []types.DocElement{
+							&types.StringElement{Content: "some "},
+							&types.QuotedText{
+								Kind: types.Italic,
+								Elements: []types.DocElement{
+									&types.StringElement{Content: "very italic"},
+								},
+							},
+							&types.StringElement{Content: " content"},
+						},
+					},
+				},
+			},
+		},
+	}
+	compare(t, expectedDocument, actualContent)
+}
+
+func xTestAllQuotes(t *testing.T) {
+	// given an inline with invalid bold (3)
+	actualContent := "*bold phrase* & **char**acter**s**\n" +
+		"_italic phrase_ & __char__acter__s__\n" +
+		"*_bold italic phrase_* & **__char__**acter**__s__**\n" +
+		"`monospace phrase` & ``char``acter``s``\n" +
+		"`*monospace bold phrase*` & ``**char**``acter``**s**``\n" +
+		"`_monospace italic phrase_` & ``__char__``acter``__s__``\n" +
+		"`*_monospace bold italic phrase_*` & \n" +
+		"``**__char__**``acter``**__s__**``"
+	expectedDocument := &types.Document{
+		Elements: []types.DocElement{
+			&types.InlineContent{
+				Elements: []types.DocElement{
+					&types.StringElement{Content: "a paragraph with * some bold content*"},
+				},
+			},
+		},
+	}
+	compare(t, expectedDocument, actualContent)
+
+}

--- a/renderer/html5/html5_renderer.go
+++ b/renderer/html5/html5_renderer.go
@@ -65,8 +65,8 @@ func renderDocElement(docElement types.DocElement) ([]byte, error) {
 	switch docElement.(type) {
 	case *types.InlineContent:
 		return renderInlineContent(*docElement.(*types.InlineContent))
-	case *types.BoldQuote:
-		return renderBoldQuote(*docElement.(*types.BoldQuote))
+	case *types.QuotedText:
+		return renderQuotedText(*docElement.(*types.QuotedText))
 	case *types.StringElement:
 		return renderStringElement(*docElement.(*types.StringElement))
 	default:
@@ -94,11 +94,16 @@ func renderInlineContent(inlineContent types.InlineContent) ([]byte, error) {
 	return result.Bytes(), nil
 }
 
-func renderBoldQuote(q types.BoldQuote) ([]byte, error) {
+func renderQuotedText(t types.QuotedText) ([]byte, error) {
 	result := bytes.NewBuffer(make([]byte, 0))
-	err := boldContentTemplate.Execute(result, q.Content)
-	if err != nil {
-		return nil, errors.Wrapf(err, "unable to render bold quote")
+	switch t.Kind {
+	case types.Bold:
+		err := boldContentTemplate.Execute(result, t.Elements[0].(*types.StringElement).Content)
+		if err != nil {
+			return nil, errors.Wrapf(err, "unable to render bold quote")
+		}
+	default:
+		return nil, errors.Errorf("unsupported quoted text kind: %v", t.Kind)
 	}
 	log.Debugf("rendered bold quote: %s", result.Bytes())
 	return result.Bytes(), nil


### PR DESCRIPTION
Bold quote can contain italic and monospaced quotes, and vice-versa.

Also refactor `types/typ_utils.go` by removing duplicate/similar functions.
Also remove unnecessary golang blocks in grammar (when no specific
initialization is done)

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>