### PR TITLE
fix(build): update codecov config

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -30,4 +30,4 @@ ignore:
   # - "test_*.rb"       # wildcards accepted
   # - "**/*.py"         # glob accepted
   # - "[a-z]+/test_.*"  # regexp accepted
-  - "parser/asciidoc_parser.go"
+  - "pkg/parser/asciidoc_parser.go"


### PR DESCRIPTION
ignored content was invalid, which means that
`pkg/parser/asciidoc_parser.go` code was included in
the coverage

Fixes #134

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>