### PR TITLE
fix(parser/renderer): unique section id

### DIFF
--- a/pkg/parser/section_test.go
+++ b/pkg/parser/section_test.go
@@ -603,6 +603,53 @@ a paragraph`
 			}
 			verify(GinkgoT(), expectedResult, actualContent)
 		})
+
+		It("sections with same title", func() {
+			actualContent := `== section 1
+
+== section 1`
+			section1aTitle := types.SectionTitle{
+				Attributes: types.ElementAttributes{
+					types.AttrID: "_section_1",
+				},
+				Elements: types.InlineElements{
+					types.StringElement{Content: "section 1"},
+				},
+			}
+			section1bTitle := types.SectionTitle{
+				Attributes: types.ElementAttributes{
+					types.AttrID: "_section_1_2",
+				},
+				Elements: types.InlineElements{
+					types.StringElement{Content: "section 1"},
+				},
+			}
+
+			expectedResult := types.Document{
+				Attributes: types.DocumentAttributes{},
+				ElementReferences: map[string]interface{}{
+					"_section_1":   section1aTitle,
+					"_section_1_2": section1bTitle,
+				},
+				Footnotes:          types.Footnotes{},
+				FootnoteReferences: types.FootnoteReferences{},
+				Elements: []interface{}{
+					types.Section{
+						Level: 1,
+						Title: section1aTitle,
+						Elements: []interface{}{
+							types.BlankLine{},
+						},
+					},
+					types.Section{
+						Level:    1,
+						Title:    section1bTitle,
+						Elements: []interface{}{},
+					},
+				},
+			}
+			verify(GinkgoT(), expectedResult, actualContent)
+		})
 	})
 
 	Context("invalid sections", func() {

--- a/pkg/renderer/html5/section_test.go
+++ b/pkg/renderer/html5/section_test.go
@@ -64,6 +64,23 @@ var _ = Describe("sections", func() {
 </div>`
 			verify(GinkgoT(), expectedResult, actualContent)
 		})
+
+		It("sections with same title", func() {
+			actualContent := `== section 1
+
+== section 1`
+			expectedResult := `<div class="sect1">
+<h2 id="_section_1">section 1</h2>
+<div class="sectionbody">
+</div>
+</div>
+<div class="sect1">
+<h2 id="_section_1_2">section 1</h2>
+<div class="sectionbody">
+</div>
+</div>`
+			verify(GinkgoT(), expectedResult, actualContent)
+		})
 	})
 
 	Context("section with elements", func() {

--- a/pkg/types/document_xrefs.go
+++ b/pkg/types/document_xrefs.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	"fmt"
+
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
@@ -26,8 +28,22 @@ func (c *ElementReferencesCollector) Visit(element Visitable) error {
 	case Section:
 		elementID := e.Title.Attributes[AttrID]
 		if elementID, ok := elementID.(string); ok {
-			log.Debugf("Adding element reference: %v", elementID)
-			c.ElementReferences[elementID] = e.Title
+			for i := 1; ; i++ {
+				var key string
+				if i == 1 {
+					key = elementID
+				} else {
+					key = fmt.Sprintf("%s_%d", elementID, i)
+				}
+				if _, found := c.ElementReferences[key]; !found {
+					log.Debugf("Adding element reference: %v", key)
+					c.ElementReferences[key] = e.Title
+					// override the element id
+					e.Title.Attributes[AttrID] = key
+					break
+				}
+
+			}
 		} else {
 			return errors.Errorf("unexpected type of element id: %T", elementID)
 		}


### PR DESCRIPTION
change section id when collecting references, if
another section (or element) with the same id already
exists and was referenced.

fixes #184

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>