### PR TITLE
feat(renderer): support dropping of principal text in ordered list item

### DIFF
--- a/pkg/renderer/html5/ordered_list_test.go
+++ b/pkg/renderer/html5/ordered_list_test.go
@@ -345,4 +345,38 @@ a. foo
 		verify(GinkgoT(), expectedResult, actualContent)
 	})
 
+	It("drop principal text in list item", func() {
+		actualContent := `. {blank}
++
+----
+print("one")
+----
+. {blank}
++
+----
+print("one")
+----`
+		expectedResult := `<div class="olist arabic">
+<ol class="arabic">
+<li>
+<p></p>
+<div class="listingblock">
+<div class="content">
+<pre>print("one")</pre>
+</div>
+</div>
+</li>
+<li>
+<p></p>
+<div class="listingblock">
+<div class="content">
+<pre>print("one")</pre>
+</div>
+</div>
+</li>
+</ol>
+</div>`
+		verify(GinkgoT(), expectedResult, actualContent)
+	})
+
 })


### PR DESCRIPTION
well, all the work was done in #266, so this PR just adds a text to
verify that it works now ;)

Fixes #265

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>