### PR TITLE
chore(build): build with go 1.12 on Travis-ci and AppVeyor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ sudo: false
 language: go
 
 go:
-  - "1.9.x"
   - "1.10.x"
   - "1.11.x"
+  - "1.12.x"
   - tip
 
 os:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,9 +10,9 @@ environment:
   GOPATH: c:\gopath
   DEPTESTBYPASS501: "1"
   matrix:
-    - GO_VERSION: "1.9"
     - GO_VERSION: "1.10"
     - GO_VERSION: "1.11"
+    - GO_VERSION: "1.12"
 
 init:
   - git config --global core.autocrlf input


### PR DESCRIPTION
retain/build only 3 stable versions of Go

Fixes #323