### PR TITLE
feat(renderer): render headings with support for default and custom ID

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,10 @@
-hash: 10cb315acf28bc682cd4a496e2f5332a6cccdfab7400482ef93b9fa731f5dd7e
-updated: 2017-06-19T22:24:47.258597159+02:00
+hash: 277ac9f640750873736bfdc58fa22984ccc67fb7f473fdbf6db5bc87c05e53dc
+updated: 2017-07-09T13:50:51.059589264+02:00
 imports:
 - name: github.com/go-test/deep
   version: f49763a6ea0a91026be26f8213bebee726b4185f
 - name: github.com/mna/pigeon
-  version: 4468ff667da4e27301e257e6920165ddeb00c491
+  version: 3ad7b4379454d41dc287081d455492b3b00b81df
 - name: github.com/pkg/errors
   version: 645ef00459ed84a119197bfb8d8205042c6df63d
 - name: github.com/sirupsen/logrus
@@ -20,6 +20,10 @@ imports:
   version: 478fcf54317e52ab69f40bb4c7a1520288d7f7ea
   subpackages:
   - unix
+- name: golang.org/x/text
+  version: 47a200a05c8b3fd1b698571caecbb68beb2611ec
+  subpackages:
+  - unicode
 testImports:
 - name: github.com/davecgh/go-spew
   version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9

--- a/glide.yaml
+++ b/glide.yaml
@@ -13,3 +13,6 @@ import:
   vcs: git
   version: ^1.0.0
 - package: github.com/go-test/deep
+- package: golang.org/x/text
+  subpackages:
+    - unicode

--- a/parser/asciidoc-grammar.peg
+++ b/parser/asciidoc-grammar.peg
@@ -18,8 +18,8 @@ Line <- Heading / ListItem / BlockImage / DelimitedBlock / MetadataElement / Par
 // ------------------------------------------
 // Headings
 // ------------------------------------------
-Heading <- level:("="+) WS+ content:InlineContent {
-     return types.NewHeading(level, content.(*types.InlineContent))
+Heading <- metadata:(MetadataElement)* level:("="+) WS+ content:InlineContent {
+     return types.NewHeading(level, content.(*types.InlineContent), metadata.([]interface{}))
 }
 
 // ------------------------------------------

--- a/parser/asciidoc_parser_test.go
+++ b/parser/asciidoc_parser_test.go
@@ -40,11 +40,17 @@ func TestHeadingOnly(t *testing.T) {
 	actualContent := "= a heading"
 	expectedDocument := &types.Document{
 		Elements: []types.DocElement{
-			&types.Heading{Level: 1, Content: &types.InlineContent{
-				Elements: []types.DocElement{
-					&types.StringElement{Content: "a heading"},
+			&types.Heading{
+				Level: 1,
+				Content: &types.InlineContent{
+					Elements: []types.DocElement{
+						&types.StringElement{Content: "a heading"},
+					},
 				},
-			}},
+				ID: &types.ElementID{
+					Value: "_a_heading",
+				},
+			},
 		}}
 	compare(t, expectedDocument, actualContent)
 }
@@ -89,11 +95,17 @@ func TestSection2(t *testing.T) {
 	actualContent := `== section 1`
 	expectedDocument := &types.Document{
 		Elements: []types.DocElement{
-			&types.Heading{Level: 2, Content: &types.InlineContent{
-				Elements: []types.DocElement{
-					&types.StringElement{Content: "section 1"},
+			&types.Heading{
+				Level: 2,
+				Content: &types.InlineContent{
+					Elements: []types.DocElement{
+						&types.StringElement{Content: "section 1"},
+					},
 				},
-			}},
+				ID: &types.ElementID{
+					Value: "_section_1",
+				},
+			},
 		},
 	}
 	compare(t, expectedDocument, actualContent)
@@ -106,17 +118,29 @@ func TestHeadingWithSection2(t *testing.T) {
 		"== section 1"
 	expectedDocument := &types.Document{
 		Elements: []types.DocElement{
-			&types.Heading{Level: 1, Content: &types.InlineContent{
-				Elements: []types.DocElement{
-					&types.StringElement{Content: "a heading"},
+			&types.Heading{
+				Level: 1,
+				Content: &types.InlineContent{
+					Elements: []types.DocElement{
+						&types.StringElement{Content: "a heading"},
+					},
 				},
-			}},
+				ID: &types.ElementID{
+					Value: "_a_heading",
+				},
+			},
 			&types.BlankLine{},
-			&types.Heading{Level: 2, Content: &types.InlineContent{
-				Elements: []types.DocElement{
-					&types.StringElement{Content: "section 1"},
+			&types.Heading{
+				Level: 2,
+				Content: &types.InlineContent{
+					Elements: []types.DocElement{
+						&types.StringElement{Content: "section 1"},
+					},
 				},
-			}},
+				ID: &types.ElementID{
+					Value: "_section_1",
+				},
+			},
 		},
 	}
 	compare(t, expectedDocument, actualContent)
@@ -128,11 +152,16 @@ func TestHeadingWithInvalidSection2(t *testing.T) {
 		" == section 1"
 	expectedDocument := &types.Document{
 		Elements: []types.DocElement{
-			&types.Heading{Level: 1, Content: &types.InlineContent{
-				Elements: []types.DocElement{
-					&types.StringElement{Content: "a heading"},
+			&types.Heading{
+				Level: 1, Content: &types.InlineContent{
+					Elements: []types.DocElement{
+						&types.StringElement{Content: "a heading"},
+					},
 				},
-			}},
+				ID: &types.ElementID{
+					Value: "_a_heading",
+				},
+			},
 			&types.BlankLine{},
 			&types.Paragraph{
 				Lines: []*types.InlineContent{
@@ -192,17 +221,29 @@ func TestHeadingSectionInlineWithBoldQuote(t *testing.T) {
 		"a paragraph with *bold content*"
 	expectedDocument := &types.Document{
 		Elements: []types.DocElement{
-			&types.Heading{Level: 1, Content: &types.InlineContent{
-				Elements: []types.DocElement{
-					&types.StringElement{Content: "a heading"},
+			&types.Heading{
+				Level: 1,
+				Content: &types.InlineContent{
+					Elements: []types.DocElement{
+						&types.StringElement{Content: "a heading"},
+					},
 				},
-			}},
+				ID: &types.ElementID{
+					Value: "_a_heading",
+				},
+			},
 			&types.BlankLine{},
-			&types.Heading{Level: 2, Content: &types.InlineContent{
-				Elements: []types.DocElement{
-					&types.StringElement{Content: "section 1"},
+			&types.Heading{
+				Level: 2,
+				Content: &types.InlineContent{
+					Elements: []types.DocElement{
+						&types.StringElement{Content: "section 1"},
+					},
 				},
-			}},
+				ID: &types.ElementID{
+					Value: "_section_1",
+				},
+			},
 			&types.BlankLine{},
 			&types.Paragraph{
 				Lines: []*types.InlineContent{

--- a/renderer/html5/heading.go
+++ b/renderer/html5/heading.go
@@ -1,0 +1,52 @@
+package html5
+
+import (
+	"bytes"
+	"context"
+	"html/template"
+
+	"github.com/bytesparadise/libasciidoc/types"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+var mainHeaderTmpl *template.Template
+var sectionHeaderTmpl *template.Template
+
+// initializes the templates
+func init() {
+	mainHeaderTmpl = newTemplate("heading", `<div id="header">
+<h1>{{.Content}}</h1>
+</div>`)
+	sectionHeaderTmpl = newTemplate("heading", `<h{{.Level}} id="{{.ID}}">{{.Content}}</h{{.Level}}>`)
+}
+
+func renderHeading(ctx context.Context, heading types.Heading) ([]byte, error) {
+	result := bytes.NewBuffer(make([]byte, 0))
+	var tmpl *template.Template
+	switch heading.Level {
+	case 1:
+		tmpl = mainHeaderTmpl
+	default:
+		tmpl = sectionHeaderTmpl
+	}
+	renderedContent, err := renderElement(ctx, heading.Content)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error while rendering heading content")
+	}
+	content := template.HTML(string(renderedContent))
+	err = tmpl.Execute(result, struct {
+		Level   int
+		ID      string
+		Content template.HTML
+	}{
+		Level:   heading.Level,
+		ID:      heading.ID.Value,
+		Content: content,
+	})
+	if err != nil {
+		return nil, errors.Wrapf(err, "error while rendering heading")
+	}
+	log.Debugf("rendered heading: %s", result.Bytes())
+	return result.Bytes(), nil
+}

--- a/renderer/html5/heading_test.go
+++ b/renderer/html5/heading_test.go
@@ -11,7 +11,13 @@ func TestRenderHeading(t *testing.T) {
 </div>`
 		verify(t, expected, content)
 	})
-	t.Run("heading with bold content", func(t *testing.T) {
+	t.Run("heading with just bold content", func(t *testing.T) {
+		// given
+		content := `==  *2 spaces and bold content*`
+		expected := `<h2 id="__strong_2_spaces_and_bold_content_strong"><strong>2 spaces and bold content</strong></h2>`
+		verify(t, expected, content)
+	})
+	t.Run("heading with nested bold content", func(t *testing.T) {
 		// given
 		content := `== a section title, with *bold content*`
 		expected := `<h2 id="_a_section_title_with_strong_bold_content_strong">a section title, with <strong>bold content</strong></h2>`

--- a/renderer/html5/heading_test.go
+++ b/renderer/html5/heading_test.go
@@ -1,0 +1,27 @@
+package html5_test
+
+import "testing"
+
+func TestRenderHeading(t *testing.T) {
+	t.Run("heading level 1", func(t *testing.T) {
+		// given
+		content := "= a title"
+		expected := `<div id="header">
+<h1>a title</h1>
+</div>`
+		verify(t, expected, content)
+	})
+	t.Run("heading with bold content", func(t *testing.T) {
+		// given
+		content := `== a section title, with *bold content*`
+		expected := `<h2 id="_a_section_title_with_strong_bold_content_strong">a section title, with <strong>bold content</strong></h2>`
+		verify(t, expected, content)
+	})
+	t.Run("heading with custom ID", func(t *testing.T) {
+		// given
+		content := `[#custom_id]
+== a section title, with *bold content*`
+		expected := `<h2 id="custom_id">a section title, with <strong>bold content</strong></h2>`
+		verify(t, expected, content)
+	})
+}

--- a/renderer/html5/inline_content.go
+++ b/renderer/html5/inline_content.go
@@ -1,0 +1,22 @@
+package html5
+
+import (
+	"bytes"
+
+	"context"
+
+	"github.com/bytesparadise/libasciidoc/types"
+	"github.com/pkg/errors"
+)
+
+func renderInlineContent(ctx context.Context, content types.InlineContent) ([]byte, error) {
+	renderedElementsBuff := bytes.NewBuffer(make([]byte, 0))
+	for _, element := range content.Elements {
+		renderedElement, err := renderElement(ctx, element)
+		if err != nil {
+			return nil, errors.Wrapf(err, "unable to render paragraph element")
+		}
+		renderedElementsBuff.Write(renderedElement)
+	}
+	return renderedElementsBuff.Bytes(), nil
+}

--- a/renderer/html5/paragraph.go
+++ b/renderer/html5/paragraph.go
@@ -25,13 +25,11 @@ func init() {
 func renderParagraph(ctx context.Context, paragraph types.Paragraph) ([]byte, error) {
 	renderedElementsBuff := bytes.NewBuffer(make([]byte, 0))
 	for _, line := range paragraph.Lines {
-		for _, element := range line.Elements {
-			renderedElement, err := renderElement(ctx, element)
-			if err != nil {
-				return nil, errors.Wrapf(err, "unable to render inline content element")
-			}
-			renderedElementsBuff.Write(renderedElement)
+		renderedElement, err := renderInlineContent(ctx, *line)
+		if err != nil {
+			return nil, errors.Wrapf(err, "unable to render paragraph element")
 		}
+		renderedElementsBuff.Write(renderedElement)
 	}
 	result := bytes.NewBuffer(make([]byte, 0))
 	// here we must preserve the HTML tags

--- a/renderer/html5/renderer.go
+++ b/renderer/html5/renderer.go
@@ -24,6 +24,8 @@ func Render(ctx context.Context, document types.Document, output io.Writer) erro
 
 func renderElement(ctx context.Context, element types.DocElement) ([]byte, error) {
 	switch element.(type) {
+	case *types.Heading:
+		return renderHeading(ctx, *element.(*types.Heading))
 	case *types.Paragraph:
 		return renderParagraph(ctx, *element.(*types.Paragraph))
 	case *types.QuotedText:
@@ -32,6 +34,8 @@ func renderElement(ctx context.Context, element types.DocElement) ([]byte, error
 		return renderBlockImage(ctx, *element.(*types.BlockImage))
 	case *types.DelimitedBlock:
 		return renderDelimitedBlock(ctx, *element.(*types.DelimitedBlock))
+	case *types.InlineContent:
+		return renderInlineContent(ctx, *element.(*types.InlineContent))
 	case *types.StringElement:
 		return renderStringElement(ctx, *element.(*types.StringElement))
 	default:

--- a/types/type_utils.go
+++ b/types/type_utils.go
@@ -3,6 +3,8 @@ package types
 import (
 	"bytes"
 	"reflect"
+	"strings"
+	"unicode"
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -110,4 +112,112 @@ func stringify(elements []interface{}) (*string, error) {
 	result := buff.String()
 	log.Debugf("stringified %v -> '%s' (%v characters)", elements, result, len(result))
 	return &result, nil
+}
+
+//NormalizationFunc a function that is used to normalize a string.
+type NormalizationFunc func(string) ([]byte, error)
+
+//ReplaceNonAlphanumerics replaces all non alphanumerical characters and remove (accents)
+// in the given 'source' with the given 'replacement'.
+func ReplaceNonAlphanumerics(replacement string) NormalizationFunc {
+	return func(source string) ([]byte, error) {
+		buf := bytes.NewBuffer(make([]byte, 0))
+		_, err := buf.WriteString(replacement)
+		if err != nil {
+			return nil, errors.Wrapf(err, "unable to normalize value")
+		}
+		lastCharIsSpace := true
+		for _, r := range source {
+			if unicode.Is(unicode.Letter, r) || unicode.Is(unicode.Number, r) {
+				_, err := buf.WriteString(strings.ToLower(string(r)))
+				if err != nil {
+					return nil, errors.Wrapf(err, "unable to normalize value")
+				}
+				lastCharIsSpace = false
+			} else if !lastCharIsSpace && (unicode.Is(unicode.Space, r) || unicode.Is(unicode.Punct, r)) {
+				_, err := buf.WriteString(replacement)
+				if err != nil {
+					return nil, errors.Wrapf(err, "unable to normalize value")
+				}
+				lastCharIsSpace = true
+			}
+		}
+		result := strings.TrimSuffix(buf.String(), replacement)
+		return []byte(result), nil
+	}
+}
+
+//ReplaceNonAlphanumericCharsVisitor a visitor that builds a string representation of the visited elements,
+// in which all non-alphanumeric characters have been replaced with a "_"
+
+type ReplaceNonAlphanumericsVisitor struct {
+	buf       bytes.Buffer
+	normalize NormalizationFunc
+}
+
+func NewReplaceNonAlphanumericsVisitor() *ReplaceNonAlphanumericsVisitor {
+	buf := bytes.NewBuffer(make([]byte, 0))
+	return &ReplaceNonAlphanumericsVisitor{
+		buf:       *buf,
+		normalize: ReplaceNonAlphanumerics("_"),
+	}
+}
+
+func (v *ReplaceNonAlphanumericsVisitor) Visit(element interface{}) error {
+	switch element := element.(type) {
+	case InlineContent, QuotedText:
+		// nothing to do at this level
+	case StringElement:
+		normalized, err := v.normalize(element.Content)
+		if err != nil {
+			return errors.Wrapf(err, "error while normalizing String Element")
+		}
+		v.buf.Write(normalized)
+	default:
+		return errors.Errorf("unsupported type of element to visit: %v", reflect.TypeOf(element))
+	}
+	return nil
+}
+
+func (v *ReplaceNonAlphanumericsVisitor) BeforeVisit(element interface{}) error {
+	switch element := element.(type) {
+	case QuotedText:
+		switch element.Kind {
+		case Bold:
+			v.buf.WriteString("_strong")
+		case Italic:
+			v.buf.WriteString("_italic")
+		case Monospace:
+			v.buf.WriteString("_monospace")
+		default:
+			return errors.Errorf("unsupported kind of quoted text: %d", element.Kind)
+		}
+	default:
+		// ignore
+	}
+	return nil
+}
+
+func (v *ReplaceNonAlphanumericsVisitor) AfterVisit(element interface{}) error {
+	switch element := element.(type) {
+	case QuotedText:
+		switch element.Kind {
+		case Bold:
+			v.buf.WriteString("_strong")
+		case Italic:
+			v.buf.WriteString("_italic")
+		case Monospace:
+			v.buf.WriteString("_monospace")
+		default:
+			return errors.Errorf("unsupported kind of quoted text: %d", element.Kind)
+		}
+	default:
+		// ignore
+	}
+	return nil
+}
+
+func (v *ReplaceNonAlphanumericsVisitor) NormalizedContent() string {
+	result := v.buf.String()
+	return result
 }

--- a/types/type_utils_test.go
+++ b/types/type_utils_test.go
@@ -10,19 +10,19 @@ import (
 
 func TestNormalize(t *testing.T) {
 	t.Run("hello", func(t *testing.T) {
-		verify(t, "_hello", "hello")
+		verify(t, "hello", "hello")
 	})
 	t.Run("héllo with an accent", func(t *testing.T) {
 		verify(t, "_héllo_1_2_and_3_spaces", " héllo 1.2   and 3 Spaces")
 	})
 	t.Run("a an accent and a swedish character", func(t *testing.T) {
-		verify(t, `_a_à`, `A à ⌘`)
+		verify(t, `a_à`, `A à ⌘`)
 	})
 	t.Run("AŁA", func(t *testing.T) {
-		verify(t, `_aŁa_0_1`, `AŁA 0.1 ?`)
+		verify(t, `ała_0_1`, `AŁA 0.1 ?`)
 	})
 	t.Run("it's  2 spaces, here !", func(t *testing.T) {
-		verify(t, `_it_s_2_spaces_here`, `it's  2 spaces, here !`)
+		verify(t, `it_s_2_spaces_here`, `it's  2 spaces, here !`)
 	})
 }
 

--- a/types/type_utils_test.go
+++ b/types/type_utils_test.go
@@ -1,0 +1,35 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalize(t *testing.T) {
+	t.Run("hello", func(t *testing.T) {
+		verify(t, "_hello", "hello")
+	})
+	t.Run("héllo with an accent", func(t *testing.T) {
+		verify(t, "_héllo_1_2_and_3_spaces", " héllo 1.2   and 3 Spaces")
+	})
+	t.Run("a an accent and a swedish character", func(t *testing.T) {
+		verify(t, `_a_à`, `A à ⌘`)
+	})
+	t.Run("AŁA", func(t *testing.T) {
+		verify(t, `_aŁa_0_1`, `AŁA 0.1 ?`)
+	})
+	t.Run("it's  2 spaces, here !", func(t *testing.T) {
+		verify(t, `_it_s_2_spaces_here`, `it's  2 spaces, here !`)
+	})
+}
+
+func verify(t *testing.T, expected, input string) {
+	t.Logf("Processing '%s'", input)
+	result, err := ReplaceNonAlphanumerics("_")(input)
+	require.Nil(t, err)
+	t.Logf("Normalized result: '%s'", string(result))
+	assert.Equal(t, expected, string(result))
+}


### PR DESCRIPTION
Default heading ID based on the content of the ID, with some transformation
to make it a valid CSS selector.
Add support for Visitor on all `types.DocElement` implementations.

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>