### PR TITLE
feat(parser/renderer): support file inclusion with line ranges

### DIFF
--- a/pkg/parser/asciidoc-grammar.peg
+++ b/pkg/parser/asciidoc-grammar.peg
@@ -2,7 +2,10 @@
 package parser 
 
 import (
+    "strconv"
+
     "github.com/bytesparadise/libasciidoc/pkg/types"
+
     log "github.com/sirupsen/logrus"
 )
 
@@ -224,9 +227,13 @@ AttributeGroup <- "[" !WS attributes:(GenericAttribute)*  "]" {
     return types.NewAttributeGroup(attributes.([]interface{}))
 }
 
-GenericAttribute <- key:(AttributeKey) "=" value:(AttributeValue) ","? WS* { // value is set
+GenericAttribute <-  GenericAttributeWithValue / GenericAttributeWithoutValue
+
+GenericAttributeWithValue <- key:(AttributeKey) "=" value:(AttributeValue) ","? WS* { // value is set
     return types.NewGenericAttribute(key.(string), value)
-} / key:(AttributeKey) ","? WS* { // value is not set
+}
+
+GenericAttributeWithoutValue <- key:(AttributeKey) ","? WS* { // value is not set
     return types.NewGenericAttribute(key.(string), nil)
 }
 
@@ -449,8 +456,60 @@ TableOfContentsMacro <- "toc::[]" NEWLINE
 // ------------------------------------------
 // File inclusions
 // ------------------------------------------
-FileInclude <- "include::" path:(URL) inlineAttributes:(InlineAttributes) WS* EOL {
+FileInclude <- "include::" path:(URL) inlineAttributes:(FileIncludeAttributes) WS* EOL {
     return types.NewFileInclusion(path.(string), inlineAttributes.(types.ElementAttributes))
+}
+
+FileIncludeAttributes <- "[" attrs:(LineRangesAttribute / GenericAttribute)* "]" {
+    return types.NewInlineAttributes(attrs.([]interface{}))
+} 
+
+LineRangesAttribute <- "lines=" lines:(LineRangesAttributeValue) ","? { 
+    return types.NewLineRangesAttribute(lines)
+} 
+
+LineRangesAttributeValue <- value:(MultipleRanges 
+                        / MultipleQuotedRanges 
+                        / MultilineRange 
+                        / MultilineQuotedRange 
+                        / SinglelineQuotedRange
+                        / SinglelineRange 
+                        / UndefinedLineRange) WS* (&"," / &"]") {
+    return value, nil
+}
+
+MultipleRanges <- first:(MultilineRange / SinglelineRange) 
+    others:(";" other:(MultilineRange / SinglelineRange) {
+        return other, nil
+    })+ {
+        return append([]interface{}{first}, others.([]interface{})...), nil
+    }
+
+MultipleQuotedRanges <- "\"" first:(MultilineRange / SinglelineRange) 
+    others:("," other:(MultilineRange / SinglelineRange) {
+        return other, nil
+    })+ "\"" {
+        return append([]interface{}{first}, others.([]interface{})...), nil
+    }
+
+MultilineRange <- start:(NUMBER) ".." end:(NUMBER) { // eg: lines=12..14
+    return types.NewMultilineRange(start.(int), end.(int))
+} 
+
+MultilineQuotedRange <- "\"" start:(NUMBER) ".." end:(NUMBER) "\"" { // eg: lines=12..14
+    return types.NewMultilineRange(start.(int), end.(int))
+} 
+
+SinglelineRange <- singleline:(NUMBER) { // eg: lines=12
+    return types.NewSingleLineRange(singleline.(int))
+}
+
+SinglelineQuotedRange <- "\"" singleline:(NUMBER) "\"" { // eg: lines=12
+    return types.NewSingleLineRange(singleline.(int))
+}
+
+UndefinedLineRange <- (!"]" !"," !WS .)* {
+    return string(c.text), nil
 }
 
 // ------------------------------------------
@@ -1344,6 +1403,10 @@ URL_SCHEME <- "http://" / "https://" / "ftp://" / "irc://" / "mailto:"
 
 DIGIT <- [0-9] {
     return string(c.text), nil
+}
+
+NUMBER <- "-"? DIGIT+ {
+    return strconv.Atoi(string(c.text))
 }
 
 WS <- " " / "\t" {

--- a/pkg/parser/file_inclusion_test.go
+++ b/pkg/parser/file_inclusion_test.go
@@ -146,4 +146,145 @@ include::includes/chapter-a.adoc[]
 			verify(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
 		})
 	})
+
+	Context("file inclusion with line ranges", func() {
+
+		Context("file inclusion with unquoted line ranges", func() {
+
+			It("file inclusion with single unquoted line", func() {
+				actualContent := `include::includes/chapter-a.adoc[lines=1]`
+				expectedResult := types.FileInclusion{
+					Attributes: types.ElementAttributes{
+						types.AttrLineRanges: types.LineRanges{
+							{Start: 1, End: 1},
+						},
+					},
+					Path: "includes/chapter-a.adoc",
+				}
+				verify(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
+			})
+
+			It("file inclusion with multiple unquoted lines", func() {
+				actualContent := `include::includes/chapter-a.adoc[lines=1..2]`
+				expectedResult := types.FileInclusion{
+					Attributes: types.ElementAttributes{
+						types.AttrLineRanges: types.LineRanges{
+							{Start: 1, End: 2},
+						},
+					},
+					Path: "includes/chapter-a.adoc",
+				}
+				verify(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
+			})
+
+			It("file inclusion with multiple unquoted ranges", func() {
+				actualContent := `include::includes/chapter-a.adoc[lines=1;3..4;6..-1]`
+				expectedResult := types.FileInclusion{
+					Attributes: types.ElementAttributes{
+						types.AttrLineRanges: types.LineRanges{
+							{Start: 1, End: 1},
+							{Start: 3, End: 4},
+							{Start: 6, End: -1},
+						},
+					},
+					Path: "includes/chapter-a.adoc",
+				}
+				verify(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
+			})
+
+			It("file inclusion with invalid unquoted range - case 1", func() {
+				actualContent := `include::includes/chapter-a.adoc[lines=1;3..4;6..foo]` // not a number
+				expectedResult := types.FileInclusion{
+					Attributes: types.ElementAttributes{
+						types.AttrLineRanges: `1;3..4;6..foo`,
+					},
+					Path: "includes/chapter-a.adoc",
+				}
+				verify(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
+			})
+
+			It("file inclusion with invalid unquoted range - case 2", func() {
+				actualContent := `include::includes/chapter-a.adoc[lines=1,3..4,6..-1]` // using commas instead of semi-colons
+				expectedResult := types.FileInclusion{
+					Attributes: types.ElementAttributes{
+						types.AttrLineRanges: types.LineRanges{
+							{Start: 1, End: 1},
+						},
+						"3..4":  nil,
+						"6..-1": nil,
+					},
+					Path: "includes/chapter-a.adoc",
+				}
+				verify(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
+			})
+		})
+
+		Context("file inclusion with quoted line ranges", func() {
+
+			It("file inclusion with single quoted line", func() {
+				actualContent := `include::includes/chapter-a.adoc[lines="1"]`
+				expectedResult := types.FileInclusion{
+					Attributes: types.ElementAttributes{
+						types.AttrLineRanges: types.LineRanges{
+							{Start: 1, End: 1},
+						},
+					},
+					Path: "includes/chapter-a.adoc",
+				}
+				verify(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
+			})
+
+			It("file inclusion with multiple quoted lines", func() {
+				actualContent := `include::includes/chapter-a.adoc[lines="1..2"]`
+				expectedResult := types.FileInclusion{
+					Attributes: types.ElementAttributes{
+						types.AttrLineRanges: types.LineRanges{
+							{Start: 1, End: 2},
+						},
+					},
+					Path: "includes/chapter-a.adoc",
+				}
+				verify(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
+			})
+
+			It("file inclusion with multiple quoted ranges", func() {
+				actualContent := `include::includes/chapter-a.adoc[lines="1,3..4,6..-1"]`
+				expectedResult := types.FileInclusion{
+					Attributes: types.ElementAttributes{
+						types.AttrLineRanges: types.LineRanges{
+							{Start: 1, End: 1},
+							{Start: 3, End: 4},
+							{Start: 6, End: -1},
+						},
+					},
+					Path: "includes/chapter-a.adoc",
+				}
+				verify(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
+			})
+
+			It("file inclusion with invalid quoted range - case 1", func() {
+				actualContent := `include::includes/chapter-a.adoc[lines="1,3..4,6..foo"]` // not a number
+				expectedResult := types.FileInclusion{
+					Attributes: types.ElementAttributes{
+						types.AttrLineRanges: `"1`, // viewed as a string
+						"3..4":              nil,
+						"6..foo":            nil,
+					},
+					Path: "includes/chapter-a.adoc",
+				}
+				verify(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
+			})
+
+			It("file inclusion with invalid quoted range - case 2", func() {
+				actualContent := `include::includes/chapter-a.adoc[lines="1;3..4;6..10"]` // using semi-colons instead of commas
+				expectedResult := types.FileInclusion{
+					Attributes: types.ElementAttributes{
+						types.AttrLineRanges: `"1;3..4;6..10"`,
+					},
+					Path: "includes/chapter-a.adoc",
+				}
+				verify(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
+			})
+		})
+	})
 })

--- a/pkg/renderer/html5/file_inclusion_test.go
+++ b/pkg/renderer/html5/file_inclusion_test.go
@@ -293,15 +293,89 @@ include::includes/hello_world.go[]
 </div>`
 				verify(GinkgoT(), expectedResult, actualContent)
 			})
+		})
+	})
 
-			It("should include go file within passthrough block", func() {
-				Skip("missing support for passthrough blocks")
-				actualContent := `++++
-include::includes/hello_world.go[]
-++++`
-				expectedResult := ``
+	Context("file inclusions with line range", func() {
+
+		Context("file inclusions as paragraph with line range", func() {
+
+			It("should include single line as paragraph", func() {
+				actualContent := `include::includes/hello_world.go[lines=1]`
+				expectedResult := `<div class="paragraph">
+<p>package includes</p>
+</div>`
+				verify(GinkgoT(), expectedResult, actualContent)
+			})
+
+			It("should include multiple lines as paragraph", func() {
+				actualContent := `include::includes/hello_world.go[lines=5..7]`
+				expectedResult := `<div class="paragraph">
+<p>func helloworld() {
+	fmt.Println(&#34;hello, world!&#34;)
+}</p>
+</div>`
+				verify(GinkgoT(), expectedResult, actualContent)
+			})
+
+			It("should include multiple ranges as paragraph", func() {
+				actualContent := `include::includes/hello_world.go[lines=1..2;5..7]`
+				expectedResult := `<div class="paragraph">
+<p>package includes</p>
+</div>
+<div class="paragraph">
+<p>func helloworld() {
+	fmt.Println(&#34;hello, world!&#34;)
+}</p>
+</div>`
 				verify(GinkgoT(), expectedResult, actualContent)
 			})
 		})
+
+		Context("file inclusions in listing blocks with line range", func() {
+
+			It("should include single line in listing block", func() {
+				actualContent := `----
+include::includes/hello_world.go[lines=1]
+----`
+				expectedResult := `<div class="listingblock">
+<div class="content">
+<pre>package includes</pre>
+</div>
+</div>`
+				verify(GinkgoT(), expectedResult, actualContent)
+			})
+
+			It("should include multiple lines in listing block", func() {
+				actualContent := `----
+include::includes/hello_world.go[lines=5..7]
+----`
+				expectedResult := `<div class="listingblock">
+<div class="content">
+<pre>func helloworld() {
+	fmt.Println("hello, world!")
+}</pre>
+</div>
+</div>`
+				verify(GinkgoT(), expectedResult, actualContent)
+			})
+
+			It("should include multiple ranges in listing block", func() {
+				actualContent := `----
+include::includes/hello_world.go[lines=1..2;5..7]
+----`
+				expectedResult := `<div class="listingblock">
+<div class="content">
+<pre>package includes
+
+func helloworld() {
+	fmt.Println("hello, world!")
+}</pre>
+</div>
+</div>`
+				verify(GinkgoT(), expectedResult, actualContent)
+			})
+		})
+
 	})
 })

--- a/pkg/renderer/pre_render.go
+++ b/pkg/renderer/pre_render.go
@@ -9,18 +9,11 @@ import (
 // - wraps elements in a preamble
 // - generated the ToC
 func Prerender(ctx *Context) error {
-	doc, err := ProcessFileInclusions(ctx.Document)
+	err := ProcessFileInclusions(ctx)
 	if err != nil {
 		return errors.Wrap(err, "failed to pre-render document")
 	}
-	doc, err = IncludePreamble(doc)
-	if err != nil {
-		return errors.Wrap(err, "failed to pre-render document")
-	}
-	doc, err = IncludeTableOfContents(doc)
-	if err != nil {
-		return errors.Wrap(err, "failed to pre-render document")
-	}
-	ctx.Document = doc
+	IncludePreamble(ctx)
+	IncludeTableOfContents(ctx)
 	return nil
 }

--- a/pkg/renderer/preamble.go
+++ b/pkg/renderer/preamble.go
@@ -7,9 +7,8 @@ import (
 
 // IncludePreamble wraps all document elements before the first section in a `Preamble`,
 // unless the document has no section. Returns a new document with the changes.
-func IncludePreamble(doc types.Document) (types.Document, error) {
-	doc.Elements = insertPreamble(doc.Elements)
-	return doc, nil
+func IncludePreamble(ctx *Context) {
+	ctx.Document.Elements = insertPreamble(ctx.Document.Elements)
 }
 
 func insertPreamble(blocks []interface{}) []interface{} {

--- a/pkg/renderer/preamble_test.go
+++ b/pkg/renderer/preamble_test.go
@@ -1,6 +1,8 @@
 package renderer_test
 
 import (
+	"context"
+
 	"github.com/bytesparadise/libasciidoc/pkg/renderer"
 	"github.com/bytesparadise/libasciidoc/pkg/types"
 	. "github.com/onsi/ginkgo"
@@ -258,7 +260,7 @@ var _ = Describe("preambles", func() {
 })
 
 func verifyPreamble(expectedContent, actualContent types.Document) {
-	result, err := renderer.IncludePreamble(actualContent)
-	assert.NoError(GinkgoT(), err)
-	assert.Equal(GinkgoT(), expectedContent, result)
+	ctx := renderer.Wrap(context.Background(), actualContent)
+	renderer.IncludePreamble(ctx)
+	assert.Equal(GinkgoT(), expectedContent, ctx.Document)
 }

--- a/pkg/renderer/table_of_contents.go
+++ b/pkg/renderer/table_of_contents.go
@@ -7,11 +7,10 @@ import (
 
 // IncludeTableOfContents includes a Table Of Contents in the document
 // if the `toc` attribute is present
-func IncludeTableOfContents(doc types.Document) (types.Document, error) {
-	if location, ok := doc.Attributes.GetAsString(types.AttrTableOfContents); ok {
-		doc.Elements = insertTableOfContents(doc.Elements, location)
+func IncludeTableOfContents(ctx *Context) {
+	if location, ok := ctx.Document.Attributes.GetAsString(types.AttrTableOfContents); ok {
+		ctx.Document.Elements = insertTableOfContents(ctx.Document.Elements, location)
 	}
-	return doc, nil
 }
 func insertTableOfContents(elements []interface{}, location string) []interface{} {
 	log.Debugf("inserting a table of contents at location `%s`", location)

--- a/pkg/renderer/table_of_contents_test.go
+++ b/pkg/renderer/table_of_contents_test.go
@@ -1,6 +1,8 @@
 package renderer_test
 
 import (
+	"context"
+
 	"github.com/bytesparadise/libasciidoc/pkg/renderer"
 	"github.com/bytesparadise/libasciidoc/pkg/types"
 	. "github.com/onsi/ginkgo"
@@ -156,7 +158,7 @@ var _ = Describe("table of contents", func() {
 })
 
 func verifyTableOfContents(expectedContent, actualContent types.Document) {
-	result, err := renderer.IncludeTableOfContents(actualContent)
-	assert.NoError(GinkgoT(), err)
-	assert.Equal(GinkgoT(), expectedContent, result)
+	ctx := renderer.Wrap(context.Background(), actualContent)
+	renderer.IncludeTableOfContents(ctx)
+	assert.Equal(GinkgoT(), expectedContent, ctx.Document)
 }

--- a/pkg/types/element_attributes.go
+++ b/pkg/types/element_attributes.go
@@ -45,6 +45,8 @@ const (
 	AttrQandA string = "qanda"
 	// AttrLevelOffset the `leveloffset` attribute used in file inclusions
 	AttrLevelOffset = "leveloffset"
+	// AttrLineRanges the `lines` attribute used in file inclusions
+	AttrLineRanges = "lines"
 )
 
 // ElementWithAttributes an element on which attributes can be added/set

--- a/pkg/types/grammar_types_test.go
+++ b/pkg/types/grammar_types_test.go
@@ -2,8 +2,11 @@ package types_test
 
 import (
 	"github.com/bytesparadise/libasciidoc/pkg/types"
+
 	"github.com/davecgh/go-spew/spew"
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -1489,3 +1492,52 @@ func verify(t GinkgoTInterface, expectation, actual interface{}) {
 	t.Logf("expected document: `%s`", spew.Sdump(expectation))
 	assert.EqualValues(t, expectation, actual)
 }
+
+var _ = Describe("line ranges", func() {
+
+	ranges := newLineRanges(
+		types.LineRange{Start: 1, End: 1},
+		types.LineRange{Start: 3, End: 4},
+		types.LineRange{Start: 6, End: -1},
+	)
+
+	It("should match line 1", func() {
+		Expect(ranges.Match(1)).Should(BeTrue())
+	})
+
+	It("should not match line 2", func() {
+		Expect(ranges.Match(2)).Should(BeFalse())
+	})
+
+	It("should match line 6", func() {
+		Expect(ranges.Match(6)).Should(BeTrue())
+	})
+
+	It("should match line 100", func() {
+		Expect(ranges.Match(100)).Should(BeTrue())
+	})
+
+})
+
+func newLineRanges(values ...interface{}) types.LineRanges {
+	return types.NewLineRanges(values...)
+}
+
+var _ = Describe("fole inclusions", func() {
+
+	DescribeTable("check asciidoc file",
+		func(path string, expectation bool) {
+			f := types.FileInclusion{
+				Path: path,
+			}
+			Expect(f.IsAsciidoc()).Should(Equal(expectation))
+		},
+		Entry("foo.adoc", "foo.adoc", true),
+		Entry("foo.asc", "foo.asc", true),
+		Entry("foo.ad", "foo.ad", true),
+		Entry("foo.asciidoc", "foo.asciidoc", true),
+		Entry("foo.txt", "foo.txt", true),
+		Entry("foo.csv", "foo.csv", false),
+		Entry("foo.go", "foo.go", false),
+	)
+})


### PR DESCRIPTION
support multiple line ranges separated by semi colons or by
commas if declared within quotes.

Fixes #315