### PR TITLE
refactor(cmd): make cmd args in line with asciidoctor

### DIFF
--- a/cmd/libasciidoc/root_cmd_test.go
+++ b/cmd/libasciidoc/root_cmd_test.go
@@ -22,24 +22,12 @@ var _ = Describe("root cmd", func() {
 		root := main.NewRootCmd()
 		buf := new(bytes.Buffer)
 		root.SetOutput(buf)
-		root.SetArgs([]string{"-s", "test/test.adoc"})
+		root.SetArgs([]string{"test/test.adoc"})
 		// when
 		err := root.Execute()
 		// then
 		require.NoError(GinkgoT(), err)
 		require.NotEmpty(GinkgoT(), buf)
-	})
-
-	It("missing source flag", func() {
-		// given
-		root := main.NewRootCmd()
-		buf := new(bytes.Buffer)
-		root.SetOutput(buf)
-		// when
-		err := root.Execute()
-		// then
-		GinkgoT().Logf("command output: %v", buf.String())
-		require.Error(GinkgoT(), err)
 	})
 
 	It("should fail to parse bad log level", func() {
@@ -60,7 +48,7 @@ var _ = Describe("root cmd", func() {
 		root := main.NewRootCmd()
 		buf := new(bytes.Buffer)
 		root.SetOutput(buf)
-		root.SetArgs([]string{"-n", "-s", "test/test.adoc"})
+		root.SetArgs([]string{"-s", "test/test.adoc"})
 		// when
 		err := root.Execute()
 		// then
@@ -90,7 +78,7 @@ var _ = Describe("root cmd", func() {
 		os.Stdin = tmpfile
 		defer func() { os.Stdin = oldstdin }()
 
-		root.SetArgs([]string{"-s", "-"})
+		root.SetArgs([]string{})
 		// when
 		err = root.Execute()
 
@@ -99,6 +87,26 @@ var _ = Describe("root cmd", func() {
 		Expect(buf.String()).To(ContainSubstring(content))
 		require.NoError(GinkgoT(), err)
 		require.NotEmpty(GinkgoT(), buf)
+	})
+
+	It("should render multiple files", func() {
+		// given
+		root := main.NewRootCmd()
+		root.SetArgs([]string{"-s", "test/admonition.adoc", "test/test.adoc"})
+		// when
+		err := root.Execute()
+		// then
+		require.NoError(GinkgoT(), err)
+	})
+
+	It("when rendering multiple files, return last error", func() {
+		// given
+		root := main.NewRootCmd()
+		root.SetArgs([]string{"-s", "test/doesnotexist.adoc", "test/test.adoc"})
+		// when
+		err := root.Execute()
+		// then
+		require.Error(GinkgoT(), err)
 	})
 })
 

--- a/cmd/libasciidoc/test/admonition.adoc
+++ b/cmd/libasciidoc/test/admonition.adoc
@@ -1,0 +1,12 @@
+NOTE: this is a note
+
+[NOTE]
+a para note
+
+[NOTE]
+----
+multiple
+
+paras
+
+----


### PR DESCRIPTION
See #96 

```
libasciidoc is a tool to generate an html output from an asciidoc file

Positional args:
If no files are specified, input is read from STDIN
If more than 1 file is specified, then output is written to ".html" file alongside the source file

Usage:
  libasciidoc FILE... [flags]
  libasciidoc [command]

Available Commands:
  help        Help about the command
  version     Print the version number of libasciidoc

Flags:
  -h, --help               help for libasciidoc
      --log string         log level to set {debug, info, warning, error, fatal, panic} (default "warning")
  -s, --no-header-footer   Do not render header/footer (Default: false)

Use "libasciidoc [command] --help" for more information about a command.
```