### PR TITLE
feat(parser/renderer): support adoc file inclusion in delimited blocks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ generate: prebuild-checks
 ## generate the .go file based on the asciidoc grammar
 generate-optimized:
 	@echo "generating the parser (optimized)..."
-	@pigeon -optimize-grammar -alternate-entrypoints InlineElementsWithoutSubtitution ./pkg/parser/asciidoc-grammar.peg > ./pkg/parser/asciidoc_parser.go
+	@pigeon -optimize-grammar -alternate-entrypoints InlineElementsWithoutSubtitution,DocumentToInclude ./pkg/parser/asciidoc-grammar.peg > ./pkg/parser/asciidoc_parser.go
 
 
 .PHONY: test

--- a/pkg/parser/asciidoc-grammar.peg
+++ b/pkg/parser/asciidoc-grammar.peg
@@ -449,7 +449,7 @@ TableOfContentsMacro <- "toc::[]" NEWLINE
 // ------------------------------------------
 // File inclusions
 // ------------------------------------------
-FileInclude <- "include::" path:(URL) inlineAttributes:(InlineAttributes) {
+FileInclude <- "include::" path:(URL) inlineAttributes:(InlineAttributes) WS* EOL {
     return types.NewFileInclusion(path.(string), inlineAttributes.(types.ElementAttributes))
 }
 
@@ -691,7 +691,7 @@ InlineElement <- !EOL !LineBreak
 // special case for re-parsing a group of elements after a document substitution:
 // we should treat substitution that did not happen (eg: missing attribute) as regular
 // strings - (used by the inline element renderer)
-InlineElementsWithoutSubtitution <- !BlankLine !BlockDelimiter elements:(InlineElementWithoutSubtitution)* linebreak:(LineBreak)? EOL { // absorbs heading and trailing spaces
+InlineElementsWithoutSubtitution <- !BlankLine !BlockDelimiter elements:(InlineElementWithoutSubtitution)* linebreak:(LineBreak)? EOL { 
     return types.NewInlineElements(append(elements.([]interface{}), linebreak))
 } 
 
@@ -708,6 +708,17 @@ InlineElementWithoutSubtitution <- !EOL !LineBreak
         / Parenthesis 
         / Word) {
     return element, nil
+}
+
+// special case for parsing files to include in delimited blocks
+DocumentToInclude <- elements:(BlankLine / ParagraphToInclude)* EOF {
+    return elements, nil
+}
+
+ParagraphToInclude <- lines:(!EOF line:(InlineElementsWithoutSubtitution) {
+    return line, nil
+})+ {
+    return types.NewParagraph(lines.([]interface{}))
 }
 
 // ----------------------------------------------------------------------------
@@ -1029,7 +1040,7 @@ FencedBlock <- FencedBlockDelimiter content:(FencedBlockContent)* (FencedBlockDe
     return types.NewDelimitedBlock(types.Fenced, content.([]interface{}), types.None)
 }
 
-FencedBlockContent <- BlankLine / List / BlockParagraph
+FencedBlockContent <- BlankLine / FileInclude / List / BlockParagraph
 
 // -------------------------------------------------------------------------------------
 // Listing blocks
@@ -1037,30 +1048,36 @@ FencedBlockContent <- BlankLine / List / BlockParagraph
 ListingBlockDelimiter <- "----" WS* EOL
 
 // listing block: verbatim content
-ListingBlock <- ListingBlockDelimiter content:(ListingBlockContent)* ((ListingBlockDelimiter) / EOF) {
+ListingBlock <- ListingBlockDelimiter content:(ListingBlockElement)* ((ListingBlockDelimiter) / EOF) {
     return types.NewDelimitedBlock(types.Listing, content.([]interface{}), types.None)
 }
 
-ListingBlockContent <- lines:(ListingBlockLine)+ {
+ListingBlockElement <- ListingFileInclude / ListingBlockParagraph
+
+ListingFileInclude <- !ListingBlockDelimiter !EOF include:(FileInclude) {
+    return include, nil
+}
+
+ListingBlockParagraph <- lines:(ListingBlockLine)+ {
     return types.NewParagraph(lines.([]interface{}), nil)
 }
 
 ListingBlockLine <- !ListingBlockDelimiter !EOF line:(ListingBlockLineContent) EOL {
-    return line.(types.InlineElements), nil
+    return line, nil
 }
 
 ListingBlockLineContent <- (Alphanums / Spaces / (!ListingBlockDelimiter !EOL  .){
-    return string(c.text), nil
-})* { // skip EOL in line content, and stop when quote block delimiter is encountered
-    return types.NewInlineElements(string(c.text))
-}
+        return string(c.text), nil
+    })* { // skip EOL in line content, and stop when quote block delimiter is encountered
+        return types.NewInlineElements(string(c.text))
+    }
 
 // -------------------------------------------------------------------------------------
 // Example blocks
 // -------------------------------------------------------------------------------------
 ExampleBlockDelimiter <- "====" WS* EOL
 
-ExampleBlock <- ExampleBlockDelimiter content:(BlankLine / List / BlockParagraph)*  (ExampleBlockDelimiter / EOF) {
+ExampleBlock <- ExampleBlockDelimiter content:(BlankLine / FileInclude / List / BlockParagraph)*  (ExampleBlockDelimiter / EOF) {
     return types.NewDelimitedBlock(types.Example, content.([]interface{}), types.None)
 }
 
@@ -1101,7 +1118,7 @@ VerseBlock <- &{
     verse, ok := c.state["verse"].(bool); 
     return ok && verse, nil
 }
-verse:(QuoteBlockDelimiter content:(VerseBlockContent)* (QuoteBlockDelimiter / EOF) {
+verse:(QuoteBlockDelimiter content:(VerseBlockElement)* (QuoteBlockDelimiter / EOF) {
     return types.NewDelimitedBlock(types.Verse, content.([]interface{}), types.None)
 }) #{
     c.state["verse"] = false
@@ -1110,7 +1127,14 @@ verse:(QuoteBlockDelimiter content:(VerseBlockContent)* (QuoteBlockDelimiter / E
     return verse, nil
 }
 
-VerseBlockContent <- lines:(VerseBlockLine)+ {
+VerseBlockElement <- VerseFileInclude / VerseBlockParagraph
+
+
+VerseFileInclude <- !QuoteBlockDelimiter !EOF include:(FileInclude) {
+    return include, nil
+}
+
+VerseBlockParagraph <- lines:(VerseBlockLine)+ {
     return types.NewParagraph(lines.([]interface{}), nil)
 }
 
@@ -1131,7 +1155,7 @@ SidebarBlock <- SidebarBlockDelimiter content:(SidebarBlockContent)*  (SidebarBl
     return types.NewDelimitedBlock(types.Sidebar, content.([]interface{}), types.None)
 }
 
-SidebarBlockContent <- BlankLine / List / NonSidebarBlock / BlockParagraph
+SidebarBlockContent <- BlankLine / FileInclude / List / NonSidebarBlock / BlockParagraph
 
 NonSidebarBlock <- !SidebarBlock content:(DelimitedBlock) {
     return content, nil

--- a/pkg/parser/file_inclusion_test.go
+++ b/pkg/parser/file_inclusion_test.go
@@ -8,7 +8,7 @@ import (
 
 var _ = Describe("file inclusions", func() {
 
-	It("include adoc file with leveloffset attribute", func() {
+	It("should include adoc file with leveloffset attribute", func() {
 		actualContent := "include::includes/chapter-a.adoc[leveloffset=+1]"
 		expectedResult := types.FileInclusion{
 			Attributes: types.ElementAttributes{
@@ -17,5 +17,133 @@ var _ = Describe("file inclusions", func() {
 			Path: "includes/chapter-a.adoc",
 		}
 		verify(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
+	})
+
+	Context("file inclusion in delimited blocks", func() {
+
+		It("should include adoc file within fenced block", func() {
+			actualContent := "```\n" +
+				"include::includes/chapter-a.adoc[]\n" +
+				"```"
+			expectedResult := types.DelimitedBlock{
+				Attributes: types.ElementAttributes{},
+				Kind:       types.Fenced,
+				Elements: []interface{}{
+					types.FileInclusion{
+						Attributes: types.ElementAttributes{},
+						Path:       "includes/chapter-a.adoc",
+					},
+				},
+			}
+			verify(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
+		})
+
+		It("should include adoc file within listing block", func() {
+			actualContent := `----
+include::includes/chapter-a.adoc[]
+----`
+			expectedResult := types.DelimitedBlock{
+				Attributes: types.ElementAttributes{},
+				Kind:       types.Listing,
+				Elements: []interface{}{
+					types.FileInclusion{
+						Attributes: types.ElementAttributes{},
+						Path:       "includes/chapter-a.adoc",
+					},
+				},
+			}
+			verify(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
+		})
+
+		It("should include adoc file within example block", func() {
+			actualContent := `====
+include::includes/chapter-a.adoc[]
+====`
+			expectedResult := types.DelimitedBlock{
+				Attributes: types.ElementAttributes{},
+				Kind:       types.Example,
+				Elements: []interface{}{
+					types.FileInclusion{
+						Attributes: types.ElementAttributes{},
+						Path:       "includes/chapter-a.adoc",
+					},
+				},
+			}
+			verify(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
+		})
+
+		It("should include adoc file within quote block", func() {
+			actualContent := `____
+include::includes/chapter-a.adoc[]
+____`
+			expectedResult := types.DelimitedBlock{
+				Attributes: types.ElementAttributes{},
+				Kind:       types.Quote,
+				Elements: []interface{}{
+					types.FileInclusion{
+						Attributes: types.ElementAttributes{},
+						Path:       "includes/chapter-a.adoc",
+					},
+				},
+			}
+			verify(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
+		})
+
+		It("should include adoc file within verse block", func() {
+			actualContent := `[verse]
+____
+include::includes/chapter-a.adoc[]
+____`
+			expectedResult := types.DelimitedBlock{
+				Attributes: types.ElementAttributes{
+					types.AttrKind:        types.Verse,
+					types.AttrQuoteAuthor: "",
+					types.AttrQuoteTitle:  "",
+				},
+				Kind: types.Verse,
+				Elements: []interface{}{
+					types.FileInclusion{
+						Attributes: types.ElementAttributes{},
+						Path:       "includes/chapter-a.adoc",
+					},
+				},
+			}
+			verify(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
+		})
+
+		It("should include adoc file within sidebar block", func() {
+			actualContent := `****
+include::includes/chapter-a.adoc[]
+****`
+			expectedResult := types.DelimitedBlock{
+				Attributes: types.ElementAttributes{},
+				Kind:       types.Sidebar,
+				Elements: []interface{}{
+					types.FileInclusion{
+						Attributes: types.ElementAttributes{},
+						Path:       "includes/chapter-a.adoc",
+					},
+				},
+			}
+			verify(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
+		})
+
+		It("should include adoc file within passthrough block", func() {
+			Skip("missing support for passthrough blocks")
+			actualContent := `++++
+include::includes/chapter-a.adoc[]
+++++`
+			expectedResult := types.DelimitedBlock{
+				Attributes: types.ElementAttributes{},
+				// Kind:       types.Passthrough,
+				Elements: []interface{}{
+					types.FileInclusion{
+						Attributes: types.ElementAttributes{},
+						Path:       "includes/chapter-a.adoc",
+					},
+				},
+			}
+			verify(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
+		})
 	})
 })

--- a/pkg/renderer/file_inclusions_test.go
+++ b/pkg/renderer/file_inclusions_test.go
@@ -11,7 +11,7 @@ import (
 
 var _ = Describe("file inclusions", func() {
 
-	It("should include file with section 0 at root level without offset", func() {
+	It("should include adoc file with section 0 at root level without offset", func() {
 		actualContent := types.Document{
 			Attributes:         types.DocumentAttributes{},
 			ElementReferences:  types.ElementReferences{},
@@ -93,7 +93,7 @@ var _ = Describe("file inclusions", func() {
 		verifyFileInclusions(expectedContent, actualContent)
 	})
 
-	It("should include file with section 0 at root level with valid offset", func() {
+	It("should include adoc file with section 0 at root level with valid offset", func() {
 		actualContent := types.Document{
 			Attributes:         types.DocumentAttributes{},
 			ElementReferences:  types.ElementReferences{},
@@ -177,7 +177,7 @@ var _ = Describe("file inclusions", func() {
 		verifyFileInclusions(expectedContent, actualContent)
 	})
 
-	It("should include file with section 0 within existin section with valid offset", func() {
+	It("should include adoc file with section 0 within existin section with valid offset", func() {
 		actualContent := types.Document{
 			Attributes:         types.DocumentAttributes{},
 			ElementReferences:  types.ElementReferences{},
@@ -292,7 +292,7 @@ var _ = Describe("file inclusions", func() {
 		verifyFileInclusions(expectedContent, actualContent)
 	})
 
-	It("should include file with 2 paragraphs at root level without offset", func() {
+	It("should include adoc file with 2 paragraphs at root level without offset", func() {
 		actualContent := types.Document{
 			Attributes:         types.DocumentAttributes{},
 			ElementReferences:  types.ElementReferences{},
@@ -349,6 +349,93 @@ var _ = Describe("file inclusions", func() {
 					Lines: []types.InlineElements{
 						{
 							types.StringElement{Content: "last line of grandchild"},
+						},
+					},
+				},
+				types.BlankLine{},
+				types.Paragraph{
+					Attributes: types.ElementAttributes{},
+					Lines: []types.InlineElements{
+						{
+							types.StringElement{Content: "a second paragraph"},
+						},
+					},
+				},
+			},
+		}
+		verifyFileInclusions(expectedContent, actualContent)
+	})
+
+	It("should include unparsed adoc file in delimited block", func() {
+		actualContent := types.Document{
+			Attributes:         types.DocumentAttributes{},
+			ElementReferences:  types.ElementReferences{},
+			Footnotes:          types.Footnotes{},
+			FootnoteReferences: types.FootnoteReferences{},
+			Elements: []interface{}{
+				types.Paragraph{
+					Attributes: types.ElementAttributes{},
+					Lines: []types.InlineElements{
+						{
+							types.StringElement{Content: "a first paragraph"},
+						},
+					},
+				},
+				types.DelimitedBlock{
+					Kind:       types.Source,
+					Attributes: types.ElementAttributes{},
+					Elements: []interface{}{
+						types.FileInclusion{
+							Attributes: types.ElementAttributes{},
+							Path:       "html5/includes/chapter-a.adoc",
+						},
+					},
+				},
+				types.BlankLine{},
+				types.Paragraph{
+					Attributes: types.ElementAttributes{},
+					Lines: []types.InlineElements{
+						{
+							types.StringElement{Content: "a second paragraph"},
+						},
+					},
+				},
+			},
+		}
+		expectedContent := types.Document{
+			Attributes:         types.DocumentAttributes{},
+			ElementReferences:  types.ElementReferences{},
+			Footnotes:          types.Footnotes{},
+			FootnoteReferences: types.FootnoteReferences{},
+			Elements: []interface{}{
+				types.Paragraph{
+					Attributes: types.ElementAttributes{},
+					Lines: []types.InlineElements{
+						{
+							types.StringElement{Content: "a first paragraph"},
+						},
+					},
+				},
+				types.DelimitedBlock{
+					Kind:       types.Source,
+					Attributes: types.ElementAttributes{},
+					Elements: []interface{}{
+						types.Paragraph{
+							Attributes: types.ElementAttributes{},
+							Lines: []types.InlineElements{
+								{
+									types.StringElement{Content: "= Chapter A"},
+								},
+							},
+						},
+						types.BlankLine{},
+						types.Paragraph{
+							Attributes: types.ElementAttributes{},
+							Lines: []types.InlineElements{
+								{
+									types.StringElement{Content: "content"},
+								},
+							},
 						},
 					},
 				},

--- a/pkg/renderer/html5/delimited_block_test.go
+++ b/pkg/renderer/html5/delimited_block_test.go
@@ -142,7 +142,7 @@ end</code></pre>
 
 	Context("example blocks", func() {
 
-		It("example block with multiple elements", func() {
+		It("example block with multiple elements - case 1", func() {
 			actualContent := `====
 some listing code
 with *bold content*
@@ -161,6 +161,25 @@ with <strong>bold content</strong></p>
 <p>and a list item</p>
 </li>
 </ul>
+</div>
+</div>
+</div>`
+			verify(GinkgoT(), expectedResult, actualContent)
+		})
+
+		It("example block with multiple elements - case 2", func() {
+			actualContent := `====
+*bold content*
+
+and more content
+====`
+			expectedResult := `<div class="exampleblock">
+<div class="content">
+<div class="paragraph">
+<p><strong>bold content</strong></p>
+</div>
+<div class="paragraph">
+<p>and more content</p>
 </div>
 </div>
 </div>`

--- a/pkg/renderer/html5/file_inclusion_test.go
+++ b/pkg/renderer/html5/file_inclusion_test.go
@@ -29,4 +29,129 @@ include::includes/chapter-a.adoc[leveloffset=+1]`
 </div>`
 		verify(GinkgoT(), expectedResult, actualContent)
 	})
+
+	Context("file inclusion in delimited blocks", func() {
+
+		It("should include adoc file within listing block", func() {
+			actualContent := `= Master Document
+
+preamble
+
+----
+include::includes/chapter-a.adoc[]
+----`
+			expectedResult := `<div class="paragraph">
+<p>preamble</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>= Chapter A
+
+content</pre>
+</div>
+</div>`
+			verify(GinkgoT(), expectedResult, actualContent)
+		})
+
+		It("should include adoc file within fenced block", func() {
+			actualContent := "```\n" +
+				"include::includes/chapter-a.adoc[]\n" +
+				"```"
+			expectedResult := `<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>= Chapter A
+
+content</code></pre>
+</div>
+</div>`
+			verify(GinkgoT(), expectedResult, actualContent)
+		})
+
+		It("should include adoc file within listing block", func() {
+			actualContent := `----
+include::includes/chapter-a.adoc[]
+----`
+			expectedResult := `<div class="listingblock">
+<div class="content">
+<pre>= Chapter A
+
+content</pre>
+</div>
+</div>`
+			verify(GinkgoT(), expectedResult, actualContent)
+		})
+
+		It("should include adoc file within example block", func() {
+			actualContent := `====
+include::includes/chapter-a.adoc[]
+====`
+			expectedResult := `<div class="exampleblock">
+<div class="content">
+<div class="paragraph">
+<p>= Chapter A</p>
+</div>
+<div class="paragraph">
+<p>content</p>
+</div>
+</div>
+</div>`
+			verify(GinkgoT(), expectedResult, actualContent)
+		})
+
+		It("should include adoc file within quote block", func() {
+			actualContent := `____
+include::includes/chapter-a.adoc[]
+____`
+			expectedResult := `<div class="quoteblock">
+<blockquote>
+<div class="paragraph">
+<p>= Chapter A</p>
+</div>
+<div class="paragraph">
+<p>content</p>
+</div>
+</blockquote>
+</div>`
+			verify(GinkgoT(), expectedResult, actualContent)
+		})
+
+		It("should include adoc file within verse block", func() {
+			actualContent := `[verse]
+____
+include::includes/chapter-a.adoc[]
+____`
+			expectedResult := `<div class="verseblock">
+<pre class="content">= Chapter A
+
+content</pre>
+</div>`
+			verify(GinkgoT(), expectedResult, actualContent)
+		})
+
+		It("should include adoc file within sidebar block", func() {
+			actualContent := `****
+include::includes/chapter-a.adoc[]
+****`
+			expectedResult := `<div class="sidebarblock">
+<div class="content">
+<div class="paragraph">
+<p>= Chapter A</p>
+</div>
+<div class="paragraph">
+<p>content</p>
+</div>
+</div>
+</div>`
+			verify(GinkgoT(), expectedResult, actualContent)
+		})
+
+		It("should include adoc file within passthrough block", func() {
+			Skip("missing support for passthrough blocks")
+			actualContent := `++++
+include::includes/chapter-a.adoc[]
+++++`
+			expectedResult := ``
+			verify(GinkgoT(), expectedResult, actualContent)
+		})
+	})
 })

--- a/pkg/renderer/html5/renderer.go
+++ b/pkg/renderer/html5/renderer.go
@@ -27,8 +27,9 @@ func renderElements(ctx *renderer.Context, elements []interface{}) ([]byte, erro
 		if err != nil {
 			return nil, errors.Wrapf(err, "unable to render an element")
 		}
-		// insert new line if there's already some content
-		if hasContent && len(renderedElement) > 0 {
+		// insert new line if there's already some content (except for BlankLine)
+		_, isBlankline := element.(types.BlankLine)
+		if !isBlankline && hasContent && len(renderedElement) > 0 {
 			buff.WriteString("\n")
 		}
 		buff.Write(renderedElement)

--- a/pkg/types/grammar_types.go
+++ b/pkg/types/grammar_types.go
@@ -41,11 +41,6 @@ type Substitutor interface {
 	Visit(Substituable) (interface{}, error)
 }
 
-// ElementContainer en element that has child elements as well
-type ElementContainer interface {
-	GetElements() []interface{}
-}
-
 // ------------------------------------------
 // Document
 // ------------------------------------------
@@ -439,9 +434,6 @@ type Preamble struct {
 	Elements []interface{}
 }
 
-// verify interface(s)
-var _ ElementContainer = Preamble{}
-
 // NewEmptyPreamble return an empty Preamble
 func NewEmptyPreamble() Preamble {
 	return Preamble{
@@ -502,9 +494,6 @@ type Section struct {
 	Elements []interface{}
 }
 
-// verify interface(s)
-var _ ElementContainer = Section{}
-
 // NewSection initializes a new `Section` from the given section title and elements
 func NewSection(level int, sectionTitle SectionTitle, blocks []interface{}) (Section, error) {
 	log.Debugf("initialized a new Section level %d with %d block(s)", level, len(blocks))
@@ -522,7 +511,7 @@ func (s Section) AddAttributes(attributes ElementAttributes) {
 }
 
 // GetElements returns the elements
-func (s Section) GetElements() []interface{} {
+func (s *Section) GetElements() []interface{} {
 	return s.Elements
 }
 
@@ -655,7 +644,7 @@ type List interface {
 type ListItem interface {
 	GetElements() []interface{}
 	AddElement(interface{})
-	SetElements([]interface{})
+	SetElements([]interface{}) // TODO: remove this method?
 	processContinuations([]ListItem) ListItem
 }
 
@@ -1719,6 +1708,8 @@ func NewInlineElements(elements ...interface{}) (InlineElements, error) {
 	return result, nil
 }
 
+var _ Visitable = InlineElements{}
+
 // AcceptVisitor implements Visitable#AcceptVisitor(Visitor)
 func (e InlineElements) AcceptVisitor(v Visitor) error {
 	err := v.Visit(e)
@@ -1958,6 +1949,16 @@ func (b *DelimitedBlock) AddAttributes(attributes ElementAttributes) {
 		log.Debugf("overriding kind '%s' to '%s'", b.Kind, attributes[AttrKind])
 		b.Kind = BlockKind(attributes.GetAsString(AttrKind))
 	}
+}
+
+// GetElements returns the elements
+func (b *DelimitedBlock) GetElements() []interface{} {
+	return b.Elements
+}
+
+// SetElements returns the elements
+func (b *DelimitedBlock) SetElements(elmts []interface{}) {
+	b.Elements = elmts
 }
 
 // ------------------------------------------


### PR DESCRIPTION
parsing the .adoc file with a new entry point to ignore
the section (just get paragraphs, etc.)

fixes #310