### PR TITLE
feat(cmd): add support to specify log level

### DIFF
--- a/cmd/libasciidoc/root_cmd.go
+++ b/cmd/libasciidoc/root_cmd.go
@@ -6,8 +6,11 @@ import (
 
 	"github.com/bytesparadise/libasciidoc"
 	"github.com/bytesparadise/libasciidoc/renderer"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
+
+var logLevel string
 
 // NewRootCmd returns the root command
 func NewRootCmd() *cobra.Command {
@@ -26,8 +29,19 @@ func NewRootCmd() *cobra.Command {
 			}
 			return nil
 		},
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			lvl, err := log.ParseLevel(logLevel)
+			if err != nil {
+				log.Errorf("unable to parse log level %v", err)
+				return err
+			}
+			log.Debug("Setting log level to %v", lvl)
+			log.SetLevel(lvl)
+			return nil
+		},
 	}
 	flags := rootCmd.Flags()
 	flags.StringVarP(&source, "source", "s", "", "the path to the asciidoc source to process")
+	rootCmd.PersistentFlags().StringVar(&logLevel, "log", "warning", "log level to set {debug, info, warning, error, fatal, panic}")
 	return rootCmd
 }

--- a/cmd/libasciidoc/root_cmd_test.go
+++ b/cmd/libasciidoc/root_cmd_test.go
@@ -37,6 +37,18 @@ var _ = Describe("root cmd", func() {
 		require.Error(GinkgoT(), err)
 	})
 
+	It("should fail to parse bad log level", func() {
+		// given
+		root := main.NewRootCmd()
+		buf := new(bytes.Buffer)
+		root.SetOutput(buf)
+		root.SetArgs([]string{"--log", "debug1", "-s", "test/test.adoc"})
+		// when
+		err := root.Execute()
+		// then
+		GinkgoT().Logf("command output: %v", buf.String())
+		require.Error(GinkgoT(), err)
+	})
 })
 
 func TestRootCommand(t *testing.T) {


### PR DESCRIPTION
adds flag `--log` as follows

```
 --log string      log level to set {debug, info, warning, error, fatal, panic} (default "warning")
```