### PR TITLE
fix(parser): incorrect default image alt

### DIFF
--- a/pkg/parser/image_test.go
+++ b/pkg/parser/image_test.go
@@ -83,7 +83,7 @@ var _ = Describe("images", func() {
 			})
 
 			It("block image with alt", func() {
-				actualContent := "image::images/foo.png[the foo.png image]"
+				actualContent := `image::images/foo.png[the foo.png image]`
 				expectedResult := types.BlockImage{
 					Attributes: types.ElementAttributes{
 						types.AttrImageAlt:    "the foo.png image",
@@ -96,10 +96,10 @@ var _ = Describe("images", func() {
 			})
 
 			It("block image with dimensions and id link title meta", func() {
-				actualContent := "[#img-foobar]\n" +
-					".A title to foobar\n" +
-					"[link=http://foo.bar]\n" +
-					"image::images/foo.png[the foo.png image, 600, 400]"
+				actualContent := `[#img-foobar]
+.A title to foobar
+[link=http://foo.bar]
+image::images/foo.png[the foo.png image, 600, 400]`
 				expectedResult := types.BlockImage{
 					Attributes: types.ElementAttributes{
 						types.AttrID:          "img-foobar",
@@ -112,6 +112,36 @@ var _ = Describe("images", func() {
 					Path: "images/foo.png",
 				}
 				verify(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
+			})
+
+			It("2 block images", func() {
+				actualContent := `image::app.png[]
+image::appa.png[]`
+				expectedResult := types.Document{
+					Attributes:         types.DocumentAttributes{},
+					ElementReferences:  types.ElementReferences{},
+					Footnotes:          types.Footnotes{},
+					FootnoteReferences: types.FootnoteReferences{},
+					Elements: []interface{}{
+						types.BlockImage{
+							Attributes: types.ElementAttributes{
+								types.AttrImageAlt:    "app",
+								types.AttrImageWidth:  "",
+								types.AttrImageHeight: "",
+							},
+							Path: "app.png",
+						},
+						types.BlockImage{
+							Attributes: types.ElementAttributes{
+								types.AttrImageAlt:    "appa",
+								types.AttrImageWidth:  "",
+								types.AttrImageHeight: "",
+							},
+							Path: "appa.png",
+						},
+					},
+				}
+				verify(GinkgoT(), expectedResult, actualContent)
 			})
 		})
 

--- a/pkg/renderer/html5/image_test.go
+++ b/pkg/renderer/html5/image_test.go
@@ -78,6 +78,22 @@ image::foo.png[foo image, 600, 400]`
 			verify(GinkgoT(), expectedResult, actualContent)
 		})
 
+		It("2 block images", func() {
+			actualContent := `image::app.png[]
+image::appa.png[]`
+			expectedResult := `<div class="imageblock">
+<div class="content">
+<img src="app.png" alt="app">
+</div>
+</div>
+<div class="imageblock">
+<div class="content">
+<img src="appa.png" alt="appa">
+</div>
+</div>`
+			verify(GinkgoT(), expectedResult, actualContent)
+		})
+
 	})
 
 	Context("inline images", func() {
@@ -85,9 +101,9 @@ image::foo.png[foo image, 600, 400]`
 		Context("valid inline Images", func() {
 
 			It("inline image alone", func() {
-				actualContent := "image:foo.png[]"
+				actualContent := "image:app.png[]"
 				expectedResult := `<div class="paragraph">
-<p><span class="image"><img src="foo.png" alt="foo"></span></p>
+<p><span class="image"><img src="app.png" alt="app"></span></p>
 </div>`
 				verify(GinkgoT(), expectedResult, actualContent)
 			})

--- a/pkg/types/grammar_types.go
+++ b/pkg/types/grammar_types.go
@@ -1640,10 +1640,10 @@ func NewBlockImage(path string, inlineAttributes ElementAttributes) (BlockImage,
 	}
 	if alt, found := allAttributes[AttrImageAlt]; !found || alt == "" {
 		_, filename := filepath.Split(path)
-		log.Debugf("adding alt based on filename '%s'", filename)
 		ext := filepath.Ext(filename)
+		log.Debugf("adding alt based on filename '%s' (ext=%s)", filename, ext)
 		if ext != "" {
-			allAttributes[AttrImageAlt] = strings.TrimRight(filename, fmt.Sprintf(".%s", ext))
+			allAttributes[AttrImageAlt] = strings.TrimSuffix(filename, ext)
 		} else {
 			allAttributes[AttrImageAlt] = filename
 		}
@@ -1672,7 +1672,7 @@ func NewInlineImage(path string, attributes ElementAttributes) (InlineImage, err
 		log.Debugf("adding alt based on filename '%s'", filename)
 		ext := filepath.Ext(filename)
 		if ext != "" {
-			attributes[AttrImageAlt] = strings.TrimRight(filename, fmt.Sprintf(".%s", ext))
+			attributes[AttrImageAlt] = strings.TrimSuffix(filename, ext)
 		} else {
 			attributes[AttrImageAlt] = filename
 		}
@@ -1703,7 +1703,7 @@ func NewImageMacro(path string, attributes ElementAttributes) (ImageMacro, error
 		log.Debugf("adding alt based on filename '%s'", filename)
 		ext := filepath.Ext(filename)
 		if ext != "" {
-			attributes[AttrImageAlt] = strings.TrimRight(filename, fmt.Sprintf(".%s", ext))
+			attributes[AttrImageAlt] = strings.TrimSuffix(filename, ext)
 		} else {
 			attributes[AttrImageAlt] = filename
 		}


### PR DESCRIPTION
wrong usage of `string.TrimRight` instead
of `strings.TrimSuffix`. Fix applied for
image blocks and inline images as well.

fixes #198

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>