### PR TITLE
fix(parser): do not allow spaces in singleplus passthough

### DIFF
--- a/pkg/parser/asciidoc-grammar.peg
+++ b/pkg/parser/asciidoc-grammar.peg
@@ -905,6 +905,9 @@ QuotedText <- BoldText
             / EscapedSuperscriptText
             / SubScriptOrSuperScriptPrefix // if a '^' or '~' is alone (ie, badly formatted superscript or subscript, then accept it as-is) 
 
+QuotedTextPrefix <- "**" / "*" / "__" / "_" / "``" / "`" / "^^" / "^" / "~~" / "~"
+
+// TODO: remove this?
 SubScriptOrSuperScriptPrefix <- "^" / "~" { // rule used withn `words` to detect superscript or subscript portions, eg in math formulae.
     return string(c.text), nil
 }
@@ -1041,26 +1044,38 @@ UnbalancedQuotePunctuation <- "*" / "_" / "`" / "~" / "^"
 // ------------------------------------------
 Passthrough <- TriplePlusPassthrough / SinglePlusPassthrough / PassthroughMacro
 
-SinglePlusPassthrough <- "+" content:(Alphanums / Spaces / (!NEWLINE !"+" . ){
-    return string(c.text), nil
-})+ "+" {
-    return types.NewPassthrough(types.SinglePlusPassthrough, content.([]interface{}))
+SinglePlusPassthroughPrefix <- "+"
+
+SinglePlusPassthrough <- SinglePlusPassthroughPrefix content:(SinglePlusPassthroughContent) SinglePlusPassthroughPrefix !Alphanum {
+    return types.NewPassthrough(types.SinglePlusPassthrough, []interface{}{content})
 }
 
-TriplePlusPassthrough <- "+++" content:(Alphanums / Spaces / (!"+++" .) {
-    return string(c.text), nil
-})* "+++" {
-    return types.NewPassthrough(types.TriplePlusPassthrough, content.([]interface{}))
+SinglePlusPassthroughContent <- ((!SinglePlusPassthroughPrefix !WS !NEWLINE .) (!(WS+ SinglePlusPassthroughPrefix) !SinglePlusPassthroughPrefix !NEWLINE .)* { // no space in the first or last position of the content, but allowed elsewhere
+    return types.NewStringElement(string(c.text))
+}) / ((!WS !NEWLINE !SinglePlusPassthroughPrefix .)  { // a single character
+    return types.NewStringElement(string(c.text))
+})
+
+TriplePlusPassthroughPrefix <- "+++"
+
+TriplePlusPassthrough <- TriplePlusPassthroughPrefix content:(TriplePlusPassthroughContent) TriplePlusPassthroughPrefix !Alphanum {
+    return types.NewPassthrough(types.TriplePlusPassthrough, []interface{}{content})
 }
+
+TriplePlusPassthroughContent <- ((!TriplePlusPassthroughPrefix .)* { // spaces and newlines are also allowed in the first or last position of the content and elsewhere too
+    return types.NewStringElement(string(c.text))
+}) / ((!WS !NEWLINE !TriplePlusPassthroughPrefix .)?  { // a single character
+    return types.NewStringElement(string(c.text))
+})
 
 PassthroughMacro <- "pass:[" content:(PassthroughMacroCharacter)* "]" {
-    return types.NewPassthrough(types.PassthroughMacro, content.([]interface{}))
+    return types.NewPassthrough(types.PassthroughMacro, []interface{}{content})
 } / "pass:q[" content:(QuotedText / PassthroughMacroCharacter)* "]" {
     return types.NewPassthrough(types.PassthroughMacro, content.([]interface{}))
 }
 
-PassthroughMacroCharacter <- (Alphanums / Spaces / (!"]"  .){
-    return string(c.text), nil
+PassthroughMacroCharacter <- (Alphanums / Spaces / (!"]" .){
+    return types.NewStringElement(string(c.text))
 })
 
 // ------------------------------------------
@@ -1496,7 +1511,7 @@ Dot <- "." {
     return string(c.text), nil
 }
 
-Word <- (Alphanums / ((!NEWLINE !WS !Parenthesis !"." !SubScriptOrSuperScriptPrefix  .){
+Word <- (Alphanums / QuotedTextPrefix / ((!NEWLINE !WS !Parenthesis !"." !QuotedTextPrefix .){
     return string(c.text), nil
 })+ / "."+){ // word cannot contain parenthesis. Dots and ellipsis are treated as independent words (but will be combined afterwards)
     return string(c.text), nil

--- a/pkg/parser/paragraph_test.go
+++ b/pkg/parser/paragraph_test.go
@@ -56,6 +56,25 @@ var _ = Describe("paragraphs", func() {
 			verifyWithPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
 		})
 
+		It("paragraph with non-alphnum character before bold text", func() {
+			actualContent := "+*some bold content*"
+			expectedResult := types.Paragraph{
+				Attributes: types.ElementAttributes{},
+				Lines: []types.InlineElements{
+					{
+						types.StringElement{Content: "+"},
+						types.QuotedText{
+							Kind: types.Bold,
+							Elements: types.InlineElements{
+								types.StringElement{Content: "some bold content"},
+							},
+						},
+					},
+				},
+			}
+			verifyWithPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
+		})
+
 		It("paragraph with id and title", func() {
 			actualContent := `[#foo]
 .a title

--- a/pkg/parser/passthrough_test.go
+++ b/pkg/parser/passthrough_test.go
@@ -86,8 +86,8 @@ var _ = Describe("passthroughs", func() {
 			verifyWithPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
 		})
 
-		It("tripleplus passthrough with line break", func() {
-			actualContent := "+++hello,\nworld+++"
+		It("tripleplus passthrough with line breaks", func() {
+			actualContent := "+++\nhello,\nworld\n+++"
 			expectedResult := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
@@ -96,7 +96,7 @@ var _ = Describe("passthroughs", func() {
 							Kind: types.TriplePlusPassthrough,
 							Elements: types.InlineElements{
 								types.StringElement{
-									Content: "hello,\nworld",
+									Content: "\nhello,\nworld\n",
 								},
 							},
 						},
@@ -130,7 +130,7 @@ var _ = Describe("passthroughs", func() {
 
 	})
 
-	Context("singlePlus Passthrough", func() {
+	Context("singleplus passthrough", func() {
 
 		It("singleplus passthrough with words", func() {
 			actualContent := `+hello, world+`
@@ -149,7 +149,7 @@ var _ = Describe("passthroughs", func() {
 					},
 				},
 			}
-			verifyWithPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
+			verifyWithPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("Paragraph"))
 		})
 
 		It("singleplus empty passthrough", func() {
@@ -167,19 +167,52 @@ var _ = Describe("passthroughs", func() {
 			verifyWithPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
 		})
 
-		It("singleplus passthrough with spaces", func() {
-			actualContent := `+ *hello*, world +`
+		It("invalid singleplus passthrough with spaces - case 1", func() {
+			actualContent := `+*hello*, world +` // invalid: space before last `+`
 			expectedResult := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						types.Passthrough{
-							Kind: types.SinglePlusPassthrough,
+						types.StringElement{
+							Content: "+",
+						},
+						types.QuotedText{
+							Kind: types.Bold,
 							Elements: types.InlineElements{
 								types.StringElement{
-									Content: " *hello*, world ",
+									Content: "hello",
 								},
 							},
+						},
+						types.StringElement{
+							Content: ", world",
+						},
+						types.LineBreak{},
+					},
+				},
+			}
+			verifyWithPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
+		})
+
+		It("invalid singleplus passthrough with spaces - case 2", func() {
+			actualContent := `+ *hello*, world+` // invalid: space after first `+`
+			expectedResult := types.Paragraph{
+				Attributes: types.ElementAttributes{},
+				Lines: []types.InlineElements{
+					{
+						types.StringElement{
+							Content: "+ ",
+						},
+						types.QuotedText{
+							Kind: types.Bold,
+							Elements: types.InlineElements{
+								types.StringElement{
+									Content: "hello",
+								},
+							},
+						},
+						types.StringElement{
+							Content: ", world+",
 						},
 					},
 				},
@@ -187,7 +220,34 @@ var _ = Describe("passthroughs", func() {
 			verifyWithPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
 		})
 
-		It("singleplus passthrough with line break", func() {
+		It("invalid singleplus passthrough with spaces - case 3", func() {
+			actualContent := `+ *hello*, world +` // invalid: spaces within
+			expectedResult := types.Paragraph{
+				Attributes: types.ElementAttributes{},
+				Lines: []types.InlineElements{
+					{
+						types.StringElement{
+							Content: "+ ",
+						},
+						types.QuotedText{
+							Kind: types.Bold,
+							Elements: types.InlineElements{
+								types.StringElement{
+									Content: "hello",
+								},
+							},
+						},
+						types.StringElement{
+							Content: ", world",
+						},
+						types.LineBreak{},
+					},
+				},
+			}
+			verifyWithPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
+		})
+
+		It("invalid singleplus passthrough with line break", func() {
 			actualContent := "+hello,\nworld+"
 			expectedResult := types.Paragraph{
 				Attributes: types.ElementAttributes{},

--- a/pkg/renderer/html5/passthrough_test.go
+++ b/pkg/renderer/html5/passthrough_test.go
@@ -70,6 +70,14 @@ var _ = Describe("passthroughs", func() {
 </div>`
 			verify(GinkgoT(), expectedResult, actualContent)
 		})
+
+		It("invalid singleplus passthrough in paragraph", func() {
+			actualContent := `The text + *hello*, world + is not passed through.`
+			expectedResult := `<div class="paragraph">
+<p>The text &#43; <strong>hello</strong>, world &#43; is not passed through.</p>
+</div>`
+			verify(GinkgoT(), expectedResult, actualContent)
+		})
 	})
 
 	Context("passthrough Macro", func() {

--- a/pkg/types/grammar_types.go
+++ b/pkg/types/grammar_types.go
@@ -1884,7 +1884,7 @@ func Verbatim(content []interface{}) ([]interface{}, error) {
 			c = Apply(c, func(s string) string {
 				return strings.TrimRight(c, "\n\r")
 			})
-			result[i] = NewStringElement(c)
+			result[i], _ = NewStringElement(c)
 		}
 	}
 	return result, nil
@@ -2096,8 +2096,8 @@ type StringElement struct {
 }
 
 // NewStringElement initializes a new `StringElement` from the given content
-func NewStringElement(content string) StringElement {
-	return StringElement{Content: content}
+func NewStringElement(content string) (StringElement, error) {
+	return StringElement{Content: content}, nil
 }
 
 // AcceptVisitor implements Visitable#AcceptVisitor(Visitor)

--- a/pkg/types/grammar_types_utils.go
+++ b/pkg/types/grammar_types_utils.go
@@ -112,7 +112,8 @@ func mergeElements(elements ...interface{}) InlineElements {
 // and returns a new buffer, or returns the given arguments if the buffer was empty
 func appendBuffer(elements []interface{}, buff *bytes.Buffer) ([]interface{}, *bytes.Buffer) {
 	if buff.Len() > 0 {
-		return append(elements, NewStringElement(buff.String())), bytes.NewBuffer(nil)
+		s, _ := NewStringElement(buff.String())
+		return append(elements, s), bytes.NewBuffer(nil)
 	}
 	return elements, buff
 }


### PR DESCRIPTION
Do not accept content such as `+ foo bar+` or `+foo bar +`
as valid passthrough: no space allowed after opening `+`
or before closing `+` characters.

Fixes #337

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>