### PR TITLE
feat(parser/renderer): support recursive file inclusions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ generate: prebuild-checks
 ## generate the .go file based on the asciidoc grammar
 generate-optimized:
 	@echo "generating the parser (optimized)..."
-	@pigeon -optimize-grammar -alternate-entrypoints InlineElementsWithoutSubtitution,DocumentToInclude ./pkg/parser/asciidoc-grammar.peg > ./pkg/parser/asciidoc_parser.go
+	@pigeon -optimize-grammar -alternate-entrypoints InlineElementsWithoutSubtitution,VerbatimBlock ./pkg/parser/asciidoc-grammar.peg > ./pkg/parser/asciidoc_parser.go
 
 
 .PHONY: test

--- a/pkg/parser/asciidoc-grammar.peg
+++ b/pkg/parser/asciidoc-grammar.peg
@@ -769,15 +769,23 @@ InlineElementWithoutSubtitution <- !EOL !LineBreak
     return element, nil
 }
 
-// special case for parsing files to include in delimited blocks
-DocumentToInclude <- elements:(BlankLine / ParagraphToInclude)* EOF {
+// special case for parsing files to include in delimited blocks with 'verbatim' substitution
+VerbatimBlock <- elements:(BlankLine / FileInclude / VerbatimParagraph)* EOF {
     return elements, nil
 }
 
-ParagraphToInclude <- lines:(!EOF line:(InlineElementsWithoutSubtitution) {
+VerbatimParagraph <- lines:(!EOF line:(VerbatimParagraphLine) {
     return line, nil
 })+ {
     return types.NewParagraph(lines.([]interface{}))
+}
+
+VerbatimParagraphLine <- !BlockDelimiter !BlankLine elements:(VerbatimParagraphLineElement)* linebreak:(LineBreak)? EOL { 
+    return types.NewInlineElements(append(elements.([]interface{}), linebreak))
+} 
+
+VerbatimParagraphLineElement <- (!EOL !LineBreak .)+ {
+    return string(c.text), nil
 }
 
 // ----------------------------------------------------------------------------

--- a/pkg/renderer/file_inclusion.go
+++ b/pkg/renderer/file_inclusion.go
@@ -5,11 +5,11 @@ import (
 	"bytes"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strconv"
 
 	"github.com/bytesparadise/libasciidoc/pkg/parser"
 	"github.com/bytesparadise/libasciidoc/pkg/types"
-	"github.com/davecgh/go-spew/spew"
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -24,6 +24,7 @@ func ProcessFileInclusions(ctx *Context) error {
 
 // ProcessFileInclusions inspects the DOM and replaces all `FileInclusions`
 func processFileInclusions(elements []interface{}, withinDelimitedBlock bool) ([]interface{}, error) {
+	log.Debugf("processing file inclusions in %d element(s)", len(elements))
 	result := []interface{}{}
 	for _, element := range elements {
 		switch e := element.(type) {
@@ -42,11 +43,11 @@ func processFileInclusions(elements []interface{}, withinDelimitedBlock bool) ([
 			e.Elements = elements
 			result = append(result, e)
 		case types.FileInclusion:
-			docElements, err := parseFileToInclude(e, withinDelimitedBlock)
+			elements, err := parseFileToInclude(e, withinDelimitedBlock)
 			if err != nil {
 				return result, errors.Wrapf(err, "fail to process file inclusions")
 			}
-			result = append(result, docElements...)
+			result = append(result, elements...)
 		default:
 			result = append(result, e)
 		}
@@ -55,38 +56,65 @@ func processFileInclusions(elements []interface{}, withinDelimitedBlock bool) ([
 }
 
 func parseFileToInclude(file types.FileInclusion, withinDelimitedBlock bool) ([]interface{}, error) {
-	if withinDelimitedBlock || !file.IsAsciidoc() {
-		return parseNestedFileToInclude(file)
+	log.Debugf("parsing file '%s' to include...", file.Path)
+	options := []parser.Option{}
+	if withinDelimitedBlock {
+		options = append(options, parser.Entrypoint("VerbatimBlock"))
 	}
-	log.Debugf("parsing content from '%s'", file.Path)
-	doc, err := parser.ParseFile(file.Path)
+	content, restoreWD, err := readFile(file)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to read file to include: %s", file.Path)
+	}
+	defer restoreWD()
+	c, err := parser.Parse(file.Path, content, options...)
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to parse file to include")
 	}
-	if log.IsLevelEnabled(log.DebugLevel) {
-		log.Debug("document to include:")
-		spew.Dump(doc)
-	}
-	doc, err = ApplyLevelOffset(doc.(types.Document), file.Attributes.GetAsString(types.AttrLevelOffset))
+	doc, err := ApplyLevelOffset(c, file.Attributes.GetAsString(types.AttrLevelOffset))
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to parse file to include")
 	}
-	return doc.(types.Document).Elements, nil
+	// recursively process the elements returned by the parsing of the file to include
+	return processFileInclusions(doc.Elements, withinDelimitedBlock)
 }
 
-func parseNestedFileToInclude(file types.FileInclusion) ([]interface{}, error) {
-	log.Debug("including raw lines...")
-	f, err := os.Open(file.Path)
+// readFile returns the content of the file, taking into account the optional ranges to limit the content
+func readFile(file types.FileInclusion) ([]byte, func(), error) {
+	log.Debugf("reading '%s'...", file.Path)
+	// manage new working directory based on the file's location
+	// so that if this file also includes other files with relative path,
+	// then the it can work ;)
+	wd, err := os.Getwd()
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to read file to include")
+		return nil, func() {}, err
+	}
+	absPath, err := filepath.Abs(file.Path)
+	if err != nil {
+		return nil, func() {}, err
+	}
+	dir := filepath.Dir(absPath)
+	err = os.Chdir(dir)
+	if err != nil {
+		return nil, func() {}, err
+	}
+	restoreWDFunc := func() {
+		err = os.Chdir(wd) // restore the previous working directory
+		if err != nil {
+			log.WithError(err).Error("failed to restore previous working directory")
+		}
+	}
+	// read the file per-se
+	f, err := os.Open(absPath)
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, "unable to read file to include")
 	}
 	defer func() {
 		if closeErr := f.Close(); closeErr != nil {
 			err = closeErr
 		}
 	}()
-	buf := new(bytes.Buffer)
 	if lr, exists := file.Attributes[types.AttrLineRanges]; exists {
+		buf := new(bytes.Buffer)
 		if lineRanges, ok := lr.(types.LineRanges); ok { // could be a string if the input was invalid
 			scanner := bufio.NewScanner(bufio.NewReader(f))
 			line := 1
@@ -96,48 +124,43 @@ func parseNestedFileToInclude(file types.FileInclusion) ([]interface{}, error) {
 				if lineRanges.Match(line) {
 					_, err := buf.WriteString(scanner.Text())
 					if err != nil {
-						return nil, err
+						return nil, nil, errors.Wrap(err, "unable to parse file to include")
 					}
 					_, err = buf.WriteString("\n")
 					if err != nil {
-						return nil, err
+						return nil, nil, errors.Wrap(err, "unable to parse file to include")
 					}
-					log.Debugf("wrote line %d in buffer: '%s'", line, buf.String())
 				}
 				line++
 			}
-			log.Debugf("document lines to include: \n%s", buf.String())
 		}
-	} else {
-		// just read all the doc
-		b, err := ioutil.ReadAll(f)
-		if err != nil {
-			return nil, err
-		}
-		_, err = buf.Write(b)
-		if err != nil {
-			return nil, err
-		}
+		return buf.Bytes(), restoreWDFunc, nil
 	}
-
-	r, err := parser.Parse(file.Path, buf.Bytes(),
-		parser.Entrypoint("DocumentToInclude"))
-	if err != nil {
-		return nil, errors.Wrap(err, "unable to parse file to include")
-	}
-	elements, ok := r.([]interface{})
-	if !ok {
-		return nil, errors.Wrap(err, "failed to include file")
-	}
-	return elements, nil
+	// just read all the doc
+	content, err := ioutil.ReadAll(f)
+	return content, restoreWDFunc, err
 }
 
 // ApplyLevelOffset returns a document in which all section levels have been offset
-func ApplyLevelOffset(doc types.Document, levelOffset string) (types.Document, error) {
-	elements := doc.Elements
+func ApplyLevelOffset(c interface{}, levelOffset string) (types.Document, error) {
+	var doc types.Document
+	switch c := c.(type) {
+	case types.Document:
+		doc = c
+	case []interface{}:
+		doc = types.Document{
+			Attributes:         types.DocumentAttributes{},
+			ElementReferences:  types.ElementReferences{},
+			Footnotes:          types.Footnotes{},
+			FootnoteReferences: types.FootnoteReferences{},
+			Elements:           c,
+		}
+	default:
+		return types.Document{}, errors.Errorf("fail to apply level offset '%s' to document to include: unexpected type of content: %T", levelOffset, c)
+	}
 	// before returning the the doc elements, we need to check if there's a 'section 0', i.e., a title
 	if title, ok := doc.Attributes[types.AttrTitle]; ok {
-		elements = []interface{}{
+		doc.Elements = []interface{}{
 			types.Section{
 				Level:    0,
 				Title:    title.(types.SectionTitle),
@@ -151,9 +174,8 @@ func ApplyLevelOffset(doc types.Document, levelOffset string) (types.Document, e
 			return types.Document{}, errors.Wrapf(err, "fail to apply level offset '%s' to document to include", levelOffset)
 		}
 		// traverse the document and apply the offset on all sections
-		elements = doApplyLevelOffset(elements, offset)
+		doc.Elements = doApplyLevelOffset(doc.Elements, offset)
 	}
-	doc.Elements = elements
 	return doc, nil
 }
 

--- a/pkg/renderer/file_inclusion_test.go
+++ b/pkg/renderer/file_inclusion_test.go
@@ -13,529 +13,724 @@ import (
 
 var _ = Describe("file inclusions", func() {
 
-	It("should include adoc file with section 0 at root level without offset", func() {
-		actualContent := types.Document{
-			Attributes:         types.DocumentAttributes{},
-			ElementReferences:  types.ElementReferences{},
-			Footnotes:          types.Footnotes{},
-			FootnoteReferences: types.FootnoteReferences{},
-			Elements: []interface{}{
-				types.Paragraph{
-					Attributes: types.ElementAttributes{},
-					Lines: []types.InlineElements{
-						{
-							types.StringElement{Content: "a first paragraph"},
-						},
-					},
-				},
-				types.FileInclusion{
-					Attributes: types.ElementAttributes{},
-					Path:       "html5/includes/chapter-a.adoc",
-				},
-				types.BlankLine{},
-				types.Paragraph{
-					Attributes: types.ElementAttributes{},
-					Lines: []types.InlineElements{
-						{
-							types.StringElement{Content: "a second paragraph"},
-						},
-					},
-				},
-			},
-		}
-		expectedResult := types.Document{
-			Attributes:         types.DocumentAttributes{},
-			ElementReferences:  types.ElementReferences{},
-			Footnotes:          types.Footnotes{},
-			FootnoteReferences: types.FootnoteReferences{},
-			Elements: []interface{}{
-				types.Paragraph{
-					Attributes: types.ElementAttributes{},
-					Lines: []types.InlineElements{
-						{
-							types.StringElement{Content: "a first paragraph"},
-						},
-					},
-				},
-				types.Section{
-					Level: 0,
-					Title: types.SectionTitle{
-						Attributes: types.ElementAttributes{
-							types.AttrID:       "chapter_a",
-							types.AttrCustomID: false,
-						},
-						Elements: []interface{}{
-							types.StringElement{
-								Content: "Chapter A",
+	Context("simple inclusions", func() {
+		It("should include adoc file with section 0 at root level without offset", func() {
+			actualContent := types.Document{
+				Attributes:         types.DocumentAttributes{},
+				ElementReferences:  types.ElementReferences{},
+				Footnotes:          types.Footnotes{},
+				FootnoteReferences: types.FootnoteReferences{},
+				Elements: []interface{}{
+					types.Paragraph{
+						Attributes: types.ElementAttributes{},
+						Lines: []types.InlineElements{
+							{
+								types.StringElement{Content: "a first paragraph"},
 							},
 						},
 					},
-					Elements: []interface{}{
-						types.Paragraph{
-							Attributes: types.ElementAttributes{},
-							Lines: []types.InlineElements{
-								{
-									types.StringElement{Content: "content"},
-								},
+					types.FileInclusion{
+						Attributes: types.ElementAttributes{},
+						Path:       "html5/includes/chapter-a.adoc",
+					},
+					types.BlankLine{},
+					types.Paragraph{
+						Attributes: types.ElementAttributes{},
+						Lines: []types.InlineElements{
+							{
+								types.StringElement{Content: "a second paragraph"},
 							},
 						},
 					},
 				},
-				types.BlankLine{},
-				types.Paragraph{
-					Attributes: types.ElementAttributes{},
-					Lines: []types.InlineElements{
-						{
-							types.StringElement{Content: "a second paragraph"},
-						},
-					},
-				},
-			},
-		}
-		verifyFileInclusions(expectedResult, actualContent)
-	})
-
-	It("should include adoc file with section 0 at root level with valid offset", func() {
-		actualContent := types.Document{
-			Attributes:         types.DocumentAttributes{},
-			ElementReferences:  types.ElementReferences{},
-			Footnotes:          types.Footnotes{},
-			FootnoteReferences: types.FootnoteReferences{},
-			Elements: []interface{}{
-				types.Paragraph{
-					Attributes: types.ElementAttributes{},
-					Lines: []types.InlineElements{
-						{
-							types.StringElement{Content: "a first paragraph"},
-						},
-					},
-				},
-				types.FileInclusion{
-					Attributes: types.ElementAttributes{
-						types.AttrLevelOffset: "+1",
-					},
-					Path: "html5/includes/chapter-a.adoc",
-				},
-				types.BlankLine{},
-				types.Paragraph{
-					Attributes: types.ElementAttributes{},
-					Lines: []types.InlineElements{
-						{
-							types.StringElement{Content: "a second paragraph"},
-						},
-					},
-				},
-			},
-		}
-		expectedResult := types.Document{
-			Attributes:         types.DocumentAttributes{},
-			ElementReferences:  types.ElementReferences{},
-			Footnotes:          types.Footnotes{},
-			FootnoteReferences: types.FootnoteReferences{},
-			Elements: []interface{}{
-				types.Paragraph{
-					Attributes: types.ElementAttributes{},
-					Lines: []types.InlineElements{
-						{
-							types.StringElement{Content: "a first paragraph"},
-						},
-					},
-				},
-				types.Section{
-					Level: 1,
-					Title: types.SectionTitle{
-						Attributes: types.ElementAttributes{
-							types.AttrID:       "chapter_a",
-							types.AttrCustomID: false,
-						},
-						Elements: []interface{}{
-							types.StringElement{
-								Content: "Chapter A",
+			}
+			expectedResult := types.Document{
+				Attributes:         types.DocumentAttributes{},
+				ElementReferences:  types.ElementReferences{},
+				Footnotes:          types.Footnotes{},
+				FootnoteReferences: types.FootnoteReferences{},
+				Elements: []interface{}{
+					types.Paragraph{
+						Attributes: types.ElementAttributes{},
+						Lines: []types.InlineElements{
+							{
+								types.StringElement{Content: "a first paragraph"},
 							},
 						},
 					},
-					Elements: []interface{}{
-						types.Paragraph{
-							Attributes: types.ElementAttributes{},
-							Lines: []types.InlineElements{
-								{
-									types.StringElement{Content: "content"},
-								},
-							},
-						},
-					},
-				},
-				types.BlankLine{},
-				types.Paragraph{
-					Attributes: types.ElementAttributes{},
-					Lines: []types.InlineElements{
-						{
-							types.StringElement{Content: "a second paragraph"},
-						},
-					},
-				},
-			},
-		}
-		verifyFileInclusions(expectedResult, actualContent)
-	})
-
-	It("should include adoc file with section 0 within existin section with valid offset", func() {
-		actualContent := types.Document{
-			Attributes:         types.DocumentAttributes{},
-			ElementReferences:  types.ElementReferences{},
-			Footnotes:          types.Footnotes{},
-			FootnoteReferences: types.FootnoteReferences{},
-			Elements: []interface{}{
-				types.Section{
-					Level: 1,
-					Title: types.SectionTitle{
-						Attributes: types.ElementAttributes{
-							types.AttrID:       "chapter_a",
-							types.AttrCustomID: false,
-						},
-						Elements: []interface{}{
-							types.StringElement{
-								Content: "Chapter A",
-							},
-						},
-					},
-					Elements: []interface{}{
-						types.Paragraph{
-							Attributes: types.ElementAttributes{},
-							Lines: []types.InlineElements{
-								{
-									types.StringElement{Content: "a first paragraph"},
-								},
-							},
-						},
-						types.FileInclusion{
+					types.Section{
+						Level: 0,
+						Title: types.SectionTitle{
 							Attributes: types.ElementAttributes{
-								types.AttrLevelOffset: "+2",
+								types.AttrID:       "chapter_a",
+								types.AttrCustomID: false,
 							},
-							Path: "html5/includes/chapter-a.adoc",
-						},
-						types.BlankLine{},
-						types.Paragraph{
-							Attributes: types.ElementAttributes{},
-							Lines: []types.InlineElements{
-								{
-									types.StringElement{Content: "a second paragraph"},
+							Elements: []interface{}{
+								types.StringElement{
+									Content: "Chapter A",
 								},
 							},
-						},
-					},
-				},
-			},
-		}
-		expectedResult := types.Document{
-			Attributes:         types.DocumentAttributes{},
-			ElementReferences:  types.ElementReferences{},
-			Footnotes:          types.Footnotes{},
-			FootnoteReferences: types.FootnoteReferences{},
-			Elements: []interface{}{
-				types.Section{
-					Level: 1,
-					Title: types.SectionTitle{
-						Attributes: types.ElementAttributes{
-							types.AttrID:       "chapter_a",
-							types.AttrCustomID: false,
 						},
 						Elements: []interface{}{
-							types.StringElement{
-								Content: "Chapter A",
-							},
-						},
-					},
-					Elements: []interface{}{
-						types.Paragraph{
-							Attributes: types.ElementAttributes{},
-							Lines: []types.InlineElements{
-								{
-									types.StringElement{Content: "a first paragraph"},
-								},
-							},
-						},
-						types.Section{
-							Level: 2,
-							Title: types.SectionTitle{
-								Attributes: types.ElementAttributes{
-									types.AttrID:       "chapter_a",
-									types.AttrCustomID: false,
-								},
-								Elements: []interface{}{
-									types.StringElement{
-										Content: "Chapter A",
+							types.Paragraph{
+								Attributes: types.ElementAttributes{},
+								Lines: []types.InlineElements{
+									{
+										types.StringElement{Content: "content"},
 									},
 								},
 							},
+						},
+					},
+					types.BlankLine{},
+					types.Paragraph{
+						Attributes: types.ElementAttributes{},
+						Lines: []types.InlineElements{
+							{
+								types.StringElement{Content: "a second paragraph"},
+							},
+						},
+					},
+				},
+			}
+			verifyFileInclusions(expectedResult, actualContent)
+		})
+
+		It("should include adoc file with section 0 at root level with valid offset", func() {
+			actualContent := types.Document{
+				Attributes:         types.DocumentAttributes{},
+				ElementReferences:  types.ElementReferences{},
+				Footnotes:          types.Footnotes{},
+				FootnoteReferences: types.FootnoteReferences{},
+				Elements: []interface{}{
+					types.Paragraph{
+						Attributes: types.ElementAttributes{},
+						Lines: []types.InlineElements{
+							{
+								types.StringElement{Content: "a first paragraph"},
+							},
+						},
+					},
+					types.FileInclusion{
+						Attributes: types.ElementAttributes{
+							types.AttrLevelOffset: "+1",
+						},
+						Path: "html5/includes/chapter-a.adoc",
+					},
+					types.BlankLine{},
+					types.Paragraph{
+						Attributes: types.ElementAttributes{},
+						Lines: []types.InlineElements{
+							{
+								types.StringElement{Content: "a second paragraph"},
+							},
+						},
+					},
+				},
+			}
+			expectedResult := types.Document{
+				Attributes:         types.DocumentAttributes{},
+				ElementReferences:  types.ElementReferences{},
+				Footnotes:          types.Footnotes{},
+				FootnoteReferences: types.FootnoteReferences{},
+				Elements: []interface{}{
+					types.Paragraph{
+						Attributes: types.ElementAttributes{},
+						Lines: []types.InlineElements{
+							{
+								types.StringElement{Content: "a first paragraph"},
+							},
+						},
+					},
+					types.Section{
+						Level: 1,
+						Title: types.SectionTitle{
+							Attributes: types.ElementAttributes{
+								types.AttrID:       "chapter_a",
+								types.AttrCustomID: false,
+							},
 							Elements: []interface{}{
-								types.Paragraph{
-									Attributes: types.ElementAttributes{},
-									Lines: []types.InlineElements{
-										{
-											types.StringElement{Content: "content"},
+								types.StringElement{
+									Content: "Chapter A",
+								},
+							},
+						},
+						Elements: []interface{}{
+							types.Paragraph{
+								Attributes: types.ElementAttributes{},
+								Lines: []types.InlineElements{
+									{
+										types.StringElement{Content: "content"},
+									},
+								},
+							},
+						},
+					},
+					types.BlankLine{},
+					types.Paragraph{
+						Attributes: types.ElementAttributes{},
+						Lines: []types.InlineElements{
+							{
+								types.StringElement{Content: "a second paragraph"},
+							},
+						},
+					},
+				},
+			}
+			verifyFileInclusions(expectedResult, actualContent)
+		})
+
+		It("should include adoc file with section 0 within existin section with valid offset", func() {
+			actualContent := types.Document{
+				Attributes:         types.DocumentAttributes{},
+				ElementReferences:  types.ElementReferences{},
+				Footnotes:          types.Footnotes{},
+				FootnoteReferences: types.FootnoteReferences{},
+				Elements: []interface{}{
+					types.Section{
+						Level: 1,
+						Title: types.SectionTitle{
+							Attributes: types.ElementAttributes{
+								types.AttrID:       "chapter_a",
+								types.AttrCustomID: false,
+							},
+							Elements: []interface{}{
+								types.StringElement{
+									Content: "Chapter A",
+								},
+							},
+						},
+						Elements: []interface{}{
+							types.Paragraph{
+								Attributes: types.ElementAttributes{},
+								Lines: []types.InlineElements{
+									{
+										types.StringElement{Content: "a first paragraph"},
+									},
+								},
+							},
+							types.FileInclusion{
+								Attributes: types.ElementAttributes{
+									types.AttrLevelOffset: "+2",
+								},
+								Path: "html5/includes/chapter-a.adoc",
+							},
+							types.BlankLine{},
+							types.Paragraph{
+								Attributes: types.ElementAttributes{},
+								Lines: []types.InlineElements{
+									{
+										types.StringElement{Content: "a second paragraph"},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			expectedResult := types.Document{
+				Attributes:         types.DocumentAttributes{},
+				ElementReferences:  types.ElementReferences{},
+				Footnotes:          types.Footnotes{},
+				FootnoteReferences: types.FootnoteReferences{},
+				Elements: []interface{}{
+					types.Section{
+						Level: 1,
+						Title: types.SectionTitle{
+							Attributes: types.ElementAttributes{
+								types.AttrID:       "chapter_a",
+								types.AttrCustomID: false,
+							},
+							Elements: []interface{}{
+								types.StringElement{
+									Content: "Chapter A",
+								},
+							},
+						},
+						Elements: []interface{}{
+							types.Paragraph{
+								Attributes: types.ElementAttributes{},
+								Lines: []types.InlineElements{
+									{
+										types.StringElement{Content: "a first paragraph"},
+									},
+								},
+							},
+							types.Section{
+								Level: 2,
+								Title: types.SectionTitle{
+									Attributes: types.ElementAttributes{
+										types.AttrID:       "chapter_a",
+										types.AttrCustomID: false,
+									},
+									Elements: []interface{}{
+										types.StringElement{
+											Content: "Chapter A",
+										},
+									},
+								},
+								Elements: []interface{}{
+									types.Paragraph{
+										Attributes: types.ElementAttributes{},
+										Lines: []types.InlineElements{
+											{
+												types.StringElement{Content: "content"},
+											},
+										},
+									},
+								},
+							},
+							types.BlankLine{},
+							types.Paragraph{
+								Attributes: types.ElementAttributes{},
+								Lines: []types.InlineElements{
+									{
+										types.StringElement{Content: "a second paragraph"},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			verifyFileInclusions(expectedResult, actualContent)
+		})
+
+		It("should include adoc file with 2 paragraphs at root level without offset", func() {
+			actualContent := types.Document{
+				Attributes:         types.DocumentAttributes{},
+				ElementReferences:  types.ElementReferences{},
+				Footnotes:          types.Footnotes{},
+				FootnoteReferences: types.FootnoteReferences{},
+				Elements: []interface{}{
+					types.Paragraph{
+						Attributes: types.ElementAttributes{},
+						Lines: []types.InlineElements{
+							{
+								types.StringElement{Content: "a first paragraph"},
+							},
+						},
+					},
+					types.FileInclusion{
+						Path: "html5/includes/grandchild-include.adoc",
+					},
+					types.BlankLine{},
+					types.Paragraph{
+						Attributes: types.ElementAttributes{},
+						Lines: []types.InlineElements{
+							{
+								types.StringElement{Content: "a second paragraph"},
+							},
+						},
+					},
+				},
+			}
+			expectedResult := types.Document{
+				Attributes:         types.DocumentAttributes{},
+				ElementReferences:  types.ElementReferences{},
+				Footnotes:          types.Footnotes{},
+				FootnoteReferences: types.FootnoteReferences{},
+				Elements: []interface{}{
+					types.Paragraph{
+						Attributes: types.ElementAttributes{},
+						Lines: []types.InlineElements{
+							{
+								types.StringElement{Content: "a first paragraph"},
+							},
+						},
+					},
+					types.Paragraph{
+						Attributes: types.ElementAttributes{},
+						Lines: []types.InlineElements{
+							{
+								types.StringElement{Content: "first line of grandchild"},
+							},
+						},
+					},
+					types.BlankLine{},
+					types.Paragraph{
+						Attributes: types.ElementAttributes{},
+						Lines: []types.InlineElements{
+							{
+								types.StringElement{Content: "last line of grandchild"},
+							},
+						},
+					},
+					types.BlankLine{},
+					types.Paragraph{
+						Attributes: types.ElementAttributes{},
+						Lines: []types.InlineElements{
+							{
+								types.StringElement{Content: "a second paragraph"},
+							},
+						},
+					},
+				},
+			}
+			verifyFileInclusions(expectedResult, actualContent)
+		})
+
+		It("should include unparsed adoc file in delimited block", func() {
+			actualContent := types.Document{
+				Attributes:         types.DocumentAttributes{},
+				ElementReferences:  types.ElementReferences{},
+				Footnotes:          types.Footnotes{},
+				FootnoteReferences: types.FootnoteReferences{},
+				Elements: []interface{}{
+					types.Paragraph{
+						Attributes: types.ElementAttributes{},
+						Lines: []types.InlineElements{
+							{
+								types.StringElement{Content: "a first paragraph"},
+							},
+						},
+					},
+					types.DelimitedBlock{
+						Kind:       types.Source,
+						Attributes: types.ElementAttributes{},
+						Elements: []interface{}{
+							types.FileInclusion{
+								Attributes: types.ElementAttributes{},
+								Path:       "html5/includes/chapter-a.adoc",
+							},
+						},
+					},
+					types.BlankLine{},
+					types.Paragraph{
+						Attributes: types.ElementAttributes{},
+						Lines: []types.InlineElements{
+							{
+								types.StringElement{Content: "a second paragraph"},
+							},
+						},
+					},
+				},
+			}
+			expectedResult := types.Document{
+				Attributes:         types.DocumentAttributes{},
+				ElementReferences:  types.ElementReferences{},
+				Footnotes:          types.Footnotes{},
+				FootnoteReferences: types.FootnoteReferences{},
+				Elements: []interface{}{
+					types.Paragraph{
+						Attributes: types.ElementAttributes{},
+						Lines: []types.InlineElements{
+							{
+								types.StringElement{Content: "a first paragraph"},
+							},
+						},
+					},
+					types.DelimitedBlock{
+						Kind:       types.Source,
+						Attributes: types.ElementAttributes{},
+						Elements: []interface{}{
+							types.Paragraph{
+								Attributes: types.ElementAttributes{},
+								Lines: []types.InlineElements{
+									{
+										types.StringElement{Content: "= Chapter A"},
+									},
+								},
+							},
+							types.BlankLine{},
+							types.Paragraph{
+								Attributes: types.ElementAttributes{},
+								Lines: []types.InlineElements{
+									{
+										types.StringElement{Content: "content"},
+									},
+								},
+							},
+						},
+					},
+					types.BlankLine{},
+					types.Paragraph{
+						Attributes: types.ElementAttributes{},
+						Lines: []types.InlineElements{
+							{
+								types.StringElement{Content: "a second paragraph"},
+							},
+						},
+					},
+				},
+			}
+			verifyFileInclusions(expectedResult, actualContent)
+		})
+
+		It("should include unparsed adoc file with line range in delimited block", func() {
+			actualContent := types.Document{
+				Attributes:         types.DocumentAttributes{},
+				ElementReferences:  types.ElementReferences{},
+				Footnotes:          types.Footnotes{},
+				FootnoteReferences: types.FootnoteReferences{},
+				Elements: []interface{}{
+					types.Paragraph{
+						Attributes: types.ElementAttributes{},
+						Lines: []types.InlineElements{
+							{
+								types.StringElement{Content: "a first paragraph"},
+							},
+						},
+					},
+					types.DelimitedBlock{
+						Kind:       types.Source,
+						Attributes: types.ElementAttributes{},
+						Elements: []interface{}{
+							types.FileInclusion{
+								Attributes: types.ElementAttributes{
+									types.AttrLineRanges: types.LineRanges{
+										{Start: 3, End: 3},
+									},
+								},
+								Path: "html5/includes/chapter-a.adoc",
+							},
+						},
+					},
+					types.BlankLine{},
+					types.Paragraph{
+						Attributes: types.ElementAttributes{},
+						Lines: []types.InlineElements{
+							{
+								types.StringElement{Content: "a second paragraph"},
+							},
+						},
+					},
+				},
+			}
+			expectedResult := types.Document{
+				Attributes:         types.DocumentAttributes{},
+				ElementReferences:  types.ElementReferences{},
+				Footnotes:          types.Footnotes{},
+				FootnoteReferences: types.FootnoteReferences{},
+				Elements: []interface{}{
+					types.Paragraph{
+						Attributes: types.ElementAttributes{},
+						Lines: []types.InlineElements{
+							{
+								types.StringElement{Content: "a first paragraph"},
+							},
+						},
+					},
+					types.DelimitedBlock{
+						Kind:       types.Source,
+						Attributes: types.ElementAttributes{},
+						Elements: []interface{}{
+							types.Paragraph{
+								Attributes: types.ElementAttributes{},
+								Lines: []types.InlineElements{
+									{
+										types.StringElement{Content: "content"},
+									},
+								},
+							},
+						},
+					},
+					types.BlankLine{},
+					types.Paragraph{
+						Attributes: types.ElementAttributes{},
+						Lines: []types.InlineElements{
+							{
+								types.StringElement{Content: "a second paragraph"},
+							},
+						},
+					},
+				},
+			}
+			verifyFileInclusions(expectedResult, actualContent)
+		})
+	})
+
+	Context("recursive file inclusions", func() {
+
+		It("should include child and grand child content in a paragraph", func() {
+			actualContent := types.Document{
+				Attributes:         types.DocumentAttributes{},
+				ElementReferences:  types.ElementReferences{},
+				Footnotes:          types.Footnotes{},
+				FootnoteReferences: types.FootnoteReferences{},
+				Elements: []interface{}{
+					types.FileInclusion{
+						Attributes: types.ElementAttributes{},
+						Path:       "html5/includes/parent-include.adoc",
+					},
+				},
+			}
+			expectedResult := types.Document{
+				Attributes:         types.DocumentAttributes{},
+				ElementReferences:  types.ElementReferences{},
+				Footnotes:          types.Footnotes{},
+				FootnoteReferences: types.FootnoteReferences{},
+				Elements: []interface{}{
+					types.Paragraph{
+						Attributes: types.ElementAttributes{},
+						Lines: []types.InlineElements{
+							{
+								types.StringElement{
+									Content: "first line of parent",
+								},
+							},
+						},
+					},
+					types.BlankLine{},
+					types.Paragraph{
+						Attributes: types.ElementAttributes{},
+						Lines: []types.InlineElements{
+							{
+								types.StringElement{
+									Content: "first line of child",
+								},
+							},
+						},
+					},
+					types.BlankLine{},
+					types.Paragraph{
+						Attributes: types.ElementAttributes{},
+						Lines: []types.InlineElements{
+							{
+								types.StringElement{
+									Content: "first line of grandchild",
+								},
+							},
+						},
+					},
+					types.BlankLine{},
+					types.Paragraph{
+						Attributes: types.ElementAttributes{},
+						Lines: []types.InlineElements{
+							{
+								types.StringElement{
+									Content: "last line of grandchild",
+								},
+							},
+						},
+					},
+					types.BlankLine{},
+					types.Paragraph{
+						Attributes: types.ElementAttributes{},
+						Lines: []types.InlineElements{
+							{
+								types.StringElement{
+									Content: "last line of child",
+								},
+							},
+						},
+					},
+					types.BlankLine{},
+					types.Paragraph{
+						Attributes: types.ElementAttributes{},
+						Lines: []types.InlineElements{
+							{
+								types.StringElement{
+									Content: "last line of parent",
+								},
+							},
+						},
+					},
+				},
+			}
+			verifyFileInclusions(expectedResult, actualContent)
+		})
+
+		It("should include child and grand child content in a listing block", func() {
+			actualContent := types.Document{
+				Attributes:         types.DocumentAttributes{},
+				ElementReferences:  types.ElementReferences{},
+				Footnotes:          types.Footnotes{},
+				FootnoteReferences: types.FootnoteReferences{},
+				Elements: []interface{}{
+					types.DelimitedBlock{
+						Attributes: types.ElementAttributes{},
+						Kind:       types.Listing,
+						Elements: []interface{}{
+							types.FileInclusion{
+								Attributes: types.ElementAttributes{},
+								Path:       "html5/includes/parent-include.adoc",
+							},
+						},
+					},
+				},
+			}
+			expectedResult := types.Document{
+				Attributes:         types.DocumentAttributes{},
+				ElementReferences:  types.ElementReferences{},
+				Footnotes:          types.Footnotes{},
+				FootnoteReferences: types.FootnoteReferences{},
+				Elements: []interface{}{
+					types.DelimitedBlock{
+						Attributes: types.ElementAttributes{},
+						Kind:       types.Listing,
+						Elements: []interface{}{
+							types.Paragraph{
+								Attributes: types.ElementAttributes{},
+								Lines: []types.InlineElements{
+									{
+										types.StringElement{
+											Content: "first line of parent",
+										},
+									},
+								},
+							},
+							types.BlankLine{},
+							types.Paragraph{
+								Attributes: types.ElementAttributes{},
+								Lines: []types.InlineElements{
+									{
+										types.StringElement{
+											Content: "first line of child",
+										},
+									},
+								},
+							},
+							types.BlankLine{},
+							types.Paragraph{
+								Attributes: types.ElementAttributes{},
+								Lines: []types.InlineElements{
+									{
+										types.StringElement{
+											Content: "first line of grandchild",
+										},
+									},
+								},
+							},
+							types.BlankLine{},
+							types.Paragraph{
+								Attributes: types.ElementAttributes{},
+								Lines: []types.InlineElements{
+									{
+										types.StringElement{
+											Content: "last line of grandchild",
+										},
+									},
+								},
+							},
+							types.BlankLine{},
+							types.Paragraph{
+								Attributes: types.ElementAttributes{},
+								Lines: []types.InlineElements{
+									{
+										types.StringElement{
+											Content: "last line of child",
+										},
+									},
+								},
+							},
+							types.BlankLine{},
+							types.Paragraph{
+								Attributes: types.ElementAttributes{},
+								Lines: []types.InlineElements{
+									{
+										types.StringElement{
+											Content: "last line of parent",
 										},
 									},
 								},
 							},
 						},
-						types.BlankLine{},
-						types.Paragraph{
-							Attributes: types.ElementAttributes{},
-							Lines: []types.InlineElements{
-								{
-									types.StringElement{Content: "a second paragraph"},
-								},
-							},
-						},
 					},
 				},
-			},
-		}
-		verifyFileInclusions(expectedResult, actualContent)
-	})
-
-	It("should include adoc file with 2 paragraphs at root level without offset", func() {
-		actualContent := types.Document{
-			Attributes:         types.DocumentAttributes{},
-			ElementReferences:  types.ElementReferences{},
-			Footnotes:          types.Footnotes{},
-			FootnoteReferences: types.FootnoteReferences{},
-			Elements: []interface{}{
-				types.Paragraph{
-					Attributes: types.ElementAttributes{},
-					Lines: []types.InlineElements{
-						{
-							types.StringElement{Content: "a first paragraph"},
-						},
-					},
-				},
-				types.FileInclusion{
-					Path: "html5/includes/grandchild-include.adoc",
-				},
-				types.BlankLine{},
-				types.Paragraph{
-					Attributes: types.ElementAttributes{},
-					Lines: []types.InlineElements{
-						{
-							types.StringElement{Content: "a second paragraph"},
-						},
-					},
-				},
-			},
-		}
-		expectedResult := types.Document{
-			Attributes:         types.DocumentAttributes{},
-			ElementReferences:  types.ElementReferences{},
-			Footnotes:          types.Footnotes{},
-			FootnoteReferences: types.FootnoteReferences{},
-			Elements: []interface{}{
-				types.Paragraph{
-					Attributes: types.ElementAttributes{},
-					Lines: []types.InlineElements{
-						{
-							types.StringElement{Content: "a first paragraph"},
-						},
-					},
-				},
-				types.Paragraph{
-					Attributes: types.ElementAttributes{},
-					Lines: []types.InlineElements{
-						{
-							types.StringElement{Content: "first line of grandchild"},
-						},
-					},
-				},
-				types.BlankLine{},
-				types.Paragraph{
-					Attributes: types.ElementAttributes{},
-					Lines: []types.InlineElements{
-						{
-							types.StringElement{Content: "last line of grandchild"},
-						},
-					},
-				},
-				types.BlankLine{},
-				types.Paragraph{
-					Attributes: types.ElementAttributes{},
-					Lines: []types.InlineElements{
-						{
-							types.StringElement{Content: "a second paragraph"},
-						},
-					},
-				},
-			},
-		}
-		verifyFileInclusions(expectedResult, actualContent)
-	})
-
-	It("should include unparsed adoc file in delimited block", func() {
-		actualContent := types.Document{
-			Attributes:         types.DocumentAttributes{},
-			ElementReferences:  types.ElementReferences{},
-			Footnotes:          types.Footnotes{},
-			FootnoteReferences: types.FootnoteReferences{},
-			Elements: []interface{}{
-				types.Paragraph{
-					Attributes: types.ElementAttributes{},
-					Lines: []types.InlineElements{
-						{
-							types.StringElement{Content: "a first paragraph"},
-						},
-					},
-				},
-				types.DelimitedBlock{
-					Kind:       types.Source,
-					Attributes: types.ElementAttributes{},
-					Elements: []interface{}{
-						types.FileInclusion{
-							Attributes: types.ElementAttributes{},
-							Path:       "html5/includes/chapter-a.adoc",
-						},
-					},
-				},
-				types.BlankLine{},
-				types.Paragraph{
-					Attributes: types.ElementAttributes{},
-					Lines: []types.InlineElements{
-						{
-							types.StringElement{Content: "a second paragraph"},
-						},
-					},
-				},
-			},
-		}
-		expectedResult := types.Document{
-			Attributes:         types.DocumentAttributes{},
-			ElementReferences:  types.ElementReferences{},
-			Footnotes:          types.Footnotes{},
-			FootnoteReferences: types.FootnoteReferences{},
-			Elements: []interface{}{
-				types.Paragraph{
-					Attributes: types.ElementAttributes{},
-					Lines: []types.InlineElements{
-						{
-							types.StringElement{Content: "a first paragraph"},
-						},
-					},
-				},
-				types.DelimitedBlock{
-					Kind:       types.Source,
-					Attributes: types.ElementAttributes{},
-					Elements: []interface{}{
-						types.Paragraph{
-							Attributes: types.ElementAttributes{},
-							Lines: []types.InlineElements{
-								{
-									types.StringElement{Content: "= Chapter A"},
-								},
-							},
-						},
-						types.BlankLine{},
-						types.Paragraph{
-							Attributes: types.ElementAttributes{},
-							Lines: []types.InlineElements{
-								{
-									types.StringElement{Content: "content"},
-								},
-							},
-						},
-					},
-				},
-				types.BlankLine{},
-				types.Paragraph{
-					Attributes: types.ElementAttributes{},
-					Lines: []types.InlineElements{
-						{
-							types.StringElement{Content: "a second paragraph"},
-						},
-					},
-				},
-			},
-		}
-		verifyFileInclusions(expectedResult, actualContent)
-	})
-
-	It("should include unparsed adoc file with line range in delimited block", func() {
-		actualContent := types.Document{
-			Attributes:         types.DocumentAttributes{},
-			ElementReferences:  types.ElementReferences{},
-			Footnotes:          types.Footnotes{},
-			FootnoteReferences: types.FootnoteReferences{},
-			Elements: []interface{}{
-				types.Paragraph{
-					Attributes: types.ElementAttributes{},
-					Lines: []types.InlineElements{
-						{
-							types.StringElement{Content: "a first paragraph"},
-						},
-					},
-				},
-				types.DelimitedBlock{
-					Kind:       types.Source,
-					Attributes: types.ElementAttributes{},
-					Elements: []interface{}{
-						types.FileInclusion{
-							Attributes: types.ElementAttributes{
-								types.AttrLineRanges: types.LineRanges{
-									{Start: 3, End: 3},
-								},
-							},
-							Path: "html5/includes/chapter-a.adoc",
-						},
-					},
-				},
-				types.BlankLine{},
-				types.Paragraph{
-					Attributes: types.ElementAttributes{},
-					Lines: []types.InlineElements{
-						{
-							types.StringElement{Content: "a second paragraph"},
-						},
-					},
-				},
-			},
-		}
-		expectedResult := types.Document{
-			Attributes:         types.DocumentAttributes{},
-			ElementReferences:  types.ElementReferences{},
-			Footnotes:          types.Footnotes{},
-			FootnoteReferences: types.FootnoteReferences{},
-			Elements: []interface{}{
-				types.Paragraph{
-					Attributes: types.ElementAttributes{},
-					Lines: []types.InlineElements{
-						{
-							types.StringElement{Content: "a first paragraph"},
-						},
-					},
-				},
-				types.DelimitedBlock{
-					Kind:       types.Source,
-					Attributes: types.ElementAttributes{},
-					Elements: []interface{}{
-						types.Paragraph{
-							Attributes: types.ElementAttributes{},
-							Lines: []types.InlineElements{
-								{
-									types.StringElement{Content: "content"},
-								},
-							},
-						},
-					},
-				},
-				types.BlankLine{},
-				types.Paragraph{
-					Attributes: types.ElementAttributes{},
-					Lines: []types.InlineElements{
-						{
-							types.StringElement{Content: "a second paragraph"},
-						},
-					},
-				},
-			},
-		}
-		verifyFileInclusions(expectedResult, actualContent)
+			}
+			verifyFileInclusions(expectedResult, actualContent)
+		})
 	})
 
 	Context("lines to include with ranges", func() {

--- a/pkg/renderer/html5/file_inclusion_test.go
+++ b/pkg/renderer/html5/file_inclusion_test.go
@@ -376,6 +376,53 @@ func helloworld() {
 				verify(GinkgoT(), expectedResult, actualContent)
 			})
 		})
+	})
 
+	Context("recursive file inclusions", func() {
+
+		It("should include child and grandchild content in paragraphs", func() {
+			actualContent := `include::includes/parent-include.adoc[]`
+			expectedResult := `<div class="paragraph">
+<p>first line of parent</p>
+</div>
+<div class="paragraph">
+<p>first line of child</p>
+</div>
+<div class="paragraph">
+<p>first line of grandchild</p>
+</div>
+<div class="paragraph">
+<p>last line of grandchild</p>
+</div>
+<div class="paragraph">
+<p>last line of child</p>
+</div>
+<div class="paragraph">
+<p>last line of parent</p>
+</div>`
+			verify(GinkgoT(), expectedResult, actualContent)
+		})
+
+		It("should include child and grandchild content in listing block", func() {
+			actualContent := `----
+include::includes/parent-include.adoc[]
+----`
+			expectedResult := `<div class="listingblock">
+<div class="content">
+<pre>first line of parent
+
+first line of child
+
+first line of grandchild
+
+last line of grandchild
+
+last line of child
+
+last line of parent</pre>
+</div>
+</div>`
+			verify(GinkgoT(), expectedResult, actualContent)
+		})
 	})
 })

--- a/pkg/renderer/html5/includes/parent-include.adoc
+++ b/pkg/renderer/html5/includes/parent-include.adoc
@@ -1,0 +1,5 @@
+first line of parent
+
+include::child-include.adoc[]
+
+last line of parent


### PR DESCRIPTION
support recursive file inclusions
also: simply code for renderer, avoid duplicate/similar funcs

fixes #311

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>