### PR TITLE
feat(renderer): support 'imagesdir' attribute

### DIFF
--- a/cmd/libasciidoc/root_cmd.go
+++ b/cmd/libasciidoc/root_cmd.go
@@ -45,7 +45,7 @@ If more than 1 file is specified, then output is written to ".html" file alongsi
 						log.Debugf("Starting to process file %v", path)
 						_, e := libasciidoc.ConvertFileToHTML(context.Background(), source, out, renderer.IncludeHeaderFooter(!noHeaderFooter)) //renderer.IncludeHeaderFooter(true)
 						if e != nil {
-							log.Errorf("error while rendering file ", err)
+							log.Errorf("error while rendering file: %v ", e)
 							err = e
 						}
 					}

--- a/libasciidoc.go
+++ b/libasciidoc.go
@@ -55,7 +55,7 @@ func ConvertToHTML(ctx context.Context, r io.Reader, output io.Writer, options .
 	log.Infof("parsing stats:")
 	log.Infof("- parsing duration:                %v", duration)
 	log.Infof("- expressions processed:           %v", stats.ExprCnt)
-	log.Infof("- choice expressions alternatives:\n%s", string(b))
+	log.Debugf("- choice expressions alternatives:\n%s", string(b)) // only displayed in debug level, i.e, not always
 	return convertToHTML(ctx, doc, output, options...)
 }
 

--- a/pkg/renderer/context.go
+++ b/pkg/renderer/context.go
@@ -114,6 +114,22 @@ func (ctx *Context) GetAndIncrementTableCounter() int {
 	return 1
 }
 
+const imagesdir = "imagesdir"
+
+// GetImagesDir returns the value of the `imagesdir` attribute if it was set (as a string), empty string otherwise
+func (ctx *Context) GetImagesDir() string {
+	if v := ctx.Document.Attributes[imagesdir]; v != nil {
+		if v, ok := v.(string); ok {
+			return v
+		}
+	}
+	return ""
+}
+
+// -----------------------
+// context.Context methods
+// -----------------------
+
 // Deadline wrapper implementation of context.Context.Deadline()
 func (ctx *Context) Deadline() (deadline time.Time, ok bool) {
 	return ctx.context.Deadline()

--- a/pkg/renderer/html5/image_test.go
+++ b/pkg/renderer/html5/image_test.go
@@ -2,8 +2,9 @@ package html5_test
 
 import . "github.com/onsi/ginkgo"
 
-var _ = Describe("Images", func() {
-	Context("block Images", func() {
+var _ = Describe("images", func() {
+
+	Context("block images", func() {
 
 		It("block image alone", func() {
 
@@ -48,10 +49,12 @@ var _ = Describe("Images", func() {
 </div>`
 			verify(GinkgoT(), expectedResult, actualContent)
 		})
+
 	})
 
-	Context("inline Images", func() {
-		Context("valid Inline Images", func() {
+	Context("inline images", func() {
+
+		Context("valid inline Images", func() {
 
 			It("inline image alone", func() {
 				actualContent := "image:foo.png[]"
@@ -95,6 +98,77 @@ var _ = Describe("Images", func() {
 </div>`
 				verify(GinkgoT(), expectedResult, actualContent)
 			})
+		})
+	})
+
+	Context("imagesdir", func() {
+
+		It("block image with relative location", func() {
+
+			actualContent := `:imagesdir: ./assets
+image::foo.png[]`
+			expectedResult := `<div class="imageblock">
+<div class="content">
+<img src="./assets/foo.png" alt="foo">
+</div>
+</div>`
+			verify(GinkgoT(), expectedResult, actualContent)
+		})
+
+		It("2 block images with relative locations and imagedir changed in-between", func() {
+
+			actualContent := `:imagesdir: ./assets1
+image::foo.png[]
+
+:imagesdir: ./assets2
+image::bar.png[]`
+			expectedResult := `<div class="imageblock">
+<div class="content">
+<img src="./assets1/foo.png" alt="foo">
+</div>
+</div>
+<div class="imageblock">
+<div class="content">
+<img src="./assets2/bar.png" alt="bar">
+</div>
+</div>`
+			verify(GinkgoT(), expectedResult, actualContent)
+		})
+
+		It("block image with absolute URL", func() {
+
+			actualContent := `:imagesdir: ./assets
+image::https://example.com/foo.png[]`
+			expectedResult := `<div class="imageblock">
+<div class="content">
+<img src="https://example.com/foo.png" alt="foo">
+</div>
+</div>`
+			verify(GinkgoT(), expectedResult, actualContent)
+		})
+
+		It("block image with absolute filepath", func() {
+
+			actualContent := `:imagesdir: ./assets
+image::/bar/foo.png[]`
+			expectedResult := `<div class="imageblock">
+<div class="content">
+<img src="/bar/foo.png" alt="foo">
+</div>
+</div>`
+			verify(GinkgoT(), expectedResult, actualContent)
+		})
+
+		It("block image with absolute file scheme and path", func() {
+
+			actualContent := `:imagesdir: ./assets
+image::file:///bar/foo.png[]`
+			expectedResult := `<div class="imageblock">
+<div class="content">
+<img src="file:///bar/foo.png" alt="foo">
+</div>
+</div>`
+			verify(GinkgoT(), expectedResult, actualContent)
 		})
 	})
 })


### PR DESCRIPTION
`imagesdir` attribute is used if the image path is
relative. If it's a valid URL or an absolute path
on the FS, it's not used.

Fixes #160

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>