### PR TITLE
fix(renderer): escape content of listing and source blocks

### DIFF
--- a/pkg/renderer/html5/delimited_block.go
+++ b/pkg/renderer/html5/delimited_block.go
@@ -39,7 +39,7 @@ func init() {
 	listingBlockTmpl = newTextTemplate("listing block", `{{ $ctx := .Context }}{{ with .Data }}<div {{ if .ID }}id="{{ .ID }}" {{ end }}class="listingblock">{{ if .Title }}
 <div class="title">{{ escape .Title }}</div>{{ end }}
 <div class="content">
-<pre>{{ range $index, $element := .Elements }}{{ renderPlainString $ctx $element | printf "%s" }}{{ end }}</pre>
+<pre>{{ range $index, $element := .Elements }}{{ renderPlainString $ctx $element | printf "%s" | escape }}{{ end }}</pre>
 </div>
 </div>{{ end }}`,
 		texttemplate.FuncMap{
@@ -51,7 +51,7 @@ func init() {
 		`{{ $ctx := .Context }}{{ with .Data }}<div {{ if .ID }}id="{{ .ID }}" {{ end }}class="listingblock">{{ if .Title }}
 <div class="title">{{ escape .Title }}</div>{{ end }}
 <div class="content">
-<pre class="highlight"><code{{ if .Language}} class="language-{{ .Language}}" data-lang="{{ .Language}}"{{ end }}>{{ range $index, $element := .Elements }}{{ renderPlainString $ctx $element | printf "%s" }}{{ end }}</code></pre>
+<pre class="highlight"><code{{ if .Language}} class="language-{{ .Language}}" data-lang="{{ .Language}}"{{ end }}>{{ range $index, $element := .Elements }}{{ renderPlainString $ctx $element | printf "%s" | escape }}{{ end }}</code></pre>
 </div>
 </div>{{ end }}`,
 		texttemplate.FuncMap{

--- a/pkg/renderer/html5/delimited_block_test.go
+++ b/pkg/renderer/html5/delimited_block_test.go
@@ -82,10 +82,10 @@ end
 ----`
 			expectedResult := `<div class="listingblock">
 <div class="content">
-<pre class="highlight"><code>require 'sinatra'
+<pre class="highlight"><code>require &#39;sinatra&#39;
 
-get '/hi' do
-  "Hello World!"
+get &#39;/hi&#39; do
+  &#34;Hello World!&#34;
 end</code></pre>
 </div>
 </div>`
@@ -105,10 +105,10 @@ end
 			expectedResult := `<div class="listingblock">
 <div class="title">Source block title</div>
 <div class="content">
-<pre class="highlight"><code class="language-ruby" data-lang="ruby">require 'sinatra'
+<pre class="highlight"><code class="language-ruby" data-lang="ruby">require &#39;sinatra&#39;
 
-get '/hi' do
-  "Hello World!"
+get &#39;/hi&#39; do
+  &#34;Hello World!&#34;
 end</code></pre>
 </div>
 </div>`
@@ -129,11 +129,35 @@ end
 			expectedResult := `<div id="id-for-source-block" class="listingblock">
 <div class="title">app.rb</div>
 <div class="content">
-<pre class="highlight"><code class="language-ruby" data-lang="ruby">require 'sinatra'
+<pre class="highlight"><code class="language-ruby" data-lang="ruby">require &#39;sinatra&#39;
 
-get '/hi' do
-  "Hello World!"
+get &#39;/hi&#39; do
+  &#34;Hello World!&#34;
 end</code></pre>
+</div>
+</div>`
+			verify(GinkgoT(), expectedResult, actualContent)
+		})
+
+		It("with html content", func() {
+			actualContent := `----
+<a>link</a>
+----`
+			expectedResult := `<div class="listingblock">
+<div class="content">
+<pre>&lt;a&gt;link&lt;/a&gt;</pre>
+</div>
+</div>`
+			verify(GinkgoT(), expectedResult, actualContent)
+		})
+
+		It("with other content", func() {
+			actualContent := `----
+  a<<b
+----`
+			expectedResult := `<div class="listingblock">
+<div class="content">
+<pre>  a&lt;&lt;b</pre>
 </div>
 </div>`
 			verify(GinkgoT(), expectedResult, actualContent)

--- a/pkg/renderer/html5/file_inclusion_test.go
+++ b/pkg/renderer/html5/file_inclusion_test.go
@@ -242,10 +242,10 @@ include::includes/hello_world.go[]
 <div class="content">
 <pre>package includes
 
-import "fmt"
+import &#34;fmt&#34;
 
 func helloworld() {
-	fmt.Println("hello, world!")
+	fmt.Println(&#34;hello, world!&#34;)
 }</pre>
 </div>
 </div>`
@@ -412,7 +412,7 @@ include::includes/hello_world.go[lines=5..7]
 				expectedResult := `<div class="listingblock">
 <div class="content">
 <pre>func helloworld() {
-	fmt.Println("hello, world!")
+	fmt.Println(&#34;hello, world!&#34;)
 }</pre>
 </div>
 </div>`
@@ -428,7 +428,7 @@ include::includes/hello_world.go[lines=1..2;5..7]
 <pre>package includes
 
 func helloworld() {
-	fmt.Println("hello, world!")
+	fmt.Println(&#34;hello, world!&#34;)
 }</pre>
 </div>
 </div>`

--- a/pkg/renderer/html5/ordered_list_test.go
+++ b/pkg/renderer/html5/ordered_list_test.go
@@ -362,7 +362,7 @@ print("one")
 <p></p>
 <div class="listingblock">
 <div class="content">
-<pre>print("one")</pre>
+<pre>print(&#34;one&#34;)</pre>
 </div>
 </div>
 </li>
@@ -370,7 +370,7 @@ print("one")
 <p></p>
 <div class="listingblock">
 <div class="content">
-<pre>print("one")</pre>
+<pre>print(&#34;one&#34;)</pre>
 </div>
 </div>
 </li>


### PR DESCRIPTION
in particular, all `<`, `>`, `'` and `"` characters

Fixes #341

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>