### PR TITLE
feat(renderer): support "Q and A" labeled lists

### DIFF
--- a/pkg/parser/delimited_block_test.go
+++ b/pkg/parser/delimited_block_test.go
@@ -1323,8 +1323,9 @@ end
 			verify(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
 		})
 
-		It("with source and languages attributes", func() {
+		It("with title, source and languages attributes", func() {
 			actualContent := `[source,ruby]
+.Source block title
 ----
 require 'sinatra'
 
@@ -1336,6 +1337,7 @@ end
 				Attributes: types.ElementAttributes{
 					types.AttrKind:     types.Source,
 					types.AttrLanguage: "ruby",
+					types.AttrTitle:    "Source block title",
 				},
 				Kind: types.Source,
 				Elements: []interface{}{

--- a/pkg/parser/list_test.go
+++ b/pkg/parser/list_test.go
@@ -604,6 +604,61 @@ second term:: definition of the second term`
 		})
 	})
 
+	Context("q and a", func() {
+
+		It("q and a with title", func() {
+			actualContent := `.Q&A
+[qanda]
+What is libsciidoc?::
+	An implementation of the AsciiDoc processor in Golang.
+What is the answer to the Ultimate Question?:: 42`
+
+			expectedResult := types.LabeledList{
+				Attributes: types.ElementAttributes{
+					types.AttrTitle: "Q&A",
+					types.AttrQandA:  nil,
+				},
+				Items: []types.LabeledListItem{
+					{
+						Attributes: types.ElementAttributes{},
+						Level:      1,
+						Term:       "What is libsciidoc?",
+						Elements: []interface{}{
+							types.Paragraph{
+								Attributes: types.ElementAttributes{},
+								Lines: []types.InlineElements{
+									{
+										types.StringElement{
+											Content: "An implementation of the AsciiDoc processor in Golang.",
+										},
+									},
+								},
+							},
+						},
+					},
+					{
+						Attributes: types.ElementAttributes{},
+						Level:      1,
+						Term:       "What is the answer to the Ultimate Question?",
+						Elements: []interface{}{
+							types.Paragraph{
+								Attributes: types.ElementAttributes{},
+								Lines: []types.InlineElements{
+									{
+										types.StringElement{
+											Content: "42",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			verify(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
+		})
+	})
+
 	Context("unordered list", func() {
 		Context("ordered list item alone", func() {
 

--- a/pkg/renderer/html5/delimited_block_test.go
+++ b/pkg/renderer/html5/delimited_block_test.go
@@ -92,8 +92,9 @@ end</code></pre>
 			verify(GinkgoT(), expectedResult, actualContent)
 		})
 
-		It("with source and languages attributes", func() {
+		It("with title, source and languages attributes", func() {
 			actualContent := `[source,ruby]
+.Source block title
 ----
 require 'sinatra'
 
@@ -102,6 +103,7 @@ get '/hi' do
 end
 ----`
 			expectedResult := `<div class="listingblock">
+<div class="title">Source block title</div>
 <div class="content">
 <pre class="highlight"><code class="language-ruby" data-lang="ruby">require 'sinatra'
 

--- a/pkg/renderer/html5/document.go
+++ b/pkg/renderer/html5/document.go
@@ -2,6 +2,7 @@ package html5
 
 import (
 	"bytes"
+	"html"
 	htmltemplate "html/template"
 	"io"
 	texttemplate "text/template"
@@ -23,7 +24,7 @@ func init() {
 <!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
 <meta name="viewport" content="width=device-width, initial-scale=1.0">{{ if .Generator }}
 <meta name="generator" content="{{ .Generator }}">{{ end }}
-<title>{{ .Title }}</title>
+<title>{{ escape .Title }}</title>
 </head>
 <body class="article">
 <div id="header">
@@ -40,7 +41,10 @@ Last updated {{ .LastUpdated }}
 </div>
 </div>
 </body>
-</html>`)
+</html>`,
+		texttemplate.FuncMap{
+			"escape": html.EscapeString,
+		})
 
 }
 

--- a/pkg/renderer/html5/document_details.go
+++ b/pkg/renderer/html5/document_details.go
@@ -17,14 +17,14 @@ var documentAuthorDetailsTmpl texttemplate.Template
 
 func init() {
 	documentDetailsTmpl = newTextTemplate("document details", `<div class="details">{{ if .Authors }}
-{{.Authors}}{{ end }}{{ if .RevNumber }}
-<span id="revnumber">version {{.RevNumber}},</span>{{ end }}{{ if .RevDate }}
-<span id="revdate">{{.RevDate}}</span>{{ end }}{{ if .RevRemark }}
-<br><span id="revremark">{{.RevRemark}}</span>{{ end }}
+{{ .Authors }}{{ end }}{{ if .RevNumber }}
+<span id="revnumber">version {{ .RevNumber }},</span>{{ end }}{{ if .RevDate }}
+<span id="revdate">{{ .RevDate }}</span>{{ end }}{{ if .RevRemark }}
+<br><span id="revremark">{{ .RevRemark }}</span>{{ end }}
 </div>`)
 
-	documentAuthorDetailsTmpl = newTextTemplate("author details", `{{ if .Name }}<span id="author{{.Index}}" class="author">{{.Name}}</span><br>{{ end }}{{ if .Email }}
-<span id="email{{.Index}}" class="email"><a href="mailto:{{.Email}}">{{.Email}}</a></span><br>{{ end }}`)
+	documentAuthorDetailsTmpl = newTextTemplate("author details", `{{ if .Name }}<span id="author{{ .Index }}" class="author">{{ .Name }}</span><br>{{ end }}{{ if .Email }}
+<span id="email{{ .Index }}" class="email"><a href="mailto:{{ .Email }}">{{ .Email }}</a></span><br>{{ end }}`)
 }
 
 func renderDocumentDetails(ctx *renderer.Context) (*htmltemplate.HTML, error) {

--- a/pkg/renderer/html5/labeled_list_test.go
+++ b/pkg/renderer/html5/labeled_list_test.go
@@ -367,4 +367,30 @@ Item 3 description`
 			verify(GinkgoT(), expectedDocument, actualContent)
 		})
 	})
+
+	Context("q and a", func() {
+
+		It("q and a with title", func() {
+			actualContent := `.Q&A
+[qanda]
+What is libsciidoc?::
+	An implementation of the AsciiDoc processor in Golang.
+What is the answer to the Ultimate Question?:: 42`
+
+			expectedDocument := `<div class="qlist qanda">
+<div class="title">Q&amp;A</div>
+<ol>
+<li>
+<p><em>What is libsciidoc?</em></p>
+<p>An implementation of the AsciiDoc processor in Golang.</p>
+</li>
+<li>
+<p><em>What is the answer to the Ultimate Question?</em></p>
+<p>42</p>
+</li>
+</ol>
+</div>`
+			verify(GinkgoT(), expectedDocument, actualContent)
+		})
+	})
 })

--- a/pkg/renderer/html5/literal_blocks.go
+++ b/pkg/renderer/html5/literal_blocks.go
@@ -2,6 +2,7 @@ package html5
 
 import (
 	"bytes"
+	"html"
 	"math"
 	"strings"
 	texttemplate "text/template"
@@ -17,12 +18,13 @@ var literalBlockTmpl texttemplate.Template
 // initializes the templates
 func init() {
 	literalBlockTmpl = newTextTemplate("literal block", `{{ $ctx := .Context }}{{ with .Data }}<div {{ if .ID }}id="{{ .ID }}" {{ end }}class="literalblock">
-{{ if .Title }}<div class="title">{{ .Title }}</div>
+{{ if .Title }}<div class="title">{{ escape .Title }}</div>
 {{ end }}<div class="content">
 <pre>{{ $lines := .Lines }}{{ range $index, $line := $lines}}{{ $line }}{{ includeNewline $ctx $index $lines }}{{ end }}</pre>
 </div>
 </div>{{ end }}`, texttemplate.FuncMap{
 		"includeNewline": includeNewline,
+		"escape":         html.EscapeString,
 	})
 }
 
@@ -60,7 +62,7 @@ func renderLiteralBlock(ctx *renderer.Context, b types.LiteralBlock) ([]byte, er
 			Lines []string
 		}{
 			ID:    b.Attributes.GetAsString(types.AttrID),
-			Title: b.Attributes.GetAsString(types.AttrTitle),
+			Title: getTitle(b.Attributes),
 			Lines: lines,
 		}})
 	if err != nil {

--- a/pkg/renderer/html5/ordered_list.go
+++ b/pkg/renderer/html5/ordered_list.go
@@ -2,6 +2,7 @@ package html5
 
 import (
 	"bytes"
+	"html"
 	texttemplate "text/template"
 
 	"github.com/bytesparadise/libasciidoc/pkg/renderer"
@@ -16,7 +17,7 @@ var orderedListTmpl texttemplate.Template
 func init() {
 	orderedListTmpl = newTextTemplate("ordered list",
 		`{{ $ctx := .Context }}{{ with .Data }}{{ $items := .Items }}{{ $firstItem := index $items 0 }}<div{{ if .ID }} id="{{ .ID }}"{{ end }} class="olist {{ $firstItem.NumberingStyle }}{{ if .Role }} {{ .Role }}{{ end}}">
-{{ if .Title }}<div class="title">{{ .Title }}</div>
+{{ if .Title }}<div class="title">{{ escape .Title }}</div>
 {{ end }}<ol class="{{ $firstItem.NumberingStyle }}"{{ style $firstItem.NumberingStyle }}{{ if .Start }} start="{{ .Start }}"{{ end }}>
 {{ range $itemIndex, $item := $items }}<li>
 {{ renderElements $ctx $item.Elements | printf "%s" }}
@@ -26,6 +27,7 @@ func init() {
 		texttemplate.FuncMap{
 			"renderElements": renderElements,
 			"style":          numberingType,
+			"escape":         html.EscapeString,
 		})
 
 }

--- a/pkg/renderer/html5/quoted_text.go
+++ b/pkg/renderer/html5/quoted_text.go
@@ -19,11 +19,11 @@ var superscriptTextTmpl texttemplate.Template
 
 // initializes the templates
 func init() {
-	boldTextTmpl = newTextTemplate("bold text", "<strong>{{.}}</strong>")
-	italicTextTmpl = newTextTemplate("italic text", "<em>{{.}}</em>")
-	monospaceTextTmpl = newTextTemplate("monospace text", "<code>{{.}}</code>")
-	subscriptTextTmpl = newTextTemplate("subscript text", "<sub>{{.}}</sub>")
-	superscriptTextTmpl = newTextTemplate("superscript text", "<sup>{{.}}</sup>")
+	boldTextTmpl = newTextTemplate("bold text", "<strong>{{ . }}</strong>")
+	italicTextTmpl = newTextTemplate("italic text", "<em>{{ . }}</em>")
+	monospaceTextTmpl = newTextTemplate("monospace text", "<code>{{ . }}</code>")
+	subscriptTextTmpl = newTextTemplate("subscript text", "<sub>{{ . }}</sub>")
+	superscriptTextTmpl = newTextTemplate("superscript text", "<sup>{{ . }}</sup>")
 }
 
 func renderQuotedText(ctx *renderer.Context, t types.QuotedText) ([]byte, error) {

--- a/pkg/renderer/html5/section.go
+++ b/pkg/renderer/html5/section.go
@@ -31,7 +31,7 @@ func init() {
 		})
 	section1ContentTmpl = newTextTemplate("section 1",
 		`{{ $ctx := .Context }}{{ with .Data }}<div class="{{ .Class }}">
-{{.SectionTitle}}
+{{ .SectionTitle }}
 <div class="sectionbody">{{ $elements := renderElements $ctx .Elements | printf "%s" }}{{ if $elements }}
 {{ $elements }}{{ end }}
 </div>
@@ -48,7 +48,7 @@ func init() {
 			"renderElements": renderElements,
 		})
 	sectionHeaderTmpl = newTextTemplate("other sectionTitle",
-		`<h{{.Level}} id="{{.ID}}">{{.Content}}</h{{.Level}}>`)
+		`<h{{ .Level }} id="{{ .ID }}">{{ .Content }}</h{{ .Level }}>`)
 }
 
 func renderPreamble(ctx *renderer.Context, p types.Preamble) ([]byte, error) {

--- a/pkg/renderer/html5/string.go
+++ b/pkg/renderer/html5/string.go
@@ -10,7 +10,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var stringTmpl = newHTMLTemplate("string element", "{{.}}")
+var stringTmpl = newHTMLTemplate("string element", "{{ . }}")
 
 func renderStringElement(ctx *renderer.Context, str types.StringElement) ([]byte, error) {
 	buf := bytes.NewBuffer(nil)

--- a/pkg/renderer/html5/table.go
+++ b/pkg/renderer/html5/table.go
@@ -3,6 +3,7 @@ package html5
 import (
 	"bytes"
 	"fmt"
+	"html"
 	"math"
 	texttemplate "text/template"
 
@@ -16,7 +17,7 @@ var tableTmpl texttemplate.Template
 
 func init() {
 	tableTmpl = newTextTemplate("table", `{{ $ctx := .Context }}{{ with .Data }}<table class="tableblock frame-all grid-all stretch">{{ if .Lines }}
-{{ if .Title }}<caption class="title">{{ .Title }}</caption>
+{{ if .Title }}<caption class="title">{{ escape .Title }}</caption>
 {{ end }}<colgroup>
 {{ $cellWidths := .CellWidths }}{{ range $index, $width := $cellWidths }}<col style="width: {{ $width }}%;">{{ includeNewline $ctx $index $cellWidths }}{{ end }}
 </colgroup>
@@ -34,6 +35,7 @@ func init() {
 		texttemplate.FuncMap{
 			"renderElement":  renderElement,
 			"includeNewline": includeNewline,
+			"escape":         html.EscapeString,
 		})
 }
 
@@ -59,8 +61,7 @@ func renderTable(ctx *renderer.Context, t types.Table) ([]byte, error) {
 	}
 	var title string
 	if titleAttr, ok := t.Attributes[types.AttrTitle].(string); ok {
-		c := ctx.GetAndIncrementTableCounter()
-		title = fmt.Sprintf("Table %d. %s", c, titleAttr)
+		title = fmt.Sprintf("Table %d. %s", ctx.GetAndIncrementTableCounter(), html.EscapeString(titleAttr))
 	}
 	err := tableTmpl.Execute(result, ContextualPipeline{
 		Context: ctx,

--- a/pkg/renderer/html5/table_of_contents.go
+++ b/pkg/renderer/html5/table_of_contents.go
@@ -18,11 +18,11 @@ var tableOfContentSectionSetTmpl texttemplate.Template
 func init() {
 	tableOfContentTmpl = newTextTemplate("toc", `<div id="toc" class="toc">
 <div id="toctitle">Table of Contents</div>
-{{.Content}}
+{{ .Content }}
 </div>`)
-	tableOfContentSectionSetTmpl = newTextTemplate("toc section", `<ul class="sectlevel{{.Level}}">
-{{ range .Elements }}<li><a href="#{{.Href}}">{{.Title}}</a>{{ if .Subelements }}
-{{.Subelements}}
+	tableOfContentSectionSetTmpl = newTextTemplate("toc section", `<ul class="sectlevel{{ .Level }}">
+{{ range .Elements }}<li><a href="#{{ .Href }}">{{ .Title }}</a>{{ if .Subelements }}
+{{ .Subelements }}
 </li>{{else}}</li>{{end}}
 {{end}}</ul>`)
 }

--- a/pkg/renderer/html5/unordered_list.go
+++ b/pkg/renderer/html5/unordered_list.go
@@ -2,6 +2,7 @@ package html5
 
 import (
 	"bytes"
+	"html"
 	texttemplate "text/template"
 
 	"github.com/bytesparadise/libasciidoc/pkg/renderer"
@@ -16,7 +17,7 @@ var unorderedListTmpl texttemplate.Template
 func init() {
 	unorderedListTmpl = newTextTemplate("unordered list",
 		`{{ $ctx := .Context }}{{ with .Data }}<div{{ if .ID }} id="{{ .ID }}"{{ end }} class="ulist{{ if .Checklist }} checklist{{ end }}{{ if .Role }} {{ .Role }}{{ end}}">
-{{ if .Title }}<div class="title">{{ .Title }}</div>
+{{ if .Title }}<div class="title">{{ escape .Title }}</div>
 {{ end }}<ul{{ if .Checklist }} class="checklist"{{ end }}>
 {{ $items := .Items }}{{ range $itemIndex, $item := $items }}<li>
 {{ $elements := $item.Elements }}{{ renderElements $ctx $elements | printf "%s" }}
@@ -25,6 +26,7 @@ func init() {
 </div>{{ end }}`,
 		texttemplate.FuncMap{
 			"renderElements": renderElements,
+			"escape":         html.EscapeString,
 		})
 }
 
@@ -52,7 +54,7 @@ func renderUnorderedList(ctx *renderer.Context, l types.UnorderedList) ([]byte, 
 			Items     []types.UnorderedListItem
 		}{
 			ID:        l.Attributes.GetAsString(types.AttrID),
-			Title:     l.Attributes.GetAsString(types.AttrTitle),
+			Title:     getTitle(l.Attributes),
 			Role:      l.Attributes.GetAsString(types.AttrRole),
 			Checklist: checkList,
 			Items:     l.Items,

--- a/pkg/types/element_attributes.go
+++ b/pkg/types/element_attributes.go
@@ -35,6 +35,8 @@ const (
 	AttrCheckStyle string = "checkstyle"
 	// AttrStart the "start" attribute in an ordered list
 	AttrStart string = "start"
+	// AttrQandA the "qanda" attribute for Q&A labeled lists
+	AttrQandA string = "qanda"
 )
 
 // ElementWithAttributes an element on which attributes can be added/set


### PR DESCRIPTION
also, use the `html.EscapeString` on all titles

fixes #271

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>