### PR TITLE
fix(renderer): avoid double encoding of document attributes

### DIFF
--- a/pkg/parser/asciidoc-grammar.peg
+++ b/pkg/parser/asciidoc-grammar.peg
@@ -678,7 +678,7 @@ InlineElement <- !EOL !LineBreak
 // special case for re-parsing a group of elements after a document substitution:
 // we should treat substitution that did not happen (eg: missing attribute) as regular
 // strings - (used by the inline element renderer)
-InlineElementsWithoutSubtitution <- !BlankLine !BlockDelimiter elements:(InlineElementWithoutSubtitution)+ linebreak:(LineBreak)? EOL { // absorbs heading and trailing spaces
+InlineElementsWithoutSubtitution <- !BlankLine !BlockDelimiter elements:(InlineElementWithoutSubtitution)* linebreak:(LineBreak)? EOL { // absorbs heading and trailing spaces
     return types.NewInlineElements(append(elements.([]interface{}), linebreak))
 } 
 
@@ -857,7 +857,7 @@ Passthrough <- TriplePlusPassthrough / SinglePlusPassthrough / PassthroughMacro
 
 SinglePlusPassthrough <- "+" content:(Alphanums / Spaces / (!NEWLINE !"+" . ){
     return string(c.text), nil
-})* "+" {
+})+ "+" {
     return types.NewPassthrough(types.SinglePlusPassthrough, content.([]interface{}))
 }
 

--- a/pkg/parser/passthrough_test.go
+++ b/pkg/parser/passthrough_test.go
@@ -158,9 +158,8 @@ var _ = Describe("passthroughs", func() {
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						types.Passthrough{
-							Kind:     types.SinglePlusPassthrough,
-							Elements: types.InlineElements{},
+						types.StringElement{
+							Content: "++",
 						},
 					},
 				},

--- a/pkg/renderer/html5/document_attribute_substitution.go
+++ b/pkg/renderer/html5/document_attribute_substitution.go
@@ -8,7 +8,6 @@ import (
 	"github.com/bytesparadise/libasciidoc/pkg/types"
 )
 
-
 func processAttributeDeclaration(ctx *renderer.Context, attr types.DocumentAttributeDeclaration) error {
 	ctx.Document.Attributes.AddDeclaration(attr)
 	return nil

--- a/pkg/renderer/html5/document_attribute_substitution_test.go
+++ b/pkg/renderer/html5/document_attribute_substitution_test.go
@@ -1,7 +1,10 @@
 package html5_test
 
 import (
+	"fmt"
+
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 )
 
 var _ = Describe("document with attributes", func() {
@@ -92,23 +95,46 @@ author is {author}.`
 		})
 	})
 
-	Context("predefined elements", func() {
+	Context("predefined attributes", func() {
 
-		It("single space", func() {
-			actualContent := `a {sp} here.`
-			expectedResult := `<div class="paragraph">
-<p>a   here.</p>
-</div>`
-			verify(GinkgoT(), expectedResult, actualContent)
-		})
-
-		It("blank", func() {
-			actualContent := `a {blank} here.`
-			expectedResult := `<div class="paragraph">
-<p>a  here.</p>
-</div>`
-			verify(GinkgoT(), expectedResult, actualContent)
-		})
+		DescribeTable("predefined attributes in a paragraph",
+			func(code, rendered string) {
+				actualContent := fmt.Sprintf(`the {%s} symbol`, code)
+				expectedResult := fmt.Sprintf(`<div class="paragraph">
+<p>the %s symbol</p>
+</div>`, rendered)
+				verify(GinkgoT(), expectedResult, actualContent)
+			},
+			Entry("sp symbol", "sp", " "),
+			Entry("blank symbol", "blank", ""),
+			Entry("empty symbol", "empty", ""),
+			Entry("nbsp symbol", "nbsp", "&#160;"),
+			Entry("zwsp symbol", "zwsp", "&#8203;"),
+			Entry("wj symbol", "wj", "&#8288;"),
+			Entry("apos symbol", "apos", "&#39;"),
+			Entry("quot symbol", "quot", "&#34;"),
+			Entry("lsquo symbol", "lsquo", "&#8216;"),
+			Entry("rsquo symbol", "rsquo", "&#8217;"),
+			Entry("ldquo symbol", "ldquo", "&#8220;"),
+			Entry("rdquo symbol", "rdquo", "&#8221;"),
+			Entry("deg symbol", "deg", "&#176;"),
+			Entry("plus symbol", "plus", "&#43;"),
+			Entry("brvbar symbol", "brvbar", "&#166;"),
+			Entry("vbar symbol", "vbar", "|"),
+			Entry("amp symbol", "amp", "&amp;"),
+			Entry("lt symbol", "lt", "&lt;"),
+			Entry("gt symbol", "gt", "&gt;"),
+			Entry("startsb symbol", "startsb", "["),
+			Entry("endsb symbol", "endsb", "]"),
+			Entry("caret symbol", "caret", "^"),
+			Entry("asterisk symbol", "asterisk", "*"),
+			Entry("tilde symbol", "tilde", "~"),
+			Entry("backslash symbol", "backslash", `\`),
+			Entry("backtick symbol", "backtick", "`"),
+			Entry("two-colons symbol", "two-colons", "::"),
+			Entry("two-semicolons symbol", "two-semicolons", ";"),
+			Entry("cpp symbol", "cpp", "C++"),
+		)
 
 		It("overriding predefined attribute", func() {
 			actualContent := `:blank: foo
@@ -120,4 +146,5 @@ a {blank} here.`
 			verify(GinkgoT(), expectedResult, actualContent)
 		})
 	})
+
 })

--- a/pkg/renderer/html5/passthrough_test.go
+++ b/pkg/renderer/html5/passthrough_test.go
@@ -41,14 +41,16 @@ var _ = Describe("passthroughs", func() {
 
 		It("an empty standalone singleplus passthrough", func() {
 			actualContent := `++`
-			expectedResult := ``
+			expectedResult := `<div class="paragraph">
+<p>&#43;&#43;</p>
+</div>`
 			verify(GinkgoT(), expectedResult, actualContent)
 		})
 
 		It("an empty singleplus passthrough in a paragraph", func() {
 			actualContent := `++ with more content afterwards...`
 			expectedResult := `<div class="paragraph">
-<p> with more content afterwards&#8230;&#8203;</p>
+<p>&#43;&#43; with more content afterwards&#8230;&#8203;</p>
 </div>`
 			verify(GinkgoT(), expectedResult, actualContent)
 		})

--- a/pkg/renderer/html5/renderer.go
+++ b/pkg/renderer/html5/renderer.go
@@ -121,6 +121,8 @@ func renderElement(ctx *renderer.Context, element interface{}) ([]byte, error) {
 	case types.DocumentAttributeReset:
 		// 'process' function do not return any rendered content, but may return an error
 		return nil, processAttributeReset(ctx, e)
+	case types.DocumentAttributeSubstitution:
+		return renderAttributeSubstitution(ctx, e)
 	case types.LineBreak:
 		return renderLineBreak()
 	case types.SingleLineComment:


### PR DESCRIPTION
unescape the document attributes substitution before it
is escaped again

fixes #295

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>