### PR TITLE
feat(parser/renderer): add user macro feature

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -68,6 +68,26 @@ where the returned `map[string]interface{}` object contains the document's title
 
 For now, the sole option to pass as a last argument is `renderer.IncludeHeaderFooter` to include the `<header>` and `<footer>` elements in the generated HTML document or not. Default is `false`, which means that only the `<body>` part of the HTML document is generated.
 
+=== Macro definition
+
+The user can define a macro by calling `renderer.DefineMacro()` and passing return value to conversion functions.
+
+`renderer.DefineMacro()` defines a macro by the given name and associates the given template. The template is an implementation of `renderer.MacroTemplate` interface (ex. `text.Template`)
+
+Libasciidoc calls `Execute()` method and passes `types.UserMacro` object to template when rendering.
+
+An example the following:
+
+```
+var tmplStr = `<span>Example: {{.Value}}{{.Attributes.GetAsString "suffix"}}</span>`
+var t = template.New("example")
+var tmpl = template.Must(t.Parse(tmplStr))
+
+output := &strings.Builder{}
+content := strings.NewReader(`example::hello world[suffix=!!!!!]`)
+libasciidoc.ConvertToHTML(context.Background(), content, output, renderer.DefineMacro(tmpl.Name(), tmpl))
+```
+
 == How to contribute
 
 Please refer to the link:CONTRIBUTE.adoc[Contribute] page.

--- a/pkg/parser/asciidoc-grammar.peg
+++ b/pkg/parser/asciidoc-grammar.peg
@@ -214,6 +214,7 @@ DocumentElement <- !EOF // when reaching EOF, do not try to parse a new document
             / DocumentAttributeDeclaration 
             / DocumentAttributeReset 
             / TableOfContentsMacro
+            / UserMacroBlock
             / Paragraph) {
     return element, nil
 }
@@ -549,6 +550,29 @@ TitleElement <- element:(Spaces / Dot / CrossReference / Passthrough / InlineIma
 TableOfContentsMacro <- "toc::[]" NEWLINE
 
 // ------------------------------------------
+// User Macro
+// ------------------------------------------
+UserMacroBlock <- name:(UserMacroName) "::" value:(UserMacroValue) attrs:(UserMacroAttributes) {
+    return types.NewUserMacroBlock(name.(string), value.(string), attrs.(types.ElementAttributes), string(c.text))
+}
+
+InlineUserMacro <- name:(UserMacroName) ":" value:(UserMacroValue) attrs:(UserMacroAttributes) {
+    return types.NewInlineUserMacro(name.(string), value.(string), attrs.(types.ElementAttributes), string(c.text))
+}
+
+UserMacroName <- (!URL_SCHEME !"." !":" !"[" !"]" !WS !EOL .)+ {
+    return string(c.text), nil
+}
+
+UserMacroValue <- (!":" !"[" !"]" !EOL .)* {
+    return string(c.text), nil
+}
+
+UserMacroAttributes <- "[" attrs:(GenericAttribute)* "]" {
+    return types.NewInlineAttributes(attrs.([]interface{}))
+}
+
+// ------------------------------------------
 // File inclusions
 // ------------------------------------------
 FileInclusion <- incl:("include::" path:(Location) inlineAttributes:(FileIncludeAttributes) { 
@@ -834,6 +858,7 @@ InlineElement <- !EOL !LineBreak
         / Link 
         / Passthrough 
         / InlineFootnote 
+        / InlineUserMacro 
         / Alphanums 
         / QuotedText 
         / CrossReference 

--- a/pkg/parser/user_macro_test.go
+++ b/pkg/parser/user_macro_test.go
@@ -1,0 +1,53 @@
+package parser_test
+
+import (
+	"github.com/bytesparadise/libasciidoc/pkg/parser"
+	"github.com/bytesparadise/libasciidoc/pkg/types"
+	. "github.com/onsi/ginkgo"
+)
+
+var _ = Describe("user macros", func() {
+
+	Context("user macros", func() {
+
+		It("user block macro", func() {
+			actualContent := "git::some/url.git[key1=value1,key2=value2]"
+			expectedResult := types.UserMacro{
+				Kind:  types.BlockMacro,
+				Name:  "git",
+				Value: "some/url.git",
+				Attributes: types.ElementAttributes{
+					"key1": "value1",
+					"key2": "value2",
+				},
+				RawText: "git::some/url.git[key1=value1,key2=value2]",
+			}
+			verifyWithPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
+		})
+
+		It("inline user macro", func() {
+			actualContent := "repository: git:some/url.git[key1=value1,key2=value2]"
+			expectedResult := types.Paragraph{
+				Attributes: types.ElementAttributes{},
+				Lines: []types.InlineElements{
+					{
+						types.StringElement{
+							Content: "repository: ",
+						},
+						types.UserMacro{
+							Kind:  types.InlineMacro,
+							Name:  "git",
+							Value: "some/url.git",
+							Attributes: types.ElementAttributes{
+								"key1": "value1",
+								"key2": "value2",
+							},
+							RawText: "git:some/url.git[key1=value1,key2=value2]",
+						},
+					},
+				},
+			}
+			verifyWithPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
+		})
+	})
+})

--- a/pkg/renderer/html5/renderer.go
+++ b/pkg/renderer/html5/renderer.go
@@ -125,6 +125,8 @@ func renderElement(ctx *renderer.Context, element interface{}) ([]byte, error) {
 		return renderAttributeSubstitution(ctx, e), nil
 	case types.LineBreak:
 		return renderLineBreak()
+	case types.UserMacro:
+		return renderUserMacro(ctx, e)
 	case types.SingleLineComment:
 		return nil, nil // nothing to do
 	default:

--- a/pkg/renderer/html5/user_macro.go
+++ b/pkg/renderer/html5/user_macro.go
@@ -1,0 +1,33 @@
+package html5
+
+import (
+	"bytes"
+
+	"github.com/bytesparadise/libasciidoc/pkg/renderer"
+	"github.com/bytesparadise/libasciidoc/pkg/types"
+)
+
+func renderUserMacro(ctx *renderer.Context, um types.UserMacro) ([]byte, error) {
+	buf := bytes.NewBuffer([]byte{})
+	macro, err := ctx.MacroTemplate(um.Name)
+	if err != nil {
+		if um.Kind == types.BlockMacro {
+			// fallback to paragraph
+			p, _ := types.NewParagraph([]interface{}{
+				types.InlineElements{
+					types.StringElement{Content: um.RawText},
+				},
+			}, nil)
+			return renderParagraph(ctx, p)
+		}
+		// fallback to render raw text
+		_, err = buf.WriteString(um.RawText)
+	} else {
+		err = macro.Execute(buf, um)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+
+}

--- a/pkg/renderer/html5/user_macro_test.go
+++ b/pkg/renderer/html5/user_macro_test.go
@@ -1,0 +1,135 @@
+package html5_test
+
+import (
+	"html"
+	texttemplate "text/template"
+
+	"github.com/bytesparadise/libasciidoc/pkg/renderer"
+	. "github.com/onsi/ginkgo"
+)
+
+var helloMacroTmpl *texttemplate.Template
+
+var _ = Describe("user macros", func() {
+
+	Context("user macros", func() {
+		It("undefined macro block", func() {
+
+			actualContent := "hello::[]"
+			expectedResult := `<div class="paragraph">
+<p>hello::[]</p>
+</div>`
+			verify(GinkgoT(), expectedResult, actualContent)
+		})
+
+		It("user macro block", func() {
+
+			actualContent := "hello::[]"
+			expectedResult := `<div class="helloblock">
+<div class="content">
+<span>hello world</span>
+</div>
+</div>`
+			verify(GinkgoT(), expectedResult, actualContent, renderer.DefineMacro(helloMacroTmpl.Name(), helloMacroTmpl))
+		})
+
+		It("user macro block with attribute", func() {
+
+			actualContent := `hello::[suffix="!!!!"]`
+			expectedResult := `<div class="helloblock">
+<div class="content">
+<span>hello world!!!!</span>
+</div>
+</div>`
+			verify(GinkgoT(), expectedResult, actualContent, renderer.DefineMacro(helloMacroTmpl.Name(), helloMacroTmpl))
+		})
+
+		It("user macro block with value", func() {
+
+			actualContent := `hello::John Doe[]`
+			expectedResult := `<div class="helloblock">
+<div class="content">
+<span>hello John Doe</span>
+</div>
+</div>`
+			verify(GinkgoT(), expectedResult, actualContent, renderer.DefineMacro(helloMacroTmpl.Name(), helloMacroTmpl))
+		})
+
+		It("user macro block with value and attributes", func() {
+
+			actualContent := `hello::John Doe[prefix="Hi ",suffix="!!"]`
+			expectedResult := `<div class="helloblock">
+<div class="content">
+<span>Hi John Doe!!</span>
+</div>
+</div>`
+			verify(GinkgoT(), expectedResult, actualContent, renderer.DefineMacro(helloMacroTmpl.Name(), helloMacroTmpl))
+		})
+
+		It("undefined inline macro", func() {
+
+			actualContent := "hello:[]"
+			expectedResult := `<div class="paragraph">
+<p>hello:[]</p>
+</div>`
+			verify(GinkgoT(), expectedResult, actualContent)
+		})
+
+		It("inline macro", func() {
+
+			actualContent := "AAA hello:[]"
+			expectedResult := `<div class="paragraph">
+<p>AAA <span>hello world</span></p>
+</div>`
+			verify(GinkgoT(), expectedResult, actualContent, renderer.DefineMacro(helloMacroTmpl.Name(), helloMacroTmpl))
+		})
+
+		It("inline macro with attribute", func() {
+
+			actualContent := `AAA hello:[suffix="!!!!!"]`
+			expectedResult := `<div class="paragraph">
+<p>AAA <span>hello world!!!!!</span></p>
+</div>`
+			verify(GinkgoT(), expectedResult, actualContent, renderer.DefineMacro(helloMacroTmpl.Name(), helloMacroTmpl))
+		})
+
+		It("inline macro with value", func() {
+
+			actualContent := `AAA hello:John Doe[]`
+			expectedResult := `<div class="paragraph">
+<p>AAA <span>hello John Doe</span></p>
+</div>`
+			verify(GinkgoT(), expectedResult, actualContent, renderer.DefineMacro(helloMacroTmpl.Name(), helloMacroTmpl))
+		})
+
+		It("inline macro with value and attributes", func() {
+
+			actualContent := `AAA hello:John Doe[prefix="Hi ",suffix="!!"]`
+			expectedResult := `<div class="paragraph">
+<p>AAA <span>Hi John Doe!!</span></p>
+</div>`
+			verify(GinkgoT(), expectedResult, actualContent, renderer.DefineMacro(helloMacroTmpl.Name(), helloMacroTmpl))
+		})
+
+	})
+})
+
+func init() {
+	t := texttemplate.New("hello")
+	t.Funcs(texttemplate.FuncMap{
+		"escape": html.EscapeString,
+	})
+	helloMacroTmpl = texttemplate.Must(t.Parse(`{{- if eq .Kind "block" -}}
+<div class="helloblock">
+<div class="content">
+{{end -}}
+<span>
+{{- if .Attributes.Has "prefix"}}{{escape (.Attributes.GetAsString "prefix")}} {{else}}hello {{end -}}
+{{- if ne .Value ""}}{{escape .Value}}{{else}}world{{- end -}}
+{{- escape (.Attributes.GetAsString "suffix") -}}
+</span>
+{{- if eq .Kind "block"}}
+</div>
+</div>
+{{- end -}}`))
+}

--- a/pkg/renderer/options.go
+++ b/pkg/renderer/options.go
@@ -1,6 +1,8 @@
 package renderer
 
-import "time"
+import (
+	"time"
+)
 
 //Option the options when rendering a document
 type Option func(ctx *Context)
@@ -35,6 +37,13 @@ func IncludeHeaderFooter(value bool) Option {
 func Entrypoint(entrypoint string) Option {
 	return func(ctx *Context) {
 		ctx.options[keyEntrypoint] = entrypoint
+	}
+}
+
+// DefineMacro defines the given template to a user macro with the given name
+func DefineMacro(name string, t MacroTemplate) Option {
+	return func(ctx *Context) {
+		ctx.macros[name] = t
 	}
 }
 

--- a/pkg/types/grammar_types.go
+++ b/pkg/types/grammar_types.go
@@ -436,6 +436,45 @@ type TableOfContentsMacro struct {
 }
 
 // ------------------------------------------
+// User Macro
+// ------------------------------------------
+
+const (
+	// InlineMacro a inline user macro
+	InlineMacro MacroKind = "inline"
+	// BlockMacro a block user macro
+	BlockMacro MacroKind = "block"
+)
+
+// MacroKind the type of user macro
+type MacroKind string
+
+// UserMacro the structure for User Macro
+type UserMacro struct {
+	Kind       MacroKind
+	Name       string
+	Value      string
+	Attributes ElementAttributes
+	RawText    string
+}
+
+// NewUserMacroBlock returns an UserMacro
+func NewUserMacroBlock(name, value string, attrs ElementAttributes, raw string) (UserMacro, error) {
+	return UserMacro{Name: name, Kind: BlockMacro, Value: value, Attributes: attrs, RawText: raw}, nil
+}
+
+// AddAttributes adds all given attributes to the current set of attribute of the element
+func (d UserMacro) AddAttributes(attributes ElementAttributes) {
+	d.Attributes.AddAll(attributes)
+
+}
+
+// NewInlineUserMacro returns an UserMacro
+func NewInlineUserMacro(name, value string, attrs ElementAttributes, raw string) (UserMacro, error) {
+	return UserMacro{Name: name, Kind: InlineMacro, Value: value, Attributes: attrs, RawText: raw}, nil
+}
+
+// ------------------------------------------
 // Preamble
 // ------------------------------------------
 


### PR DESCRIPTION
fixes #334 

* add parse rules for user macro to parser.
* add `renderer.DefineMacro()` that returns `renderer.Option` to renderer.
* user can define a rendering function for macro by call `renderer.DefineMacro()` and pass to `renderer.Wrap()`.

ex.

```go
func helloMacro(cm types.UserMacro) ([]byte, error) {
    // render content
}

...
    renderer.Wrap(context.Background(), doc, renderer.DefineMacro("hello", helloMacro))
...
```