### PR TITLE
fix(renderer): do not always render preamble withing wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ coverage.txt
 *.html
 *.test
 !test/**/*.html
+*libasciidoc.html

--- a/pkg/renderer/html5/section_test.go
+++ b/pkg/renderer/html5/section_test.go
@@ -228,6 +228,59 @@ Listing block content is commonly used to preserve code input.</pre>
 </div>`
 			verify(GinkgoT(), expectedResult, actualContent)
 		})
+	})
 
+	Context("preambles", func() {
+
+		It("should include preamble wrapper", func() {
+			actualContent := `= Title
+
+preamble 
+here
+
+== section 1
+
+content here`
+			expectedResult := `<div id="preamble">
+<div class="sectionbody">
+<div class="paragraph">
+<p>preamble
+here</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_section_1">section 1</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>content here</p>
+</div>
+</div>
+</div>`
+			verify(GinkgoT(), expectedResult, actualContent)
+		})
+
+		It("should not include preamble wrapper", func() {
+			actualContent := `preamble 
+here
+
+== section 1
+
+content here
+`
+			expectedResult := `<div class="paragraph">
+<p>preamble
+here</p>
+</div>
+<div class="sect1">
+<h2 id="_section_1">section 1</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>content here</p>
+</div>
+</div>
+</div>`
+			verify(GinkgoT(), expectedResult, actualContent)
+		})
 	})
 })

--- a/pkg/types/document_attributes.go
+++ b/pkg/types/document_attributes.go
@@ -48,6 +48,12 @@ func (a DocumentAttributes) HasAuthors() bool {
 	return exists
 }
 
+// HasTitle returns `true` if the document has a title, ie, a section with level = 0
+func (a DocumentAttributes) HasTitle() bool {
+	_, found := a[title]
+	return found
+}
+
 // GetTitle retrieves the document title in its metadata, or returns nil if the title was not specified
 func (a DocumentAttributes) GetTitle() (SectionTitle, error) {
 	if t, found := a[title]; found {


### PR DESCRIPTION
depends if the document has a section level 0 (ie, a title)

fixes #298