### PR TITLE
fix(cli): command hangs when no arg is provided

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,12 @@ test: deps generate-optimized
 	@echo $(COVERPKGS)
 	@ginkgo -r --randomizeAllSpecs --randomizeSuites --failOnPending --trace --race --compilers=2  --cover -coverpkg $(COVERPKGS)
 
+.PHONY: test-no-coverage
+## run all tests excluding fixtures and vendored packages, without coverage
+test-no-coverage: deps generate-optimized
+	@echo $(COVERPKGS)
+	@ginkgo -r --randomizeAllSpecs --randomizeSuites --failOnPending --trace --race --compilers=2
+
 .PHONY: test-fixtures
 ## run all fixtures tests
 test-fixtures: deps generate-optimized

--- a/cmd/libasciidoc/root_cmd_test.go
+++ b/cmd/libasciidoc/root_cmd_test.go
@@ -3,9 +3,6 @@ package main_test
 import (
 	"bytes"
 	"io/ioutil"
-	"log"
-	"os"
-	"testing"
 
 	main "github.com/bytesparadise/libasciidoc/cmd/libasciidoc"
 	"github.com/stretchr/testify/require"
@@ -72,40 +69,11 @@ var _ = Describe("root cmd", func() {
 		Expect(buf.String()).ToNot(ContainSubstring(`<div id="footer">`))
 	})
 
-	It("process stdin", func() {
+	It("render multiple files", func() {
 		// given
 		root := main.NewRootCmd()
 		buf := new(bytes.Buffer)
 		root.SetOutput(buf)
-		content := "some content"
-		tmpfile, err := ioutil.TempFile("", "example")
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		defer os.Remove(tmpfile.Name()) // clean up
-
-		if _, err := tmpfile.Write([]byte(content)); err != nil {
-			log.Fatal(err)
-		}
-		_, err = tmpfile.Seek(0, 0)
-		require.NoError(GinkgoT(), err)
-		oldstdin := os.Stdin
-		os.Stdin = tmpfile
-		defer func() { os.Stdin = oldstdin }()
-		root.SetArgs([]string{})
-		// when
-		err = root.Execute()
-		//then
-		GinkgoT().Logf("command output: %v", buf.String())
-		Expect(buf.String()).To(ContainSubstring(content))
-		require.NoError(GinkgoT(), err)
-		require.NotEmpty(GinkgoT(), buf)
-	})
-
-	It("render multiple files", func() {
-		// given
-		root := main.NewRootCmd()
 		root.SetArgs([]string{"-s", "test/admonition.adoc", "test/test.adoc"})
 		// when
 		err := root.Execute()
@@ -116,14 +84,24 @@ var _ = Describe("root cmd", func() {
 	It("when rendering multiple files, return last error", func() {
 		// given
 		root := main.NewRootCmd()
+		buf := new(bytes.Buffer)
+		root.SetOutput(buf)
 		root.SetArgs([]string{"-s", "test/doesnotexist.adoc", "test/test.adoc"})
 		// when
 		err := root.Execute()
 		// then
 		require.Error(GinkgoT(), err)
 	})
+
+	It("show help when executed with no arg", func() {
+		// given
+		root := main.NewRootCmd()
+		buf := new(bytes.Buffer)
+		root.SetOutput(buf)
+		root.SetArgs([]string{})
+		// when
+		err := root.Execute()
+		// then
+		require.NoError(GinkgoT(), err)
+	})
 })
-
-func TestRootCommand(t *testing.T) {
-
-}

--- a/cmd/libasciidoc/version_cmd.go
+++ b/cmd/libasciidoc/version_cmd.go
@@ -11,7 +11,7 @@ import (
 func NewVersionCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "version",
-		Short: "Print the version number of libasciidoc",
+		Short: "Print the version and build info",
 		Run: func(cmd *cobra.Command, args []string) {
 			if libasciidoc.BuildTag != "" {
 				fmt.Fprintf(cmd.OutOrStdout(), "tag:        %s\n", libasciidoc.BuildTag)


### PR DESCRIPTION
also, make sure output is written in the command output,
not always the console (which avoids unnecessary logs
in the console during tests)
also, avoid duplicate error messages when file to process
is not found

also, add a goal to run tests without coverage

fixes #236

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>