### PR TITLE
feat(parser/renderer): support for document attributes

### DIFF
--- a/libasciidoc.go
+++ b/libasciidoc.go
@@ -15,7 +15,7 @@ import (
 // ConvertToHTMLBody converts the content of the given reader `r` into an set of <DIV> elements for an HTML/BODY document.
 // The conversion result is written in the given writer `w`, whereas the document metadata (title, etc.) (or an error if a problem occurred) is returned
 // as the result of the function call.
-func ConvertToHTMLBody(r io.Reader, w io.Writer) (*types.DocumentMetadata, error) {
+func ConvertToHTMLBody(r io.Reader, w io.Writer) (*types.DocumentAttributes, error) {
 	doc, err := parser.ParseReader("", r)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error while parsing the document")
@@ -28,7 +28,7 @@ func ConvertToHTMLBody(r io.Reader, w io.Writer) (*types.DocumentMetadata, error
 		return nil, errors.Wrapf(err, "error while rendering the document")
 	}
 	log.Debugf("Done processing document")
-	return document.Metadata, nil
+	return document.Attributes, nil
 }
 
 // ConvertToHTML converts the content of the given reader `r` into a full HTML document, written in the given writer `w`.

--- a/parser/asciidoc-grammar.peg
+++ b/parser/asciidoc-grammar.peg
@@ -17,7 +17,7 @@ DocumentBlock <- !EOF content:(Section / StandaloneBlock) {
     return content.(types.DocElement), nil
 }
 
-StandaloneBlock <- List / BlockImage / DelimitedBlock / Paragraph / MetadataElement / BlankLine
+StandaloneBlock <- DocumentAttribute / List / BlockImage / DelimitedBlock / Paragraph / ElementAttribute / BlankLine //TODO: should Paragraph be the last type ?
 
 Section <- Section1 / Section2 / Section3 / Section4 / Section5 / Section6
 
@@ -75,37 +75,51 @@ Section6Block <- !Section1 !Section2 !Section3 !Section4 !Section5 !Section6 con
 // ------------------------------------------
 Heading <- Heading1 / Heading2 / Heading3 / Heading4 / Heading5 / Heading6
 
-Heading1 <- metadata:(MetadataElement)* level:("=") WS+ content:InlineContent (BlankLine? / EOF) {
-     return types.NewHeading(1, content.(*types.InlineContent), metadata.([]interface{}))
+Heading1 <- attributes:(ElementAttribute)* level:("=") WS+ content:InlineContent (BlankLine? / EOF) { //TODO: replace `(BlankLine? / EOF)` with `EOL` to allow for immediate attributes or any other content ?
+     return types.NewHeading(1, content.(*types.InlineContent), attributes.([]interface{}))
 }
 
-Heading2 <- metadata:(MetadataElement)* level:("==") WS+ content:InlineContent (BlankLine? / EOF) {
-     return types.NewHeading(2, content.(*types.InlineContent), metadata.([]interface{}))
+Heading2 <- attributes:(ElementAttribute)* level:("==") WS+ content:InlineContent (BlankLine? / EOF) {
+     return types.NewHeading(2, content.(*types.InlineContent), attributes.([]interface{}))
 }
 
-Heading3 <- metadata:(MetadataElement)* level:("===") WS+ content:InlineContent (BlankLine? / EOF) {
-     return types.NewHeading(3, content.(*types.InlineContent), metadata.([]interface{}))
+Heading3 <- attributes:(ElementAttribute)* level:("===") WS+ content:InlineContent (BlankLine? / EOF) {
+     return types.NewHeading(3, content.(*types.InlineContent), attributes.([]interface{}))
 }
 
-Heading4 <- metadata:(MetadataElement)* level:("====") WS+ content:InlineContent (BlankLine? / EOF) {
-     return types.NewHeading(4, content.(*types.InlineContent), metadata.([]interface{}))
+Heading4 <- attributes:(ElementAttribute)* level:("====") WS+ content:InlineContent (BlankLine? / EOF) {
+     return types.NewHeading(4, content.(*types.InlineContent), attributes.([]interface{}))
 }
 
-Heading5 <- metadata:(MetadataElement)* level:("=====") WS+ content:InlineContent (BlankLine? / EOF) {
-     return types.NewHeading(5, content.(*types.InlineContent), metadata.([]interface{}))
+Heading5 <- attributes:(ElementAttribute)* level:("=====") WS+ content:InlineContent (BlankLine? / EOF) {
+     return types.NewHeading(5, content.(*types.InlineContent), attributes.([]interface{}))
 }
 
-Heading6 <- metadata:(MetadataElement)* level:("======") WS+ content:InlineContent (BlankLine? / EOF) {
-     return types.NewHeading(6, content.(*types.InlineContent), metadata.([]interface{}))
+Heading6 <- attributes:(ElementAttribute)* level:("======") WS+ content:InlineContent (BlankLine? / EOF) {
+     return types.NewHeading(6, content.(*types.InlineContent), attributes.([]interface{}))
+}
+
+
+// ------------------------------------------
+// Document Attribute
+// ------------------------------------------
+DocumentAttribute <- DocumentAttributeWithNameOnly / DocumentAttributeWithNameAndValue 
+
+DocumentAttributeWithNameOnly <- ":" name:((!NEWLINE !":" !WS .)+) ":" WS* EOL {
+    return types.NewDocumentAttribute(name.([]interface{}), nil)
+}
+
+DocumentAttributeWithNameAndValue <- ":" name:((!NEWLINE !":" !WS .)+) ":" WS+ value:(!NEWLINE .)* EOL {
+    return types.NewDocumentAttribute(name.([]interface{}), value.([]interface{}))
 }
 
 // ------------------------------------------
 // List Items
 // ------------------------------------------
-List <- metadata:(MetadataElement)* 
+List <- attributes:(ElementAttribute)* 
     // list items can be followed by an optional, single blank line
     elements:(ListItem BlankLine?)+ {
-    return types.NewList(elements.([]interface{}), metadata.([]interface{}))
+    return types.NewList(elements.([]interface{}), attributes.([]interface{}))
 }
 
 ListItem <- WS* level:('*'+ / '-') WS+ content:(ListItemContent) {
@@ -119,8 +133,8 @@ ListItemContent <- lines:(!(WS* ('*'+ / '-') WS+) InlineContent)+ {
 // Paragraphs
 // ------------------------------------------
 // a paragraph is a group of line ending with a blank line (or end of file)
-Paragraph <- metadata:(MetadataElement)* lines:(InlineContent)+ {
-    return types.NewParagraph(c.text, lines.([]interface{}), metadata.([]interface{}))
+Paragraph <- attributes:(ElementAttribute)* lines:(InlineContent)+ {
+    return types.NewParagraph(c.text, lines.([]interface{}), attributes.([]interface{}))
 } 
 
 // an inline content element may begin and end with spaces, 
@@ -166,9 +180,9 @@ ExternalLink <- url:(URL_SCHEME URL) text:('[' (URL_TEXT)* ']')? {
 // ------------------------------------------
 // Images
 // ------------------------------------------
-BlockImage <- metadata:(MetadataElement)* image:BlockImageMacro  WS* EOL {
+BlockImage <- attributes:(ElementAttribute)* image:BlockImageMacro  WS* EOL {
     // here we can ignore the blank line in the returned element
-    return types.NewBlockImage(c.text, *image.(*types.ImageMacro), metadata.([]interface{}))
+    return types.NewBlockImage(c.text, *image.(*types.ImageMacro), attributes.([]interface{}))
 }
 
 BlockImageMacro <- "image::" path:(URL) '[' attributes:(URL_TEXT?) ']' {
@@ -201,7 +215,7 @@ SourceBlockLine <- (!EOL .)* NEWLINE
 // ------------------------------------------
 // Meta Elements
 // ------------------------------------------
-MetadataElement <- meta:(ElementLink / ElementID / ElementTitle) 
+ElementAttribute <- meta:(ElementLink / ElementID / ElementTitle) 
 
 // a link attached to an element, such as a BlockImage
 ElementLink <- "[" WS* "link" WS* "=" WS* path:URL WS* "]" EOL {

--- a/parser/asciidoc_parser_test.go
+++ b/parser/asciidoc_parser_test.go
@@ -21,7 +21,7 @@ var _ = Describe("Parsing content", func() {
 			"\n" +
 			"a paragraph with *bold content*"
 		expectedDocument := &types.Document{
-			Metadata: &types.DocumentMetadata{
+			Attributes: &types.DocumentAttributes{
 				"title": "a heading",
 			},
 			Elements: []types.DocElement{
@@ -85,7 +85,6 @@ func verify(t GinkgoTInterface, expectedDocument *types.Document, content string
 	}
 	require.Nil(t, err)
 	actualDocument := result.(*types.Document)
-	t.Logf("actual document structure: %+v", actualDocument.Elements)
 	t.Logf("actual document: `%s`", actualDocument.String(0))
 	t.Logf("expected document: `%s`", expectedDocument.String(0))
 	assert.EqualValues(t, *expectedDocument, *actualDocument)

--- a/parser/blank_line_test.go
+++ b/parser/blank_line_test.go
@@ -11,7 +11,7 @@ var _ = Describe("Blank lines", func() {
 
 second paragraph`
 		expectedDocument := &types.Document{
-			Metadata: &types.DocumentMetadata{},
+			Attributes: &types.DocumentAttributes{},
 			Elements: []types.DocElement{
 				&types.Paragraph{
 					Lines: []*types.InlineContent{
@@ -43,7 +43,7 @@ second paragraph`
 second paragraph
 `
 		expectedDocument := &types.Document{
-			Metadata: &types.DocumentMetadata{},
+			Attributes: &types.DocumentAttributes{},
 			Elements: []types.DocElement{
 				&types.Paragraph{
 					Lines: []*types.InlineContent{

--- a/parser/delimited_block_test.go
+++ b/parser/delimited_block_test.go
@@ -11,7 +11,7 @@ var _ = Describe("Delimited Blocks", func() {
 		content := "some source code"
 		actualContent := "```\n" + content + "\n```"
 		expectedDocument := &types.Document{
-			Metadata: &types.DocumentMetadata{},
+			Attributes: &types.DocumentAttributes{},
 			Elements: []types.DocElement{
 				&types.DelimitedBlock{
 					Kind:    types.SourceBlock,
@@ -26,7 +26,7 @@ var _ = Describe("Delimited Blocks", func() {
 		content := "some source code\nwith an empty line\n\nin the middle"
 		actualContent := "```\n" + content + "\n```"
 		expectedDocument := &types.Document{
-			Metadata: &types.DocumentMetadata{},
+			Attributes: &types.DocumentAttributes{},
 			Elements: []types.DocElement{
 				&types.DelimitedBlock{
 					Kind:    types.SourceBlock,
@@ -41,7 +41,7 @@ var _ = Describe("Delimited Blocks", func() {
 		content := ""
 		actualContent := "```\n" + content + "```"
 		expectedDocument := &types.Document{
-			Metadata: &types.DocumentMetadata{},
+			Attributes: &types.DocumentAttributes{},
 			Elements: []types.DocElement{
 				&types.DelimitedBlock{
 					Kind:    types.SourceBlock,

--- a/parser/document_attributes_test.go
+++ b/parser/document_attributes_test.go
@@ -1,0 +1,205 @@
+package parser_test
+
+import (
+	"github.com/bytesparadise/libasciidoc/types"
+	. "github.com/onsi/ginkgo"
+)
+
+var _ = Describe("Parsing Document Attributes", func() {
+
+	Context("Valid document attributes", func() {
+
+		It("heading section with attributes", func() {
+
+			actualContent := `= a heading
+:toc:
+:date: 2017-01-01
+:author: Xavier
+
+a paragraph`
+			expectedDocument := &types.Document{
+				Attributes: &types.DocumentAttributes{
+					"title": "a heading",
+				},
+				Elements: []types.DocElement{
+					&types.Section{
+						Heading: types.Heading{
+							Level: 1,
+							Content: &types.InlineContent{
+								Elements: []types.InlineElement{
+									&types.StringElement{Content: "a heading"},
+								},
+							},
+							ID: &types.ElementID{
+								Value: "_a_heading",
+							},
+						},
+						Elements: []types.DocElement{
+							&types.DocumentAttribute{Name: "toc"},
+							&types.DocumentAttribute{Name: "date", Value: "2017-01-01"},
+							&types.DocumentAttribute{Name: "author", Value: "Xavier"},
+							&types.Paragraph{
+								Lines: []*types.InlineContent{
+									&types.InlineContent{
+										Elements: []types.InlineElement{
+											&types.StringElement{Content: "a paragraph"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			verify(GinkgoT(), expectedDocument, actualContent)
+		})
+
+		It("attributes and paragraph without blank line in-between", func() {
+
+			actualContent := `:toc:
+:date:  2017-01-01
+:author: Xavier
+a paragraph`
+			expectedDocument := &types.Document{
+				Attributes: &types.DocumentAttributes{},
+				Elements: []types.DocElement{
+					&types.DocumentAttribute{Name: "toc"},
+					&types.DocumentAttribute{Name: "date", Value: "2017-01-01"},
+					&types.DocumentAttribute{Name: "author", Value: "Xavier"},
+					&types.Paragraph{
+						Lines: []*types.InlineContent{
+							&types.InlineContent{
+								Elements: []types.InlineElement{
+									&types.StringElement{Content: "a paragraph"},
+								},
+							},
+						},
+					},
+				},
+			}
+			verify(GinkgoT(), expectedDocument, actualContent)
+		})
+
+		It("contiguous attributes and paragraph with blank line in-between", func() {
+
+			actualContent := `:toc:
+:date: 2017-01-01
+:author: Xavier
+
+a paragraph`
+			expectedDocument := &types.Document{
+				Attributes: &types.DocumentAttributes{},
+				Elements: []types.DocElement{
+					&types.DocumentAttribute{Name: "toc"},
+					&types.DocumentAttribute{Name: "date", Value: "2017-01-01"},
+					&types.DocumentAttribute{Name: "author", Value: "Xavier"},
+					&types.Paragraph{
+						Lines: []*types.InlineContent{
+							&types.InlineContent{
+								Elements: []types.InlineElement{
+									&types.StringElement{Content: "a paragraph"},
+								},
+							},
+						},
+					},
+				},
+			}
+			verify(GinkgoT(), expectedDocument, actualContent)
+		})
+
+		It("splitted attributes and paragraph with blank line in-between", func() {
+
+			actualContent := `:toc:
+:date: 2017-01-01
+
+:author: Xavier
+
+a paragraph`
+			expectedDocument := &types.Document{
+				Attributes: &types.DocumentAttributes{},
+				Elements: []types.DocElement{
+					&types.DocumentAttribute{Name: "toc"},
+					&types.DocumentAttribute{Name: "date", Value: "2017-01-01"},
+					&types.DocumentAttribute{Name: "author", Value: "Xavier"},
+					&types.Paragraph{
+						Lines: []*types.InlineContent{
+							&types.InlineContent{
+								Elements: []types.InlineElement{
+									&types.StringElement{Content: "a paragraph"},
+								},
+							},
+						},
+					},
+				},
+			}
+			verify(GinkgoT(), expectedDocument, actualContent)
+		})
+
+		It("no heading and attributes in body", func() {
+
+			actualContent := `a paragraph
+		
+:toc:
+:date: 2017-01-01
+:author: Xavier`
+			expectedDocument := &types.Document{
+				Attributes: &types.DocumentAttributes{},
+				Elements: []types.DocElement{
+					&types.Paragraph{
+						Lines: []*types.InlineContent{
+							&types.InlineContent{
+								Elements: []types.InlineElement{
+									&types.StringElement{Content: "a paragraph"},
+								},
+							},
+						},
+					},
+					&types.DocumentAttribute{Name: "toc"},
+					&types.DocumentAttribute{Name: "date", Value: "2017-01-01"},
+					&types.DocumentAttribute{Name: "author", Value: "Xavier"},
+				},
+			}
+			verify(GinkgoT(), expectedDocument, actualContent)
+		})
+	})
+
+	Context("Valid document attributes", func() {
+		It("paragraph and without blank line in between", func() {
+
+			actualContent := `a paragraph
+:toc:
+:date: 2017-01-01
+:author: Xavier`
+			expectedDocument := &types.Document{
+				Attributes: &types.DocumentAttributes{},
+				Elements: []types.DocElement{
+					&types.Paragraph{
+						Lines: []*types.InlineContent{
+							&types.InlineContent{
+								Elements: []types.InlineElement{
+									&types.StringElement{Content: "a paragraph"},
+								},
+							},
+							&types.InlineContent{
+								Elements: []types.InlineElement{
+									&types.StringElement{Content: ":toc:"},
+								},
+							},
+							&types.InlineContent{
+								Elements: []types.InlineElement{
+									&types.StringElement{Content: ":date: 2017-01-01"},
+								},
+							},
+							&types.InlineContent{
+								Elements: []types.InlineElement{
+									&types.StringElement{Content: ":author: Xavier"},
+								},
+							},
+						},
+					},
+				},
+			}
+			verify(GinkgoT(), expectedDocument, actualContent)
+		})
+	})
+})

--- a/parser/external_link_test.go
+++ b/parser/external_link_test.go
@@ -10,7 +10,7 @@ var _ = Describe("External Links", func() {
 	It("external link", func() {
 		actualContent := "a link to https://foo.bar"
 		expectedDocument := &types.Document{
-			Metadata: &types.DocumentMetadata{},
+			Attributes: &types.DocumentAttributes{},
 			Elements: []types.DocElement{
 				&types.Paragraph{
 					Lines: []*types.InlineContent{
@@ -32,7 +32,7 @@ var _ = Describe("External Links", func() {
 	It("external link with empty text", func() {
 		actualContent := "a link to https://foo.bar[]"
 		expectedDocument := &types.Document{
-			Metadata: &types.DocumentMetadata{},
+			Attributes: &types.DocumentAttributes{},
 			Elements: []types.DocElement{
 				&types.Paragraph{
 					Lines: []*types.InlineContent{
@@ -55,7 +55,7 @@ var _ = Describe("External Links", func() {
 	It("external link with text", func() {
 		actualContent := "a link to mailto:foo@bar[the foo@bar email]"
 		expectedDocument := &types.Document{
-			Metadata: &types.DocumentMetadata{},
+			Attributes: &types.DocumentAttributes{},
 			Elements: []types.DocElement{
 				&types.Paragraph{
 					Lines: []*types.InlineContent{

--- a/parser/image_test.go
+++ b/parser/image_test.go
@@ -12,7 +12,7 @@ var _ = Describe("Images", func() {
 			It("block image with empty alt", func() {
 				actualContent := "image::images/foo.png[]"
 				expectedDocument := &types.Document{
-					Metadata: &types.DocumentMetadata{},
+					Attributes: &types.DocumentAttributes{},
 					Elements: []types.DocElement{
 						&types.BlockImage{
 							Macro: types.ImageMacro{
@@ -28,7 +28,7 @@ var _ = Describe("Images", func() {
 			It("block image with empty alt and trailing spaces", func() {
 				actualContent := "image::images/foo.png[]  \t\t  "
 				expectedDocument := &types.Document{
-					Metadata: &types.DocumentMetadata{},
+					Attributes: &types.DocumentAttributes{},
 					Elements: []types.DocElement{
 						&types.BlockImage{
 							Macro: types.ImageMacro{
@@ -46,7 +46,7 @@ var _ = Describe("Images", func() {
 				actualContent := `image::images/foo.png[]
 `
 				expectedDocument := &types.Document{
-					Metadata: &types.DocumentMetadata{},
+					Attributes: &types.DocumentAttributes{},
 					Elements: []types.DocElement{
 						&types.BlockImage{
 							Macro: types.ImageMacro{
@@ -64,7 +64,7 @@ var _ = Describe("Images", func() {
 				actualContent := `image::images/foo.png[]
   `
 				expectedDocument := &types.Document{
-					Metadata: &types.DocumentMetadata{},
+					Attributes: &types.DocumentAttributes{},
 					Elements: []types.DocElement{
 						&types.BlockImage{
 							Macro: types.ImageMacro{
@@ -83,7 +83,7 @@ var _ = Describe("Images", func() {
  
 			`
 				expectedDocument := &types.Document{
-					Metadata: &types.DocumentMetadata{},
+					Attributes: &types.DocumentAttributes{},
 					Elements: []types.DocElement{
 						&types.BlockImage{
 							Macro: types.ImageMacro{
@@ -101,7 +101,7 @@ var _ = Describe("Images", func() {
 			It("block image with alt", func() {
 				actualContent := "image::images/foo.png[the foo.png image]"
 				expectedDocument := &types.Document{
-					Metadata: &types.DocumentMetadata{},
+					Attributes: &types.DocumentAttributes{},
 					Elements: []types.DocElement{
 						&types.BlockImage{
 							Macro: types.ImageMacro{
@@ -122,7 +122,7 @@ var _ = Describe("Images", func() {
 				width := "600"
 				height := "400"
 				expectedDocument := &types.Document{
-					Metadata: &types.DocumentMetadata{},
+					Attributes: &types.DocumentAttributes{},
 					Elements: []types.DocElement{
 						&types.BlockImage{
 							Macro: types.ImageMacro{
@@ -144,7 +144,7 @@ var _ = Describe("Images", func() {
 			It("block image appending inline content", func() {
 				actualContent := "a paragraph\nimage::images/foo.png[]"
 				expectedDocument := &types.Document{
-					Metadata: &types.DocumentMetadata{},
+					Attributes: &types.DocumentAttributes{},
 					Elements: []types.DocElement{
 						&types.Paragraph{
 							Lines: []*types.InlineContent{
@@ -173,7 +173,7 @@ var _ = Describe("Images", func() {
 			It("inline image with empty alt", func() {
 				actualContent := "image:images/foo.png[]"
 				expectedDocument := &types.Document{
-					Metadata: &types.DocumentMetadata{},
+					Attributes: &types.DocumentAttributes{},
 					Elements: []types.DocElement{
 						&types.Paragraph{
 							Lines: []*types.InlineContent{
@@ -197,7 +197,7 @@ var _ = Describe("Images", func() {
 			It("inline image with empty alt and trailing spaces", func() {
 				actualContent := "image:images/foo.png[]  \t\t  "
 				expectedDocument := &types.Document{
-					Metadata: &types.DocumentMetadata{},
+					Attributes: &types.DocumentAttributes{},
 					Elements: []types.DocElement{
 						&types.Paragraph{
 							Lines: []*types.InlineContent{
@@ -224,7 +224,7 @@ var _ = Describe("Images", func() {
 			It("inline image surrounded with test", func() {
 				actualContent := "a foo image:images/foo.png[] bar..."
 				expectedDocument := &types.Document{
-					Metadata: &types.DocumentMetadata{},
+					Attributes: &types.DocumentAttributes{},
 					Elements: []types.DocElement{
 						&types.Paragraph{
 							Lines: []*types.InlineContent{
@@ -254,7 +254,7 @@ var _ = Describe("Images", func() {
 			It("inline image with alt", func() {
 				actualContent := "image:images/foo.png[the foo.png image]"
 				expectedDocument := &types.Document{
-					Metadata: &types.DocumentMetadata{},
+					Attributes: &types.DocumentAttributes{},
 					Elements: []types.DocElement{
 						&types.Paragraph{
 							Lines: []*types.InlineContent{
@@ -279,7 +279,7 @@ var _ = Describe("Images", func() {
 			It("inline image appending inline content", func() {
 				actualContent := "a paragraph\nimage::images/foo.png[]"
 				expectedDocument := &types.Document{
-					Metadata: &types.DocumentMetadata{},
+					Attributes: &types.DocumentAttributes{},
 					Elements: []types.DocElement{
 						&types.Paragraph{
 							Lines: []*types.InlineContent{

--- a/parser/list_test.go
+++ b/parser/list_test.go
@@ -12,7 +12,7 @@ var _ = Describe("List Items", func() {
 			It("1 list with a single item", func() {
 				actualContent := "* a list item"
 				expectedDocument := &types.Document{
-					Metadata: &types.DocumentMetadata{},
+					Attributes: &types.DocumentAttributes{},
 					Elements: []types.DocElement{
 						&types.List{
 							Items: []*types.ListItem{
@@ -38,7 +38,7 @@ var _ = Describe("List Items", func() {
 				actualContent := "[#listID]\n" +
 					"* a list item"
 				expectedDocument := &types.Document{
-					Metadata: &types.DocumentMetadata{},
+					Attributes: &types.DocumentAttributes{},
 					Elements: []types.DocElement{
 						&types.List{
 							ID: &types.ElementID{Value: "listID"},
@@ -66,7 +66,7 @@ var _ = Describe("List Items", func() {
 				actualContent := "* a first item\n" +
 					"* a second item with *bold content*"
 				expectedDocument := &types.Document{
-					Metadata: &types.DocumentMetadata{},
+					Attributes: &types.DocumentAttributes{},
 					Elements: []types.DocElement{
 						&types.List{
 							Items: []*types.ListItem{
@@ -109,7 +109,7 @@ var _ = Describe("List Items", func() {
 				actualContent := "- a first item\n" +
 					"- a second item with *bold content*"
 				expectedDocument := &types.Document{
-					Metadata: &types.DocumentMetadata{},
+					Attributes: &types.DocumentAttributes{},
 					Elements: []types.DocElement{
 						&types.List{
 							Items: []*types.ListItem{
@@ -154,7 +154,7 @@ var _ = Describe("List Items", func() {
 					"\n" +
 					"* a second item with *bold content*"
 				expectedDocument := &types.Document{
-					Metadata: &types.DocumentMetadata{},
+					Attributes: &types.DocumentAttributes{},
 					Elements: []types.DocElement{
 						&types.List{
 							Items: []*types.ListItem{
@@ -199,7 +199,7 @@ var _ = Describe("List Items", func() {
 					"* item 2\n" +
 					"on 2 lines, too."
 				expectedDocument := &types.Document{
-					Metadata: &types.DocumentMetadata{},
+					Attributes: &types.DocumentAttributes{},
 					Elements: []types.DocElement{
 						&types.List{
 							Items: []*types.ListItem{
@@ -250,7 +250,7 @@ var _ = Describe("List Items", func() {
 					"\n" +
 					"* an item in the second list"
 				expectedDocument := &types.Document{
-					Metadata: &types.DocumentMetadata{},
+					Attributes: &types.DocumentAttributes{},
 					Elements: []types.DocElement{
 						&types.List{
 							Items: []*types.ListItem{
@@ -303,7 +303,7 @@ var _ = Describe("List Items", func() {
 					"* item 2\n" +
 					"** item 2.1\n"
 				expectedDocument := &types.Document{
-					Metadata: &types.DocumentMetadata{},
+					Attributes: &types.DocumentAttributes{},
 					Elements: []types.DocElement{
 						&types.List{
 							Items: []*types.ListItem{
@@ -432,7 +432,7 @@ var _ = Describe("List Items", func() {
 					"** item 1.2\n" +
 					"* item 2"
 				expectedDocument := &types.Document{
-					Metadata: &types.DocumentMetadata{},
+					Attributes: &types.DocumentAttributes{},
 					Elements: []types.DocElement{
 						&types.List{
 							Items: []*types.ListItem{
@@ -514,7 +514,7 @@ var _ = Describe("List Items", func() {
 			It("invalid list item", func() {
 				actualContent := "*an invalid list item"
 				expectedDocument := &types.Document{
-					Metadata: &types.DocumentMetadata{},
+					Attributes: &types.DocumentAttributes{},
 					Elements: []types.DocElement{
 						&types.Paragraph{
 							Lines: []*types.InlineContent{

--- a/parser/meta_elements_test.go
+++ b/parser/meta_elements_test.go
@@ -12,7 +12,7 @@ var _ = Describe("Meta Elements", func() {
 		It("element link alone", func() {
 			actualContent := "[link=http://foo.bar]"
 			expectedDocument := &types.Document{
-				Metadata: &types.DocumentMetadata{},
+				Attributes: &types.DocumentAttributes{},
 				Elements: []types.DocElement{
 					&types.ElementLink{Path: "http://foo.bar"},
 				},
@@ -23,7 +23,7 @@ var _ = Describe("Meta Elements", func() {
 		It("element link with spaces", func() {
 			actualContent := "[ link = http://foo.bar ]"
 			expectedDocument := &types.Document{
-				Metadata: &types.DocumentMetadata{},
+				Attributes: &types.DocumentAttributes{},
 				Elements: []types.DocElement{
 					&types.ElementLink{Path: "http://foo.bar"},
 				},
@@ -34,7 +34,7 @@ var _ = Describe("Meta Elements", func() {
 		It("element link invalid", func() {
 			actualContent := "[ link = http://foo.bar"
 			expectedDocument := &types.Document{
-				Metadata: &types.DocumentMetadata{},
+				Attributes: &types.DocumentAttributes{},
 				Elements: []types.DocElement{
 					&types.Paragraph{
 						Lines: []*types.InlineContent{
@@ -57,7 +57,7 @@ var _ = Describe("Meta Elements", func() {
 		It("element id", func() {
 			actualContent := "[#img-foobar]"
 			expectedDocument := &types.Document{
-				Metadata: &types.DocumentMetadata{},
+				Attributes: &types.DocumentAttributes{},
 				Elements: []types.DocElement{
 					&types.ElementID{Value: "img-foobar"},
 				},
@@ -68,7 +68,7 @@ var _ = Describe("Meta Elements", func() {
 		It("element id with spaces", func() {
 			actualContent := "[ #img-foobar ]"
 			expectedDocument := &types.Document{
-				Metadata: &types.DocumentMetadata{},
+				Attributes: &types.DocumentAttributes{},
 				Elements: []types.DocElement{
 					&types.ElementID{Value: "img-foobar"},
 				},
@@ -79,7 +79,7 @@ var _ = Describe("Meta Elements", func() {
 		It("element id invalid", func() {
 			actualContent := "[#img-foobar"
 			expectedDocument := &types.Document{
-				Metadata: &types.DocumentMetadata{},
+				Attributes: &types.DocumentAttributes{},
 				Elements: []types.DocElement{
 					&types.Paragraph{
 						Lines: []*types.InlineContent{
@@ -96,7 +96,7 @@ var _ = Describe("Meta Elements", func() {
 		It("element title", func() {
 			actualContent := ".a title"
 			expectedDocument := &types.Document{
-				Metadata: &types.DocumentMetadata{},
+				Attributes: &types.DocumentAttributes{},
 				Elements: []types.DocElement{
 					&types.ElementTitle{Value: "a title"},
 				},
@@ -107,7 +107,7 @@ var _ = Describe("Meta Elements", func() {
 		It("element title invalid1", func() {
 			actualContent := ". a title"
 			expectedDocument := &types.Document{
-				Metadata: &types.DocumentMetadata{},
+				Attributes: &types.DocumentAttributes{},
 				Elements: []types.DocElement{
 					&types.Paragraph{
 						Lines: []*types.InlineContent{
@@ -122,7 +122,7 @@ var _ = Describe("Meta Elements", func() {
 		It("element title invalid2", func() {
 			actualContent := "!a title"
 			expectedDocument := &types.Document{
-				Metadata: &types.DocumentMetadata{},
+				Attributes: &types.DocumentAttributes{},
 				Elements: []types.DocElement{
 					&types.Paragraph{
 						Lines: []*types.InlineContent{

--- a/parser/paragraph_test.go
+++ b/parser/paragraph_test.go
@@ -10,7 +10,7 @@ var _ = Describe("Paragraphs", func() {
 	It("paragraph with 1 word", func() {
 		actualContent := "hello"
 		expectedDocument := &types.Document{
-			Metadata: &types.DocumentMetadata{},
+			Attributes: &types.DocumentAttributes{},
 			Elements: []types.DocElement{
 				&types.Paragraph{
 					Lines: []*types.InlineContent{
@@ -29,7 +29,7 @@ var _ = Describe("Paragraphs", func() {
 	It("paragraph with few words", func() {
 		actualContent := "a paragraph with some content"
 		expectedDocument := &types.Document{
-			Metadata: &types.DocumentMetadata{},
+			Attributes: &types.DocumentAttributes{},
 			Elements: []types.DocElement{
 				&types.Paragraph{
 					Lines: []*types.InlineContent{
@@ -48,7 +48,7 @@ var _ = Describe("Paragraphs", func() {
 	It("paragraph with bold content", func() {
 		actualContent := "a paragraph with *some bold content*"
 		expectedDocument := &types.Document{
-			Metadata: &types.DocumentMetadata{},
+			Attributes: &types.DocumentAttributes{},
 			Elements: []types.DocElement{
 				&types.Paragraph{
 					Lines: []*types.InlineContent{
@@ -75,7 +75,7 @@ var _ = Describe("Paragraphs", func() {
 .a title
 a paragraph`
 		expectedDocument := &types.Document{
-			Metadata: &types.DocumentMetadata{},
+			Attributes: &types.DocumentAttributes{},
 			Elements: []types.DocElement{
 				&types.Paragraph{
 					ID:    &types.ElementID{Value: "foo"},

--- a/parser/quoted_text_test.go
+++ b/parser/quoted_text_test.go
@@ -10,7 +10,7 @@ var _ = Describe("Quoted Texts", func() {
 	It("bold text of 1 word", func() {
 		actualContent := "*hello*"
 		expectedDocument := &types.Document{
-			Metadata: &types.DocumentMetadata{},
+			Attributes: &types.DocumentAttributes{},
 			Elements: []types.DocElement{
 				&types.Paragraph{
 					Lines: []*types.InlineContent{
@@ -34,7 +34,7 @@ var _ = Describe("Quoted Texts", func() {
 	It("bold text of 2 words", func() {
 		actualContent := "*bold    content*"
 		expectedDocument := &types.Document{
-			Metadata: &types.DocumentMetadata{},
+			Attributes: &types.DocumentAttributes{},
 			Elements: []types.DocElement{
 				&types.Paragraph{
 					Lines: []*types.InlineContent{
@@ -58,7 +58,7 @@ var _ = Describe("Quoted Texts", func() {
 	It("bold text of 3 words", func() {
 		actualContent := "*some bold content*"
 		expectedDocument := &types.Document{
-			Metadata: &types.DocumentMetadata{},
+			Attributes: &types.DocumentAttributes{},
 			Elements: []types.DocElement{
 				&types.Paragraph{
 					Lines: []*types.InlineContent{
@@ -82,7 +82,7 @@ var _ = Describe("Quoted Texts", func() {
 	It("inline with bold text", func() {
 		actualContent := "a paragraph with *some bold content*"
 		expectedDocument := &types.Document{
-			Metadata: &types.DocumentMetadata{},
+			Attributes: &types.DocumentAttributes{},
 			Elements: []types.DocElement{
 				&types.Paragraph{
 					Lines: []*types.InlineContent{
@@ -107,7 +107,7 @@ var _ = Describe("Quoted Texts", func() {
 	It("inline with invalid bold text1", func() {
 		actualContent := "a paragraph with *some bold content"
 		expectedDocument := &types.Document{
-			Metadata: &types.DocumentMetadata{},
+			Attributes: &types.DocumentAttributes{},
 			Elements: []types.DocElement{
 				&types.Paragraph{
 					Lines: []*types.InlineContent{
@@ -126,7 +126,7 @@ var _ = Describe("Quoted Texts", func() {
 	It("inline with invalid bold text2", func() {
 		actualContent := "a paragraph with *some bold content *"
 		expectedDocument := &types.Document{
-			Metadata: &types.DocumentMetadata{},
+			Attributes: &types.DocumentAttributes{},
 			Elements: []types.DocElement{
 				&types.Paragraph{
 					Lines: []*types.InlineContent{
@@ -145,7 +145,7 @@ var _ = Describe("Quoted Texts", func() {
 	It("inline with invalid bold text3", func() {
 		actualContent := "a paragraph with * some bold content*"
 		expectedDocument := &types.Document{
-			Metadata: &types.DocumentMetadata{},
+			Attributes: &types.DocumentAttributes{},
 			Elements: []types.DocElement{
 				&types.Paragraph{
 					Lines: []*types.InlineContent{
@@ -164,7 +164,7 @@ var _ = Describe("Quoted Texts", func() {
 	It("italic text with3 words", func() {
 		actualContent := "_some italic content_"
 		expectedDocument := &types.Document{
-			Metadata: &types.DocumentMetadata{},
+			Attributes: &types.DocumentAttributes{},
 			Elements: []types.DocElement{
 				&types.Paragraph{
 					Lines: []*types.InlineContent{
@@ -188,7 +188,7 @@ var _ = Describe("Quoted Texts", func() {
 	It("monospace text with3 words", func() {
 		actualContent := "`some monospace content`"
 		expectedDocument := &types.Document{
-			Metadata: &types.DocumentMetadata{},
+			Attributes: &types.DocumentAttributes{},
 			Elements: []types.DocElement{
 				&types.Paragraph{
 					Lines: []*types.InlineContent{
@@ -212,7 +212,7 @@ var _ = Describe("Quoted Texts", func() {
 	It("italic text within bold text", func() {
 		actualContent := "some *bold and _italic content_ together*."
 		expectedDocument := &types.Document{
-			Metadata: &types.DocumentMetadata{},
+			Attributes: &types.DocumentAttributes{},
 			Elements: []types.DocElement{
 				&types.Paragraph{
 					Lines: []*types.InlineContent{
@@ -245,7 +245,7 @@ var _ = Describe("Quoted Texts", func() {
 	It("invalid italic text within bold text", func() {
 		actualContent := "some *bold and _italic content _ together*."
 		expectedDocument := &types.Document{
-			Metadata: &types.DocumentMetadata{},
+			Attributes: &types.DocumentAttributes{},
 			Elements: []types.DocElement{
 				&types.Paragraph{
 					Lines: []*types.InlineContent{
@@ -271,7 +271,7 @@ var _ = Describe("Quoted Texts", func() {
 	It("italic text within invalid bold text", func() {
 		actualContent := "some *bold and _italic content_ together *."
 		expectedDocument := &types.Document{
-			Metadata: &types.DocumentMetadata{},
+			Attributes: &types.DocumentAttributes{},
 			Elements: []types.DocElement{
 				&types.Paragraph{
 					Lines: []*types.InlineContent{
@@ -297,7 +297,7 @@ var _ = Describe("Quoted Texts", func() {
 	It("bold text within italic text", func() {
 		actualContent := "_some *bold* content_"
 		expectedDocument := &types.Document{
-			Metadata: &types.DocumentMetadata{},
+			Attributes: &types.DocumentAttributes{},
 			Elements: []types.DocElement{
 				&types.Paragraph{
 					Lines: []*types.InlineContent{
@@ -328,7 +328,7 @@ var _ = Describe("Quoted Texts", func() {
 	It("monospace text within bold text within italic quote", func() {
 		actualContent := "*some _italic and `monospaced content`_*"
 		expectedDocument := &types.Document{
-			Metadata: &types.DocumentMetadata{},
+			Attributes: &types.DocumentAttributes{},
 			Elements: []types.DocElement{
 				&types.Paragraph{
 					Lines: []*types.InlineContent{
@@ -364,7 +364,7 @@ var _ = Describe("Quoted Texts", func() {
 	It("italic text within italic text", func() {
 		actualContent := "_some _very italic_ content_"
 		expectedDocument := &types.Document{
-			Metadata: &types.DocumentMetadata{},
+			Attributes: &types.DocumentAttributes{},
 			Elements: []types.DocElement{
 				&types.Paragraph{
 					Lines: []*types.InlineContent{

--- a/parser/section_test.go
+++ b/parser/section_test.go
@@ -12,7 +12,7 @@ var _ = Describe("Sections", func() {
 		It("section with heading only", func() {
 			actualContent := "= a heading"
 			expectedDocument := &types.Document{
-				Metadata: &types.DocumentMetadata{
+				Attributes: &types.DocumentAttributes{
 					"title": "a heading",
 				},
 				Elements: []types.DocElement{
@@ -37,7 +37,7 @@ var _ = Describe("Sections", func() {
 		It("section level 2", func() {
 			actualContent := `== section 2`
 			expectedDocument := &types.Document{
-				Metadata: &types.DocumentMetadata{},
+				Attributes: &types.DocumentAttributes{},
 				Elements: []types.DocElement{
 					&types.Section{
 						Heading: types.Heading{
@@ -61,7 +61,7 @@ var _ = Describe("Sections", func() {
 		It("section level 2 with quoted text", func() {
 			actualContent := `==  *2 spaces and bold content*`
 			expectedDocument := &types.Document{
-				Metadata: &types.DocumentMetadata{},
+				Attributes: &types.DocumentAttributes{},
 				Elements: []types.DocElement{
 					&types.Section{
 						Heading: types.Heading{
@@ -91,7 +91,7 @@ var _ = Describe("Sections", func() {
 				"\n" +
 				"== section 2"
 			expectedDocument := &types.Document{
-				Metadata: &types.DocumentMetadata{
+				Attributes: &types.DocumentAttributes{
 					"title": "a heading",
 				}, Elements: []types.DocElement{
 					&types.Section{
@@ -133,7 +133,7 @@ var _ = Describe("Sections", func() {
 				"\n" +
 				"=== section 3"
 			expectedDocument := &types.Document{
-				Metadata: &types.DocumentMetadata{
+				Attributes: &types.DocumentAttributes{
 					"title": "a heading",
 				},
 				Elements: []types.DocElement{
@@ -175,7 +175,7 @@ var _ = Describe("Sections", func() {
 			actualContent := `== a title
 and a paragraph`
 			expectedDocument := &types.Document{
-				Metadata: &types.DocumentMetadata{},
+				Attributes: &types.DocumentAttributes{},
 				Elements: []types.DocElement{
 					&types.Section{
 						Heading: types.Heading{
@@ -208,7 +208,7 @@ and a paragraph`
 		It("section level 2 with a paragraph separated by empty line", func() {
 			actualContent := "== a title\n\nand a paragraph"
 			expectedDocument := &types.Document{
-				Metadata: &types.DocumentMetadata{},
+				Attributes: &types.DocumentAttributes{},
 				Elements: []types.DocElement{
 					&types.Section{
 						Heading: types.Heading{
@@ -242,7 +242,7 @@ and a paragraph`
 		It("section level 2 with a paragraph separated by non-empty line", func() {
 			actualContent := "== a title\n    \nand a paragraph"
 			expectedDocument := &types.Document{
-				Metadata: &types.DocumentMetadata{},
+				Attributes: &types.DocumentAttributes{},
 				Elements: []types.DocElement{
 					&types.Section{
 						Heading: types.Heading{
@@ -285,7 +285,7 @@ a paragraph
 == Section B
 a paragraph`
 			expectedDocument := &types.Document{
-				Metadata: &types.DocumentMetadata{
+				Attributes: &types.DocumentAttributes{
 					"title": "a title",
 				},
 				Elements: []types.DocElement{
@@ -388,7 +388,7 @@ a paragraph`
 		It("heading invalid - missing space", func() {
 			actualContent := "=a heading"
 			expectedDocument := &types.Document{
-				Metadata: &types.DocumentMetadata{},
+				Attributes: &types.DocumentAttributes{},
 				Elements: []types.DocElement{
 					&types.Paragraph{
 						Lines: []*types.InlineContent{
@@ -406,7 +406,7 @@ a paragraph`
 		It("heading invalid - heading space", func() {
 			actualContent := " = a heading"
 			expectedDocument := &types.Document{
-				Metadata: &types.DocumentMetadata{},
+				Attributes: &types.DocumentAttributes{},
 				Elements: []types.DocElement{
 					&types.Paragraph{
 						Lines: []*types.InlineContent{
@@ -426,7 +426,7 @@ a paragraph`
 				"\n" +
 				" == section 2"
 			expectedDocument := &types.Document{
-				Metadata: &types.DocumentMetadata{
+				Attributes: &types.DocumentAttributes{
 					"title": "a heading",
 				},
 				Elements: []types.DocElement{

--- a/renderer/html5/blank_line_test.go
+++ b/renderer/html5/blank_line_test.go
@@ -27,4 +27,14 @@ second paragraph`
 </div>`
 		verify(GinkgoT(), expected, content)
 	})
+	It("blank lines at end of document", func() {
+		content := `first paragraph
+		
+		
+		`
+		expected := `<div class="paragraph">
+<p>first paragraph</p>
+</div>`
+		verify(GinkgoT(), expected, content)
+	})
 })

--- a/renderer/html5/document_attribute_test.go
+++ b/renderer/html5/document_attribute_test.go
@@ -1,0 +1,32 @@
+package html5_test
+
+import . "github.com/onsi/ginkgo"
+
+var _ = Describe("Rendering With Attributes", func() {
+	It("some attributes then a paragraph", func() {
+		content := `:toc:
+:date: 2017-01-01
+:author: Xavier
+a paragraph`
+
+		expected := `<div class="paragraph">
+<p>a paragraph</p>
+</div>`
+		verify(GinkgoT(), expected, content)
+	})
+})
+
+var _ = Describe("Rendering With Attributes", func() {
+	It("a paragraph then some attributes", func() {
+		content := `a paragraph
+
+:toc:
+:date: 2017-01-01
+:author: Xavier`
+
+		expected := `<div class="paragraph">
+<p>a paragraph</p>
+</div>`
+		verify(GinkgoT(), expected, content)
+	})
+})

--- a/renderer/html5/paragraph_test.go
+++ b/renderer/html5/paragraph_test.go
@@ -24,4 +24,20 @@ with more content afterwards...</p>
 </div>`
 		verify(GinkgoT(), expected, content)
 	})
+
+	It("2 paragraphs and blank line", func() {
+		content := `
+*bold content* with more content afterwards...
+
+and here another paragraph
+
+`
+		expected := `<div class="paragraph">
+<p><strong>bold content</strong> with more content afterwards...</p>
+</div>
+<div class="paragraph">
+<p>and here another paragraph</p>
+</div>`
+		verify(GinkgoT(), expected, content)
+	})
 })

--- a/types/document_metadata.go
+++ b/types/document_metadata.go
@@ -1,21 +1,29 @@
 package types
 
-// DocumentMetadata the document metadata
-type DocumentMetadata map[string]string
+// DocumentAttributes the document metadata
+type DocumentAttributes map[string]interface{}
 
 const (
 	title string = "title"
 )
 
 // GetTitle retrieves the document title in its metadata, or returns nil if the title was not specified
-func (m DocumentMetadata) GetTitle() *string {
+func (m DocumentAttributes) GetTitle() *string {
 	if t, ok := m[title]; ok {
-		return &t
+		if t, ok := t.(string); ok {
+			return &t
+		}
 	}
 	return nil
 }
 
 // SetTitle sets the title in the document metadata
-func (m DocumentMetadata) SetTitle(t string) {
+func (m DocumentAttributes) SetTitle(t string) {
 	m[title] = t
+}
+
+// Add adds the given attribute
+func (m DocumentAttributes) Add(a *DocumentAttribute) {
+	// TODO: raise a warning if there was already a name/value
+	m[a.Name] = a.Value
 }

--- a/types/type_utils.go
+++ b/types/type_utils.go
@@ -138,15 +138,11 @@ func isMn(r rune) bool {
 	return unicode.Is(unicode.Mn, r) // Mn: nonspacing marks
 }
 
-//ReplaceNonAlphanumerics replaces all non alphanumerical characters and remove (accents)
+// NewReplaceNonAlphanumericsFunc replaces all non alphanumerical characters and remove (accents)
 // in the given 'source' with the given 'replacement'.
 func NewReplaceNonAlphanumericsFunc(replacement string) NormalizationFunc {
 	return func(source string) ([]byte, error) {
 		buf := bytes.NewBuffer(make([]byte, 0))
-		// _, err := buf.WriteString(replacement)
-		// if err != nil {
-		// 	return nil, errors.Wrapf(err, "unable to normalize value")
-		// }
 		lastCharIsSpace := false
 		for _, r := range strings.TrimLeft(source, " ") { // ignore heading spaces
 			if unicode.Is(unicode.Letter, r) || unicode.Is(unicode.Number, r) {


### PR DESCRIPTION
Support document attribute in the form: ":name: value" or
":name:" at any location in the document.
For now, document attributes are silently ignored during
rendering.

Rename "Metadata" -> "Attributes" for document and elements.

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>