### PR TITLE
WIP - feat(renderer): support inclusion of non-asciidoc file and in delimited blocks

### DIFF
--- a/pkg/renderer/file_inclusions_test.go
+++ b/pkg/renderer/file_inclusions_test.go
@@ -11,7 +11,7 @@ import (
 
 var _ = Describe("file inclusions", func() {
 
-	It("should include file with section 0 at root level without offset", func() {
+	It("should include adoc file with section 0 at root level without offset", func() {
 		actualContent := types.Document{
 			Attributes:         types.DocumentAttributes{},
 			ElementReferences:  types.ElementReferences{},
@@ -93,7 +93,7 @@ var _ = Describe("file inclusions", func() {
 		verifyFileInclusions(expectedContent, actualContent)
 	})
 
-	It("should include file with section 0 at root level with valid offset", func() {
+	It("should include adoc file with section 0 at root level with valid offset", func() {
 		actualContent := types.Document{
 			Attributes:         types.DocumentAttributes{},
 			ElementReferences:  types.ElementReferences{},
@@ -177,7 +177,7 @@ var _ = Describe("file inclusions", func() {
 		verifyFileInclusions(expectedContent, actualContent)
 	})
 
-	It("should include file with section 0 within existin section with valid offset", func() {
+	It("should include adoc file with section 0 within existin section with valid offset", func() {
 		actualContent := types.Document{
 			Attributes:         types.DocumentAttributes{},
 			ElementReferences:  types.ElementReferences{},
@@ -292,7 +292,7 @@ var _ = Describe("file inclusions", func() {
 		verifyFileInclusions(expectedContent, actualContent)
 	})
 
-	It("should include file with 2 paragraphs at root level without offset", func() {
+	It("should include adoc file with 2 paragraphs at root level without offset", func() {
 		actualContent := types.Document{
 			Attributes:         types.DocumentAttributes{},
 			ElementReferences:  types.ElementReferences{},
@@ -366,6 +366,191 @@ var _ = Describe("file inclusions", func() {
 		verifyFileInclusions(expectedContent, actualContent)
 	})
 
+	It("should include raw file at root", func() {
+		actualContent := types.Document{
+			Attributes:         types.DocumentAttributes{},
+			ElementReferences:  types.ElementReferences{},
+			Footnotes:          types.Footnotes{},
+			FootnoteReferences: types.FootnoteReferences{},
+			Elements: []interface{}{
+				types.Paragraph{
+					Attributes: types.ElementAttributes{},
+					Lines: []types.InlineElements{
+						{
+							types.StringElement{Content: "a first paragraph"},
+						},
+					},
+				},
+				types.FileInclusion{
+					Attributes: types.ElementAttributes{},
+					Path:       "html5/includes/sample.html",
+				},
+				types.BlankLine{},
+				types.Paragraph{
+					Attributes: types.ElementAttributes{},
+					Lines: []types.InlineElements{
+						{
+							types.StringElement{Content: "a second paragraph"},
+						},
+					},
+				},
+			},
+		}
+		expectedContent := types.Document{
+			Attributes:         types.DocumentAttributes{},
+			ElementReferences:  types.ElementReferences{},
+			Footnotes:          types.Footnotes{},
+			FootnoteReferences: types.FootnoteReferences{},
+			Elements: []interface{}{
+				types.Paragraph{
+					Attributes: types.ElementAttributes{},
+					Lines: []types.InlineElements{
+						{
+							types.StringElement{Content: "a first paragraph"},
+						},
+					},
+				},
+				types.Paragraph{
+					Attributes: types.ElementAttributes{},
+					Lines: []types.InlineElements{
+						{
+							types.StringElement{Content: "<html>"},
+						},
+						{
+							types.StringElement{Content: "<head>"},
+						},
+						{
+							types.StringElement{Content: "    <title>*foo*</title>"},
+						},
+						{
+							types.StringElement{Content: `    <script src="main.js"></script>`},
+						},
+						{
+							types.StringElement{Content: "</head>"},
+						},
+						{
+							types.StringElement{Content: "<body>"},
+						},
+						{
+							types.StringElement{Content: "</body>"},
+						},
+						{
+							types.StringElement{Content: "</html>"},
+						},
+					},
+				},
+				types.BlankLine{},
+				types.Paragraph{
+					Attributes: types.ElementAttributes{},
+					Lines: []types.InlineElements{
+						{
+							types.StringElement{Content: "a second paragraph"},
+						},
+					},
+				},
+			},
+		}
+		verifyFileInclusions(expectedContent, actualContent)
+	})
+
+	It("should include raw file in delimited block", func() {
+		actualContent := types.Document{
+			Attributes:         types.DocumentAttributes{},
+			ElementReferences:  types.ElementReferences{},
+			Footnotes:          types.Footnotes{},
+			FootnoteReferences: types.FootnoteReferences{},
+			Elements: []interface{}{
+				types.Paragraph{
+					Attributes: types.ElementAttributes{},
+					Lines: []types.InlineElements{
+						{
+							types.StringElement{Content: "a first paragraph"},
+						},
+					},
+				},
+				types.DelimitedBlock{
+					Kind:       types.Source,
+					Attributes: types.ElementAttributes{},
+					Elements: []interface{}{
+						types.FileInclusion{
+							Attributes: types.ElementAttributes{},
+							Path:       "html5/includes/sample.html",
+						},
+					},
+				},
+				types.BlankLine{},
+				types.Paragraph{
+					Attributes: types.ElementAttributes{},
+					Lines: []types.InlineElements{
+						{
+							types.StringElement{Content: "a second paragraph"},
+						},
+					},
+				},
+			},
+		}
+		expectedContent := types.Document{
+			Attributes:         types.DocumentAttributes{},
+			ElementReferences:  types.ElementReferences{},
+			Footnotes:          types.Footnotes{},
+			FootnoteReferences: types.FootnoteReferences{},
+			Elements: []interface{}{
+				types.Paragraph{
+					Attributes: types.ElementAttributes{},
+					Lines: []types.InlineElements{
+						{
+							types.StringElement{Content: "a first paragraph"},
+						},
+					},
+				},
+				types.DelimitedBlock{
+					Kind:       types.Source,
+					Attributes: types.ElementAttributes{},
+					Elements: []interface{}{
+						types.Paragraph{
+							Attributes: types.ElementAttributes{},
+							Lines: []types.InlineElements{
+								{
+									types.StringElement{Content: "<html>"},
+								},
+								{
+									types.StringElement{Content: "<head>"},
+								},
+								{
+									types.StringElement{Content: "    <title>*foo*</title>"},
+								},
+								{
+									types.StringElement{Content: `    <script src="main.js"></script>`},
+								},
+								{
+									types.StringElement{Content: "</head>"},
+								},
+								{
+									types.StringElement{Content: "<body>"},
+								},
+								{
+									types.StringElement{Content: "</body>"},
+								},
+								{
+									types.StringElement{Content: "</html>"},
+								},
+							},
+						},
+					},
+				},
+				types.BlankLine{},
+				types.Paragraph{
+					Attributes: types.ElementAttributes{},
+					Lines: []types.InlineElements{
+						{
+							types.StringElement{Content: "a second paragraph"},
+						},
+					},
+				},
+			},
+		}
+		verifyFileInclusions(expectedContent, actualContent)
+	})
 })
 
 func verifyFileInclusions(expectedContent, actualContent types.Document) {

--- a/pkg/types/grammar_types.go
+++ b/pkg/types/grammar_types.go
@@ -44,6 +44,7 @@ type Substitutor interface {
 // ElementContainer en element that has child elements as well
 type ElementContainer interface {
 	GetElements() []interface{}
+	SetElements([]interface{})
 }
 
 // ------------------------------------------
@@ -439,9 +440,6 @@ type Preamble struct {
 	Elements []interface{}
 }
 
-// verify interface(s)
-var _ ElementContainer = Preamble{}
-
 // NewEmptyPreamble return an empty Preamble
 func NewEmptyPreamble() Preamble {
 	return Preamble{
@@ -503,7 +501,7 @@ type Section struct {
 }
 
 // verify interface(s)
-var _ ElementContainer = Section{}
+var _ ElementContainer = &Section{}
 
 // NewSection initializes a new `Section` from the given section title and elements
 func NewSection(level int, sectionTitle SectionTitle, blocks []interface{}) (Section, error) {
@@ -522,8 +520,13 @@ func (s Section) AddAttributes(attributes ElementAttributes) {
 }
 
 // GetElements returns the elements
-func (s Section) GetElements() []interface{} {
+func (s *Section) GetElements() []interface{} {
 	return s.Elements
+}
+
+// SetElements sets the elements of the section (overriding the existing ones)
+func (s *Section) SetElements(elements []interface{}) {
+	s.Elements = elements
 }
 
 // AcceptVisitor implements Visitable#AcceptVisitor(Visitor)
@@ -1915,6 +1918,9 @@ type DelimitedBlock struct {
 	Elements   []interface{}
 }
 
+// verify interface(s)
+var _ ElementContainer = &DelimitedBlock{}
+
 // Substitution the substitution group to apply when initializing a delimited block
 type Substitution func([]interface{}) ([]interface{}, error)
 
@@ -1958,6 +1964,16 @@ func (b *DelimitedBlock) AddAttributes(attributes ElementAttributes) {
 		log.Debugf("overriding kind '%s' to '%s'", b.Kind, attributes[AttrKind])
 		b.Kind = BlockKind(attributes.GetAsString(AttrKind))
 	}
+}
+
+// GetElements returns the elements
+func (b *DelimitedBlock) GetElements() []interface{} {
+	return b.Elements
+}
+
+// SetElements returns the elements
+func (b *DelimitedBlock) SetElements(elmts []interface{}) {
+	b.Elements = elmts
 }
 
 // ------------------------------------------


### PR DESCRIPTION
support inclusions in delimited blocks
support non-asciidoc files (just reading the files without
parsing)

Fixes #310 #312