### PR TITLE
refactor(renderer): Refactor paragraph renderer

### DIFF
--- a/renderer/html5/document.go
+++ b/renderer/html5/document.go
@@ -104,12 +104,12 @@ func renderElements(ctx *renderer.Context, elements []types.DocElement) ([]byte,
 	for _, element := range elements {
 		content, err := renderElement(ctx, element)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to render the document")
+			return nil, errors.Wrapf(err, "failed to render the elements")
 		}
 		// if there's already some content, we need to insert a `\n` before writing
 		// the rendering output of the current element (if application, ie, not empty)
 		if hasContent && len(content) > 0 {
-			renderedElementsBuff.Write([]byte("\n"))
+			renderedElementsBuff.WriteString("\n")
 		}
 		// if the element was rendering into 'something' (ie, not enpty result)
 		if len(content) > 0 {

--- a/renderer/html5/document_details_test.go
+++ b/renderer/html5/document_details_test.go
@@ -47,7 +47,7 @@ Last updated {{.LastUpdated}}
 </div>
 </body>
 </html>`
-			verify(GinkgoT(), expectedResult, actualContent, renderer.IncludeHeaderFooter(true))
+			verify(GinkgoT(), expectedResult, actualContent, renderer.IncludeHeaderFooter(true), renderer.LastUpdated(time.Now()))
 		})
 
 		It("header with 2 authors and no revision", func() {

--- a/renderer/html5/document_test.go
+++ b/renderer/html5/document_test.go
@@ -35,7 +35,7 @@ Last updated {{.LastUpdated}}
 </div>
 </body>
 </html>`
-			verify(GinkgoT(), expectedResult, actualContent, renderer.IncludeHeaderFooter(true))
+			verify(GinkgoT(), expectedResult, actualContent, renderer.IncludeHeaderFooter(true), renderer.LastUpdated(time.Now()))
 		})
 	})
 

--- a/renderer/html5/paragraph.go
+++ b/renderer/html5/paragraph.go
@@ -2,55 +2,47 @@ package html5
 
 import (
 	"bytes"
-	"html/template"
+	texttemplate "text/template"
 
 	"github.com/bytesparadise/libasciidoc/renderer"
 	"github.com/bytesparadise/libasciidoc/types"
 	"github.com/pkg/errors"
 )
 
-var paragraphTmpl template.Template
+var paragraphTmpl texttemplate.Template
 
 // initializes the template
 func init() {
-	// TODO: use iterator and render func in the paragraph template
-	paragraphTmpl = newHTMLTemplate("paragraph",
-		`<div {{ if ne .ID "" }}id="{{.ID}}" {{ end }}class="paragraph">{{ if ne .Title "" }}
-<div class="doctitle">{{.Title}}</div>{{ end }}
-<p>{{.Lines}}</p>
-</div>`)
+	paragraphTmpl = newTextTemplate("paragraph",
+		`{{ $ctx := .Context }}{{ with .Data }}{{ $renderedElements := renderElements $ctx .Lines | printf "%s"  }}{{ if ne $renderedElements "" }}<div {{ if ne .ID "" }}id="{{ .ID }}" {{ end }}class="paragraph">{{ if ne .Title "" }}
+<div class="doctitle">{{ .Title }}</div>{{ end }}
+<p>{{ $renderedElements }}</p>
+</div>{{ end }}{{ end }}`,
+		texttemplate.FuncMap{
+			"renderElements": renderInlineContents,
+			"notLastItem":    notLastItem,
+		})
 }
 
 func renderParagraph(ctx *renderer.Context, p types.Paragraph) ([]byte, error) {
-	renderedLinesBuff := bytes.NewBuffer(nil)
-	for i, line := range p.Lines {
-		renderedLine, err := renderInlineContent(ctx, line)
-		if err != nil {
-			return nil, errors.Wrapf(err, "unable to render paragraph line")
-		}
-		renderedLinesBuff.Write(renderedLine)
-		if i < len(p.Lines)-1 {
-			renderedLinesBuff.WriteString("\n")
-		}
-
-	}
-	// skip rendering if there's no content in the paragraph (eg: empty passthough)
-	if renderedLinesBuff.Len() == 0 {
-		return []byte{}, nil
+	if len(p.Lines) == 0 {
+		return make([]byte, 0), nil
 	}
 	result := bytes.NewBuffer(nil)
-	err := paragraphTmpl.Execute(result, struct {
-		ID    string
-		Title string
-		Lines template.HTML
-	}{
-		ID:    p.ID.Value,
-		Title: p.Title.Value,
-		Lines: template.HTML(renderedLinesBuff.String()), // here we must preserve the HTML tags
+	err := paragraphTmpl.Execute(result, ContextualPipeline{
+		Context: ctx,
+		Data: struct {
+			ID    string
+			Title string
+			Lines []types.InlineContent
+		}{
+			ID:    p.ID.Value,
+			Title: p.Title.Value,
+			Lines: p.Lines,
+		},
 	})
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to render paragraph")
 	}
-	// log.Debugf("rendered paragraph: %s", result.Bytes())
 	return result.Bytes(), nil
 }

--- a/renderer/html5/renderer.go
+++ b/renderer/html5/renderer.go
@@ -100,6 +100,22 @@ func renderPlainStringForInlineElements(ctx *renderer.Context, elements []types.
 	return buff.Bytes(), nil
 }
 
+// renderElements renders each element and includes an `\n` character until the last item
+func renderInlineContents(ctx *renderer.Context, elements []types.InlineContent) ([]byte, error) {
+	buff := bytes.NewBuffer(nil)
+	for i, e := range elements {
+		renderedElement, err := renderElement(ctx, e)
+		if err != nil {
+			return nil, errors.Wrap(err, "unable to render element")
+		}
+		buff.Write(renderedElement)
+		if i < len(elements)-1 {
+			buff.WriteString("\n")
+		}
+	}
+	return buff.Bytes(), nil
+}
+
 // notLastItem returns true if the given index is NOT the last entry in the given description lines, false otherwise.
 func notLastItem(index int, content interface{}) bool {
 	switch reflect.TypeOf(content).Kind() {


### PR DESCRIPTION
move call to rendering paragraph elements in the
template instead of a function.

Fixes #74

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>