### PR TITLE
fix(types): attach child elements to correct parent in ordered list

### DIFF
--- a/pkg/parser/labeled_list_test.go
+++ b/pkg/parser/labeled_list_test.go
@@ -602,4 +602,192 @@ second term:: definition of the second term`
 		}
 		verify(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
 	})
+
+	It("max level of labeled items - case 1", func() {
+		actualContent := `.Labeled, max nesting
+level 1:: description 1
+level 2::: description 2
+level 3:::: description 3
+level 1:: description 1`
+		expectedResult := types.LabeledList{
+			Attributes: types.ElementAttributes{
+				types.AttrTitle: "Labeled, max nesting",
+			},
+			Items: []types.LabeledListItem{
+				{
+					Level:      1,
+					Term:       "level 1",
+					Attributes: types.ElementAttributes{},
+					Elements: []interface{}{
+						types.Paragraph{
+							Attributes: types.ElementAttributes{},
+							Lines: []types.InlineElements{
+								{
+									types.StringElement{
+										Content: "description 1",
+									},
+								},
+							},
+						},
+						types.LabeledList{
+							Attributes: types.ElementAttributes{},
+							Items: []types.LabeledListItem{
+								{
+									Level:      2,
+									Term:       "level 2",
+									Attributes: types.ElementAttributes{},
+									Elements: []interface{}{
+										types.Paragraph{
+											Attributes: types.ElementAttributes{},
+											Lines: []types.InlineElements{
+												{
+													types.StringElement{
+														Content: "description 2",
+													},
+												},
+											},
+										},
+										types.LabeledList{
+											Attributes: types.ElementAttributes{},
+											Items: []types.LabeledListItem{
+												{
+													Level:      3,
+													Term:       "level 3",
+													Attributes: types.ElementAttributes{},
+													Elements: []interface{}{
+														types.Paragraph{
+															Attributes: types.ElementAttributes{},
+															Lines: []types.InlineElements{
+																{
+																	types.StringElement{
+																		Content: "description 3",
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Level:      1,
+					Term:       "level 1",
+					Attributes: types.ElementAttributes{},
+					Elements: []interface{}{
+						types.Paragraph{
+							Attributes: types.ElementAttributes{},
+							Lines: []types.InlineElements{
+								{
+									types.StringElement{
+										Content: "description 1",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		verify(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
+	})
+
+	It("max level of labeled items - case 2", func() {
+		actualContent := `.Labeled, max nesting
+level 1:: description 1
+level 2::: description 2
+level 3:::: description 3
+level 2::: description 2`
+		expectedResult := types.LabeledList{
+			Attributes: types.ElementAttributes{
+				types.AttrTitle: "Labeled, max nesting",
+			},
+			Items: []types.LabeledListItem{
+				{
+					Level:      1,
+					Term:       "level 1",
+					Attributes: types.ElementAttributes{},
+					Elements: []interface{}{
+						types.Paragraph{
+							Attributes: types.ElementAttributes{},
+							Lines: []types.InlineElements{
+								{
+									types.StringElement{
+										Content: "description 1",
+									},
+								},
+							},
+						},
+						types.LabeledList{
+							Attributes: types.ElementAttributes{},
+							Items: []types.LabeledListItem{
+								{
+									Level:      2,
+									Term:       "level 2",
+									Attributes: types.ElementAttributes{},
+									Elements: []interface{}{
+										types.Paragraph{
+											Attributes: types.ElementAttributes{},
+											Lines: []types.InlineElements{
+												{
+													types.StringElement{
+														Content: "description 2",
+													},
+												},
+											},
+										},
+										types.LabeledList{
+											Attributes: types.ElementAttributes{},
+											Items: []types.LabeledListItem{
+												{
+													Level:      3,
+													Term:       "level 3",
+													Attributes: types.ElementAttributes{},
+													Elements: []interface{}{
+														types.Paragraph{
+															Attributes: types.ElementAttributes{},
+															Lines: []types.InlineElements{
+																{
+																	types.StringElement{
+																		Content: "description 3",
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+								{
+									Level:      2,
+									Term:       "level 2",
+									Attributes: types.ElementAttributes{},
+									Elements: []interface{}{
+										types.Paragraph{
+											Attributes: types.ElementAttributes{},
+											Lines: []types.InlineElements{
+												{
+													types.StringElement{
+														Content: "description 2",
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		verify(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
+	})
 })

--- a/pkg/parser/ordered_list_test.go
+++ b/pkg/parser/ordered_list_test.go
@@ -184,7 +184,6 @@ var _ = Describe("ordered lists", func() {
 				},
 				Items: []types.OrderedListItem{
 					{
-
 						Level:          1,
 						Position:       1,
 						NumberingStyle: types.LowerRoman,
@@ -196,6 +195,297 @@ var _ = Describe("ordered lists", func() {
 			verify(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
 		})
 
+		It("max level of ordered items - case 1", func() {
+			actualContent := `.Ordered, max nesting
+. level 1
+.. level 2
+... level 3
+.... level 4
+..... level 5
+. level 1`
+			expectedResult := types.OrderedList{
+				Attributes: types.ElementAttributes{
+					types.AttrTitle: "Ordered, max nesting",
+				},
+				Items: []types.OrderedListItem{
+					{
+						Level:          1,
+						Position:       1,
+						NumberingStyle: types.Arabic,
+						Attributes:     types.ElementAttributes{},
+						Elements: []interface{}{
+							types.Paragraph{
+								Attributes: types.ElementAttributes{},
+								Lines: []types.InlineElements{
+									{
+										types.StringElement{
+											Content: "level 1",
+										},
+									},
+								},
+							},
+							types.OrderedList{
+								Attributes: types.ElementAttributes{},
+								Items: []types.OrderedListItem{
+									{
+										Level:          2,
+										Position:       1,
+										NumberingStyle: types.LowerAlpha,
+										Attributes:     types.ElementAttributes{},
+										Elements: []interface{}{
+											types.Paragraph{
+												Attributes: types.ElementAttributes{},
+												Lines: []types.InlineElements{
+													{
+														types.StringElement{
+															Content: "level 2",
+														},
+													},
+												},
+											},
+											types.OrderedList{
+												Attributes: types.ElementAttributes{},
+												Items: []types.OrderedListItem{
+													{
+														Level:          3,
+														Position:       1,
+														NumberingStyle: types.LowerRoman,
+														Attributes:     types.ElementAttributes{},
+														Elements: []interface{}{
+															types.Paragraph{
+																Attributes: types.ElementAttributes{},
+																Lines: []types.InlineElements{
+																	{
+																		types.StringElement{
+																			Content: "level 3",
+																		},
+																	},
+																},
+															},
+															types.OrderedList{
+																Attributes: types.ElementAttributes{},
+																Items: []types.OrderedListItem{
+																	{
+																		Level:          4,
+																		Position:       1,
+																		NumberingStyle: types.UpperAlpha,
+																		Attributes:     types.ElementAttributes{},
+																		Elements: []interface{}{
+																			types.Paragraph{
+																				Attributes: types.ElementAttributes{},
+																				Lines: []types.InlineElements{
+																					{
+																						types.StringElement{
+																							Content: "level 4",
+																						},
+																					},
+																				},
+																			},
+																			types.OrderedList{
+																				Attributes: types.ElementAttributes{},
+																				Items: []types.OrderedListItem{
+																					{
+																						Level:          5,
+																						Position:       1,
+																						NumberingStyle: types.UpperRoman,
+																						Attributes:     types.ElementAttributes{},
+																						Elements: []interface{}{
+																							types.Paragraph{
+																								Attributes: types.ElementAttributes{},
+																								Lines: []types.InlineElements{
+																									{
+																										types.StringElement{
+																											Content: "level 5",
+																										},
+																									},
+																								},
+																							},
+																						},
+																					},
+																				},
+																			},
+																		},
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					{
+						Level:          1,
+						Position:       2,
+						NumberingStyle: types.Arabic,
+						Attributes:     types.ElementAttributes{},
+						Elements: []interface{}{
+							types.Paragraph{
+								Attributes: types.ElementAttributes{},
+								Lines: []types.InlineElements{
+									{
+										types.StringElement{
+											Content: "level 1",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			verify(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
+		})
+
+		It("max level of ordered items - case 2", func() {
+			actualContent := `.Ordered, max nesting
+. level 1
+.. level 2
+... level 3
+.... level 4
+..... level 5
+.. level 2`
+			expectedResult := types.OrderedList{
+				Attributes: types.ElementAttributes{
+					types.AttrTitle: "Ordered, max nesting",
+				},
+				Items: []types.OrderedListItem{
+					{
+						Level:          1,
+						Position:       1,
+						NumberingStyle: types.Arabic,
+						Attributes:     types.ElementAttributes{},
+						Elements: []interface{}{
+							types.Paragraph{
+								Attributes: types.ElementAttributes{},
+								Lines: []types.InlineElements{
+									{
+										types.StringElement{
+											Content: "level 1",
+										},
+									},
+								},
+							},
+							types.OrderedList{
+								Attributes: types.ElementAttributes{},
+								Items: []types.OrderedListItem{
+									{
+										Level:          2,
+										Position:       1,
+										NumberingStyle: types.LowerAlpha,
+										Attributes:     types.ElementAttributes{},
+										Elements: []interface{}{
+											types.Paragraph{
+												Attributes: types.ElementAttributes{},
+												Lines: []types.InlineElements{
+													{
+														types.StringElement{
+															Content: "level 2",
+														},
+													},
+												},
+											},
+											types.OrderedList{
+												Attributes: types.ElementAttributes{},
+												Items: []types.OrderedListItem{
+													{
+														Level:          3,
+														Position:       1,
+														NumberingStyle: types.LowerRoman,
+														Attributes:     types.ElementAttributes{},
+														Elements: []interface{}{
+															types.Paragraph{
+																Attributes: types.ElementAttributes{},
+																Lines: []types.InlineElements{
+																	{
+																		types.StringElement{
+																			Content: "level 3",
+																		},
+																	},
+																},
+															},
+															types.OrderedList{
+																Attributes: types.ElementAttributes{},
+																Items: []types.OrderedListItem{
+																	{
+																		Level:          4,
+																		Position:       1,
+																		NumberingStyle: types.UpperAlpha,
+																		Attributes:     types.ElementAttributes{},
+																		Elements: []interface{}{
+																			types.Paragraph{
+																				Attributes: types.ElementAttributes{},
+																				Lines: []types.InlineElements{
+																					{
+																						types.StringElement{
+																							Content: "level 4",
+																						},
+																					},
+																				},
+																			},
+																			types.OrderedList{
+																				Attributes: types.ElementAttributes{},
+																				Items: []types.OrderedListItem{
+																					{
+																						Level:          5,
+																						Position:       1,
+																						NumberingStyle: types.UpperRoman,
+																						Attributes:     types.ElementAttributes{},
+																						Elements: []interface{}{
+																							types.Paragraph{
+																								Attributes: types.ElementAttributes{},
+																								Lines: []types.InlineElements{
+																									{
+																										types.StringElement{
+																											Content: "level 5",
+																										},
+																									},
+																								},
+																							},
+																						},
+																					},
+																				},
+																			},
+																		},
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+									{
+										Level:          2,
+										Position:       2,
+										NumberingStyle: types.LowerAlpha,
+										Attributes:     types.ElementAttributes{},
+										Elements: []interface{}{
+											types.Paragraph{
+												Attributes: types.ElementAttributes{},
+												Lines: []types.InlineElements{
+													{
+														types.StringElement{
+															Content: "level 2",
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			verify(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
+		})
 	})
 
 	Context("items without numbers", func() {
@@ -556,7 +846,6 @@ var _ = Describe("ordered lists", func() {
 					},
 				},
 			}
-
 			verify(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
 		})
 	})

--- a/pkg/parser/unordered_list_test.go
+++ b/pkg/parser/unordered_list_test.go
@@ -781,6 +781,297 @@ on 2 lines, too.`
 			verify(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
 		})
 
+		It("max level of unordered items - case 1", func() {
+			actualContent := `.Unordered, max nesting
+* level 1
+** level 2
+*** level 3
+**** level 4
+***** level 5
+* level 1`
+			expectedResult := types.UnorderedList{
+				Attributes: types.ElementAttributes{
+					types.AttrTitle: "Unordered, max nesting",
+				},
+				Items: []types.UnorderedListItem{
+					{
+						Level:       1,
+						BulletStyle: types.OneAsterisk,
+						CheckStyle:  types.NoCheck,
+						Attributes:  types.ElementAttributes{},
+						Elements: []interface{}{
+							types.Paragraph{
+								Attributes: types.ElementAttributes{},
+								Lines: []types.InlineElements{
+									{
+										types.StringElement{
+											Content: "level 1",
+										},
+									},
+								},
+							},
+							types.UnorderedList{
+								Attributes: types.ElementAttributes{},
+								Items: []types.UnorderedListItem{
+									{
+										Level:       2,
+										BulletStyle: types.TwoAsterisks,
+										CheckStyle:  types.NoCheck,
+										Attributes:  types.ElementAttributes{},
+										Elements: []interface{}{
+											types.Paragraph{
+												Attributes: types.ElementAttributes{},
+												Lines: []types.InlineElements{
+													{
+														types.StringElement{
+															Content: "level 2",
+														},
+													},
+												},
+											},
+											types.UnorderedList{
+												Attributes: types.ElementAttributes{},
+												Items: []types.UnorderedListItem{
+													{
+														Level:       3,
+														BulletStyle: types.ThreeAsterisks,
+														CheckStyle:  types.NoCheck,
+														Attributes:  types.ElementAttributes{},
+														Elements: []interface{}{
+															types.Paragraph{
+																Attributes: types.ElementAttributes{},
+																Lines: []types.InlineElements{
+																	{
+																		types.StringElement{
+																			Content: "level 3",
+																		},
+																	},
+																},
+															},
+															types.UnorderedList{
+																Attributes: types.ElementAttributes{},
+																Items: []types.UnorderedListItem{
+																	{
+																		Level:       4,
+																		BulletStyle: types.FourAsterisks,
+																		CheckStyle:  types.NoCheck,
+																		Attributes:  types.ElementAttributes{},
+																		Elements: []interface{}{
+																			types.Paragraph{
+																				Attributes: types.ElementAttributes{},
+																				Lines: []types.InlineElements{
+																					{
+																						types.StringElement{
+																							Content: "level 4",
+																						},
+																					},
+																				},
+																			},
+																			types.UnorderedList{
+																				Attributes: types.ElementAttributes{},
+																				Items: []types.UnorderedListItem{
+																					{
+																						Level:       5,
+																						BulletStyle: types.FiveAsterisks,
+																						CheckStyle:  types.NoCheck,
+																						Attributes:  types.ElementAttributes{},
+																						Elements: []interface{}{
+																							types.Paragraph{
+																								Attributes: types.ElementAttributes{},
+																								Lines: []types.InlineElements{
+																									{
+																										types.StringElement{
+																											Content: "level 5",
+																										},
+																									},
+																								},
+																							},
+																						},
+																					},
+																				},
+																			},
+																		},
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					{
+						Level:       1,
+						BulletStyle: types.OneAsterisk,
+						CheckStyle:  types.NoCheck,
+						Attributes:  types.ElementAttributes{},
+						Elements: []interface{}{
+							types.Paragraph{
+								Attributes: types.ElementAttributes{},
+								Lines: []types.InlineElements{
+									{
+										types.StringElement{
+											Content: "level 1",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			verify(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
+		})
+
+		It("max level of unordered items - case 2", func() {
+			actualContent := `.Unordered, max nesting
+* level 1
+** level 2
+*** level 3
+**** level 4
+***** level 5
+** level 2`
+			expectedResult := types.UnorderedList{
+				Attributes: types.ElementAttributes{
+					types.AttrTitle: "Unordered, max nesting",
+				},
+				Items: []types.UnorderedListItem{
+					{
+						Level:       1,
+						BulletStyle: types.OneAsterisk,
+						CheckStyle:  types.NoCheck,
+						Attributes:  types.ElementAttributes{},
+						Elements: []interface{}{
+							types.Paragraph{
+								Attributes: types.ElementAttributes{},
+								Lines: []types.InlineElements{
+									{
+										types.StringElement{
+											Content: "level 1",
+										},
+									},
+								},
+							},
+							types.UnorderedList{
+								Attributes: types.ElementAttributes{},
+								Items: []types.UnorderedListItem{
+									{
+										Level:       2,
+										BulletStyle: types.TwoAsterisks,
+										CheckStyle:  types.NoCheck,
+										Attributes:  types.ElementAttributes{},
+										Elements: []interface{}{
+											types.Paragraph{
+												Attributes: types.ElementAttributes{},
+												Lines: []types.InlineElements{
+													{
+														types.StringElement{
+															Content: "level 2",
+														},
+													},
+												},
+											},
+											types.UnorderedList{
+												Attributes: types.ElementAttributes{},
+												Items: []types.UnorderedListItem{
+													{
+														Level:       3,
+														BulletStyle: types.ThreeAsterisks,
+														CheckStyle:  types.NoCheck,
+														Attributes:  types.ElementAttributes{},
+														Elements: []interface{}{
+															types.Paragraph{
+																Attributes: types.ElementAttributes{},
+																Lines: []types.InlineElements{
+																	{
+																		types.StringElement{
+																			Content: "level 3",
+																		},
+																	},
+																},
+															},
+															types.UnorderedList{
+																Attributes: types.ElementAttributes{},
+																Items: []types.UnorderedListItem{
+																	{
+																		Level:       4,
+																		BulletStyle: types.FourAsterisks,
+																		CheckStyle:  types.NoCheck,
+																		Attributes:  types.ElementAttributes{},
+																		Elements: []interface{}{
+																			types.Paragraph{
+																				Attributes: types.ElementAttributes{},
+																				Lines: []types.InlineElements{
+																					{
+																						types.StringElement{
+																							Content: "level 4",
+																						},
+																					},
+																				},
+																			},
+																			types.UnorderedList{
+																				Attributes: types.ElementAttributes{},
+																				Items: []types.UnorderedListItem{
+																					{
+																						Level:       5,
+																						BulletStyle: types.FiveAsterisks,
+																						CheckStyle:  types.NoCheck,
+																						Attributes:  types.ElementAttributes{},
+																						Elements: []interface{}{
+																							types.Paragraph{
+																								Attributes: types.ElementAttributes{},
+																								Lines: []types.InlineElements{
+																									{
+																										types.StringElement{
+																											Content: "level 5",
+																										},
+																									},
+																								},
+																							},
+																						},
+																					},
+																				},
+																			},
+																		},
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+									{
+										Level:       2,
+										BulletStyle: types.TwoAsterisks,
+										CheckStyle:  types.NoCheck,
+										Attributes:  types.ElementAttributes{},
+										Elements: []interface{}{
+											types.Paragraph{
+												Attributes: types.ElementAttributes{},
+												Lines: []types.InlineElements{
+													{
+														types.StringElement{
+															Content: "level 2",
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			verify(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
+		})
 	})
 
 	Context("invalid content", func() {

--- a/pkg/types/grammar_types.go
+++ b/pkg/types/grammar_types.go
@@ -882,16 +882,18 @@ func newOrderedList(elements []ListItem) (OrderedList, error) {
 		// log.Debugf("list item %v -> level= %d", item.Elements[0], item.Level)
 		// join item *values* in the parent item when the level decreased
 		if item.Level < previousLevel {
-			parentLayer := bufferedItemsPerLevel[previousLevel-2]
-			parentItem := parentLayer[len(parentLayer)-1]
-			log.Debugf("moving buffered items at level %d (%v) in parent (%v) ", previousLevel, bufferedItemsPerLevel[previousLevel-1][0].NumberingStyle, parentItem.NumberingStyle)
-			childList, err := toOrderedList(bufferedItemsPerLevel[previousLevel-1])
-			if err != nil {
-				return OrderedList{}, err
+			for i := previousLevel; i > item.Level; i-- {
+				parentLayer := bufferedItemsPerLevel[i-2]
+				parentItem := parentLayer[len(parentLayer)-1]
+				log.Debugf("moving buffered items at level %d (%v) in parent (%v) ", i, bufferedItemsPerLevel[i-1][0].NumberingStyle, parentItem.NumberingStyle)
+				childList, err := toOrderedList(bufferedItemsPerLevel[i-1])
+				if err != nil {
+					return OrderedList{}, err
+				}
+				parentItem.Elements = append(parentItem.Elements, childList)
+				// clear the previously buffered items at level 'previousLevel'
+				delete(bufferedItemsPerLevel, i-1)
 			}
-			parentItem.Elements = append(parentItem.Elements, childList)
-			// clear the previously buffered items at level 'previousLevel'
-			delete(bufferedItemsPerLevel, previousLevel-1)
 		}
 		// new level of element: put it in the buffer
 		if item.Level > len(bufferedItemsPerLevel) {


### PR DESCRIPTION
attach child elements of all sub levels when a new item of a given
level is processed

also verified on unordered list and labeled list.

fixes #293

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>