### PR TITLE
feat(parser/renderer): support for delimited source blocks

### DIFF
--- a/parser/asciidoc-grammar.peg
+++ b/parser/asciidoc-grammar.peg
@@ -13,7 +13,7 @@ Document <- lines:Line* EOF {
 	return types.NewDocument(lines.([]interface{}))
 }
 
-Line <- Heading / ListItem / BlockImage / MetadataElement / Paragraph / BlankLine
+Line <- Heading / ListItem / BlockImage / DelimitedBlock / MetadataElement / Paragraph / BlankLine
 
 // ------------------------------------------
 // Headings
@@ -23,7 +23,7 @@ Heading <- level:("="+) WS+ content:InlineContent {
 }
 
 // ------------------------------------------
-// Lists
+// List Type
 // ------------------------------------------
 //TODO: Blank lines are required before and after a list
 //TODO: Additionally, blank lines are permitted, but not required, between list items.
@@ -32,7 +32,7 @@ ListItem <- WS* ('*' / '-') WS+ content:(InlineContent) {
 }
 
 // ------------------------------------------
-// Paragraph content
+// Paragraph Type
 // ------------------------------------------
 // a paragraph is a group of line ending with a blank line (or end of file)
 Paragraph <- lines:(InlineContent)+ (BlankLine/EOF) {
@@ -44,7 +44,7 @@ InlineContent <- !NEWLINE elements:(QuotedText / ExternalLink / Word / WS)+ EOL 
 } 
 
 // ------------------------------------------
-// Quotes: bold, italic and monospace
+// Quote Types (bold, italic and monospace)
 // ------------------------------------------
 QuotedText <- BoldText / ItalicText / MonospaceText
 
@@ -68,7 +68,7 @@ QuotedTextContentWord <- (!NEWLINE !WS !'*' !'_' !'`' .)+ // cannot have '*', '_
 InvalidQuotedTextContentWord <- (!NEWLINE !WS  .)+ // can have '*', '_' or '`' within, maybe because the user made an error (extra or missing space, for example)
 
 // ------------------------------------------
-// Links
+// Link Type
 // ------------------------------------------
 ExternalLink <- url:(URL_SCHEME URL) text:('[' (URL_TEXT)* ']')? {
     if text != nil {
@@ -78,7 +78,7 @@ ExternalLink <- url:(URL_SCHEME URL) text:('[' (URL_TEXT)* ']')? {
 }
 
 // ------------------------------------------
-// Images
+// Image Type
 // ------------------------------------------
 BlockImage <- metadata:(MetadataElement)* image:BlockImageMacro {
     // here we can ignore the blank line in the returned element
@@ -94,7 +94,21 @@ BlockImageMacro <- "image::" path:(URL) '[' attributes:(URL_TEXT?) ']' EOL {
 }
 
 // ------------------------------------------
-// meta-element types
+// Delimited Block Types
+// ------------------------------------------
+
+DelimitedBlock <- SourceBlock
+
+SourceBlock <- SourceBlockDelimiter NEWLINE content:(SourceBlockLine)*  SourceBlockDelimiter {
+    return types.NewDelimitedBlock(types.SourceBlock, content.([]interface{}))
+}
+
+SourceBlockDelimiter <- "```"
+
+SourceBlockLine <- (!EOL .)* NEWLINE
+
+// ------------------------------------------
+// Meta Element Types
 // ------------------------------------------
 MetadataElement <- meta:(ElementLink / ElementID / ElementTitle) 
 
@@ -114,7 +128,7 @@ ElementTitle <- "." !WS title:(!NEWLINE .)+ EOL {
 }
 
 // ------------------------------------------
-// Base types
+// Base Types
 // ------------------------------------------
 Word <- (!NEWLINE !WS .)+ {
     return string(c.text), nil

--- a/parser/asciidoc_parser_test.go
+++ b/parser/asciidoc_parser_test.go
@@ -23,7 +23,7 @@ func init() {
 }
 
 func compare(t *testing.T, expectedDocument *types.Document, content string) {
-	t.Log(fmt.Sprintf("processing '%s'", content))
+	t.Log(fmt.Sprintf("processing:\n%s", content))
 	reader := strings.NewReader(content)
 	result, err := ParseReader("", reader)
 	if err != nil {

--- a/parser/delimited_block_test.go
+++ b/parser/delimited_block_test.go
@@ -1,0 +1,52 @@
+package parser_test
+
+import (
+	"testing"
+
+	"github.com/bytesparadise/libasciidoc/types"
+)
+
+func TestDelimitedSourceBlockWithSingleLine(t *testing.T) {
+	// given a source block of 1 line
+	content := "some source code"
+	actualContent := "```\n" + content + "\n```"
+	expectedDocument := &types.Document{
+		Elements: []types.DocElement{
+			&types.DelimitedBlock{
+				Kind:    types.SourceBlock,
+				Content: content,
+			},
+		},
+	}
+	compare(t, expectedDocument, actualContent)
+}
+
+func TestDelimitedSourceBlockWithMultipleLines(t *testing.T) {
+	// given a source block of multiple lines
+	content := "some source code\nwith an empty line\n\nin the middle"
+	actualContent := "```\n" + content + "\n```"
+	expectedDocument := &types.Document{
+		Elements: []types.DocElement{
+			&types.DelimitedBlock{
+				Kind:    types.SourceBlock,
+				Content: content,
+			},
+		},
+	}
+	compare(t, expectedDocument, actualContent)
+}
+
+func TestDelimitedSourceBlockWithNoLine(t *testing.T) {
+	// given an empty source block
+	content := ""
+	actualContent := "```\n" + content + "```"
+	expectedDocument := &types.Document{
+		Elements: []types.DocElement{
+			&types.DelimitedBlock{
+				Kind:    types.SourceBlock,
+				Content: content,
+			},
+		},
+	}
+	compare(t, expectedDocument, actualContent)
+}

--- a/renderer/html5/delimited_block.go
+++ b/renderer/html5/delimited_block.go
@@ -1,0 +1,33 @@
+package html5
+
+import (
+	"bytes"
+	"context"
+	"html/template"
+
+	"github.com/bytesparadise/libasciidoc/types"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+var sourceBlockTmpl *template.Template
+
+// initializes the templates
+func init() {
+	sourceBlockTmpl = newTemplate("delimited source block", `<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>{{.Content}}</code></pre>
+</div>
+</div>`)
+}
+
+func renderDelimitedBlock(ctx context.Context, block types.DelimitedBlock) ([]byte, error) {
+	log.Debugf("rendering delimited block with content: %s", block.Content)
+	result := bytes.NewBuffer(make([]byte, 0))
+	err := sourceBlockTmpl.Execute(result, block)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to render delimited block")
+	}
+	log.Debugf("rendered delimited block: %s", result.Bytes())
+	return result.Bytes(), nil
+}

--- a/renderer/html5/delimited_block_test.go
+++ b/renderer/html5/delimited_block_test.go
@@ -1,0 +1,18 @@
+package html5_test
+
+import "testing"
+
+func TestRenderDelimitedSourceBlock(t *testing.T) {
+	t.Run("source with multiple lines", func(t *testing.T) {
+		// given
+		content := "```\nsome source code\n\nhere\n```"
+		expected := `<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>some source code
+
+here</code></pre>
+</div>
+</div>`
+		verify(t, expected, content)
+	})
+}

--- a/renderer/html5/image.go
+++ b/renderer/html5/image.go
@@ -11,29 +11,21 @@ import (
 )
 
 var blockImageTmpl *template.Template
-var blockImageMacroTmpl *template.Template
 
 // initializes the templates
 func init() {
-	blockImageTmpl = newTemplate("block image", `
-<div{{if .ID }} id="{{.ID.Value}}"{{ end }} class="imageblock">
+	blockImageTmpl = newTemplate("block image", `<div{{if .ID }} id="{{.ID.Value}}"{{ end }} class="imageblock">
 <div class="content">
 {{if .Link}}<a class="image" href="{{.Link.Path}}">{{end}}<img src="{{.Macro.Path}}" alt="{{.Macro.Alt}}"{{if .Macro.Width}} width="{{.Macro.Width}}"{{end}}{{if .Macro.Height}} height="{{.Macro.Height}}"{{end}}>{{if .Link}}</a>{{end}}
-</div>
-{{if .Title}}<div class="title">{{.Title.Content}}</div>{{end}}
-</div>`)
-	blockImageMacroTmpl = newTemplate("block image", "")
+</div>{{if .Title}}
+<div class="title">{{.Title.Content}}</div>
+{{else}}
+{{end}}</div>`)
 }
 
-// <div id="img-foobar" class="imageblock">
-// <div class="content">
-// <a class="image" href="http://foo.bar"><img src="images/foo.png" alt="the foo.png image" width="600" height="400"></a>
-// </div>
-// <div class="title">Figure 1. A title to foobar</div>
-// </div>
-func renderBlockImage(ctx context.Context, block types.BlockImage) ([]byte, error) {
+func renderBlockImage(ctx context.Context, img types.BlockImage) ([]byte, error) {
 	result := bytes.NewBuffer(make([]byte, 0))
-	err := blockImageTmpl.Execute(result, block)
+	err := blockImageTmpl.Execute(result, img)
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to render block image")
 	}

--- a/renderer/html5/image_test.go
+++ b/renderer/html5/image_test.go
@@ -6,32 +6,44 @@ func TestRenderImageBlocks(t *testing.T) {
 	t.Run("image alone", func(t *testing.T) {
 		// given
 		content := "image::foo.png[]"
-		expected := `<div class="imageblock"><div class="content"><img src="foo.png" alt="foo"></div></div>`
+		expected := `<div class="imageblock">
+<div class="content">
+<img src="foo.png" alt="foo">
+</div>
+</div>`
 		verify(t, expected, content)
 	})
 	t.Run("image with alt", func(t *testing.T) {
 		// given
 		content := "image::foo.png[foo image]"
-		expected := `<div class="imageblock"><div class="content"><img src="foo.png" alt="foo image"></div></div>`
+		expected := `<div class="imageblock">
+<div class="content">
+<img src="foo.png" alt="foo image">
+</div>
+</div>`
 		verify(t, expected, content)
 	})
 	t.Run("image with alt and dimensions", func(t *testing.T) {
 		// given
 		content := "image::foo.png[foo image, 600, 400]"
-		expected := `<div class="imageblock"><div class="content"><img src="foo.png" alt="foo image" width="600" height="400"></div></div>`
+		expected := `<div class="imageblock">
+<div class="content">
+<img src="foo.png" alt="foo image" width="600" height="400">
+</div>
+</div>`
 		verify(t, expected, content)
 	})
 	t.Run("image with alt and dimensions", func(t *testing.T) {
-		content := "[#img-foobar]\n" +
-			".A title to foobar\n" +
-			"[link=http://foo.bar]\n" +
-			"image::images/foo.png[the foo.png image,600,400]"
-		expected := `<div id="img-foobar" class="imageblock">` +
-			`<div class="content">` +
-			`<a class="image" href="http://foo.bar"><img src="images/foo.png" alt="the foo.png image" width="600" height="400"></a>` +
-			`</div>` +
-			`<div class="title">A title to foobar</div>` +
-			`</div>`
+		content := `[#img-foobar]
+.A title to foobar
+[link=http://foo.bar]
+image::images/foo.png[the foo.png image,600,400]`
+		expected := `<div id="img-foobar" class="imageblock">
+<div class="content">
+<a class="image" href="http://foo.bar"><img src="images/foo.png" alt="the foo.png image" width="600" height="400"></a>
+</div>
+<div class="title">A title to foobar</div>
+</div>`
 		verify(t, expected, content)
 	})
 }

--- a/renderer/html5/paragraph.go
+++ b/renderer/html5/paragraph.go
@@ -16,7 +16,10 @@ var paragraphTmpl *template.Template
 
 // initializes the template
 func init() {
-	paragraphTmpl = newTemplate("paragraph", "<div class=\"paragraph\">\n<p>{{.}}</p>\n</div>")
+	paragraphTmpl = newTemplate("paragraph",
+		`<div class="paragraph">
+<p>{{.}}</p>
+</div>`)
 }
 
 func renderParagraph(ctx context.Context, paragraph types.Paragraph) ([]byte, error) {

--- a/renderer/html5/renderer.go
+++ b/renderer/html5/renderer.go
@@ -30,6 +30,8 @@ func renderElement(ctx context.Context, element types.DocElement) ([]byte, error
 		return renderQuotedText(ctx, *element.(*types.QuotedText))
 	case *types.BlockImage:
 		return renderBlockImage(ctx, *element.(*types.BlockImage))
+	case *types.DelimitedBlock:
+		return renderDelimitedBlock(ctx, *element.(*types.DelimitedBlock))
 	case *types.StringElement:
 		return renderStringElement(ctx, *element.(*types.StringElement))
 	default:

--- a/renderer/html5/renderer_test.go
+++ b/renderer/html5/renderer_test.go
@@ -20,56 +20,74 @@ func TestRenderQuotes(t *testing.T) {
 	t.Run("bold content alone", func(t *testing.T) {
 		// given
 		content := "*bold content*"
-		expected := `<div class="paragraph"><p><strong>bold content</strong></p></div>`
+		expected := `<div class="paragraph">
+<p><strong>bold content</strong></p>
+</div>`
 		verify(t, expected, content)
 	})
 	t.Run("bold content in sentence", func(t *testing.T) {
 		// given
 		content := "some *bold content*."
-		expected := `<div class="paragraph"><p>some <strong>bold content</strong>.</p></div>`
+		expected := `<div class="paragraph">
+<p>some <strong>bold content</strong>.</p>
+</div>`
 		verify(t, expected, content)
 	})
 	t.Run("italic content alone", func(t *testing.T) {
 		// given
 		content := "_italic content_"
-		expected := `<div class="paragraph"><p><em>italic content</em></p></div>`
+		expected := `<div class="paragraph">
+<p><em>italic content</em></p>
+</div>`
 		verify(t, expected, content)
 	})
 	t.Run("italic content in sentence", func(t *testing.T) {
 		// given
 		content := "some _italic content_."
-		expected := `<div class="paragraph"><p>some <em>italic content</em>.</p></div>`
+		expected := `<div class="paragraph">
+<p>some <em>italic content</em>.</p>
+</div>`
 		verify(t, expected, content)
 	})
 	t.Run("monospace content alone", func(t *testing.T) {
 		// given
 		content := "`monospace content`"
-		expected := `<div class="paragraph"><p><code>monospace content</code></p></div>`
+		expected := `<div class="paragraph">
+<p><code>monospace content</code></p>
+</div>`
 		verify(t, expected, content)
 	})
 	t.Run("monospace content in sentence", func(t *testing.T) {
 		// given
 		content := "some `monospace content`."
-		expected := `<div class="paragraph"><p>some <code>monospace content</code>.</p></div>`
+		expected := `<div class="paragraph">
+<p>some <code>monospace content</code>.</p>
+</div>`
 		verify(t, expected, content)
 	})
 	// nested quotes
 	t.Run("italic content within bold quote in sentence", func(t *testing.T) {
 		// given
 		content := "some *bold and _italic content_* together."
-		expected := `<div class="paragraph"><p>some <strong>bold and <em>italic content</em></strong> together.</p></div>`
+		expected := `<div class="paragraph">
+<p>some <strong>bold and <em>italic content</em></strong> together.</p>
+</div>`
 		verify(t, expected, content)
 	})
 	t.Run("italic content within invalid bold quote in sentence", func(t *testing.T) {
 		// given
 		content := "some *bold and _italic content_ * together."
-		expected := `<div class="paragraph"><p>some *bold and <em>italic content</em> * together.</p></div>`
+		expected := `<div class="paragraph">
+<p>some *bold and <em>italic content</em> * together.</p>
+</div>`
 		verify(t, expected, content)
 	})
 	t.Run("invalid italic content within bold quote in sentence", func(t *testing.T) {
 		// given
 		content := "some *bold and _italic content _ together*."
-		expected := `<div class="paragraph"><p>some <strong>bold and _italic content _ together</strong>.</p></div>`
+		expected := `<div class="paragraph">
+<p>some <strong>bold and _italic content _ together</strong>.</p>
+</div>`
 		verify(t, expected, content)
 	})
 }
@@ -92,7 +110,7 @@ func verify(t *testing.T, expected, content string) {
 	require.Nil(t, err)
 	require.Empty(t, err)
 	result := string(buff.Bytes())
-	assert.Equal(t, singleLine(expected), singleLine(result))
+	assert.Equal(t, expected, result)
 }
 
 func singleLine(content string) string {

--- a/types/type_utils.go
+++ b/types/type_utils.go
@@ -108,6 +108,6 @@ func stringify(elements []interface{}) (*string, error) {
 
 	}
 	result := buff.String()
-	log.Debugf("stringified %v -> '%s' (%v)", elements, result, reflect.TypeOf(result))
+	log.Debugf("stringified %v -> '%s' (%v characters)", elements, result, len(result))
 	return &result, nil
 }

--- a/types/types.go
+++ b/types/types.go
@@ -22,18 +22,18 @@ func init() {
 	log.SetFormatter(&log.TextFormatter{FullTimestamp: true})
 }
 
-// *****************************
+// ------------------------------------------
 // DocElement
-// *****************************
+// ------------------------------------------
 
 //DocElement the interface for all document elements
 type DocElement interface {
 	String() string
 }
 
-// *****************************
+// ------------------------------------------
 // Document
-// *****************************
+// ------------------------------------------
 
 //Document the top-level structure for a a document
 type Document struct {
@@ -58,9 +58,9 @@ func (d *Document) String() string {
 	return result
 }
 
-// *****************************
+// ------------------------------------------
 // Heading
-// *****************************
+// ------------------------------------------
 
 // Heading the structure for the headings
 type Heading struct {
@@ -81,9 +81,9 @@ func (h Heading) String() string {
 	return fmt.Sprintf("<Heading %d> '%s'", h.Level, h.Content.String())
 }
 
-// *****************************
+// ------------------------------------------
 // ListItem
-// *****************************
+// ------------------------------------------
 
 // ListItem the structure for the list items
 type ListItem struct {
@@ -109,9 +109,9 @@ func (l ListItem) String() string {
 	return fmt.Sprintf("<List item> %v", *l.Content)
 }
 
-// *****************************
+// ------------------------------------------
 // Paragraph
-// *****************************
+// ------------------------------------------
 
 // Paragraph the structure for the paragraph
 type Paragraph struct {
@@ -156,9 +156,9 @@ func (c InlineContent) String() string {
 	return fmt.Sprintf("<InlineContent (l=%[2]d)> %[1]v", c.Elements, len(c.Elements))
 }
 
-// *****************************
+// ------------------------------------------
 // Images
-// *****************************
+// ------------------------------------------
 
 // BlockImage the structure for the block images
 type BlockImage struct {
@@ -255,9 +255,48 @@ func (m BlockImageMacro) String() string {
 	return fmt.Sprintf("<BlockImageMacroMacro> %s[%s,w=%s h=%s]", m.Path, m.Alt, width, height)
 }
 
-// *****************************
+// ------------------------------------------
+// Delimited blocks
+// ------------------------------------------
+
+// DelimitedBlockKind the type for delimited blocks
+type DelimitedBlockKind int
+
+const (
+	// SourceBlock a source block
+	SourceBlock DelimitedBlockKind = iota
+)
+
+//DelimitedBlock the structure for the delimited blocks
+type DelimitedBlock struct {
+	Kind    DelimitedBlockKind
+	Content string
+}
+
+//NewDelimitedBlock initializes a new `DelimitedBlock` of the given kind with the given content
+func NewDelimitedBlock(kind DelimitedBlockKind, content []interface{}) (*DelimitedBlock, error) {
+	c, err := stringify(content)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to initialize a new delimited block")
+	}
+	return &DelimitedBlock{
+		Kind:    kind,
+		Content: strings.TrimSuffix(strings.TrimSuffix(*c, "\n"), "\r"), // remove "\n" or "\r\n", depending on the OS.
+	}, nil
+}
+
+func (b DelimitedBlock) String() string {
+	switch b.Kind {
+	case SourceBlock:
+		return fmt.Sprintf("<SourceBlock> %v", b.Content)
+	default:
+		return fmt.Sprintf("<Unknown type of block> %v", b.Content)
+	}
+}
+
+// ------------------------------------------
 // Meta Elements
-// *****************************
+// ------------------------------------------
 
 // ElementLink the structure for element links
 type ElementLink struct {
@@ -308,9 +347,9 @@ func (e ElementTitle) String() string {
 	return fmt.Sprintf("<ElementTitle> %s", e.Content)
 }
 
-// *****************************
+// ------------------------------------------
 // StringElement
-// *****************************
+// ------------------------------------------
 
 // StringElement the structure for strings
 type StringElement struct {
@@ -326,9 +365,9 @@ func (e StringElement) String() string {
 	return fmt.Sprintf("<String> '%s' (%d)", e.Content, len(e.Content))
 }
 
-// *****************************
+// ------------------------------------------
 // Quoted text
-// *****************************
+// ------------------------------------------
 
 // QuotedText the structure for quoted text
 type QuotedText struct {
@@ -341,7 +380,7 @@ type QuotedTextKind int
 
 const (
 	// Bold bold quoted text
-	Bold = iota
+	Bold QuotedTextKind = iota
 	// Italic italic quoted text
 	Italic
 	// Monospace monospace quoted text
@@ -365,9 +404,9 @@ func (t QuotedText) String() string {
 	return fmt.Sprintf("<QuotedText (%d)> %v", t.Kind, t.Elements)
 }
 
-// *****************************
+// ------------------------------------------
 // BlankLine
-// *****************************
+// ------------------------------------------
 
 // BlankLine the structure for the empty lines, which are used to separate logical blocks
 type BlankLine struct {
@@ -382,9 +421,9 @@ func (e BlankLine) String() string {
 	return "<BlankLine>"
 }
 
-// *****************************
+// ------------------------------------------
 // Links
-// *****************************
+// ------------------------------------------
 
 // ExternalLink the structure for the external links
 type ExternalLink struct {


### PR DESCRIPTION
Support fences (```)
Also, more strict comparisons in test (not ignoring '\n')

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>