### PR TITLE
types: tidy up initials func

### DIFF
--- a/types/grammar_types.go
+++ b/types/grammar_types.go
@@ -276,11 +276,9 @@ func NewDocumentAuthor(namePart1, namePart2, namePart3, emailAddress interface{}
 }
 
 func initials(firstPart string, otherParts ...string) string {
-	result := fmt.Sprintf("%s", firstPart[0:1])
-	if otherParts != nil {
-		for _, otherPart := range otherParts {
-			result = result + otherPart[0:1]
-		}
+	result := firstPart[0:1]
+	for _, otherPart := range otherParts {
+		result = result + otherPart[0:1]
 	}
 	return result
 }


### PR DESCRIPTION
More megacheck findings:

types/grammar_types.go:279:12: the argument is already a string, there's no need to use fmt.Sprintf (S1025)
types/grammar_types.go:280:2: unnecessary nil check around range (S1031)