### PR TITLE
chore(project): configure codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,33 @@
+codecov:
+  notify:
+    require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+  status:
+    project: yes
+    patch: yes
+    changes: no
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "header, diff"
+  behavior: default
+  require_changes: no
+
+ignore:
+  # - "path/to/folder"  # ignore folders and all its contents
+  # - "test_*.rb"       # wildcards accepted
+  # - "**/*.py"         # glob accepted
+  # - "[a-z]+/test_.*"  # regexp accepted
+  - "parser/asciidoc_parser.go"


### PR DESCRIPTION
main goal is to ignore the `parser/asciidoc_parser.go`
file which is generated and which contains some features
that are not used (yet).

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>