### PR TITLE
fix(renderer): wrap continuing element in <div>

### DIFF
--- a/pkg/renderer/html5/labeled_list.go
+++ b/pkg/renderer/html5/labeled_list.go
@@ -28,7 +28,7 @@ func init() {
 {{ end }}</dl>
 </div>{{ end }}`,
 		texttemplate.FuncMap{
-			"renderElements": renderElements,
+			"renderElements": renderListElements,
 			"escape":         html.EscapeString,
 		})
 
@@ -50,7 +50,7 @@ func init() {
 </table>
 </div>{{ end }}`,
 		texttemplate.FuncMap{
-			"renderElements": renderElements,
+			"renderElements": renderListElements,
 			"includeNewline": includeNewline,
 			"escape":         html.EscapeString,
 		})
@@ -66,7 +66,7 @@ func init() {
 {{ end }}</ol>
 </div>{{ end }}`,
 		texttemplate.FuncMap{
-			"renderElements": renderElements,
+			"renderElements": renderListElements,
 			"escape":         html.EscapeString,
 		})
 
@@ -78,12 +78,6 @@ func renderLabeledList(ctx *renderer.Context, l types.LabeledList) ([]byte, erro
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to render labeled list")
 	}
-
-	// make sure nested elements are aware of that their rendering occurs within a list
-	ctx.SetWithinList(true)
-	defer func() {
-		ctx.SetWithinList(false)
-	}()
 
 	result := bytes.NewBuffer(nil)
 	// here we must preserve the HTML tags

--- a/pkg/renderer/html5/labeled_list_test.go
+++ b/pkg/renderer/html5/labeled_list_test.go
@@ -257,8 +257,33 @@ item 2
 
 	})
 
-	Context("list item continuation", func() {
-		It("labeled list with continuation", func() {
+	Context("labeled lists with continuation", func() {
+
+		It("labeled list with paragraph continuation", func() {
+			actualContent := `item 1:: description 1
++
+foo
+
+item 2:: description 2.`
+			expectedResult := `<div class="dlist">
+<dl>
+<dt class="hdlist1">item 1</dt>
+<dd>
+<p>description 1</p>
+<div class="paragraph">
+<p>foo</p>
+</div>
+</dd>
+<dt class="hdlist1">item 2</dt>
+<dd>
+<p>description 2.</p>
+</dd>
+</dl>
+</div>`
+			verify(GinkgoT(), expectedResult, actualContent)
+		})
+
+		It("labeled list with blockcontinuation", func() {
 			actualContent := `Item 1::
 +
 ----

--- a/pkg/renderer/html5/ordered_list.go
+++ b/pkg/renderer/html5/ordered_list.go
@@ -8,7 +8,6 @@ import (
 	"github.com/bytesparadise/libasciidoc/pkg/renderer"
 	"github.com/bytesparadise/libasciidoc/pkg/types"
 	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
 )
 
 var orderedListTmpl texttemplate.Template
@@ -25,7 +24,7 @@ func init() {
 {{ end }}</ol>
 </div>{{ end }}`,
 		texttemplate.FuncMap{
-			"renderElements": renderElements,
+			"renderElements": renderListElements,
 			"style":          numberingType,
 			"escape":         html.EscapeString,
 		})
@@ -34,12 +33,6 @@ func init() {
 
 func renderOrderedList(ctx *renderer.Context, l types.OrderedList) ([]byte, error) {
 	result := bytes.NewBuffer(nil)
-	// make sure nested elements are aware of that their rendering occurs within a list
-	ctx.SetWithinList(true)
-	defer func() {
-		ctx.SetWithinList(false)
-	}()
-
 	err := orderedListTmpl.Execute(result, ContextualPipeline{
 		Context: ctx,
 		Data: struct {
@@ -59,7 +52,7 @@ func renderOrderedList(ctx *renderer.Context, l types.OrderedList) ([]byte, erro
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to render ordered list")
 	}
-	log.Debugf("rendered ordered list of items: %s", result.Bytes())
+	// log.Debugf("rendered ordered list of items: %s", result.Bytes())
 	return result.Bytes(), nil
 }
 

--- a/pkg/renderer/html5/ordered_list_test.go
+++ b/pkg/renderer/html5/ordered_list_test.go
@@ -46,6 +46,44 @@ var _ = Describe("ordered lists", func() {
 		verify(GinkgoT(), expectedResult, actualContent)
 	})
 
+	It("ordered list with paragraph continuation", func() {
+		actualContent := `. item 1
++
+foo`
+		expectedResult := `<div class="olist arabic">
+<ol class="arabic">
+<li>
+<p>item 1</p>
+<div class="paragraph">
+<p>foo</p>
+</div>
+</li>
+</ol>
+</div>`
+		verify(GinkgoT(), expectedResult, actualContent)
+	})
+
+	It("ordered list with delimited block continuation", func() {
+		actualContent := `. item 1
++
+----
+foo
+----`
+		expectedResult := `<div class="olist arabic">
+<ol class="arabic">
+<li>
+<p>item 1</p>
+<div class="listingblock">
+<div class="content">
+<pre>foo</pre>
+</div>
+</div>
+</li>
+</ol>
+</div>`
+		verify(GinkgoT(), expectedResult, actualContent)
+	})
+
 	It("ordered list with unnumbered items", func() {
 		actualContent := `. item 1
 		.. item 1.1

--- a/pkg/renderer/html5/renderer.go
+++ b/pkg/renderer/html5/renderer.go
@@ -40,6 +40,35 @@ func renderElements(ctx *renderer.Context, elements []interface{}) ([]byte, erro
 	return buff.Bytes(), nil
 }
 
+// renderListElements is similar to the `renderElements` func above,
+// but it sets the `withinList` context flag to true for the first element only
+func renderListElements(ctx *renderer.Context, elements []interface{}) ([]byte, error) {
+	log.Debugf("rendering list %d element(s)...", len(elements))
+	buff := bytes.NewBuffer(nil)
+	hasContent := false
+	for i, element := range elements {
+		if i == 0 {
+			ctx.SetWithinList(true)
+		}
+		renderedElement, err := renderElement(ctx, element)
+		if i == 0 {
+			ctx.SetWithinList(false)
+		}
+		if err != nil {
+			return nil, errors.Wrapf(err, "unable to render an element")
+		}
+		// insert new line if there's already some content
+		if hasContent && len(renderedElement) > 0 {
+			buff.WriteString("\n")
+		}
+		buff.Write(renderedElement)
+		if len(renderedElement) > 0 {
+			hasContent = true
+		}
+	}
+	// log.Debugf("rendered elements: '%s'", buff.String())
+	return buff.Bytes(), nil
+}
 
 func renderElement(ctx *renderer.Context, element interface{}) ([]byte, error) {
 	// log.Debugf("rendering element of type `%T`", element)

--- a/pkg/renderer/html5/unordered_list.go
+++ b/pkg/renderer/html5/unordered_list.go
@@ -25,17 +25,13 @@ func init() {
 {{ end }}</ul>
 </div>{{ end }}`,
 		texttemplate.FuncMap{
-			"renderElements": renderElements,
+			"renderElements": renderListElements,
 			"escape":         html.EscapeString,
 		})
 }
 
 func renderUnorderedList(ctx *renderer.Context, l types.UnorderedList) ([]byte, error) {
 	// make sure nested elements are aware of that their rendering occurs within a list
-	ctx.SetWithinList(true)
-	defer func() {
-		ctx.SetWithinList(false)
-	}()
 	checkList := false
 	if len(l.Items) > 0 {
 		if l.Items[0].CheckStyle != types.NoCheck {

--- a/pkg/renderer/html5/unordered_list_test.go
+++ b/pkg/renderer/html5/unordered_list_test.go
@@ -69,6 +69,28 @@ and a standalone paragraph`
 		verify(GinkgoT(), expectedResult, actualContent)
 	})
 
+	It("simple unordered list with continuation", func() {
+		actualContent := `* item 1
++
+foo
+
+* item 2`
+		expectedResult := `<div class="ulist">
+<ul>
+<li>
+<p>item 1</p>
+<div class="paragraph">
+<p>foo</p>
+</div>
+</li>
+<li>
+<p>item 2</p>
+</li>
+</ul>
+</div>`
+		verify(GinkgoT(), expectedResult, actualContent)
+	})
+
 	It("nested unordered lists without a title", func() {
 		actualContent := `* item 1
 ** item 1.1


### PR DESCRIPTION
Apply on all lists (ordered, unordered, labelled)

fixes #270

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>