### PR TITLE
feat(renderer): render section preamble

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 663f7ee6d2093012d467bf7b7f2967d1fdda8ed7165a10a5ba785b9cd7d36b1a
-updated: 2017-08-10T10:34:55.467681795+02:00
+hash: 2890eb41628595da96f5d32a49c1496924668cc707a3e2d469bbcdc40d7d6120
+updated: 2017-08-21T16:37:36.310336353+02:00
 imports:
 - name: github.com/go-test/deep
   version: f49763a6ea0a91026be26f8213bebee726b4185f
@@ -42,7 +42,7 @@ imports:
 - name: github.com/pkg/errors
   version: 645ef00459ed84a119197bfb8d8205042c6df63d
 - name: github.com/sirupsen/logrus
-  version: a3f95b5c423586578a4e099b11a46c2479628cac
+  version: f006c2ac4710855cf0f916dd6b77acf6b048dc6e
   repo: https://github.com/sirupsen/logrus.git
   vcs: git
 - name: github.com/stretchr/testify
@@ -50,10 +50,15 @@ imports:
   subpackages:
   - assert
   - require
+- name: golang.org/x/crypto
+  version: eb71ad9bd329b5ac0fd0148dd99bd62e8be8e035
+  subpackages:
+  - ssh/terminal
 - name: golang.org/x/sys
   version: 478fcf54317e52ab69f40bb4c7a1520288d7f7ea
   subpackages:
   - unix
+  - windows
 - name: golang.org/x/text
   version: 47a200a05c8b3fd1b698571caecbb68beb2611ec
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -17,6 +17,6 @@ import:
   subpackages:
     - unicode
 - package: github.com/onsi/ginkgo
-  version: ^1.3.1
+  version: ^1.4.0
 - package: github.com/onsi/gomega
-  version: ^1.1.0
+  version: ^1.2.0

--- a/renderer/html5/paragraph.go
+++ b/renderer/html5/paragraph.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/bytesparadise/libasciidoc/types"
 	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
 )
 
 var paragraphTmpl *template.Template
@@ -37,6 +36,6 @@ func renderParagraph(ctx context.Context, paragraph types.Paragraph) ([]byte, er
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to render inline content")
 	}
-	log.Debugf("rendered paragraph: %s", result.Bytes())
+	// log.Debugf("rendered paragraph: %s", result.Bytes())
 	return result.Bytes(), nil
 }

--- a/renderer/html5/renderer_test.go
+++ b/renderer/html5/renderer_test.go
@@ -19,6 +19,7 @@ func verify(t GinkgoTInterface, expected, content string) {
 	doc, err := parser.ParseReader("", reader)
 	require.Nil(t, err, "Error found while parsing the document")
 	actualDocument := doc.(*types.Document)
+	t.Logf("Actual document:\n%s", actualDocument.String(1))
 	buff := bytes.NewBuffer(make([]byte, 0))
 	err = Render(context.Background(), *actualDocument, buff)
 	t.Log("Done processing document")

--- a/renderer/html5/section_test.go
+++ b/renderer/html5/section_test.go
@@ -98,5 +98,84 @@ and a second paragraph`
 </div>`
 			verify(GinkgoT(), expected, content)
 		})
+
+		It("preamble then section level 2", func() {
+			content := `= a title
+		
+a preamble
+
+splitted in 2 paragraphs
+
+== section 1
+
+with some text`
+			// top-level heading is not rendered per-say,
+			// but the heading will be used to set the HTML page's <title> element
+			expected := `<div id="preamble">
+<div class="sectionbody">
+<div class="paragraph">
+<p>a preamble</p>
+</div>
+<div class="paragraph">
+<p>splitted in 2 paragraphs</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_section_1">section 1</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>with some text</p>
+</div>
+</div>
+</div>`
+			verify(GinkgoT(), expected, content)
+		})
+
+		It("preamble then 2 sections level 2", func() {
+			content := `= a title
+		
+a preamble
+
+splitted in 2 paragraphs
+
+== section 1
+
+with some text
+
+== section 2
+
+with some text, too`
+			// top-level heading is not rendered per-say,
+			// but the heading will be used to set the HTML page's <title> element
+			expected := `<div id="preamble">
+<div class="sectionbody">
+<div class="paragraph">
+<p>a preamble</p>
+</div>
+<div class="paragraph">
+<p>splitted in 2 paragraphs</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_section_1">section 1</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>with some text</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_section_2">section 2</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>with some text, too</p>
+</div>
+</div>
+</div>`
+			verify(GinkgoT(), expected, content)
+		})
+
 	})
 })

--- a/renderer/html5/string.go
+++ b/renderer/html5/string.go
@@ -7,8 +7,6 @@ import (
 
 	"github.com/bytesparadise/libasciidoc/types"
 	"github.com/pkg/errors"
-
-	log "github.com/sirupsen/logrus"
 )
 
 var stringElementTmpl *template.Template
@@ -24,6 +22,6 @@ func renderStringElement(ctx context.Context, str types.StringElement) ([]byte, 
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to render string element")
 	}
-	log.Debugf("rendered string: %s", result.Bytes())
+	// log.Debugf("rendered string: %s", result.Bytes())
 	return result.Bytes(), nil
 }

--- a/types/types.go
+++ b/types/types.go
@@ -744,7 +744,7 @@ type ElementID struct {
 
 //NewElementID initializes a new `ElementID` from the given path
 func NewElementID(id string) (*ElementID, error) {
-	log.Debugf("Initializing a new ElementID with ID=%s", id)
+	log.Debugf("Initializing a new ElementID with value=`%s`", id)
 	return &ElementID{Value: id}, nil
 }
 


### PR DESCRIPTION
all blocks before first section of level 2 are wrapped
in a 'preamble' div.
also, update ginkgo and gomega dependencies

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>