### PR TITLE
feat(renderer): support 'start' attribute when rendering an ordered list

### DIFF
--- a/pkg/renderer/html5/ordered_list.go
+++ b/pkg/renderer/html5/ordered_list.go
@@ -17,7 +17,7 @@ func init() {
 	orderedListTmpl = newTextTemplate("ordered list",
 		`{{ $ctx := .Context }}{{ with .Data }}{{ $items := .Items }}{{ $firstItem := index $items 0 }}<div{{ if .ID }} id="{{ .ID }}"{{ end }} class="olist {{ $firstItem.NumberingStyle }}{{ if .Role }} {{ .Role }}{{ end}}">
 {{ if .Title }}<div class="title">{{ .Title }}</div>
-{{ end }}<ol class="{{ $firstItem.NumberingStyle }}"{{ style $firstItem.NumberingStyle }}>
+{{ end }}<ol class="{{ $firstItem.NumberingStyle }}"{{ style $firstItem.NumberingStyle }}{{ if .Start }} start="{{ .Start }}"{{ end }}>
 {{ range $itemIndex, $item := $items }}<li>
 {{ renderElements $ctx $item.Elements | printf "%s" }}
 </li>
@@ -44,11 +44,13 @@ func renderOrderedList(ctx *renderer.Context, l types.OrderedList) ([]byte, erro
 			ID    string
 			Title string
 			Role  string
+			Start string
 			Items []types.OrderedListItem
 		}{
 			l.Attributes.GetAsString(types.AttrID),
 			l.Attributes.GetAsString(types.AttrTitle),
 			l.Attributes.GetAsString(types.AttrRole),
+			l.Attributes.GetAsString(types.AttrStart),
 			l.Items,
 		},
 	})

--- a/pkg/renderer/html5/ordered_list_test.go
+++ b/pkg/renderer/html5/ordered_list_test.go
@@ -20,6 +20,32 @@ var _ = Describe("ordered lists", func() {
 		verify(GinkgoT(), expectedResult, actualContent)
 	})
 
+	It("ordered list item with explicit start only", func() {
+		actualContent := `[start=5]
+. item`
+		expectedResult := `<div class="olist arabic">
+<ol class="arabic" start="5">
+<li>
+<p>item</p>
+</li>
+</ol>
+</div>`
+		verify(GinkgoT(), expectedResult, actualContent)
+	})
+
+	It("ordered list item with explicit quoted numbering and start", func() {
+		actualContent := `["lowerroman", start="5"]
+. item`
+		expectedResult := `<div class="olist lowerroman">
+<ol class="lowerroman" type="i" start="5">
+<li>
+<p>item</p>
+</li>
+</ol>
+</div>`
+		verify(GinkgoT(), expectedResult, actualContent)
+	})
+
 	It("ordered list with unnumbered items", func() {
 		actualContent := `. item 1
 		.. item 1.1

--- a/pkg/types/element_attributes.go
+++ b/pkg/types/element_attributes.go
@@ -33,6 +33,8 @@ const (
 	AttrLanguage string = "language"
 	// AttrCheckStyle the attribute to mark the first element of an unordered list itemd as a checked or not
 	AttrCheckStyle string = "checkstyle"
+	// AttrStart the "start" attribute in an ordered list
+	AttrStart string = "start"
 )
 
 // ElementWithAttributes an element on which attributes can be added/set


### PR DESCRIPTION
fixes #271

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>