### PR TITLE
feat(renderer): render full document

### DIFF
--- a/libasciidoc.go
+++ b/libasciidoc.go
@@ -5,20 +5,43 @@ import (
 	"io"
 
 	"github.com/bytesparadise/libasciidoc/parser"
+	"github.com/bytesparadise/libasciidoc/renderer"
 	htmlrenderer "github.com/bytesparadise/libasciidoc/renderer/html5"
 	"github.com/bytesparadise/libasciidoc/types"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
 
-// ConvertToHTML converts the content of the given reader `r` into an HTML document that is written in the given writer `w`. Returns an error if a problem occurred
-func ConvertToHTML(r io.Reader, w io.Writer) error {
+// ConvertToHTMLBody converts the content of the given reader `r` into an set of <DIV> elements for an HTML/BODY document.
+// The conversion result is written in the given writer `w`, whereas the document metadata (title, etc.) (or an error if a problem occurred) is returned
+// as the result of the function call.
+func ConvertToHTMLBody(r io.Reader, w io.Writer) (*types.DocumentMetadata, error) {
+	doc, err := parser.ParseReader("", r)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error while parsing the document")
+	}
+	document := doc.(*types.Document)
+	options := renderer.Options{}
+	options[renderer.IncludeHeaderFooter] = false // force value
+	err = htmlrenderer.Render(context.Background(), *document, w, options)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error while rendering the document")
+	}
+	log.Debugf("Done processing document")
+	return document.Metadata, nil
+}
+
+// ConvertToHTML converts the content of the given reader `r` into a full HTML document, written in the given writer `w`.
+// Returns an error if a problem occurred
+func ConvertToHTML(r io.Reader, w io.Writer, options renderer.Options) error {
+
 	doc, err := parser.ParseReader("", r)
 	if err != nil {
 		return errors.Wrapf(err, "error while parsing the document")
 	}
 	document := doc.(*types.Document)
-	err = htmlrenderer.Render(context.Background(), *document, w)
+	options[renderer.IncludeHeaderFooter] = true // force value
+	err = htmlrenderer.Render(context.Background(), *document, w, options)
 	if err != nil {
 		return errors.Wrapf(err, "error while rendering the document")
 	}

--- a/parser/asciidoc_parser_test.go
+++ b/parser/asciidoc_parser_test.go
@@ -21,12 +21,15 @@ var _ = Describe("Parsing content", func() {
 			"\n" +
 			"a paragraph with *bold content*"
 		expectedDocument := &types.Document{
+			Metadata: &types.DocumentMetadata{
+				"title": "a heading",
+			},
 			Elements: []types.DocElement{
 				&types.Section{
 					Heading: types.Heading{
 						Level: 1,
 						Content: &types.InlineContent{
-							Elements: []types.DocElement{
+							Elements: []types.InlineElement{
 								&types.StringElement{Content: "a heading"},
 							},
 						},
@@ -39,7 +42,7 @@ var _ = Describe("Parsing content", func() {
 							Heading: types.Heading{
 								Level: 2,
 								Content: &types.InlineContent{
-									Elements: []types.DocElement{
+									Elements: []types.InlineElement{
 										&types.StringElement{Content: "section 1"},
 									},
 								},
@@ -51,10 +54,10 @@ var _ = Describe("Parsing content", func() {
 								&types.Paragraph{
 									Lines: []*types.InlineContent{
 										&types.InlineContent{
-											Elements: []types.DocElement{
+											Elements: []types.InlineElement{
 												&types.StringElement{Content: "a paragraph with "},
 												&types.QuotedText{Kind: types.Bold,
-													Elements: []types.DocElement{
+													Elements: []types.InlineElement{
 														&types.StringElement{Content: "bold content"},
 													},
 												},

--- a/parser/blank_line_test.go
+++ b/parser/blank_line_test.go
@@ -11,21 +11,21 @@ var _ = Describe("Blank lines", func() {
 
 second paragraph`
 		expectedDocument := &types.Document{
+			Metadata: &types.DocumentMetadata{},
 			Elements: []types.DocElement{
 				&types.Paragraph{
 					Lines: []*types.InlineContent{
 						&types.InlineContent{
-							Elements: []types.DocElement{
+							Elements: []types.InlineElement{
 								&types.StringElement{Content: "first paragraph"},
 							},
 						},
 					},
 				},
-				// &types.BlankLine{},
 				&types.Paragraph{
 					Lines: []*types.InlineContent{
 						&types.InlineContent{
-							Elements: []types.DocElement{
+							Elements: []types.InlineElement{
 								&types.StringElement{Content: "second paragraph"},
 							},
 						},
@@ -43,23 +43,21 @@ second paragraph`
 second paragraph
 `
 		expectedDocument := &types.Document{
+			Metadata: &types.DocumentMetadata{},
 			Elements: []types.DocElement{
 				&types.Paragraph{
 					Lines: []*types.InlineContent{
 						&types.InlineContent{
-							Elements: []types.DocElement{
+							Elements: []types.InlineElement{
 								&types.StringElement{Content: "first paragraph"},
 							},
 						},
 					},
 				},
-				// &types.BlankLine{},
-				// &types.BlankLine{},
-				// &types.BlankLine{},
 				&types.Paragraph{
 					Lines: []*types.InlineContent{
 						&types.InlineContent{
-							Elements: []types.DocElement{
+							Elements: []types.InlineElement{
 								&types.StringElement{Content: "second paragraph"},
 							},
 						},

--- a/parser/delimited_block_test.go
+++ b/parser/delimited_block_test.go
@@ -11,6 +11,7 @@ var _ = Describe("Delimited Blocks", func() {
 		content := "some source code"
 		actualContent := "```\n" + content + "\n```"
 		expectedDocument := &types.Document{
+			Metadata: &types.DocumentMetadata{},
 			Elements: []types.DocElement{
 				&types.DelimitedBlock{
 					Kind:    types.SourceBlock,
@@ -25,6 +26,7 @@ var _ = Describe("Delimited Blocks", func() {
 		content := "some source code\nwith an empty line\n\nin the middle"
 		actualContent := "```\n" + content + "\n```"
 		expectedDocument := &types.Document{
+			Metadata: &types.DocumentMetadata{},
 			Elements: []types.DocElement{
 				&types.DelimitedBlock{
 					Kind:    types.SourceBlock,
@@ -39,6 +41,7 @@ var _ = Describe("Delimited Blocks", func() {
 		content := ""
 		actualContent := "```\n" + content + "```"
 		expectedDocument := &types.Document{
+			Metadata: &types.DocumentMetadata{},
 			Elements: []types.DocElement{
 				&types.DelimitedBlock{
 					Kind:    types.SourceBlock,

--- a/parser/external_link_test.go
+++ b/parser/external_link_test.go
@@ -10,11 +10,12 @@ var _ = Describe("External Links", func() {
 	It("external link", func() {
 		actualContent := "a link to https://foo.bar"
 		expectedDocument := &types.Document{
+			Metadata: &types.DocumentMetadata{},
 			Elements: []types.DocElement{
 				&types.Paragraph{
 					Lines: []*types.InlineContent{
 						&types.InlineContent{
-							Elements: []types.DocElement{
+							Elements: []types.InlineElement{
 								&types.StringElement{Content: "a link to "},
 								&types.ExternalLink{
 									URL: "https://foo.bar",
@@ -31,11 +32,12 @@ var _ = Describe("External Links", func() {
 	It("external link with empty text", func() {
 		actualContent := "a link to https://foo.bar[]"
 		expectedDocument := &types.Document{
+			Metadata: &types.DocumentMetadata{},
 			Elements: []types.DocElement{
 				&types.Paragraph{
 					Lines: []*types.InlineContent{
 						&types.InlineContent{
-							Elements: []types.DocElement{
+							Elements: []types.InlineElement{
 								&types.StringElement{Content: "a link to "},
 								&types.ExternalLink{
 									URL:  "https://foo.bar",
@@ -53,11 +55,12 @@ var _ = Describe("External Links", func() {
 	It("external link with text", func() {
 		actualContent := "a link to mailto:foo@bar[the foo@bar email]"
 		expectedDocument := &types.Document{
+			Metadata: &types.DocumentMetadata{},
 			Elements: []types.DocElement{
 				&types.Paragraph{
 					Lines: []*types.InlineContent{
 						&types.InlineContent{
-							Elements: []types.DocElement{
+							Elements: []types.InlineElement{
 								&types.StringElement{Content: "a link to "},
 								&types.ExternalLink{
 									URL:  "mailto:foo@bar",

--- a/parser/image_test.go
+++ b/parser/image_test.go
@@ -12,6 +12,7 @@ var _ = Describe("Images", func() {
 			It("block image with empty alt", func() {
 				actualContent := "image::images/foo.png[]"
 				expectedDocument := &types.Document{
+					Metadata: &types.DocumentMetadata{},
 					Elements: []types.DocElement{
 						&types.BlockImage{
 							Macro: types.ImageMacro{
@@ -27,6 +28,7 @@ var _ = Describe("Images", func() {
 			It("block image with empty alt and trailing spaces", func() {
 				actualContent := "image::images/foo.png[]  \t\t  "
 				expectedDocument := &types.Document{
+					Metadata: &types.DocumentMetadata{},
 					Elements: []types.DocElement{
 						&types.BlockImage{
 							Macro: types.ImageMacro{
@@ -44,6 +46,7 @@ var _ = Describe("Images", func() {
 				actualContent := `image::images/foo.png[]
 `
 				expectedDocument := &types.Document{
+					Metadata: &types.DocumentMetadata{},
 					Elements: []types.DocElement{
 						&types.BlockImage{
 							Macro: types.ImageMacro{
@@ -61,6 +64,7 @@ var _ = Describe("Images", func() {
 				actualContent := `image::images/foo.png[]
   `
 				expectedDocument := &types.Document{
+					Metadata: &types.DocumentMetadata{},
 					Elements: []types.DocElement{
 						&types.BlockImage{
 							Macro: types.ImageMacro{
@@ -79,6 +83,7 @@ var _ = Describe("Images", func() {
  
 			`
 				expectedDocument := &types.Document{
+					Metadata: &types.DocumentMetadata{},
 					Elements: []types.DocElement{
 						&types.BlockImage{
 							Macro: types.ImageMacro{
@@ -96,6 +101,7 @@ var _ = Describe("Images", func() {
 			It("block image with alt", func() {
 				actualContent := "image::images/foo.png[the foo.png image]"
 				expectedDocument := &types.Document{
+					Metadata: &types.DocumentMetadata{},
 					Elements: []types.DocElement{
 						&types.BlockImage{
 							Macro: types.ImageMacro{
@@ -116,6 +122,7 @@ var _ = Describe("Images", func() {
 				width := "600"
 				height := "400"
 				expectedDocument := &types.Document{
+					Metadata: &types.DocumentMetadata{},
 					Elements: []types.DocElement{
 						&types.BlockImage{
 							Macro: types.ImageMacro{
@@ -137,16 +144,17 @@ var _ = Describe("Images", func() {
 			It("block image appending inline content", func() {
 				actualContent := "a paragraph\nimage::images/foo.png[]"
 				expectedDocument := &types.Document{
+					Metadata: &types.DocumentMetadata{},
 					Elements: []types.DocElement{
 						&types.Paragraph{
 							Lines: []*types.InlineContent{
 								&types.InlineContent{
-									Elements: []types.DocElement{
+									Elements: []types.InlineElement{
 										&types.StringElement{Content: "a paragraph"},
 									},
 								},
 								&types.InlineContent{
-									Elements: []types.DocElement{
+									Elements: []types.InlineElement{
 										&types.StringElement{Content: "image::images/foo.png[]"},
 									},
 								},
@@ -165,11 +173,12 @@ var _ = Describe("Images", func() {
 			It("inline image with empty alt", func() {
 				actualContent := "image:images/foo.png[]"
 				expectedDocument := &types.Document{
+					Metadata: &types.DocumentMetadata{},
 					Elements: []types.DocElement{
 						&types.Paragraph{
 							Lines: []*types.InlineContent{
 								&types.InlineContent{
-									Elements: []types.DocElement{
+									Elements: []types.InlineElement{
 										&types.InlineImage{
 											Macro: types.ImageMacro{
 												Path: "images/foo.png",
@@ -188,11 +197,12 @@ var _ = Describe("Images", func() {
 			It("inline image with empty alt and trailing spaces", func() {
 				actualContent := "image:images/foo.png[]  \t\t  "
 				expectedDocument := &types.Document{
+					Metadata: &types.DocumentMetadata{},
 					Elements: []types.DocElement{
 						&types.Paragraph{
 							Lines: []*types.InlineContent{
 								&types.InlineContent{
-									Elements: []types.DocElement{
+									Elements: []types.InlineElement{
 										&types.InlineImage{
 											Macro: types.ImageMacro{
 												Path: "images/foo.png",
@@ -214,11 +224,12 @@ var _ = Describe("Images", func() {
 			It("inline image surrounded with test", func() {
 				actualContent := "a foo image:images/foo.png[] bar..."
 				expectedDocument := &types.Document{
+					Metadata: &types.DocumentMetadata{},
 					Elements: []types.DocElement{
 						&types.Paragraph{
 							Lines: []*types.InlineContent{
 								&types.InlineContent{
-									Elements: []types.DocElement{
+									Elements: []types.InlineElement{
 										&types.StringElement{
 											Content: "a foo ",
 										},
@@ -243,11 +254,12 @@ var _ = Describe("Images", func() {
 			It("inline image with alt", func() {
 				actualContent := "image:images/foo.png[the foo.png image]"
 				expectedDocument := &types.Document{
+					Metadata: &types.DocumentMetadata{},
 					Elements: []types.DocElement{
 						&types.Paragraph{
 							Lines: []*types.InlineContent{
 								&types.InlineContent{
-									Elements: []types.DocElement{
+									Elements: []types.InlineElement{
 										&types.InlineImage{
 											Macro: types.ImageMacro{
 												Path: "images/foo.png",
@@ -267,16 +279,17 @@ var _ = Describe("Images", func() {
 			It("inline image appending inline content", func() {
 				actualContent := "a paragraph\nimage::images/foo.png[]"
 				expectedDocument := &types.Document{
+					Metadata: &types.DocumentMetadata{},
 					Elements: []types.DocElement{
 						&types.Paragraph{
 							Lines: []*types.InlineContent{
 								&types.InlineContent{
-									Elements: []types.DocElement{
+									Elements: []types.InlineElement{
 										&types.StringElement{Content: "a paragraph"},
 									},
 								},
 								&types.InlineContent{
-									Elements: []types.DocElement{
+									Elements: []types.InlineElement{
 										&types.StringElement{Content: "image::images/foo.png[]"},
 									},
 								},

--- a/parser/list_test.go
+++ b/parser/list_test.go
@@ -12,6 +12,7 @@ var _ = Describe("List Items", func() {
 			It("1 list with a single item", func() {
 				actualContent := "* a list item"
 				expectedDocument := &types.Document{
+					Metadata: &types.DocumentMetadata{},
 					Elements: []types.DocElement{
 						&types.List{
 							Items: []*types.ListItem{
@@ -20,7 +21,7 @@ var _ = Describe("List Items", func() {
 									Content: &types.ListItemContent{
 										Lines: []*types.InlineContent{
 											&types.InlineContent{
-												Elements: []types.DocElement{
+												Elements: []types.InlineElement{
 													&types.StringElement{Content: "a list item"},
 												},
 											},
@@ -37,6 +38,7 @@ var _ = Describe("List Items", func() {
 				actualContent := "[#listID]\n" +
 					"* a list item"
 				expectedDocument := &types.Document{
+					Metadata: &types.DocumentMetadata{},
 					Elements: []types.DocElement{
 						&types.List{
 							ID: &types.ElementID{Value: "listID"},
@@ -46,7 +48,7 @@ var _ = Describe("List Items", func() {
 									Content: &types.ListItemContent{
 										Lines: []*types.InlineContent{
 											&types.InlineContent{
-												Elements: []types.DocElement{
+												Elements: []types.InlineElement{
 													&types.StringElement{Content: "a list item"},
 												},
 											},
@@ -64,6 +66,7 @@ var _ = Describe("List Items", func() {
 				actualContent := "* a first item\n" +
 					"* a second item with *bold content*"
 				expectedDocument := &types.Document{
+					Metadata: &types.DocumentMetadata{},
 					Elements: []types.DocElement{
 						&types.List{
 							Items: []*types.ListItem{
@@ -72,7 +75,7 @@ var _ = Describe("List Items", func() {
 									Content: &types.ListItemContent{
 										Lines: []*types.InlineContent{
 											&types.InlineContent{
-												Elements: []types.DocElement{
+												Elements: []types.InlineElement{
 													&types.StringElement{Content: "a first item"},
 												},
 											},
@@ -84,10 +87,10 @@ var _ = Describe("List Items", func() {
 									Content: &types.ListItemContent{
 										Lines: []*types.InlineContent{
 											&types.InlineContent{
-												Elements: []types.DocElement{
+												Elements: []types.InlineElement{
 													&types.StringElement{Content: "a second item with "},
 													&types.QuotedText{Kind: types.Bold,
-														Elements: []types.DocElement{
+														Elements: []types.InlineElement{
 															&types.StringElement{Content: "bold content"},
 														},
 													},
@@ -106,6 +109,7 @@ var _ = Describe("List Items", func() {
 				actualContent := "- a first item\n" +
 					"- a second item with *bold content*"
 				expectedDocument := &types.Document{
+					Metadata: &types.DocumentMetadata{},
 					Elements: []types.DocElement{
 						&types.List{
 							Items: []*types.ListItem{
@@ -114,7 +118,7 @@ var _ = Describe("List Items", func() {
 									Content: &types.ListItemContent{
 										Lines: []*types.InlineContent{
 											&types.InlineContent{
-												Elements: []types.DocElement{
+												Elements: []types.InlineElement{
 													&types.StringElement{Content: "a first item"},
 												},
 											},
@@ -126,10 +130,10 @@ var _ = Describe("List Items", func() {
 									Content: &types.ListItemContent{
 										Lines: []*types.InlineContent{
 											&types.InlineContent{
-												Elements: []types.DocElement{
+												Elements: []types.InlineElement{
 													&types.StringElement{Content: "a second item with "},
 													&types.QuotedText{Kind: types.Bold,
-														Elements: []types.DocElement{
+														Elements: []types.InlineElement{
 															&types.StringElement{Content: "bold content"},
 														},
 													},
@@ -150,6 +154,7 @@ var _ = Describe("List Items", func() {
 					"\n" +
 					"* a second item with *bold content*"
 				expectedDocument := &types.Document{
+					Metadata: &types.DocumentMetadata{},
 					Elements: []types.DocElement{
 						&types.List{
 							Items: []*types.ListItem{
@@ -158,7 +163,7 @@ var _ = Describe("List Items", func() {
 									Content: &types.ListItemContent{
 										Lines: []*types.InlineContent{
 											&types.InlineContent{
-												Elements: []types.DocElement{
+												Elements: []types.InlineElement{
 													&types.StringElement{Content: "a first item"},
 												},
 											},
@@ -170,10 +175,10 @@ var _ = Describe("List Items", func() {
 									Content: &types.ListItemContent{
 										Lines: []*types.InlineContent{
 											&types.InlineContent{
-												Elements: []types.DocElement{
+												Elements: []types.InlineElement{
 													&types.StringElement{Content: "a second item with "},
 													&types.QuotedText{Kind: types.Bold,
-														Elements: []types.DocElement{
+														Elements: []types.InlineElement{
 															&types.StringElement{Content: "bold content"},
 														},
 													},
@@ -194,6 +199,7 @@ var _ = Describe("List Items", func() {
 					"* item 2\n" +
 					"on 2 lines, too."
 				expectedDocument := &types.Document{
+					Metadata: &types.DocumentMetadata{},
 					Elements: []types.DocElement{
 						&types.List{
 							Items: []*types.ListItem{
@@ -202,12 +208,12 @@ var _ = Describe("List Items", func() {
 									Content: &types.ListItemContent{
 										Lines: []*types.InlineContent{
 											&types.InlineContent{
-												Elements: []types.DocElement{
+												Elements: []types.InlineElement{
 													&types.StringElement{Content: "item 1"},
 												},
 											},
 											&types.InlineContent{
-												Elements: []types.DocElement{
+												Elements: []types.InlineElement{
 													&types.StringElement{Content: "  on 2 lines."},
 												},
 											},
@@ -219,12 +225,12 @@ var _ = Describe("List Items", func() {
 									Content: &types.ListItemContent{
 										Lines: []*types.InlineContent{
 											&types.InlineContent{
-												Elements: []types.DocElement{
+												Elements: []types.InlineElement{
 													&types.StringElement{Content: "item 2"},
 												},
 											},
 											&types.InlineContent{
-												Elements: []types.DocElement{
+												Elements: []types.InlineElement{
 													&types.StringElement{Content: "on 2 lines, too."},
 												},
 											},
@@ -244,6 +250,7 @@ var _ = Describe("List Items", func() {
 					"\n" +
 					"* an item in the second list"
 				expectedDocument := &types.Document{
+					Metadata: &types.DocumentMetadata{},
 					Elements: []types.DocElement{
 						&types.List{
 							Items: []*types.ListItem{
@@ -252,7 +259,7 @@ var _ = Describe("List Items", func() {
 									Content: &types.ListItemContent{
 										Lines: []*types.InlineContent{
 											&types.InlineContent{
-												Elements: []types.DocElement{
+												Elements: []types.InlineElement{
 													&types.StringElement{Content: "an item in the first list"},
 												},
 											},
@@ -269,7 +276,7 @@ var _ = Describe("List Items", func() {
 									Content: &types.ListItemContent{
 										Lines: []*types.InlineContent{
 											&types.InlineContent{
-												Elements: []types.DocElement{
+												Elements: []types.InlineElement{
 													&types.StringElement{Content: "an item in the second list"},
 												},
 											},
@@ -296,6 +303,7 @@ var _ = Describe("List Items", func() {
 					"* item 2\n" +
 					"** item 2.1\n"
 				expectedDocument := &types.Document{
+					Metadata: &types.DocumentMetadata{},
 					Elements: []types.DocElement{
 						&types.List{
 							Items: []*types.ListItem{
@@ -304,7 +312,7 @@ var _ = Describe("List Items", func() {
 									Content: &types.ListItemContent{
 										Lines: []*types.InlineContent{
 											&types.InlineContent{
-												Elements: []types.DocElement{
+												Elements: []types.InlineElement{
 													&types.StringElement{Content: "item 1"},
 												},
 											},
@@ -317,8 +325,7 @@ var _ = Describe("List Items", func() {
 												Content: &types.ListItemContent{
 													Lines: []*types.InlineContent{
 														&types.InlineContent{
-
-															Elements: []types.DocElement{
+															Elements: []types.InlineElement{
 																&types.StringElement{Content: "item 1.1"},
 															},
 														},
@@ -330,7 +337,7 @@ var _ = Describe("List Items", func() {
 												Content: &types.ListItemContent{
 													Lines: []*types.InlineContent{
 														&types.InlineContent{
-															Elements: []types.DocElement{
+															Elements: []types.InlineElement{
 																&types.StringElement{Content: "item 1.2"},
 															},
 														},
@@ -343,7 +350,7 @@ var _ = Describe("List Items", func() {
 															Content: &types.ListItemContent{
 																Lines: []*types.InlineContent{
 																	&types.InlineContent{
-																		Elements: []types.DocElement{
+																		Elements: []types.InlineElement{
 																			&types.StringElement{Content: "item 1.2.1"},
 																		},
 																	},
@@ -358,7 +365,7 @@ var _ = Describe("List Items", func() {
 												Content: &types.ListItemContent{
 													Lines: []*types.InlineContent{
 														&types.InlineContent{
-															Elements: []types.DocElement{
+															Elements: []types.InlineElement{
 																&types.StringElement{Content: "item 1.3"},
 															},
 														},
@@ -370,7 +377,7 @@ var _ = Describe("List Items", func() {
 												Content: &types.ListItemContent{
 													Lines: []*types.InlineContent{
 														&types.InlineContent{
-															Elements: []types.DocElement{
+															Elements: []types.InlineElement{
 																&types.StringElement{Content: "item 1.4"},
 															},
 														},
@@ -385,7 +392,7 @@ var _ = Describe("List Items", func() {
 									Content: &types.ListItemContent{
 										Lines: []*types.InlineContent{
 											&types.InlineContent{
-												Elements: []types.DocElement{
+												Elements: []types.InlineElement{
 													&types.StringElement{Content: "item 2"},
 												},
 											},
@@ -398,7 +405,7 @@ var _ = Describe("List Items", func() {
 												Content: &types.ListItemContent{
 													Lines: []*types.InlineContent{
 														&types.InlineContent{
-															Elements: []types.DocElement{
+															Elements: []types.InlineElement{
 																&types.StringElement{Content: "item 2.1"},
 															},
 														},
@@ -425,6 +432,7 @@ var _ = Describe("List Items", func() {
 					"** item 1.2\n" +
 					"* item 2"
 				expectedDocument := &types.Document{
+					Metadata: &types.DocumentMetadata{},
 					Elements: []types.DocElement{
 						&types.List{
 							Items: []*types.ListItem{
@@ -433,7 +441,7 @@ var _ = Describe("List Items", func() {
 									Content: &types.ListItemContent{
 										Lines: []*types.InlineContent{
 											&types.InlineContent{
-												Elements: []types.DocElement{
+												Elements: []types.InlineElement{
 													&types.StringElement{Content: "item 1"},
 												},
 											},
@@ -446,7 +454,7 @@ var _ = Describe("List Items", func() {
 												Content: &types.ListItemContent{
 													Lines: []*types.InlineContent{
 														&types.InlineContent{
-															Elements: []types.DocElement{
+															Elements: []types.InlineElement{
 																&types.StringElement{Content: "item 1.1"},
 															},
 														},
@@ -459,7 +467,7 @@ var _ = Describe("List Items", func() {
 															Content: &types.ListItemContent{
 																Lines: []*types.InlineContent{
 																	&types.InlineContent{
-																		Elements: []types.DocElement{
+																		Elements: []types.InlineElement{
 																			&types.StringElement{Content: "item 1.1.1"},
 																		},
 																	},
@@ -474,7 +482,7 @@ var _ = Describe("List Items", func() {
 												Content: &types.ListItemContent{
 													Lines: []*types.InlineContent{
 														&types.InlineContent{
-															Elements: []types.DocElement{
+															Elements: []types.InlineElement{
 																&types.StringElement{Content: "item 1.2"},
 															},
 														},
@@ -489,7 +497,7 @@ var _ = Describe("List Items", func() {
 									Content: &types.ListItemContent{
 										Lines: []*types.InlineContent{
 											&types.InlineContent{
-												Elements: []types.DocElement{
+												Elements: []types.InlineElement{
 													&types.StringElement{Content: "item 2"},
 												},
 											},
@@ -506,11 +514,12 @@ var _ = Describe("List Items", func() {
 			It("invalid list item", func() {
 				actualContent := "*an invalid list item"
 				expectedDocument := &types.Document{
+					Metadata: &types.DocumentMetadata{},
 					Elements: []types.DocElement{
 						&types.Paragraph{
 							Lines: []*types.InlineContent{
 								&types.InlineContent{
-									Elements: []types.DocElement{
+									Elements: []types.InlineElement{
 										&types.StringElement{Content: "*an invalid list item"},
 									},
 								},

--- a/parser/meta_elements_test.go
+++ b/parser/meta_elements_test.go
@@ -12,6 +12,7 @@ var _ = Describe("Meta Elements", func() {
 		It("element link alone", func() {
 			actualContent := "[link=http://foo.bar]"
 			expectedDocument := &types.Document{
+				Metadata: &types.DocumentMetadata{},
 				Elements: []types.DocElement{
 					&types.ElementLink{Path: "http://foo.bar"},
 				},
@@ -22,6 +23,7 @@ var _ = Describe("Meta Elements", func() {
 		It("element link with spaces", func() {
 			actualContent := "[ link = http://foo.bar ]"
 			expectedDocument := &types.Document{
+				Metadata: &types.DocumentMetadata{},
 				Elements: []types.DocElement{
 					&types.ElementLink{Path: "http://foo.bar"},
 				},
@@ -32,11 +34,12 @@ var _ = Describe("Meta Elements", func() {
 		It("element link invalid", func() {
 			actualContent := "[ link = http://foo.bar"
 			expectedDocument := &types.Document{
+				Metadata: &types.DocumentMetadata{},
 				Elements: []types.DocElement{
 					&types.Paragraph{
 						Lines: []*types.InlineContent{
 							&types.InlineContent{
-								Elements: []types.DocElement{
+								Elements: []types.InlineElement{
 									&types.StringElement{Content: "[ link = "},
 									&types.ExternalLink{URL: "http://foo.bar"},
 								},
@@ -54,6 +57,7 @@ var _ = Describe("Meta Elements", func() {
 		It("element id", func() {
 			actualContent := "[#img-foobar]"
 			expectedDocument := &types.Document{
+				Metadata: &types.DocumentMetadata{},
 				Elements: []types.DocElement{
 					&types.ElementID{Value: "img-foobar"},
 				},
@@ -64,6 +68,7 @@ var _ = Describe("Meta Elements", func() {
 		It("element id with spaces", func() {
 			actualContent := "[ #img-foobar ]"
 			expectedDocument := &types.Document{
+				Metadata: &types.DocumentMetadata{},
 				Elements: []types.DocElement{
 					&types.ElementID{Value: "img-foobar"},
 				},
@@ -74,10 +79,11 @@ var _ = Describe("Meta Elements", func() {
 		It("element id invalid", func() {
 			actualContent := "[#img-foobar"
 			expectedDocument := &types.Document{
+				Metadata: &types.DocumentMetadata{},
 				Elements: []types.DocElement{
 					&types.Paragraph{
 						Lines: []*types.InlineContent{
-							&types.InlineContent{Elements: []types.DocElement{&types.StringElement{Content: "[#img-foobar"}}},
+							&types.InlineContent{Elements: []types.InlineElement{&types.StringElement{Content: "[#img-foobar"}}},
 						},
 					},
 				},
@@ -90,6 +96,7 @@ var _ = Describe("Meta Elements", func() {
 		It("element title", func() {
 			actualContent := ".a title"
 			expectedDocument := &types.Document{
+				Metadata: &types.DocumentMetadata{},
 				Elements: []types.DocElement{
 					&types.ElementTitle{Value: "a title"},
 				},
@@ -100,10 +107,11 @@ var _ = Describe("Meta Elements", func() {
 		It("element title invalid1", func() {
 			actualContent := ". a title"
 			expectedDocument := &types.Document{
+				Metadata: &types.DocumentMetadata{},
 				Elements: []types.DocElement{
 					&types.Paragraph{
 						Lines: []*types.InlineContent{
-							&types.InlineContent{Elements: []types.DocElement{&types.StringElement{Content: ". a title"}}},
+							&types.InlineContent{Elements: []types.InlineElement{&types.StringElement{Content: ". a title"}}},
 						},
 					},
 				},
@@ -114,10 +122,11 @@ var _ = Describe("Meta Elements", func() {
 		It("element title invalid2", func() {
 			actualContent := "!a title"
 			expectedDocument := &types.Document{
+				Metadata: &types.DocumentMetadata{},
 				Elements: []types.DocElement{
 					&types.Paragraph{
 						Lines: []*types.InlineContent{
-							&types.InlineContent{Elements: []types.DocElement{&types.StringElement{Content: "!a title"}}},
+							&types.InlineContent{Elements: []types.InlineElement{&types.StringElement{Content: "!a title"}}},
 						},
 					},
 				},

--- a/parser/paragraph_test.go
+++ b/parser/paragraph_test.go
@@ -10,11 +10,12 @@ var _ = Describe("Paragraphs", func() {
 	It("paragraph with 1 word", func() {
 		actualContent := "hello"
 		expectedDocument := &types.Document{
+			Metadata: &types.DocumentMetadata{},
 			Elements: []types.DocElement{
 				&types.Paragraph{
 					Lines: []*types.InlineContent{
 						&types.InlineContent{
-							Elements: []types.DocElement{
+							Elements: []types.InlineElement{
 								&types.StringElement{Content: "hello"},
 							},
 						},
@@ -28,11 +29,12 @@ var _ = Describe("Paragraphs", func() {
 	It("paragraph with few words", func() {
 		actualContent := "a paragraph with some content"
 		expectedDocument := &types.Document{
+			Metadata: &types.DocumentMetadata{},
 			Elements: []types.DocElement{
 				&types.Paragraph{
 					Lines: []*types.InlineContent{
 						&types.InlineContent{
-							Elements: []types.DocElement{
+							Elements: []types.InlineElement{
 								&types.StringElement{Content: "a paragraph with some content"},
 							},
 						},
@@ -46,15 +48,16 @@ var _ = Describe("Paragraphs", func() {
 	It("paragraph with bold content", func() {
 		actualContent := "a paragraph with *some bold content*"
 		expectedDocument := &types.Document{
+			Metadata: &types.DocumentMetadata{},
 			Elements: []types.DocElement{
 				&types.Paragraph{
 					Lines: []*types.InlineContent{
 						&types.InlineContent{
-							Elements: []types.DocElement{
+							Elements: []types.InlineElement{
 								&types.StringElement{Content: "a paragraph with "},
 								&types.QuotedText{
 									Kind: types.Bold,
-									Elements: []types.DocElement{
+									Elements: []types.InlineElement{
 										&types.StringElement{Content: "some bold content"},
 									},
 								},
@@ -72,13 +75,14 @@ var _ = Describe("Paragraphs", func() {
 .a title
 a paragraph`
 		expectedDocument := &types.Document{
+			Metadata: &types.DocumentMetadata{},
 			Elements: []types.DocElement{
 				&types.Paragraph{
 					ID:    &types.ElementID{Value: "foo"},
 					Title: &types.ElementTitle{Value: "a title"},
 					Lines: []*types.InlineContent{
 						&types.InlineContent{
-							Elements: []types.DocElement{
+							Elements: []types.InlineElement{
 								&types.StringElement{Content: "a paragraph"},
 							},
 						},

--- a/parser/quoted_text_test.go
+++ b/parser/quoted_text_test.go
@@ -10,14 +10,15 @@ var _ = Describe("Quoted Texts", func() {
 	It("bold text of 1 word", func() {
 		actualContent := "*hello*"
 		expectedDocument := &types.Document{
+			Metadata: &types.DocumentMetadata{},
 			Elements: []types.DocElement{
 				&types.Paragraph{
 					Lines: []*types.InlineContent{
 						&types.InlineContent{
-							Elements: []types.DocElement{
+							Elements: []types.InlineElement{
 								&types.QuotedText{
 									Kind: types.Bold,
-									Elements: []types.DocElement{
+									Elements: []types.InlineElement{
 										&types.StringElement{Content: "hello"},
 									},
 								},
@@ -33,14 +34,15 @@ var _ = Describe("Quoted Texts", func() {
 	It("bold text of 2 words", func() {
 		actualContent := "*bold    content*"
 		expectedDocument := &types.Document{
+			Metadata: &types.DocumentMetadata{},
 			Elements: []types.DocElement{
 				&types.Paragraph{
 					Lines: []*types.InlineContent{
 						&types.InlineContent{
-							Elements: []types.DocElement{
+							Elements: []types.InlineElement{
 								&types.QuotedText{
 									Kind: types.Bold,
-									Elements: []types.DocElement{
+									Elements: []types.InlineElement{
 										&types.StringElement{Content: "bold    content"},
 									},
 								},
@@ -56,14 +58,15 @@ var _ = Describe("Quoted Texts", func() {
 	It("bold text of 3 words", func() {
 		actualContent := "*some bold content*"
 		expectedDocument := &types.Document{
+			Metadata: &types.DocumentMetadata{},
 			Elements: []types.DocElement{
 				&types.Paragraph{
 					Lines: []*types.InlineContent{
 						&types.InlineContent{
-							Elements: []types.DocElement{
+							Elements: []types.InlineElement{
 								&types.QuotedText{
 									Kind: types.Bold,
-									Elements: []types.DocElement{
+									Elements: []types.InlineElement{
 										&types.StringElement{Content: "some bold content"},
 									},
 								},
@@ -79,15 +82,16 @@ var _ = Describe("Quoted Texts", func() {
 	It("inline with bold text", func() {
 		actualContent := "a paragraph with *some bold content*"
 		expectedDocument := &types.Document{
+			Metadata: &types.DocumentMetadata{},
 			Elements: []types.DocElement{
 				&types.Paragraph{
 					Lines: []*types.InlineContent{
 						&types.InlineContent{
-							Elements: []types.DocElement{
+							Elements: []types.InlineElement{
 								&types.StringElement{Content: "a paragraph with "},
 								&types.QuotedText{
 									Kind: types.Bold,
-									Elements: []types.DocElement{
+									Elements: []types.InlineElement{
 										&types.StringElement{Content: "some bold content"},
 									},
 								},
@@ -103,11 +107,12 @@ var _ = Describe("Quoted Texts", func() {
 	It("inline with invalid bold text1", func() {
 		actualContent := "a paragraph with *some bold content"
 		expectedDocument := &types.Document{
+			Metadata: &types.DocumentMetadata{},
 			Elements: []types.DocElement{
 				&types.Paragraph{
 					Lines: []*types.InlineContent{
 						&types.InlineContent{
-							Elements: []types.DocElement{
+							Elements: []types.InlineElement{
 								&types.StringElement{Content: "a paragraph with *some bold content"},
 							},
 						},
@@ -121,11 +126,12 @@ var _ = Describe("Quoted Texts", func() {
 	It("inline with invalid bold text2", func() {
 		actualContent := "a paragraph with *some bold content *"
 		expectedDocument := &types.Document{
+			Metadata: &types.DocumentMetadata{},
 			Elements: []types.DocElement{
 				&types.Paragraph{
 					Lines: []*types.InlineContent{
 						&types.InlineContent{
-							Elements: []types.DocElement{
+							Elements: []types.InlineElement{
 								&types.StringElement{Content: "a paragraph with *some bold content *"},
 							},
 						},
@@ -139,11 +145,12 @@ var _ = Describe("Quoted Texts", func() {
 	It("inline with invalid bold text3", func() {
 		actualContent := "a paragraph with * some bold content*"
 		expectedDocument := &types.Document{
+			Metadata: &types.DocumentMetadata{},
 			Elements: []types.DocElement{
 				&types.Paragraph{
 					Lines: []*types.InlineContent{
 						&types.InlineContent{
-							Elements: []types.DocElement{
+							Elements: []types.InlineElement{
 								&types.StringElement{Content: "a paragraph with * some bold content*"},
 							},
 						},
@@ -157,14 +164,15 @@ var _ = Describe("Quoted Texts", func() {
 	It("italic text with3 words", func() {
 		actualContent := "_some italic content_"
 		expectedDocument := &types.Document{
+			Metadata: &types.DocumentMetadata{},
 			Elements: []types.DocElement{
 				&types.Paragraph{
 					Lines: []*types.InlineContent{
 						&types.InlineContent{
-							Elements: []types.DocElement{
+							Elements: []types.InlineElement{
 								&types.QuotedText{
 									Kind: types.Italic,
-									Elements: []types.DocElement{
+									Elements: []types.InlineElement{
 										&types.StringElement{Content: "some italic content"},
 									},
 								},
@@ -180,14 +188,15 @@ var _ = Describe("Quoted Texts", func() {
 	It("monospace text with3 words", func() {
 		actualContent := "`some monospace content`"
 		expectedDocument := &types.Document{
+			Metadata: &types.DocumentMetadata{},
 			Elements: []types.DocElement{
 				&types.Paragraph{
 					Lines: []*types.InlineContent{
 						&types.InlineContent{
-							Elements: []types.DocElement{
+							Elements: []types.InlineElement{
 								&types.QuotedText{
 									Kind: types.Monospace,
-									Elements: []types.DocElement{
+									Elements: []types.InlineElement{
 										&types.StringElement{Content: "some monospace content"},
 									},
 								},
@@ -203,19 +212,20 @@ var _ = Describe("Quoted Texts", func() {
 	It("italic text within bold text", func() {
 		actualContent := "some *bold and _italic content_ together*."
 		expectedDocument := &types.Document{
+			Metadata: &types.DocumentMetadata{},
 			Elements: []types.DocElement{
 				&types.Paragraph{
 					Lines: []*types.InlineContent{
 						&types.InlineContent{
-							Elements: []types.DocElement{
+							Elements: []types.InlineElement{
 								&types.StringElement{Content: "some "},
 								&types.QuotedText{
 									Kind: types.Bold,
-									Elements: []types.DocElement{
+									Elements: []types.InlineElement{
 										&types.StringElement{Content: "bold and "},
 										&types.QuotedText{
 											Kind: types.Italic,
-											Elements: []types.DocElement{
+											Elements: []types.InlineElement{
 												&types.StringElement{Content: "italic content"},
 											},
 										},
@@ -235,15 +245,16 @@ var _ = Describe("Quoted Texts", func() {
 	It("invalid italic text within bold text", func() {
 		actualContent := "some *bold and _italic content _ together*."
 		expectedDocument := &types.Document{
+			Metadata: &types.DocumentMetadata{},
 			Elements: []types.DocElement{
 				&types.Paragraph{
 					Lines: []*types.InlineContent{
 						&types.InlineContent{
-							Elements: []types.DocElement{
+							Elements: []types.InlineElement{
 								&types.StringElement{Content: "some "},
 								&types.QuotedText{
 									Kind: types.Bold,
-									Elements: []types.DocElement{
+									Elements: []types.InlineElement{
 										&types.StringElement{Content: "bold and _italic content _ together"},
 									},
 								},
@@ -260,15 +271,16 @@ var _ = Describe("Quoted Texts", func() {
 	It("italic text within invalid bold text", func() {
 		actualContent := "some *bold and _italic content_ together *."
 		expectedDocument := &types.Document{
+			Metadata: &types.DocumentMetadata{},
 			Elements: []types.DocElement{
 				&types.Paragraph{
 					Lines: []*types.InlineContent{
 						&types.InlineContent{
-							Elements: []types.DocElement{
+							Elements: []types.InlineElement{
 								&types.StringElement{Content: "some *bold and "},
 								&types.QuotedText{
 									Kind: types.Italic,
-									Elements: []types.DocElement{
+									Elements: []types.InlineElement{
 										&types.StringElement{Content: "italic content"},
 									},
 								},
@@ -285,18 +297,19 @@ var _ = Describe("Quoted Texts", func() {
 	It("bold text within italic text", func() {
 		actualContent := "_some *bold* content_"
 		expectedDocument := &types.Document{
+			Metadata: &types.DocumentMetadata{},
 			Elements: []types.DocElement{
 				&types.Paragraph{
 					Lines: []*types.InlineContent{
 						&types.InlineContent{
-							Elements: []types.DocElement{
+							Elements: []types.InlineElement{
 								&types.QuotedText{
 									Kind: types.Italic,
-									Elements: []types.DocElement{
+									Elements: []types.InlineElement{
 										&types.StringElement{Content: "some "},
 										&types.QuotedText{
 											Kind: types.Bold,
-											Elements: []types.DocElement{
+											Elements: []types.InlineElement{
 												&types.StringElement{Content: "bold"},
 											},
 										},
@@ -315,22 +328,23 @@ var _ = Describe("Quoted Texts", func() {
 	It("monospace text within bold text within italic quote", func() {
 		actualContent := "*some _italic and `monospaced content`_*"
 		expectedDocument := &types.Document{
+			Metadata: &types.DocumentMetadata{},
 			Elements: []types.DocElement{
 				&types.Paragraph{
 					Lines: []*types.InlineContent{
 						&types.InlineContent{
-							Elements: []types.DocElement{
+							Elements: []types.InlineElement{
 								&types.QuotedText{
 									Kind: types.Bold,
-									Elements: []types.DocElement{
+									Elements: []types.InlineElement{
 										&types.StringElement{Content: "some "},
 										&types.QuotedText{
 											Kind: types.Italic,
-											Elements: []types.DocElement{
+											Elements: []types.InlineElement{
 												&types.StringElement{Content: "italic and "},
 												&types.QuotedText{
 													Kind: types.Monospace,
-													Elements: []types.DocElement{
+													Elements: []types.InlineElement{
 														&types.StringElement{Content: "monospaced content"},
 													},
 												},
@@ -350,18 +364,19 @@ var _ = Describe("Quoted Texts", func() {
 	It("italic text within italic text", func() {
 		actualContent := "_some _very italic_ content_"
 		expectedDocument := &types.Document{
+			Metadata: &types.DocumentMetadata{},
 			Elements: []types.DocElement{
 				&types.Paragraph{
 					Lines: []*types.InlineContent{
 						&types.InlineContent{
-							Elements: []types.DocElement{
+							Elements: []types.InlineElement{
 								&types.QuotedText{
 									Kind: types.Italic,
-									Elements: []types.DocElement{
+									Elements: []types.InlineElement{
 										&types.StringElement{Content: "some "},
 										&types.QuotedText{
 											Kind: types.Italic,
-											Elements: []types.DocElement{
+											Elements: []types.InlineElement{
 												&types.StringElement{Content: "very italic"},
 											},
 										},
@@ -377,28 +392,4 @@ var _ = Describe("Quoted Texts", func() {
 		verify(GinkgoT(), expectedDocument, actualContent)
 	})
 
-	// It("all supported quotes", func() {
-	// 	actualContent := "*bold phrase* & **char**acter**s**\n" +
-	// 		"_italic phrase_ & __char__acter__s__\n" +
-	// 		"*_bold italic phrase_* & **__char__**acter**__s__**\n" +
-	// 		"`monospace phrase` & ``char``acter``s``\n" +
-	// 		"`*monospace bold phrase*` & ``**char**``acter``**s**``\n" +
-	// 		"`_monospace italic phrase_` & ``__char__``acter``__s__``\n" +
-	// 		"`*_monospace bold italic phrase_*` & \n" +
-	// 		"``**__char__**``acter``**__s__**``"
-	// 	expectedDocument := &types.Document{
-	// 		Elements: []types.DocElement{
-	// 			&types.Paragraph{
-	// 				Lines: []*types.InlineContent{
-	// 					&types.InlineContent{
-	// 						Elements: []types.DocElement{
-	// 							&types.StringElement{Content: "a paragraph with * some bold content*"},
-	// 						},
-	// 					},
-	// 				},
-	// 			},
-	// 		},
-	// 	}
-	// 	verify(GinkgoT(), expectedDocument, actualContent)
-	// })
 })

--- a/parser/section_test.go
+++ b/parser/section_test.go
@@ -12,12 +12,15 @@ var _ = Describe("Sections", func() {
 		It("section with heading only", func() {
 			actualContent := "= a heading"
 			expectedDocument := &types.Document{
+				Metadata: &types.DocumentMetadata{
+					"title": "a heading",
+				},
 				Elements: []types.DocElement{
 					&types.Section{
 						Heading: types.Heading{
 							Level: 1,
 							Content: &types.InlineContent{
-								Elements: []types.DocElement{
+								Elements: []types.InlineElement{
 									&types.StringElement{Content: "a heading"},
 								},
 							},
@@ -34,12 +37,13 @@ var _ = Describe("Sections", func() {
 		It("section level 2", func() {
 			actualContent := `== section 2`
 			expectedDocument := &types.Document{
+				Metadata: &types.DocumentMetadata{},
 				Elements: []types.DocElement{
 					&types.Section{
 						Heading: types.Heading{
 							Level: 2,
 							Content: &types.InlineContent{
-								Elements: []types.DocElement{
+								Elements: []types.InlineElement{
 									&types.StringElement{Content: "section 2"},
 								},
 							},
@@ -57,14 +61,15 @@ var _ = Describe("Sections", func() {
 		It("section level 2 with quoted text", func() {
 			actualContent := `==  *2 spaces and bold content*`
 			expectedDocument := &types.Document{
+				Metadata: &types.DocumentMetadata{},
 				Elements: []types.DocElement{
 					&types.Section{
 						Heading: types.Heading{
 							Level: 2,
 							Content: &types.InlineContent{
-								Elements: []types.DocElement{
+								Elements: []types.InlineElement{
 									&types.QuotedText{
-										Elements: []types.DocElement{
+										Elements: []types.InlineElement{
 											&types.StringElement{Content: "2 spaces and bold content"},
 										},
 									},
@@ -86,12 +91,14 @@ var _ = Describe("Sections", func() {
 				"\n" +
 				"== section 2"
 			expectedDocument := &types.Document{
-				Elements: []types.DocElement{
+				Metadata: &types.DocumentMetadata{
+					"title": "a heading",
+				}, Elements: []types.DocElement{
 					&types.Section{
 						Heading: types.Heading{
 							Level: 1,
 							Content: &types.InlineContent{
-								Elements: []types.DocElement{
+								Elements: []types.InlineElement{
 									&types.StringElement{Content: "a heading"},
 								},
 							},
@@ -104,7 +111,7 @@ var _ = Describe("Sections", func() {
 								Heading: types.Heading{
 									Level: 2,
 									Content: &types.InlineContent{
-										Elements: []types.DocElement{
+										Elements: []types.InlineElement{
 											&types.StringElement{Content: "section 2"},
 										},
 									},
@@ -126,12 +133,15 @@ var _ = Describe("Sections", func() {
 				"\n" +
 				"=== section 3"
 			expectedDocument := &types.Document{
+				Metadata: &types.DocumentMetadata{
+					"title": "a heading",
+				},
 				Elements: []types.DocElement{
 					&types.Section{
 						Heading: types.Heading{
 							Level: 1,
 							Content: &types.InlineContent{
-								Elements: []types.DocElement{
+								Elements: []types.InlineElement{
 									&types.StringElement{Content: "a heading"},
 								},
 							},
@@ -144,7 +154,7 @@ var _ = Describe("Sections", func() {
 								Heading: types.Heading{
 									Level: 3,
 									Content: &types.InlineContent{
-										Elements: []types.DocElement{
+										Elements: []types.InlineElement{
 											&types.StringElement{Content: "section 3"},
 										},
 									},
@@ -165,12 +175,13 @@ var _ = Describe("Sections", func() {
 			actualContent := `== a title
 and a paragraph`
 			expectedDocument := &types.Document{
+				Metadata: &types.DocumentMetadata{},
 				Elements: []types.DocElement{
 					&types.Section{
 						Heading: types.Heading{
 							Level: 2,
 							Content: &types.InlineContent{
-								Elements: []types.DocElement{
+								Elements: []types.InlineElement{
 									&types.StringElement{Content: "a title"},
 								},
 							},
@@ -182,7 +193,7 @@ and a paragraph`
 							&types.Paragraph{
 								Lines: []*types.InlineContent{
 									&types.InlineContent{
-										Elements: []types.DocElement{
+										Elements: []types.InlineElement{
 											&types.StringElement{Content: "and a paragraph"},
 										},
 									},
@@ -197,12 +208,13 @@ and a paragraph`
 		It("section level 2 with a paragraph separated by empty line", func() {
 			actualContent := "== a title\n\nand a paragraph"
 			expectedDocument := &types.Document{
+				Metadata: &types.DocumentMetadata{},
 				Elements: []types.DocElement{
 					&types.Section{
 						Heading: types.Heading{
 							Level: 2,
 							Content: &types.InlineContent{
-								Elements: []types.DocElement{
+								Elements: []types.InlineElement{
 									&types.StringElement{Content: "a title"},
 								},
 							},
@@ -214,7 +226,7 @@ and a paragraph`
 							&types.Paragraph{
 								Lines: []*types.InlineContent{
 									&types.InlineContent{
-										Elements: []types.DocElement{
+										Elements: []types.InlineElement{
 											&types.StringElement{Content: "and a paragraph"},
 										},
 									},
@@ -230,12 +242,13 @@ and a paragraph`
 		It("section level 2 with a paragraph separated by non-empty line", func() {
 			actualContent := "== a title\n    \nand a paragraph"
 			expectedDocument := &types.Document{
+				Metadata: &types.DocumentMetadata{},
 				Elements: []types.DocElement{
 					&types.Section{
 						Heading: types.Heading{
 							Level: 2,
 							Content: &types.InlineContent{
-								Elements: []types.DocElement{
+								Elements: []types.InlineElement{
 									&types.StringElement{Content: "a title"},
 								},
 							},
@@ -247,7 +260,7 @@ and a paragraph`
 							&types.Paragraph{
 								Lines: []*types.InlineContent{
 									&types.InlineContent{
-										Elements: []types.DocElement{
+										Elements: []types.InlineElement{
 											&types.StringElement{Content: "and a paragraph"},
 										},
 									},
@@ -272,12 +285,15 @@ a paragraph
 == Section B
 a paragraph`
 			expectedDocument := &types.Document{
+				Metadata: &types.DocumentMetadata{
+					"title": "a title",
+				},
 				Elements: []types.DocElement{
 					&types.Section{
 						Heading: types.Heading{
 							Level: 1,
 							Content: &types.InlineContent{
-								Elements: []types.DocElement{
+								Elements: []types.InlineElement{
 									&types.StringElement{Content: "a title"},
 								},
 							},
@@ -290,7 +306,7 @@ a paragraph`
 								Heading: types.Heading{
 									Level: 2,
 									Content: &types.InlineContent{
-										Elements: []types.DocElement{
+										Elements: []types.InlineElement{
 											&types.StringElement{Content: "Section A"},
 										},
 									},
@@ -302,7 +318,7 @@ a paragraph`
 									&types.Paragraph{
 										Lines: []*types.InlineContent{
 											&types.InlineContent{
-												Elements: []types.DocElement{
+												Elements: []types.InlineElement{
 													&types.StringElement{Content: "a paragraph"},
 												},
 											},
@@ -313,7 +329,7 @@ a paragraph`
 										Heading: types.Heading{
 											Level: 3,
 											Content: &types.InlineContent{
-												Elements: []types.DocElement{
+												Elements: []types.InlineElement{
 													&types.StringElement{Content: "Section A.a"},
 												},
 											},
@@ -325,7 +341,7 @@ a paragraph`
 											&types.Paragraph{
 												Lines: []*types.InlineContent{
 													&types.InlineContent{
-														Elements: []types.DocElement{
+														Elements: []types.InlineElement{
 															&types.StringElement{Content: "a paragraph"},
 														},
 													},
@@ -340,7 +356,7 @@ a paragraph`
 								Heading: types.Heading{
 									Level: 2,
 									Content: &types.InlineContent{
-										Elements: []types.DocElement{
+										Elements: []types.InlineElement{
 											&types.StringElement{Content: "Section B"},
 										},
 									},
@@ -352,7 +368,7 @@ a paragraph`
 									&types.Paragraph{
 										Lines: []*types.InlineContent{
 											&types.InlineContent{
-												Elements: []types.DocElement{
+												Elements: []types.InlineElement{
 													&types.StringElement{Content: "a paragraph"},
 												},
 											},
@@ -372,11 +388,12 @@ a paragraph`
 		It("heading invalid - missing space", func() {
 			actualContent := "=a heading"
 			expectedDocument := &types.Document{
+				Metadata: &types.DocumentMetadata{},
 				Elements: []types.DocElement{
 					&types.Paragraph{
 						Lines: []*types.InlineContent{
 							&types.InlineContent{
-								Elements: []types.DocElement{
+								Elements: []types.InlineElement{
 									&types.StringElement{Content: "=a heading"},
 								},
 							},
@@ -389,11 +406,12 @@ a paragraph`
 		It("heading invalid - heading space", func() {
 			actualContent := " = a heading"
 			expectedDocument := &types.Document{
+				Metadata: &types.DocumentMetadata{},
 				Elements: []types.DocElement{
 					&types.Paragraph{
 						Lines: []*types.InlineContent{
 							&types.InlineContent{
-								Elements: []types.DocElement{
+								Elements: []types.InlineElement{
 									&types.StringElement{Content: " = a heading"},
 								},
 							},
@@ -408,11 +426,14 @@ a paragraph`
 				"\n" +
 				" == section 2"
 			expectedDocument := &types.Document{
+				Metadata: &types.DocumentMetadata{
+					"title": "a heading",
+				},
 				Elements: []types.DocElement{
 					&types.Section{
 						Heading: types.Heading{
 							Level: 1, Content: &types.InlineContent{
-								Elements: []types.DocElement{
+								Elements: []types.InlineElement{
 									&types.StringElement{Content: "a heading"},
 								},
 							},
@@ -424,7 +445,7 @@ a paragraph`
 							&types.Paragraph{
 								Lines: []*types.InlineContent{
 									&types.InlineContent{
-										Elements: []types.DocElement{
+										Elements: []types.InlineElement{
 											&types.StringElement{Content: " == section 2"},
 										},
 									},

--- a/renderer/html5/delimited_block.go
+++ b/renderer/html5/delimited_block.go
@@ -14,7 +14,7 @@ var sourceBlockTmpl *template.Template
 
 // initializes the templates
 func init() {
-	sourceBlockTmpl = newTemplate("delimited source block", `<div class="listingblock">
+	sourceBlockTmpl = newHTMLTemplate("delimited source block", `<div class="listingblock">
 <div class="content">
 <pre class="highlight"><code>{{.Content}}</code></pre>
 </div>

--- a/renderer/html5/image.go
+++ b/renderer/html5/image.go
@@ -15,14 +15,14 @@ var inlineImageTmpl *template.Template
 
 // initializes the templates
 func init() {
-	blockImageTmpl = newTemplate("block image", `<div{{if .ID }} id="{{.ID.Value}}"{{ end }} class="imageblock">
+	blockImageTmpl = newHTMLTemplate("block image", `<div{{if .ID }} id="{{.ID.Value}}"{{ end }} class="imageblock">
 <div class="content">
 {{if .Link}}<a class="image" href="{{.Link.Path}}">{{end}}<img src="{{.Macro.Path}}" alt="{{.Macro.Alt}}"{{if .Macro.Width}} width="{{.Macro.Width}}"{{end}}{{if .Macro.Height}} height="{{.Macro.Height}}"{{end}}>{{if .Link}}</a>{{end}}
 </div>{{if .Title}}
 <div class="title">{{.Title.Value}}</div>
 {{else}}
 {{end}}</div>`)
-	inlineImageTmpl = newTemplate("inline image", `<span class="image"><img src="{{.Macro.Path}}" alt="{{.Macro.Alt}}"{{if .Macro.Width}} width="{{.Macro.Width}}"{{end}}{{if .Macro.Height}} height="{{.Macro.Height}}"{{end}}></span>`)
+	inlineImageTmpl = newHTMLTemplate("inline image", `<span class="image"><img src="{{.Macro.Path}}" alt="{{.Macro.Alt}}"{{if .Macro.Width}} width="{{.Macro.Width}}"{{end}}{{if .Macro.Height}} height="{{.Macro.Height}}"{{end}}></span>`)
 }
 
 func renderBlockImage(ctx context.Context, img types.BlockImage) ([]byte, error) {

--- a/renderer/html5/list_item.go
+++ b/renderer/html5/list_item.go
@@ -17,17 +17,17 @@ var listItemContentTmpl *template.Template
 
 // initializes the templates
 func init() {
-	unorderedListTmpl = newTemplate("unordered list", `<div{{ if .ID }} id="{{.ID.Value}}"{{ end }} class="ulist">
+	unorderedListTmpl = newHTMLTemplate("unordered list", `<div{{ if .ID }} id="{{.ID.Value}}"{{ end }} class="ulist">
 <ul>
 {{.Items}}
 </ul>
 </div>`) // include an extra line-return at the end
-	listItemTmpl = newTemplate("list item", `<li>
+	listItemTmpl = newHTMLTemplate("list item", `<li>
 {{.Content}}{{ if .Children }}
 {{.Children}}
 </li>{{ else }}
 </li>{{ end }}`)
-	listItemContentTmpl = newTemplate("list item content", `<p>{{.}}</p>`)
+	listItemContentTmpl = newHTMLTemplate("list item content", `<p>{{.}}</p>`)
 }
 
 func renderList(ctx context.Context, list types.List) ([]byte, error) {

--- a/renderer/html5/paragraph.go
+++ b/renderer/html5/paragraph.go
@@ -15,7 +15,7 @@ var paragraphTmpl *template.Template
 
 // initializes the template
 func init() {
-	paragraphTmpl = newTemplate("paragraph",
+	paragraphTmpl = newHTMLTemplate("paragraph",
 		`<div {{ if .ID }}id="{{.ID.Value}}" {{ end }}class="paragraph">{{ if .Title}}
 <div class="title">{{.Title.Value}}</div>{{ end }}
 <p>{{.Lines}}</p>

--- a/renderer/html5/quoted_text.go
+++ b/renderer/html5/quoted_text.go
@@ -17,9 +17,9 @@ var monospaceTextTmpl *template.Template
 
 // initializes the templates
 func init() {
-	boldTextTmpl = newTemplate("bold text", "<strong>{{.}}</strong>")
-	italicTextTmpl = newTemplate("italic text", "<em>{{.}}</em>")
-	monospaceTextTmpl = newTemplate("monospace text", "<code>{{.}}</code>")
+	boldTextTmpl = newHTMLTemplate("bold text", "<strong>{{.}}</strong>")
+	italicTextTmpl = newHTMLTemplate("italic text", "<em>{{.}}</em>")
+	monospaceTextTmpl = newHTMLTemplate("monospace text", "<code>{{.}}</code>")
 }
 
 func renderQuotedText(ctx context.Context, t types.QuotedText) ([]byte, error) {

--- a/renderer/html5/renderer.go
+++ b/renderer/html5/renderer.go
@@ -1,24 +1,97 @@
 package html5
 
 import (
+	"bytes"
 	"context"
+	"html/template"
 	"io"
+	texttemplate "text/template"
 
 	"reflect"
 
+	"github.com/bytesparadise/libasciidoc/renderer"
 	"github.com/bytesparadise/libasciidoc/types"
 	"github.com/pkg/errors"
 )
 
+var documentTmpl *texttemplate.Template
+
+func init() {
+	documentTmpl = newTextTemplate("root document",
+		`<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+{{ if .Generator }}<meta name="generator" content="{{.Generator}}">{{ end }}
+<title>{{.Title}}</title>
+<body class="article">
+<div id="header">
+<h1>{{.Title}}</h1>
+</div>
+<div id="content">
+{{.Content}}
+</div>
+<div id="footer">
+<div id="footer-text">
+Last updated {{.LastUpdated}}
+</div>
+</div>
+</body>
+</html>`)
+}
+
 // Render renders the given document in HTML and writes the result in the given `writer`
-func Render(ctx context.Context, document types.Document, output io.Writer) error {
-	for i, element := range document.Elements {
+func Render(ctx context.Context, document types.Document, output io.Writer, options renderer.Options) error {
+	includeHeaderFooter, err := options.IncludeHeaderFooter()
+	if err != nil {
+		return errors.Wrap(err, "error while rendering the HTML document")
+	}
+
+	lastUpdated, err := options.LastUpdated()
+	if err != nil {
+		return errors.Wrap(err, "error while rendering the HTML document")
+	}
+
+	if *includeHeaderFooter {
+		// use a temporary writer for the document's content
+		renderedElementsBuff := bytes.NewBuffer(make([]byte, 0))
+		renderElements(ctx, document.Elements, renderedElementsBuff)
+		renderedHTMLElements := template.HTML(renderedElementsBuff.String())
+
+		title := "undefined"
+		if document.Metadata.GetTitle() != nil {
+			title = *document.Metadata.GetTitle()
+		}
+		err := documentTmpl.Execute(output, struct {
+			Generator   string
+			Title       string
+			Content     template.HTML
+			LastUpdated string
+		}{
+			Generator:   "libasciidoc", // TODO: externalize this value and include the lib version ?
+			Title:       title,
+			Content:     renderedHTMLElements,
+			LastUpdated: *lastUpdated,
+		})
+		if err != nil {
+			return errors.Wrap(err, "error while rendering the HTML document")
+		}
+		return nil
+	}
+	return renderElements(ctx, document.Elements, output)
+
+}
+
+func renderElements(ctx context.Context, elements []types.DocElement, output io.Writer) error {
+	for i, element := range elements {
 		content, err := renderElement(ctx, element)
 		if err != nil {
-			return errors.Wrapf(err, "failed to render document")
+			return errors.Wrapf(err, "failed to render the document")
 		}
 		output.Write(content)
-		if _, ok := element.(*types.BlankLine); !ok && i < len(document.Elements)-1 {
+		if _, ok := element.(*types.BlankLine); !ok && i < len(elements)-1 {
 			output.Write([]byte("\n"))
 		}
 	}

--- a/renderer/html5/renderer_test.go
+++ b/renderer/html5/renderer_test.go
@@ -22,7 +22,7 @@ func verify(t GinkgoTInterface, expected, content string) {
 	actualDocument := doc.(*types.Document)
 	t.Logf("Actual document:\n%s", actualDocument.String(1))
 	buff := bytes.NewBuffer(make([]byte, 0))
-	err = Render(context.Background(), *actualDocument, buff)
+	err = Render(context.Background(), *actualDocument, buff, nil)
 	t.Log("Done processing document")
 	require.Nil(t, err)
 	require.Empty(t, err)

--- a/renderer/html5/section.go
+++ b/renderer/html5/section.go
@@ -20,30 +20,30 @@ var otherSectionContentTmpl *template.Template
 
 // initializes the templates
 func init() {
-	section1ContentTmpl = newTemplate("section 1",
+	section1ContentTmpl = newHTMLTemplate("section 1",
 		`{{ if .Preamble }}<div id="preamble">
 <div class="sectionbody">
 {{.Preamble}}
 </div>
 </div>
 {{end}}{{ if .Elements }}{{.Elements}}{{end}}`)
-	section2ContentTmpl = newTemplate("section 2",
+	section2ContentTmpl = newHTMLTemplate("section 2",
 		`<div class="{{.Class}}">
 {{.Heading}}
 <div class="sectionbody">{{ if .Elements }}
 {{.Elements}}{{end}}
 </div>
 </div>`)
-	otherSectionContentTmpl = newTemplate("other section",
+	otherSectionContentTmpl = newHTMLTemplate("other section",
 		`<div class="{{.Class}}">
 {{.Heading}}{{ if .Elements }}
 {{.Elements}}{{end}}
 </div>`)
-	// 	section1HeaderTmpl = newTemplate("section 1 heading",
+	// 	section1HeaderTmpl = newHTMLTemplate("section 1 heading",
 	// 		`<div id="header">
 	// <h1>{{.Content}}</h1>
 	// </div>`)
-	otherSectionHeaderTmpl = newTemplate("other heading",
+	otherSectionHeaderTmpl = newHTMLTemplate("other heading",
 		`<h{{.Level}} id="{{.ID}}">{{.Content}}</h{{.Level}}>`)
 }
 

--- a/renderer/html5/string.go
+++ b/renderer/html5/string.go
@@ -13,7 +13,7 @@ var stringElementTmpl *template.Template
 
 // initializes the templates
 func init() {
-	stringElementTmpl = newTemplate("string element", "{{.}}")
+	stringElementTmpl = newHTMLTemplate("string element", "{{.}}")
 }
 
 func renderStringElement(ctx context.Context, str types.StringElement) ([]byte, error) {

--- a/renderer/html5/template_utils.go
+++ b/renderer/html5/template_utils.go
@@ -1,13 +1,22 @@
 package html5
 
 import (
-	"html/template"
+	htmltemplate "html/template"
+	texttemplate "text/template"
 
 	log "github.com/sirupsen/logrus"
 )
 
-func newTemplate(name, src string) *template.Template {
-	t, err := template.New(name).Parse(src)
+func newHTMLTemplate(name, src string) *htmltemplate.Template {
+	t, err := htmltemplate.New(name).Parse(src)
+	if err != nil {
+		log.Fatalf("failed to initialize '%s' template: %s", name, err.Error())
+	}
+	return t
+}
+
+func newTextTemplate(name, src string) *texttemplate.Template {
+	t, err := texttemplate.New(name).Parse(src)
 	if err != nil {
 		log.Fatalf("failed to initialize '%s' template: %s", name, err.Error())
 	}

--- a/renderer/options.go
+++ b/renderer/options.go
@@ -1,0 +1,52 @@
+package renderer
+
+import (
+	"reflect"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+//Options the options when rendering a document
+type Options map[string]interface{}
+
+const (
+	//LastUpdated the key to specify the last update of the document to render.
+	// Can be a string or a time, which will be formatted using the 2006/01/02 15:04:05 MST` pattern
+	LastUpdated string = "LastUpdated"
+	//IncludeHeaderFooter a bool value to indicate if the header and footer should be rendered
+	IncludeHeaderFooter string = "IncludeHeaderFooter"
+)
+
+// LastUpdated returns the value of the 'LastUpdated' Option if it was present,
+// otherwise it returns the current time using the `2006/01/02 15:04:05 MST` format
+func (o Options) LastUpdated() (*string, error) {
+	if lastUpdated, ok := o[LastUpdated]; ok {
+		switch lastUpdated := lastUpdated.(type) {
+		case string:
+			return &lastUpdated, nil
+		case time.Time:
+			result := lastUpdated.Format("2006/01/02 15:04:05 MST")
+			return &result, nil
+		default:
+			return nil, errors.Errorf("`LastUpdated` option is not in a valid format: %v", reflect.TypeOf(lastUpdated))
+		}
+	}
+	result := time.Now().Format("2006/01/02 15:04:05 MST")
+	return &result, nil
+}
+
+// IncludeHeaderFooter returns the value of the 'LastUpdated' Option if it was present,
+// otherwise it returns `false``
+func (o Options) IncludeHeaderFooter() (*bool, error) {
+	if includeHeaderFooter, ok := o[IncludeHeaderFooter]; ok {
+		switch includeHeaderFooter := includeHeaderFooter.(type) {
+		case bool:
+			return &includeHeaderFooter, nil
+		default:
+			return nil, errors.Errorf("`IncludeHeaderFooter` option is not in a valid format: %v", reflect.TypeOf(includeHeaderFooter))
+		}
+	}
+	result := false
+	return &result, nil
+}

--- a/types/document_metadata.go
+++ b/types/document_metadata.go
@@ -1,0 +1,21 @@
+package types
+
+// DocumentMetadata the document metadata
+type DocumentMetadata map[string]string
+
+const (
+	title string = "title"
+)
+
+// GetTitle retrieves the document title in its metadata, or returns nil if the title was not specified
+func (m DocumentMetadata) GetTitle() *string {
+	if t, ok := m[title]; ok {
+		return &t
+	}
+	return nil
+}
+
+// SetTitle sets the title in the document metadata
+func (m DocumentMetadata) SetTitle(t string) {
+	m[title] = t
+}

--- a/types/type_utils.go
+++ b/types/type_utils.go
@@ -14,14 +14,14 @@ func indent(indentLevel int) string {
 	return strings.Repeat("  ", indentLevel)
 }
 
-func toDocElements(elements []interface{}) ([]DocElement, error) {
-	result := make([]DocElement, len(elements))
+func toInlineElements(elements []interface{}) ([]InlineElement, error) {
+	result := make([]InlineElement, len(elements))
 	for i, element := range elements {
 		switch element := element.(type) {
-		case DocElement:
+		case InlineElement:
 			result[i] = element
 		default:
-			return nil, errors.Errorf("unexpected element type: %v (expected a DocElement instead)", reflect.TypeOf(element))
+			return nil, errors.Errorf("unexpected element type: %v (expected a InlineElement instead)", reflect.TypeOf(element))
 		}
 	}
 	return result, nil

--- a/types/type_utils_test.go
+++ b/types/type_utils_test.go
@@ -11,7 +11,7 @@ var _ = Describe("Normalizing String", func() {
 
 	It("hello", func() {
 		source := &InlineContent{
-			Elements: []DocElement{
+			Elements: []InlineElement{
 				&StringElement{Content: "hello"},
 			},
 		}
@@ -20,7 +20,7 @@ var _ = Describe("Normalizing String", func() {
 
 	It("héllo with an accent", func() {
 		source := &InlineContent{
-			Elements: []DocElement{
+			Elements: []InlineElement{
 				&StringElement{Content: "  héllo 1.2   and 3 Spaces"},
 			},
 		}
@@ -29,7 +29,7 @@ var _ = Describe("Normalizing String", func() {
 
 	It("a an accent and a swedish character", func() {
 		source := &InlineContent{
-			Elements: []DocElement{
+			Elements: []InlineElement{
 				&StringElement{Content: `A à ⌘`},
 			},
 		}
@@ -38,7 +38,7 @@ var _ = Describe("Normalizing String", func() {
 
 	It("AŁA", func() {
 		source := &InlineContent{
-			Elements: []DocElement{
+			Elements: []InlineElement{
 				&StringElement{Content: `AŁA 0.1 ?`},
 			},
 		}
@@ -47,7 +47,7 @@ var _ = Describe("Normalizing String", func() {
 
 	It("it's  2 spaces, here !", func() {
 		source := &InlineContent{
-			Elements: []DocElement{
+			Elements: []InlineElement{
 				&StringElement{Content: `it's  2 spaces, here !`},
 			},
 		}
@@ -57,11 +57,11 @@ var _ = Describe("Normalizing String", func() {
 	It("content with <strong> markup", func() {
 		// == a section title, with *bold content*
 		source := &InlineContent{
-			Elements: []DocElement{
+			Elements: []InlineElement{
 				&StringElement{Content: "a section title, with"},
 				&QuotedText{
 					Kind: Bold,
-					Elements: []DocElement{
+					Elements: []InlineElement{
 						&StringElement{Content: "bold content"},
 					},
 				},


### PR DESCRIPTION
Include header and footer in the full document
When rendering the body only, the function returns the document
metadata, including the document title

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>