### PR TITLE
test(fixtures): add fixtures testing framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,7 +57,7 @@ tmp
 
 # exclude code coverage merged results
 coverage.txt
-*.html
 .DS_Store
 *.html
 *.test
+!test/**

--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ generate-optimized:
 
 
 .PHONY: test
-## run all tests except in the 'vendor' package
+## run all tests excluding fixtures and vendored packages
 test: deps generate-optimized
 	@echo $(COVERPKGS)
 	@ginkgo -r --randomizeAllSpecs --randomizeSuites --failOnPending --trace --race --compilers=2  --cover -coverpkg $(COVERPKGS)

--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,11 @@ test: deps generate-optimized
 	@echo $(COVERPKGS)
 	@ginkgo -r --randomizeAllSpecs --randomizeSuites --failOnPending --trace --race --compilers=2  --cover -coverpkg $(COVERPKGS)
 
+.PHONY: test-fixtures
+## run all fixtures tests
+test-fixtures: deps generate-optimized
+	@ginkgo -r --randomizeAllSpecs --randomizeSuites --failOnPending --trace --race --compilers=2 -tags=fixtures --focus=fixtures
+
 .PHONY: build
 ## build the binary executable from CLI
 build: $(INSTALL_PREFIX) deps generate-optimized

--- a/fixtures_test.go
+++ b/fixtures_test.go
@@ -1,0 +1,61 @@
+// +build fixtures
+
+package libasciidoc_test
+
+import (
+	"bytes"
+	"context"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/bytesparadise/libasciidoc"
+	. "github.com/onsi/ginkgo"
+	"github.com/pmezard/go-difflib/difflib"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const adocExt = ".adoc"
+
+var _ = Describe("fixtures", func() {
+	matches, err := filepath.Glob("test/fixtures/*" + adocExt)
+	require.NoError(GinkgoT(), err)
+
+	for _, input := range matches {
+		Context("["+input+"]", func() {
+			in := input
+			It("render HTML", func() {
+				verifyHTMLFixture(GinkgoT(), in)
+			})
+		})
+	}
+})
+
+func verifyHTMLFixture(t GinkgoTInterface, sourcePath string) {
+	w := bytes.NewBuffer(nil)
+	f, err := os.Open(sourcePath)
+	require.NoError(t, err)
+
+	_, err = libasciidoc.ConvertToHTML(context.Background(), f, w)
+	require.NoError(t, err)
+	result := w.String()
+
+	goldPath := sourcePath[:len(sourcePath)-len(adocExt)] + ".html"
+	b, err := ioutil.ReadFile(goldPath)
+	require.NoError(t, err)
+	expect := string(b)
+
+	assert.Equal(t, expect, result, showDiff(goldPath, expect, result))
+}
+
+func showDiff(name, expect, actual string) string {
+	d, _ := difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
+		A:        difflib.SplitLines(expect),
+		B:        difflib.SplitLines(actual),
+		FromFile: "expect (" + name + ")",
+		ToFile:   "actual",
+		Context:  1,
+	})
+	return d
+}

--- a/test/fixtures/basic.adoc
+++ b/test/fixtures/basic.adoc
@@ -1,0 +1,12 @@
+= Introduction to AsciiDoc
+Doc Writer <doc@example.com>
+
+A preface about https://asciidoc.org[AsciiDoc].
+
+== First Section
+
+* item 1
+* item 2
+
+[source,ruby]
+puts "Hello, World!"

--- a/test/fixtures/basic.html
+++ b/test/fixtures/basic.html
@@ -1,0 +1,27 @@
+<div id="preamble">
+<div class="sectionbody">
+<div class="paragraph">
+<p>A preface about <a href="https://asciidoc.org">AsciiDoc</a>.</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_first_section">First Section</h2>
+<div class="sectionbody">
+<div class="ulist">
+<ul>
+<li>
+<p>item 1</p>
+</li>
+<li>
+<p>item 2</p>
+</li>
+</ul>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-ruby" data-lang="ruby">puts "Hello, World!"</code></pre>
+</div>
+</div>
+</div>
+</div>

--- a/test/fixtures/encoding.adoc
+++ b/test/fixtures/encoding.adoc
@@ -1,0 +1,13 @@
+Gregory Romé has written an AsciiDoc plugin for the Redmine project management application.
+
+https://github.com/foo-users/foo
+へと `vicmd` キーマップを足してみている試み、
+アニメーションgifです。
+
+tag::romé[]
+Gregory Romé has written an AsciiDoc plugin for the Redmine project management application.
+end::romé[]
+
+== Überschrift
+
+* Codierungen sind verrückt auf älteren Versionen von Ruby

--- a/test/fixtures/encoding.html
+++ b/test/fixtures/encoding.html
@@ -1,0 +1,25 @@
+<div class="paragraph">
+<p>Gregory Romé has written an AsciiDoc plugin for the Redmine project management application.</p>
+</div>
+<div class="paragraph">
+<p><a href="https://github.com/foo-users/foo" class="bare">https://github.com/foo-users/foo</a>
+へと <code>vicmd</code> キーマップを足してみている試み、
+アニメーションgifです。</p>
+</div>
+<div class="paragraph">
+<p>tag::romé[]
+Gregory Romé has written an AsciiDoc plugin for the Redmine project management application.
+end::romé[]</p>
+</div>
+<div class="sect1">
+<h2 id="_überschrift">Überschrift</h2>
+<div class="sectionbody">
+<div class="ulist">
+<ul>
+<li>
+<p>Codierungen sind verrückt auf älteren Versionen von Ruby</p>
+</li>
+</ul>
+</div>
+</div>
+</div>

--- a/test/fixtures/exline-mono.adoc
+++ b/test/fixtures/exline-mono.adoc
@@ -1,0 +1,3 @@
+:encoding: UTF-8
+
+The document is assumed to be encoded as `{encoding}`.

--- a/test/fixtures/exline-mono.html
+++ b/test/fixtures/exline-mono.html
@@ -1,0 +1,3 @@
+<div class="paragraph">
+<p>The document is assumed to be encoded as <code>UTF-8</code>.</p>
+</div>

--- a/test/fixtures/includes/chapter-a.adoc
+++ b/test/fixtures/includes/chapter-a.adoc
@@ -1,0 +1,3 @@
+= Chapter A
+
+content

--- a/test/fixtures/includes/child-include.adoc
+++ b/test/fixtures/includes/child-include.adoc
@@ -1,0 +1,5 @@
+first line of child
+
+include::grandchild-include.adoc[]
+
+last line of child

--- a/test/fixtures/includes/grandchild-include.adoc
+++ b/test/fixtures/includes/grandchild-include.adoc
@@ -1,0 +1,3 @@
+first line of grandchild
+
+last line of grandchild

--- a/test/fixtures/lists.adoc
+++ b/test/fixtures/lists.adoc
@@ -1,0 +1,96 @@
+= Document Title
+Doc Writer <thedoc@asciidoctor.org>
+
+Preamble paragraph.
+
+NOTE: This is test, only a test.
+
+== Lists
+
+.Unordered, basic
+* Edgar Allen Poe
+* Sheri S. Tepper
+* Bill Bryson
+
+.Unordered, max nesting
+* level 1
+** level 2
+*** level 3
+**** level 4
+***** level 5
+* level 1
+
+.Checklist
+- [*] checked
+- [x] also checked
+- [ ] not checked
+-     normal list item
+
+.Ordered, basic
+. Step 1
+. Step 2
+. Step 3
+
+.Ordered, nested
+. Step 1
+. Step 2
+.. Step 2a
+.. Step 2b
+. Step 3
+
+.Ordered, max nesting
+. level 1
+.. level 2
+... level 3
+.... level 4
+..... level 5
+. level 1
+
+.Labeled, single-line
+first term:: definition of first term
+section term:: definition of second term
+
+.Labeled, multi-line
+first term::
+definition of first term
+second term::
+definition of second term
+
+.Q&A
+[qanda]
+What is Asciidoctor?::
+  An implementation of the AsciiDoc processor in Ruby.
+What is the answer to the Ultimate Question?:: 42
+
+.Mixed
+Operating Systems::
+  Linux:::
+    . Fedora
+      * Desktop
+    . Ubuntu
+      * Desktop
+      * Server
+  BSD:::
+    . FreeBSD
+    . NetBSD
+
+Cloud Providers::
+  PaaS:::
+    . OpenShift
+    . CloudBees
+  IaaS:::
+    . Amazon EC2
+    . Rackspace
+
+.Unordered, complex
+* level 1
+** level 2
+*** level 3
+This is a new line inside an unordered list using {plus} symbol.
+We can even force content to start on a separate line... +
+Amazing, isn't it?
+**** level 4
++
+The {plus} symbol is on a new line.
+
+***** level 5

--- a/test/fixtures/lists.html
+++ b/test/fixtures/lists.html
@@ -1,0 +1,340 @@
+<div id="preamble">
+<div class="sectionbody">
+<div class="paragraph">
+<p>Preamble paragraph.</p>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+This is test, only a test.
+</td>
+</tr>
+</table>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_lists">Lists</h2>
+<div class="sectionbody">
+<div class="ulist">
+<div class="title">Unordered, basic</div>
+<ul>
+<li>
+<p>Edgar Allen Poe</p>
+</li>
+<li>
+<p>Sheri S. Tepper</p>
+</li>
+<li>
+<p>Bill Bryson</p>
+</li>
+</ul>
+</div>
+<div class="ulist">
+<div class="title">Unordered, max nesting</div>
+<ul>
+<li>
+<p>level 1</p>
+<div class="ulist">
+<ul>
+<li>
+<p>level 2</p>
+<div class="ulist">
+<ul>
+<li>
+<p>level 3</p>
+<div class="ulist">
+<ul>
+<li>
+<p>level 4</p>
+<div class="ulist">
+<ul>
+<li>
+<p>level 5</p>
+</li>
+</ul>
+</div>
+</li>
+</ul>
+</div>
+</li>
+</ul>
+</div>
+</li>
+</ul>
+</div>
+</li>
+<li>
+<p>level 1</p>
+</li>
+</ul>
+</div>
+<div class="ulist checklist">
+<div class="title">Checklist</div>
+<ul class="checklist">
+<li>
+<p>&#10003; checked</p>
+</li>
+<li>
+<p>&#10003; also checked</p>
+</li>
+<li>
+<p>&#10063; not checked</p>
+</li>
+<li>
+<p>normal list item</p>
+</li>
+</ul>
+</div>
+<div class="olist arabic">
+<div class="title">Ordered, basic</div>
+<ol class="arabic">
+<li>
+<p>Step 1</p>
+</li>
+<li>
+<p>Step 2</p>
+</li>
+<li>
+<p>Step 3</p>
+</li>
+</ol>
+</div>
+<div class="olist arabic">
+<div class="title">Ordered, nested</div>
+<ol class="arabic">
+<li>
+<p>Step 1</p>
+</li>
+<li>
+<p>Step 2</p>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p>Step 2a</p>
+</li>
+<li>
+<p>Step 2b</p>
+</li>
+</ol>
+</div>
+</li>
+<li>
+<p>Step 3</p>
+</li>
+</ol>
+</div>
+<div class="olist arabic">
+<div class="title">Ordered, max nesting</div>
+<ol class="arabic">
+<li>
+<p>level 1</p>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p>level 2</p>
+<div class="olist lowerroman">
+<ol class="lowerroman" type="i">
+<li>
+<p>level 3</p>
+<div class="olist upperalpha">
+<ol class="upperalpha" type="A">
+<li>
+<p>level 4</p>
+<div class="olist upperroman">
+<ol class="upperroman" type="I">
+<li>
+<p>level 5</p>
+</li>
+</ol>
+</div>
+</li>
+</ol>
+</div>
+</li>
+</ol>
+</div>
+</li>
+</ol>
+</div>
+</li>
+<li>
+<p>level 1</p>
+</li>
+</ol>
+</div>
+<div class="dlist">
+<div class="title">Labeled, single-line</div>
+<dl>
+<dt class="hdlist1">first term</dt>
+<dd>
+<p>definition of first term</p>
+</dd>
+<dt class="hdlist1">section term</dt>
+<dd>
+<p>definition of second term</p>
+</dd>
+</dl>
+</div>
+<div class="dlist">
+<div class="title">Labeled, multi-line</div>
+<dl>
+<dt class="hdlist1">first term</dt>
+<dd>
+<p>definition of first term</p>
+</dd>
+<dt class="hdlist1">second term</dt>
+<dd>
+<p>definition of second term</p>
+</dd>
+</dl>
+</div>
+<div class="qlist qanda">
+<div class="title">Q&amp;A</div>
+<ol>
+<li>
+<p><em>What is Asciidoctor?</em></p>
+<p>An implementation of the AsciiDoc processor in Ruby.</p>
+</li>
+<li>
+<p><em>What is the answer to the Ultimate Question?</em></p>
+<p>42</p>
+</li>
+</ol>
+</div>
+<div class="dlist">
+<div class="title">Mixed</div>
+<dl>
+<dt class="hdlist1">Operating Systems</dt>
+<dd>
+<div class="dlist">
+<dl>
+<dt class="hdlist1">Linux</dt>
+<dd>
+<div class="olist arabic">
+<ol class="arabic">
+<li>
+<p>Fedora</p>
+<div class="ulist">
+<ul>
+<li>
+<p>Desktop</p>
+</li>
+</ul>
+</div>
+</li>
+<li>
+<p>Ubuntu</p>
+<div class="ulist">
+<ul>
+<li>
+<p>Desktop</p>
+</li>
+<li>
+<p>Server</p>
+</li>
+</ul>
+</div>
+</li>
+</ol>
+</div>
+</dd>
+<dt class="hdlist1">BSD</dt>
+<dd>
+<div class="olist arabic">
+<ol class="arabic">
+<li>
+<p>FreeBSD</p>
+</li>
+<li>
+<p>NetBSD</p>
+</li>
+</ol>
+</div>
+</dd>
+</dl>
+</div>
+</dd>
+<dt class="hdlist1">Cloud Providers</dt>
+<dd>
+<div class="dlist">
+<dl>
+<dt class="hdlist1">PaaS</dt>
+<dd>
+<div class="olist arabic">
+<ol class="arabic">
+<li>
+<p>OpenShift</p>
+</li>
+<li>
+<p>CloudBees</p>
+</li>
+</ol>
+</div>
+</dd>
+<dt class="hdlist1">IaaS</dt>
+<dd>
+<div class="olist arabic">
+<ol class="arabic">
+<li>
+<p>Amazon EC2</p>
+</li>
+<li>
+<p>Rackspace</p>
+</li>
+</ol>
+</div>
+</dd>
+</dl>
+</div>
+</dd>
+</dl>
+</div>
+<div class="ulist">
+<div class="title">Unordered, complex</div>
+<ul>
+<li>
+<p>level 1</p>
+<div class="ulist">
+<ul>
+<li>
+<p>level 2</p>
+<div class="ulist">
+<ul>
+<li>
+<p>level 3
+This is a new line inside an unordered list using &#43; symbol.
+We can even force content to start on a separate line&#8230;&#8203;<br>
+Amazing, isn&#8217;t it?</p>
+<div class="ulist">
+<ul>
+<li>
+<p>level 4</p>
+<div class="paragraph">
+<p>The &#43; symbol is on a new line.</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>level 5</p>
+</li>
+</ul>
+</div>
+</li>
+</ul>
+</div>
+</li>
+</ul>
+</div>
+</li>
+</ul>
+</div>
+</li>
+</ul>
+</div>
+</div>
+</div>

--- a/test/fixtures/master.adoc
+++ b/test/fixtures/master.adoc
@@ -1,0 +1,5 @@
+= Master Document
+
+preamble
+
+include::includes/chapter-a.adoc[leveloffset=+1]

--- a/test/fixtures/master.html
+++ b/test/fixtures/master.html
@@ -1,0 +1,15 @@
+<div id="preamble">
+<div class="sectionbody">
+<div class="paragraph">
+<p>preamble</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_chapter_a">Chapter A</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>content</p>
+</div>
+</div>
+</div>

--- a/test/fixtures/parent-include.adoc
+++ b/test/fixtures/parent-include.adoc
@@ -1,0 +1,5 @@
+first line of parent
+
+include::includes/child-include.adoc[]
+
+last line of parent

--- a/test/fixtures/parent-include.html
+++ b/test/fixtures/parent-include.html
@@ -1,0 +1,18 @@
+<div class="paragraph">
+<p>first line of parent</p>
+</div>
+<div class="paragraph">
+<p>first line of child</p>
+</div>
+<div class="paragraph">
+<p>first line of grandchild</p>
+</div>
+<div class="paragraph">
+<p>last line of grandchild</p>
+</div>
+<div class="paragraph">
+<p>last line of child</p>
+</div>
+<div class="paragraph">
+<p>last line of parent</p>
+</div>

--- a/test/fixtures/sample.adoc
+++ b/test/fixtures/sample.adoc
@@ -1,0 +1,30 @@
+Document Title
+==============
+Doc Writer <thedoc@asciidoctor.org>
+:idprefix: id_
+
+Preamble paragraph.
+
+NOTE: This is test, only a test.
+
+== Section A
+
+*Section A* paragraph.
+
+=== Section A Subsection
+
+*Section A* 'subsection' paragraph.
+
+== Section B
+
+*Section B* paragraph.
+
+|===
+|a |b |c
+|1 |2 |3
+|===
+
+.Section B list
+* Item 1
+* Item 2
+* Item 3

--- a/test/fixtures/sample.html
+++ b/test/fixtures/sample.html
@@ -1,0 +1,74 @@
+<div id="preamble">
+<div class="sectionbody">
+<div class="paragraph">
+<p>Preamble paragraph.</p>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+This is test, only a test.
+</td>
+</tr>
+</table>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="id_section_a">Section A</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p><strong>Section A</strong> paragraph.</p>
+</div>
+<div class="sect2">
+<h3 id="id_section_a_subsection">Section A Subsection</h3>
+<div class="paragraph">
+<p><strong>Section A</strong> <em>subsection</em> paragraph.</p>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="id_section_b">Section B</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p><strong>Section B</strong> paragraph.</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">a</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">b</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">c</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">3</p></td>
+</tr>
+</tbody>
+</table>
+<div class="ulist">
+<div class="title">Section B list</div>
+<ul>
+<li>
+<p>Item 1</p>
+</li>
+<li>
+<p>Item 2</p>
+</li>
+<li>
+<p>Item 3</p>
+</li>
+</ul>
+</div>
+</div>
+</div>

--- a/test/fixtures/sscript.adoc
+++ b/test/fixtures/sscript.adoc
@@ -1,0 +1,5 @@
+_v_~rocket~ is the value
+^3^He is the isotope
+log~4~x^n^ is the expression
+M^me^ White is the address
+the 10^th^ point has coordinate (x~10~, y~10~)

--- a/test/fixtures/sscript.html
+++ b/test/fixtures/sscript.html
@@ -1,0 +1,7 @@
+<div class="paragraph">
+<p><em>v</em><sub>rocket</sub> is the value
+<sup>3</sup>He is the isotope
+log<sub>4</sub>x<sup>n</sup> is the expression
+M<sup>me</sup> White is the address
+the 10<sup>th</sup> point has coordinate (x<sub>10</sub>, y<sub>10</sub>)</p>
+</div>


### PR DESCRIPTION
Create a basic framework for adding test fixtures. The workflow is to
add .adoc files to the fixtures folder with corresponding .html files to
act as the "golden" HTML output. Include files are in the includes
sub-folder so as to differentiate them from the main fixture files.

Failed tests show a diff against the golden output.

Tests are currently hidden behind a "fixtures" build tag. Use
"-tags=fixtures" when running tests to activate.

The existing test fixtures are mostly taken from the asciidoctor test
fixtures. The golden files were generated with asciidoctor v1.5.7.1
using the "-s" option.

Updates #79