### PR TITLE
feat(renderer): support predefined attributes

### DIFF
--- a/pkg/parser/blank_line_test.go
+++ b/pkg/parser/blank_line_test.go
@@ -12,7 +12,7 @@ var _ = Describe("Blank lines", func() {
 second paragraph`
 		expectedResult := types.Document{
 			Attributes:         types.DocumentAttributes{},
-			ElementReferences:  map[string]interface{}{},
+			ElementReferences:  types.ElementReferences{},
 			Footnotes:          types.Footnotes{},
 			FootnoteReferences: types.FootnoteReferences{},
 			Elements: []interface{}{
@@ -46,7 +46,7 @@ second paragraph
 `
 		expectedResult := types.Document{
 			Attributes:         types.DocumentAttributes{},
-			ElementReferences:  map[string]interface{}{},
+			ElementReferences:  types.ElementReferences{},
 			Footnotes:          types.Footnotes{},
 			FootnoteReferences: types.FootnoteReferences{},
 			Elements: []interface{}{

--- a/pkg/parser/comment_test.go
+++ b/pkg/parser/comment_test.go
@@ -84,7 +84,7 @@ with multiple lines
 a second paragraph`
 			expectedResult := types.Document{
 				Attributes:         types.DocumentAttributes{},
-				ElementReferences:  map[string]interface{}{},
+				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{

--- a/pkg/parser/cross_reference_test.go
+++ b/pkg/parser/cross_reference_test.go
@@ -17,7 +17,7 @@ var _ = Describe("cross-references", func() {
 with some content linked to <<thetitle>>!`
 			expectedResult := types.Document{
 				Attributes: types.DocumentAttributes{},
-				ElementReferences: map[string]interface{}{
+				ElementReferences: types.ElementReferences{
 					"thetitle": types.SectionTitle{
 						Attributes: types.ElementAttributes{
 							types.AttrID: "thetitle",
@@ -77,7 +77,7 @@ with some content linked to <<thetitle>>!`
 with some content linked to <<thetitle,a label to the title>>!`
 			expectedResult := types.Document{
 				Attributes: types.DocumentAttributes{},
-				ElementReferences: map[string]interface{}{
+				ElementReferences: types.ElementReferences{
 					"thetitle": types.SectionTitle{
 						Attributes: types.ElementAttributes{
 							types.AttrID: "thetitle",

--- a/pkg/parser/delimited_block_test.go
+++ b/pkg/parser/delimited_block_test.go
@@ -83,7 +83,7 @@ var _ = Describe("delimited blocks", func() {
 			actualContent := "```\nsome fenced code\nwith an empty line\n\nin the middle\n```\nthen a normal paragraph."
 			expectedResult := types.Document{
 				Attributes:         types.DocumentAttributes{},
-				ElementReferences:  map[string]interface{}{},
+				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
@@ -137,7 +137,7 @@ var _ = Describe("delimited blocks", func() {
 			actualContent := "a paragraph.\n```\n" + content + "\n```\n"
 			expectedResult := types.Document{
 				Attributes:         types.DocumentAttributes{},
-				ElementReferences:  map[string]interface{}{},
+				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
@@ -309,8 +309,8 @@ in the middle
 ----
 then a normal paragraph.`
 			expectedResult := types.Document{
-				Attributes:         map[string]interface{}{},
-				ElementReferences:  map[string]interface{}{},
+				Attributes:         types.DocumentAttributes{},
+				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
@@ -360,8 +360,8 @@ then a normal paragraph.`
 some listing code
 ----`
 			expectedResult := types.Document{
-				Attributes:         map[string]interface{}{},
-				ElementReferences:  map[string]interface{}{},
+				Attributes:         types.DocumentAttributes{},
+				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
@@ -631,8 +631,8 @@ paragraphs
 ----
 `
 			expectedResult := types.Document{
-				Attributes:         map[string]interface{}{},
-				ElementReferences:  map[string]interface{}{},
+				Attributes:         types.DocumentAttributes{},
+				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{

--- a/pkg/parser/document_attributes_test.go
+++ b/pkg/parser/document_attributes_test.go
@@ -25,7 +25,7 @@ This journey begins on a bleary Monday morning.`
 						},
 					},
 				},
-				ElementReferences:  map[string]interface{}{},
+				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
@@ -507,8 +507,8 @@ v1.0:`
 :0Author: Xavier
 :Auth0r: Xavier`
 				expectedResult := types.Document{
-					Attributes:         map[string]interface{}{},
-					ElementReferences:  map[string]interface{}{},
+					Attributes:         types.DocumentAttributes{},
+					ElementReferences:  types.ElementReferences{},
 					Footnotes:          types.Footnotes{},
 					FootnoteReferences: types.FootnoteReferences{},
 					Elements: []interface{}{
@@ -530,8 +530,8 @@ v1.0:`
 :hardbreaks:
 a paragraph`
 				expectedResult := types.Document{
-					Attributes:         map[string]interface{}{},
-					ElementReferences:  map[string]interface{}{},
+					Attributes:         types.DocumentAttributes{},
+					ElementReferences:  types.ElementReferences{},
 					Footnotes:          types.Footnotes{},
 					FootnoteReferences: types.FootnoteReferences{},
 					Elements: []interface{}{
@@ -559,8 +559,8 @@ a paragraph`
 
 a paragraph`
 				expectedResult := types.Document{
-					Attributes:         map[string]interface{}{},
-					ElementReferences:  map[string]interface{}{},
+					Attributes:         types.DocumentAttributes{},
+					ElementReferences:  types.ElementReferences{},
 					Footnotes:          types.Footnotes{},
 					FootnoteReferences: types.FootnoteReferences{},
 					Elements: []interface{}{
@@ -591,8 +591,8 @@ a paragraph`
 
 a paragraph`
 				expectedResult := types.Document{
-					Attributes:         map[string]interface{}{},
-					ElementReferences:  map[string]interface{}{},
+					Attributes:         types.DocumentAttributes{},
+					ElementReferences:  types.ElementReferences{},
 					Footnotes:          types.Footnotes{},
 					FootnoteReferences: types.FootnoteReferences{},
 					Elements: []interface{}{
@@ -623,8 +623,8 @@ a paragraph`
 :date: 2017-01-01
 :author: Xavier`
 				expectedResult := types.Document{
-					Attributes:         map[string]interface{}{},
-					ElementReferences:  map[string]interface{}{},
+					Attributes:         types.DocumentAttributes{},
+					ElementReferences:  types.ElementReferences{},
 					Footnotes:          types.Footnotes{},
 					FootnoteReferences: types.FootnoteReferences{},
 					Elements: []interface{}{
@@ -653,8 +653,8 @@ a paragraph`
 			
 a paragraph written by {author}.`
 				expectedResult := types.Document{
-					Attributes:         map[string]interface{}{},
-					ElementReferences:  map[string]interface{}{},
+					Attributes:         types.DocumentAttributes{},
+					ElementReferences:  types.ElementReferences{},
 					Footnotes:          types.Footnotes{},
 					FootnoteReferences: types.FootnoteReferences{},
 					Elements: []interface{}{
@@ -682,8 +682,8 @@ a paragraph written by {author}.`
 :author2!:
 a paragraph written by {author}.`
 				expectedResult := types.Document{
-					Attributes:         map[string]interface{}{},
-					ElementReferences:  map[string]interface{}{},
+					Attributes:         types.DocumentAttributes{},
+					ElementReferences:  types.ElementReferences{},
 					Footnotes:          types.Footnotes{},
 					FootnoteReferences: types.FootnoteReferences{},
 					Elements: []interface{}{
@@ -742,7 +742,7 @@ This journey begins on a bleary Monday morning.`
 					"keywords":         "documentation, team, obstacles, journey, victory",
 					"toc":              "",
 				},
-				ElementReferences:  map[string]interface{}{},
+				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
@@ -779,7 +779,7 @@ a paragraph with *bold content*`
 						},
 					},
 				},
-				ElementReferences: map[string]interface{}{
+				ElementReferences: types.ElementReferences{
 					"_section_1": types.SectionTitle{
 						Attributes: types.ElementAttributes{
 							types.AttrID: "_section_1",
@@ -834,8 +834,8 @@ a paragraph with *bold content*`
 :date: 2017-01-01
 :author: Xavier`
 			expectedResult := types.Document{
-				Attributes:         map[string]interface{}{},
-				ElementReferences:  map[string]interface{}{},
+				Attributes:         types.DocumentAttributes{},
+				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
@@ -865,8 +865,8 @@ a paragraph with *bold content*`
 			actualContent := `:@date: 2017-01-01
 :{author}: Xavier`
 			expectedResult := types.Document{
-				Attributes:         map[string]interface{}{},
-				ElementReferences:  map[string]interface{}{},
+				Attributes:         types.DocumentAttributes{},
+				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{

--- a/pkg/parser/footnote_test.go
+++ b/pkg/parser/footnote_test.go
@@ -28,7 +28,7 @@ var _ = Describe("footnotes", func() {
 			}
 			expectedResult := types.Document{
 				Attributes:        types.DocumentAttributes{},
-				ElementReferences: map[string]interface{}{},
+				ElementReferences: types.ElementReferences{},
 				Footnotes: []types.Footnote{
 					footnote1,
 				},
@@ -79,7 +79,7 @@ var _ = Describe("footnotes", func() {
 			}
 			expectedResult := types.Document{
 				Attributes:        types.DocumentAttributes{},
-				ElementReferences: map[string]interface{}{},
+				ElementReferences: types.ElementReferences{},
 				Footnotes: []types.Footnote{
 					footnote1,
 				},
@@ -113,7 +113,7 @@ var _ = Describe("footnotes", func() {
 			}
 			expectedResult := types.Document{
 				Attributes:        types.DocumentAttributes{},
-				ElementReferences: map[string]interface{}{},
+				ElementReferences: types.ElementReferences{},
 				Footnotes: []types.Footnote{
 					footnote1,
 				},
@@ -148,7 +148,7 @@ var _ = Describe("footnotes", func() {
 		// 	}
 		// 	expectedResult := types.Document{
 		// 		Attributes:        types.DocumentAttributes{},
-		// 		ElementReferences: map[string]interface{}{},
+		// 		ElementReferences: types.ElementReferences{},
 		// 		Footnotes: types.Footnotes{
 		// 			footnote1,
 		// 		},
@@ -193,7 +193,7 @@ var _ = Describe("footnotes", func() {
 			}
 			expectedResult := types.Document{
 				Attributes:        types.DocumentAttributes{},
-				ElementReferences: map[string]interface{}{},
+				ElementReferences: types.ElementReferences{},
 				Footnotes: types.Footnotes{
 					footnote1,
 				},
@@ -245,7 +245,7 @@ var _ = Describe("footnotes", func() {
 			}
 			expectedResult := types.Document{
 				Attributes:        types.DocumentAttributes{},
-				ElementReferences: map[string]interface{}{},
+				ElementReferences: types.ElementReferences{},
 				Footnotes: types.Footnotes{
 					footnote1,
 				},
@@ -335,7 +335,7 @@ a paragraph with another footnote:[baz]`
 			Attributes: types.DocumentAttributes{
 				"doctitle": docTitle,
 			},
-			ElementReferences: map[string]interface{}{
+			ElementReferences: types.ElementReferences{
 				"_section_1": section1Title,
 			},
 			Footnotes: types.Footnotes{

--- a/pkg/parser/frontmatter_test.go
+++ b/pkg/parser/frontmatter_test.go
@@ -20,7 +20,7 @@ first paragraph`
 					"title":  "a title", // TODO: convert `title` attribute from front-matter into `doctitle` here ?
 					"author": "Xavier",
 				},
-				ElementReferences:  map[string]interface{}{},
+				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
@@ -44,8 +44,8 @@ first paragraph`
 
 first paragraph`
 			expectedResult := types.Document{
-				Attributes:         map[string]interface{}{},
-				ElementReferences:  map[string]interface{}{},
+				Attributes:         types.DocumentAttributes{},
+				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{

--- a/pkg/parser/image_test.go
+++ b/pkg/parser/image_test.go
@@ -171,8 +171,8 @@ image::appa.png[]`
 				It("paragraph with block image with alt and dimensions", func() {
 					actualContent := "a foo image::foo.png[foo image, 600, 400] bar"
 					expectedResult := types.Document{
-						Attributes:         map[string]interface{}{},
-						ElementReferences:  map[string]interface{}{},
+						Attributes:         types.DocumentAttributes{},
+						ElementReferences:  types.ElementReferences{},
 						Footnotes:          types.Footnotes{},
 						FootnoteReferences: types.FootnoteReferences{},
 						Elements: []interface{}{

--- a/pkg/parser/list_test.go
+++ b/pkg/parser/list_test.go
@@ -310,8 +310,8 @@ bar
 
 a normal paragraph.`
 			expectedResult := types.Document{
-				Attributes:         map[string]interface{}{},
-				ElementReferences:  map[string]interface{}{},
+				Attributes:         types.DocumentAttributes{},
+				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
@@ -364,8 +364,8 @@ Item 2:: something simple
 another fenced block
 ----`
 			expectedResult := types.Document{
-				Attributes:         map[string]interface{}{},
-				ElementReferences:  map[string]interface{}{},
+				Attributes:         types.DocumentAttributes{},
+				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
@@ -444,8 +444,8 @@ Item 2:: something simple
 another fenced block
 ----`
 			expectedResult := types.Document{
-				Attributes:         map[string]interface{}{},
-				ElementReferences:  map[string]interface{}{},
+				Attributes:         types.DocumentAttributes{},
+				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
@@ -2048,8 +2048,8 @@ on 2 lines, too.`
 					"\n" +
 					"* an item in the second list"
 				expectedResult := types.Document{
-					Attributes:         map[string]interface{}{},
-					ElementReferences:  map[string]interface{}{},
+					Attributes:         types.DocumentAttributes{},
+					ElementReferences:  types.ElementReferences{},
 					Footnotes:          types.Footnotes{},
 					FootnoteReferences: types.FootnoteReferences{},
 					Elements: []interface{}{
@@ -2391,8 +2391,8 @@ another delimited block
 * bar
 `
 				expectedResult := types.Document{
-					Attributes:         map[string]interface{}{},
-					ElementReferences:  map[string]interface{}{},
+					Attributes:         types.DocumentAttributes{},
+					ElementReferences:  types.ElementReferences{},
 					Footnotes:          types.Footnotes{},
 					FootnoteReferences: types.FootnoteReferences{},
 					Elements: []interface{}{
@@ -2480,8 +2480,8 @@ a delimited block
 another delimited block
 ----`
 				expectedResult := types.Document{
-					Attributes:         map[string]interface{}{},
-					ElementReferences:  map[string]interface{}{},
+					Attributes:         types.DocumentAttributes{},
+					ElementReferences:  types.ElementReferences{},
 					Footnotes:          types.Footnotes{},
 					FootnoteReferences: types.FootnoteReferences{},
 					Elements: []interface{}{

--- a/pkg/parser/literal_block_test.go
+++ b/pkg/parser/literal_block_test.go
@@ -49,8 +49,8 @@ lines.`
 
 a normal paragraph.`
 			expectedResult := types.Document{
-				Attributes:         map[string]interface{}{},
-				ElementReferences:  map[string]interface{}{},
+				Attributes:         types.DocumentAttributes{},
+				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
@@ -109,8 +109,8 @@ some literal content
 ....
 a normal paragraph.`
 			expectedResult := types.Document{
-				Attributes:         map[string]interface{}{},
-				ElementReferences:  map[string]interface{}{},
+				Attributes:         types.DocumentAttributes{},
+				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
@@ -148,8 +148,8 @@ some literal content
 
 a normal paragraph.`
 			expectedResult := types.Document{
-				Attributes:         map[string]interface{}{},
-				ElementReferences:  map[string]interface{}{},
+				Attributes:         types.DocumentAttributes{},
+				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
@@ -185,8 +185,8 @@ on two lines.
 
 a normal paragraph.`
 			expectedResult := types.Document{
-				Attributes:         map[string]interface{}{},
-				ElementReferences:  map[string]interface{}{},
+				Attributes:         types.DocumentAttributes{},
+				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{

--- a/pkg/parser/paragraph_test.go
+++ b/pkg/parser/paragraph_test.go
@@ -309,8 +309,8 @@ No space after the [NOTE]!
 [CAUTION]
 And no space after [CAUTION] either.`
 			expectedResult := types.Document{
-				Attributes:         map[string]interface{}{},
-				ElementReferences:  map[string]interface{}{},
+				Attributes:         types.DocumentAttributes{},
+				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{

--- a/pkg/parser/section_test.go
+++ b/pkg/parser/section_test.go
@@ -23,7 +23,7 @@ var _ = Describe("sections", func() {
 				Attributes: types.DocumentAttributes{
 					"doctitle": doctitle,
 				},
-				ElementReferences:  map[string]interface{}{},
+				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements:           []interface{}{},
@@ -45,7 +45,7 @@ var _ = Describe("sections", func() {
 				Attributes: types.DocumentAttributes{
 					"doctitle": doctitle,
 				},
-				ElementReferences:  map[string]interface{}{},
+				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements:           []interface{}{},
@@ -70,7 +70,7 @@ and a paragraph`
 				Attributes: types.DocumentAttributes{
 					"doctitle": doctitle,
 				},
-				ElementReferences:  map[string]interface{}{},
+				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
@@ -99,7 +99,7 @@ and a paragraph`
 			}
 			expectedResult := types.Document{
 				Attributes: types.DocumentAttributes{},
-				ElementReferences: map[string]interface{}{
+				ElementReferences: types.ElementReferences{
 					"_section_1": section1Title,
 				},
 				Footnotes:          types.Footnotes{},
@@ -132,7 +132,7 @@ and a paragraph`
 			}
 			expectedResult := types.Document{
 				Attributes: types.DocumentAttributes{},
-				ElementReferences: map[string]interface{}{
+				ElementReferences: types.ElementReferences{
 					"_2_spaces_and_bold_content": sectionTitle,
 				},
 				Footnotes:          types.Footnotes{},
@@ -172,7 +172,7 @@ and a paragraph`
 				Attributes: types.DocumentAttributes{
 					"doctitle": doctitle,
 				},
-				ElementReferences: map[string]interface{}{
+				ElementReferences: types.ElementReferences{
 					"_section_1": section1Title,
 				},
 				Footnotes:          types.Footnotes{},
@@ -214,7 +214,7 @@ a short preamble
 				Attributes: types.DocumentAttributes{
 					"doctitle": doctitle,
 				},
-				ElementReferences: map[string]interface{}{
+				ElementReferences: types.ElementReferences{
 					"_section_1": section1Title,
 				},
 				Footnotes:          types.Footnotes{},
@@ -267,7 +267,7 @@ a short preamble
 				Attributes: types.DocumentAttributes{
 					"doctitle": doctitle,
 				},
-				ElementReferences: map[string]interface{}{
+				ElementReferences: types.ElementReferences{
 					"_section_2": section2Title,
 				},
 				Footnotes:          types.Footnotes{},
@@ -296,7 +296,7 @@ and a paragraph`
 			}
 			expectedResult := types.Document{
 				Attributes: types.DocumentAttributes{},
-				ElementReferences: map[string]interface{}{
+				ElementReferences: types.ElementReferences{
 					"_a_title": section1Title,
 				},
 				Footnotes:          types.Footnotes{},
@@ -335,7 +335,7 @@ and a paragraph`
 			}
 			expectedResult := types.Document{
 				Attributes: types.DocumentAttributes{},
-				ElementReferences: map[string]interface{}{
+				ElementReferences: types.ElementReferences{
 					"_a_title": section1Title,
 				},
 				Footnotes:          types.Footnotes{},
@@ -373,7 +373,7 @@ and a paragraph`
 			}
 			expectedResult := types.Document{
 				Attributes: types.DocumentAttributes{},
-				ElementReferences: map[string]interface{}{
+				ElementReferences: types.ElementReferences{
 					"_a_title": section1Title,
 				},
 				Footnotes:          types.Footnotes{},
@@ -446,7 +446,7 @@ a paragraph`
 				Attributes: types.DocumentAttributes{
 					"doctitle": doctitle,
 				},
-				ElementReferences: map[string]interface{}{
+				ElementReferences: types.ElementReferences{
 					"_section_a":   sectionATitle,
 					"_section_a_a": sectionAaTitle,
 					"_section_b":   sectionBTitle,
@@ -516,7 +516,7 @@ a paragraph`
 			}
 			expectedResult := types.Document{
 				Attributes: types.DocumentAttributes{},
-				ElementReferences: map[string]interface{}{
+				ElementReferences: types.ElementReferences{
 					"custom_header": sectionTitle,
 				},
 				Footnotes:          types.Footnotes{},
@@ -569,7 +569,7 @@ a paragraph`
 				Attributes: types.DocumentAttributes{
 					"doctitle": doctitle,
 				},
-				ElementReferences: map[string]interface{}{
+				ElementReferences: types.ElementReferences{
 					"foo": fooTitle,
 					"bar": barTitle,
 				},
@@ -625,7 +625,7 @@ a paragraph`
 
 			expectedResult := types.Document{
 				Attributes: types.DocumentAttributes{},
-				ElementReferences: map[string]interface{}{
+				ElementReferences: types.ElementReferences{
 					"_section_1":   section1aTitle,
 					"_section_1_2": section1bTitle,
 				},
@@ -654,8 +654,8 @@ a paragraph`
 		It("header invalid - missing space", func() {
 			actualContent := "=a header"
 			expectedResult := types.Document{
-				Attributes:         map[string]interface{}{},
-				ElementReferences:  map[string]interface{}{},
+				Attributes:         types.DocumentAttributes{},
+				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
@@ -674,8 +674,8 @@ a paragraph`
 		It("header invalid - header space", func() {
 			actualContent := " = a header with a prefix space"
 			expectedResult := types.Document{
-				Attributes:         map[string]interface{}{},
-				ElementReferences:  map[string]interface{}{},
+				Attributes:         types.DocumentAttributes{},
+				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
@@ -708,7 +708,7 @@ a paragraph`
 						},
 					},
 				},
-				ElementReferences:  map[string]interface{}{},
+				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
@@ -752,7 +752,7 @@ bar`
 						},
 					},
 				},
-				ElementReferences: map[string]interface{}{
+				ElementReferences: types.ElementReferences{
 					"_header_2": header2Title,
 				},
 				Footnotes:          types.Footnotes{},
@@ -803,7 +803,7 @@ bar`
 Doc Writer <thedoc@asciidoctor.org>`
 			expectedResult := types.Document{
 				Attributes:         types.DocumentAttributes{},
-				ElementReferences:  map[string]interface{}{},
+				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{

--- a/pkg/parser/table_of_contents_test.go
+++ b/pkg/parser/table_of_contents_test.go
@@ -58,7 +58,7 @@ A short preamble
 				"doctitle": doctitleAttribute,
 				"toc":      "",
 			},
-			ElementReferences: map[string]interface{}{
+			ElementReferences: types.ElementReferences{
 				"_section_1": types.SectionTitle{
 					Attributes: types.ElementAttributes{
 						types.AttrID: "_section_1",
@@ -92,7 +92,7 @@ A short preamble
 				"doctitle": doctitleAttribute,
 				"toc":      "preamble",
 			},
-			ElementReferences: map[string]interface{}{
+			ElementReferences: types.ElementReferences{
 				"_section_1": types.SectionTitle{
 					Attributes: types.ElementAttributes{
 						types.AttrID: "_section_1",

--- a/pkg/renderer/html5/document_attribute_substitution.go
+++ b/pkg/renderer/html5/document_attribute_substitution.go
@@ -8,8 +8,9 @@ import (
 	"github.com/bytesparadise/libasciidoc/pkg/types"
 )
 
+
 func processAttributeDeclaration(ctx *renderer.Context, attr types.DocumentAttributeDeclaration) error {
-	ctx.Document.Attributes.AddAttribute(attr)
+	ctx.Document.Attributes.AddDeclaration(attr)
 	return nil
 }
 
@@ -21,6 +22,8 @@ func processAttributeReset(ctx *renderer.Context, attr types.DocumentAttributeRe
 func renderAttributeSubstitution(ctx *renderer.Context, attr types.DocumentAttributeSubstitution) ([]byte, error) {
 	result := bytes.NewBuffer(nil)
 	if value, found := ctx.Document.Attributes[attr.Name]; found {
+		result.WriteString(fmt.Sprintf("%v", value))
+	} else if value, found := predefined[attr.Name]; found {
 		result.WriteString(fmt.Sprintf("%v", value))
 	} else {
 		result.WriteString(fmt.Sprintf("{%s}", attr.Name))

--- a/pkg/renderer/html5/document_attribute_substitution_test.go
+++ b/pkg/renderer/html5/document_attribute_substitution_test.go
@@ -1,6 +1,8 @@
 package html5_test
 
-import . "github.com/onsi/ginkgo"
+import (
+	. "github.com/onsi/ginkgo"
+)
 
 var _ = Describe("document with attributes", func() {
 
@@ -90,4 +92,32 @@ author is {author}.`
 		})
 	})
 
+	Context("predefined elements", func() {
+
+		It("single space", func() {
+			actualContent := `a {sp} here.`
+			expectedResult := `<div class="paragraph">
+<p>a   here.</p>
+</div>`
+			verify(GinkgoT(), expectedResult, actualContent)
+		})
+
+		It("blank", func() {
+			actualContent := `a {blank} here.`
+			expectedResult := `<div class="paragraph">
+<p>a  here.</p>
+</div>`
+			verify(GinkgoT(), expectedResult, actualContent)
+		})
+
+		It("overriding predefined attribute", func() {
+			actualContent := `:blank: foo
+			
+a {blank} here.`
+			expectedResult := `<div class="paragraph">
+<p>a foo here.</p>
+</div>`
+			verify(GinkgoT(), expectedResult, actualContent)
+		})
+	})
 })

--- a/pkg/renderer/html5/predefined_attributes.go
+++ b/pkg/renderer/html5/predefined_attributes.go
@@ -1,0 +1,41 @@
+package html5
+
+import (
+	"github.com/bytesparadise/libasciidoc/pkg/types"
+)
+
+var predefined types.DocumentAttributes
+
+func init() {
+	predefined = types.DocumentAttributes{
+		"sp":             " ",
+		"blank":          "",
+		"empty":          "",
+		"nbsp":           "&#160;",
+		"zwsp":           "&#8203;",
+		"wj":             "&#8288;",
+		"apos":           "&#39;",
+		"quot":           "&#34;",
+		"lsquo":          "&#8216;",
+		"rsquo":          "&#8217;",
+		"ldquo":          "&#8220;",
+		"rdquo":          "&#8221;",
+		"deg":            "&#176;",
+		"plus":           "&#43;",
+		"brvbar":         "&#166;",
+		"vbar":           "|",
+		"amp":            "&amp;",
+		"lt":             "&lt;",
+		"gt":             "&gt;",
+		"startsb":        "[",
+		"endsb":          "]",
+		"caret":          "^",
+		"asterisk":       "*",
+		"tilde":          "~",
+		"backslash":      `\`,
+		"backtick":       "`",
+		"two-colons":     "::",
+		"two-semicolons": ";",
+		"cpp":            "C++",
+	}
+}

--- a/pkg/renderer/html5/predefined_attributes_test.go
+++ b/pkg/renderer/html5/predefined_attributes_test.go
@@ -1,0 +1,45 @@
+package html5
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("document with attributes", func() {
+
+	DescribeTable("predefined attributes",
+		func(code, rendered string) {
+			Expect(predefined[code]).To(Equal(rendered))
+		},
+		Entry("sp", "sp", " "),
+		Entry("blank", "blank", ""),
+		Entry("empty", "empty", ""),
+		Entry("nbsp", "nbsp", "&#160;"),
+		Entry("zwsp", "zwsp", "&#8203;"),
+		Entry("wj", "wj", "&#8288;"),
+		Entry("apos", "apos", "&#39;"),
+		Entry("quot", "quot", "&#34;"),
+		Entry("lsquo", "lsquo", "&#8216;"),
+		Entry("rsquo", "rsquo", "&#8217;"),
+		Entry("ldquo", "ldquo", "&#8220;"),
+		Entry("rdquo", "rdquo", "&#8221;"),
+		Entry("deg", "deg", "&#176;"),
+		Entry("plus", "plus", "&#43;"),
+		Entry("brvbar", "brvbar", "&#166;"),
+		Entry("vbar", "vbar", "|"),
+		Entry("amp", "amp", "&amp;"),
+		Entry("lt", "lt", "&lt;"),
+		Entry("gt", "gt", "&gt;"),
+		Entry("startsb", "startsb", "["),
+		Entry("endsb", "endsb", "]"),
+		Entry("caret", "caret", "^"),
+		Entry("asterisk", "asterisk", "*"),
+		Entry("tilde", "tilde", "~"),
+		Entry("backslash", "backslash", `\`),
+		Entry("backtick", "backtick", "`"),
+		Entry("two-colons", "two-colons", "::"),
+		Entry("two-semicolons", "two-semicolons", ";"),
+		Entry("cpp", "cpp", "C++"),
+	)
+})

--- a/pkg/types/document_attributes.go
+++ b/pkg/types/document_attributes.go
@@ -59,12 +59,20 @@ func (a DocumentAttributes) GetTitle() (SectionTitle, error) {
 	return SectionTitle{}, nil
 }
 
+// AddAll adds the given attributes
+func (a DocumentAttributes) AddAll(attrs DocumentAttributes) DocumentAttributes {
+	for k, v := range attrs {
+		a.Add(k, v)
+	}
+	return a
+}
+
 // Add adds the given attribute if its value is non-nil
 // TODO: raise a warning if there was already a name/value
-func (a DocumentAttributes) Add(key string, value interface{}) {
+func (a DocumentAttributes) Add(key string, value interface{}) DocumentAttributes {
 	// do not add nil or empty values
 	if value == nil {
-		return
+		return a
 	}
 	v := reflect.ValueOf(value)
 	k := v.Kind()
@@ -76,6 +84,7 @@ func (a DocumentAttributes) Add(key string, value interface{}) {
 	} else {
 		a[key] = value
 	}
+	return a
 }
 
 // AddNonEmpty adds the given attribute if its value is non-nil and non-empty
@@ -88,13 +97,9 @@ func (a DocumentAttributes) AddNonEmpty(key string, value interface{}) {
 	a.Add(key, value)
 }
 
-// AddAttribute adds the given attribute
+// AddDeclaration adds the given attribute
 // TODO: raise a warning if there was already a name/value
-func (a DocumentAttributes) AddAttribute(attr DocumentAttributeDeclaration) {
-	// do not add nil values
-	// if attr == nil {
-	// 	return
-	// }
+func (a DocumentAttributes) AddDeclaration(attr DocumentAttributeDeclaration) {
 	a.Add(attr.Name, attr.Value)
 }
 

--- a/pkg/types/document_attributes_test.go
+++ b/pkg/types/document_attributes_test.go
@@ -1,39 +1,43 @@
 package types_test
 
 import (
-	. "github.com/bytesparadise/libasciidoc/pkg/types"
+	"github.com/bytesparadise/libasciidoc/pkg/types"
 	. "github.com/onsi/ginkgo"
 	"github.com/stretchr/testify/assert"
 )
 
 var _ = Describe("document attributes", func() {
 
-	It("normal value", func() {
-		// given
-		attributes := DocumentAttributes{}
-		// when
-		attributes.Add("foo", "bar")
-		// then
-		assert.Equal(GinkgoT(), "bar", attributes["foo"])
-	})
+	Context("custom attributes", func() {
 
-	It("pointer to value", func() {
-		// given
-		attributes := DocumentAttributes{}
-		// when
-		bar := "bar"
-		attributes.Add("foo", &bar)
-		// then
-		assert.Equal(GinkgoT(), "bar", attributes["foo"])
-	})
+		It("normal value", func() {
+			// given
+			attributes := types.DocumentAttributes{}
+			// when
+			attributes.Add("foo", "bar")
+			// then
+			assert.Equal(GinkgoT(), "bar", attributes["foo"])
+		})
 
-	It("nil value", func() {
-		// given
-		attributes := DocumentAttributes{}
-		// when
-		attributes.Add("foo", nil)
-		// then
-		_, found := attributes["foo"]
-		assert.False(GinkgoT(), found)
+		It("pointer to value", func() {
+			// given
+			attributes := types.DocumentAttributes{}
+			// when
+			bar := "bar"
+			attributes.Add("foo", &bar)
+			// then
+			assert.Equal(GinkgoT(), "bar", attributes["foo"])
+		})
+
+		It("nil value", func() {
+			// given
+			attributes := types.DocumentAttributes{}
+			// when
+			attributes.Add("foo", nil)
+			// then
+			_, found := attributes["foo"]
+			assert.False(GinkgoT(), found)
+		})
+
 	})
 })

--- a/pkg/types/grammar_types.go
+++ b/pkg/types/grammar_types.go
@@ -48,7 +48,7 @@ func NewDocument(frontmatter, header interface{}, blocks []interface{}) (Documen
 	// elements := convertBlocksTointerface{}s(blocks)
 	// elements := filterEmptyElements(blocks, filterBlankLine(), filterEmptyPreamble())
 	elements := insertPreamble(blocks)
-	attributes := make(DocumentAttributes)
+	attributes := DocumentAttributes{}
 	if frontmatter != nil {
 		for attrName, attrValue := range frontmatter.(FrontMatter).Content {
 			attributes[attrName] = attrValue
@@ -191,7 +191,7 @@ func NewDocumentHeader(header, authors, revision interface{}, otherAttributes []
 	}
 	for _, attr := range otherAttributes {
 		if attr, ok := attr.(DocumentAttributeDeclaration); ok {
-			content.AddAttribute(attr)
+			content.AddDeclaration(attr)
 		}
 	}
 	return DocumentHeader{


### PR DESCRIPTION
use `sp`, `blanck`, etc. attributes during rendering
unless they have been explicitly declared in the
document.

fixes #266

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>