### PR TITLE
refactor(parser): do not report error when file to include is missing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,6 @@ generate-optimized:
 	@echo "generating the parser (optimized)..."
 	@pigeon -optimize-grammar -alternate-entrypoints PreparsedDocument,InlineElementsWithoutSubtitution,VerbatimBlock ./pkg/parser/asciidoc-grammar.peg > ./pkg/parser/asciidoc_parser.go
 
-
 .PHONY: test
 ## run all tests excluding fixtures and vendored packages
 test: deps generate-optimized
@@ -122,12 +121,10 @@ build: $(INSTALL_PREFIX) deps generate-optimized
 	  -o $(BINARY_PATH) \
 	  cmd/libasciidoc/*.go
 
-
 .PHONY: lint
 ## run golangci-lint against project
 lint:
 	@golangci-lint run -E gofmt,golint,megacheck,misspell ./...
-
 
 PARSER_DIFF_STATUS :=
 
@@ -140,8 +137,22 @@ else
 	@echo "parser is ok"
 endif
 
-
 .PHONY: install
 ## installs the binary executable in the $GOPATH/bin directory
 install: install-devtools build
+	@cp $(BINARY_PATH) $(GOPATH)/bin
+
+.PHONY: quick-install
+## installs the binary executable in the $GOPATH/bin directory without prior tools setup and parser generation
+quick-install:
+	$(eval BUILD_COMMIT:=$(shell git rev-parse --short HEAD))
+	$(eval BUILD_TAG:=$(shell git tag --contains $(BUILD_COMMIT)))
+	$(eval BUILD_TIME:=$(shell date -u '+%Y-%m-%dT%H:%M:%SZ'))
+	@echo "building $(BINARY_PATH) (commit:$(BUILD_COMMIT) / tag:$(BUILD_TAG) / time:$(BUILD_TIME))"
+	@go build -ldflags \
+	  " -X github.com/bytesparadise/libasciidoc.BuildCommit=$(BUILD_COMMIT)\
+	    -X github.com/bytesparadise/libasciidoc.BuildTag=$(BUILD_TAG) \
+	    -X github.com/bytesparadise/libasciidoc.BuildTime=$(BUILD_TIME)" \
+	  -o $(BINARY_PATH) \
+	  cmd/libasciidoc/*.go
 	@cp $(BINARY_PATH) $(GOPATH)/bin

--- a/cmd/libasciidoc/cmd_suite_test.go
+++ b/cmd/libasciidoc/cmd_suite_test.go
@@ -5,6 +5,8 @@ import (
 	. "github.com/onsi/gomega"
 
 	"testing"
+
+	_ "github.com/bytesparadise/libasciidoc/testsupport"
 )
 
 func TestCmd(t *testing.T) {

--- a/cmd/libasciidoc/main.go
+++ b/cmd/libasciidoc/main.go
@@ -21,16 +21,13 @@ func main() {
 }
 
 var helpCommand = &cobra.Command{
-	Use:               "help [command]",
-	Short:             "Help about the command",
-	PersistentPreRun:  func(cmd *cobra.Command, args []string) {},
-	PersistentPostRun: func(cmd *cobra.Command, args []string) {},
+	Use:   "help [command]",
+	Short: "Help about the command",
 	RunE: func(c *cobra.Command, args []string) error {
 		cmd, args, e := c.Root().Find(args)
 		if cmd == nil || e != nil || len(args) > 0 {
 			return errors.Errorf("unknown help topic: %v", strings.Join(args, " "))
 		}
-
 		helpFunc := cmd.HelpFunc()
 		helpFunc(cmd, args)
 		return nil

--- a/cmd/libasciidoc/root_cmd.go
+++ b/cmd/libasciidoc/root_cmd.go
@@ -10,20 +10,41 @@ import (
 	"path/filepath"
 
 	"github.com/bytesparadise/libasciidoc"
+	logsupport "github.com/bytesparadise/libasciidoc/pkg/log"
 	"github.com/bytesparadise/libasciidoc/pkg/renderer"
+
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
 // NewRootCmd returns the root command
 func NewRootCmd() *cobra.Command {
+
 	var noHeaderFooter bool
 	var outputName string
 	var logLevel string
+
 	rootCmd := &cobra.Command{
 		Use:   "libasciidoc [flags] FILE",
 		Short: `libasciidoc is a tool to convert from Asciidoc to HTML`,
 		Args:  cobra.ArbitraryArgs,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			lvl, err := log.ParseLevel(logLevel)
+			if err != nil {
+				fmt.Fprintf(cmd.OutOrStderr(), "unable to parse log level '%v'", logLevel)
+				return err
+			}
+			// customFormatter := new(log.TextFormatter)
+			// customFormatter.EnvironmentOverrideColors = true
+			// customFormatter.DisableLevelTruncation = true
+			// customFormatter.DisableTimestamp = true
+			// log.SetFormatter(customFormatter)
+			// log.Debugf("Setting log level to %v", lvl)
+			logsupport.Setup()
+			log.SetLevel(lvl)
+			log.SetOutput(cmd.OutOrStdout())
+			return nil
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				return helpCommand.RunE(cmd, args)
@@ -41,16 +62,6 @@ func NewRootCmd() *cobra.Command {
 					}
 				}
 			}
-			return nil
-		},
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			lvl, err := log.ParseLevel(logLevel)
-			if err != nil {
-				fmt.Fprintf(cmd.OutOrStderr(), "unable to parse log level '%v'", logLevel)
-				return err
-			}
-			log.Debugf("Setting log level to %v", lvl)
-			log.SetLevel(lvl)
 			return nil
 		},
 	}

--- a/libasciidoc.go
+++ b/libasciidoc.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bytesparadise/libasciidoc/pkg/renderer"
 	htmlrenderer "github.com/bytesparadise/libasciidoc/pkg/renderer/html5"
 	"github.com/bytesparadise/libasciidoc/pkg/types"
+
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )

--- a/libasciidoc_suite_test.go
+++ b/libasciidoc_suite_test.go
@@ -1,12 +1,10 @@
 package libasciidoc_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-
 	"testing"
 
-	_ "github.com/bytesparadise/libasciidoc/pkg/log"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
 
 func TestLibasciidoc(t *testing.T) {

--- a/libasciidoc_test.go
+++ b/libasciidoc_test.go
@@ -6,11 +6,10 @@ import (
 	"strings"
 	"time"
 
+	. "github.com/bytesparadise/libasciidoc"
+	"github.com/bytesparadise/libasciidoc/pkg/renderer"
 	"github.com/bytesparadise/libasciidoc/pkg/types"
 
-	. "github.com/bytesparadise/libasciidoc"
-	_ "github.com/bytesparadise/libasciidoc/pkg/log"
-	"github.com/bytesparadise/libasciidoc/pkg/renderer"
 	. "github.com/onsi/ginkgo"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"

--- a/pkg/log/log_init.go
+++ b/pkg/log/log_init.go
@@ -1,43 +1,14 @@
 package log
 
 import (
-	"flag"
-	"os"
-
 	log "github.com/sirupsen/logrus"
 )
 
-// initializes the level for the logger, using the optional '-debug' flag to activate the logs in 'debug' level.
-// Other tests must import this 'test' package even if unused, using:
-// import _ "github.com/bytesparadise/libasciidoc/pkg/log"
-func init() {
+// Setup configures the logger
+func Setup() {
 	customFormatter := new(log.TextFormatter)
-	customFormatter.TimestampFormat = "2006-01-02 15:04:05"
+	customFormatter.EnvironmentOverrideColors = true
+	customFormatter.DisableLevelTruncation = true
+	customFormatter.DisableTimestamp = true
 	log.SetFormatter(customFormatter)
-	if debugMode() {
-		log.SetLevel(log.DebugLevel)
-		log.Warn("Running test with logs in DEBUG level")
-	}
-	log.SetFormatter(&log.TextFormatter{FullTimestamp: false})
-}
-
-func debugMode() bool {
-	debugMode := false
-	flag.BoolVar(&debugMode, "debug", false, "when set, enables debug log messages")
-	if !flag.Parsed() {
-		flag.Parse()
-	}
-	// if the `-debug` flag was passed and captured by the `flag.Parse`
-	if debugMode {
-		// log.Info("`debug` flag found")
-		return debugMode
-	}
-	// otherwise, check the OS args
-	for _, arg := range os.Args {
-		if arg == "-debug" {
-			log.Info("`-debug` os env found")
-			return true
-		}
-	}
-	return false
 }

--- a/pkg/parser/asciidoc-grammar.peg
+++ b/pkg/parser/asciidoc-grammar.peg
@@ -62,7 +62,7 @@ PreparsedDocument <- blocks:(PreparsedDocumentBlocks) EOF {
 
 PreparsedDocumentBlocks <- (DocumentAttributeDeclaration / 
         RawSectionTitle /
-        FileInclude / 
+        FileInclusion / 
         BlankLine / 
         RawText)* 
 
@@ -197,7 +197,7 @@ DocumentAttributeValue <- (Alphanums / Spaces / (!NEWLINE  .){
 // ------------------------------------------
 DocumentElement <- !EOF // when reaching EOF, do not try to parse a new document block again
     element:(BlankLine 
-            / FileInclude
+            / FileInclusion
             / VerseBlock
             / VerseParagraph
             / ImageBlock 
@@ -325,7 +325,7 @@ QuoteAttributes <- "[" kind:(QuoteKind) WS* "," author:(QuoteAuthor) "," title:(
 } /
 // verse without specific author
 "[" kind:(QuoteKind) WS* "]" {
-    return types.NewQuoteAttributes(kind.(string), "","")
+    return types.NewQuoteAttributes(kind.(string), "", "")
 }
 
 QuoteKind <- "quote" {
@@ -341,7 +341,7 @@ VerseAttributes <- attribute:("[" kind:(VerseKind) WS* "," author:(QuoteAuthor) 
     } /
     // verse without specific author
     "[" kind:(VerseKind) WS* "]" {
-        return types.NewQuoteAttributes(kind.(string), "","")
+        return types.NewQuoteAttributes(kind.(string), "", "")
     }
 )
 #{
@@ -551,8 +551,10 @@ TableOfContentsMacro <- "toc::[]" NEWLINE
 // ------------------------------------------
 // File inclusions
 // ------------------------------------------
-FileInclude <- "include::" path:(URL) inlineAttributes:(FileIncludeAttributes) WS* EOL {
-    return types.NewFileInclusion(path.(string), inlineAttributes.(types.ElementAttributes))
+FileInclusion <- incl:("include::" path:(URL) inlineAttributes:(FileIncludeAttributes) { 
+        return types.NewFileInclusion(path.(string), inlineAttributes.(types.ElementAttributes), string(c.text))
+    }) WS* EOL {
+    return incl.(types.FileInclusion), nil
 }
 
 FileIncludeAttributes <- "[" attrs:(LineRangesAttribute / GenericAttribute)* "]" {
@@ -865,7 +867,7 @@ InlineElementWithoutSubtitution <- !EOL !LineBreak
 }
 
 // special case for parsing files to include in delimited blocks with 'verbatim' substitution
-VerbatimBlock <- elements:(BlankLine / FileInclude / VerbatimParagraph)* EOF {
+VerbatimBlock <- elements:(BlankLine / FileInclusion / VerbatimParagraph)* EOF {
     return elements, nil
 }
 
@@ -1217,7 +1219,7 @@ FencedBlock <- FencedBlockDelimiter content:(FencedBlockContent)* (FencedBlockDe
     return types.NewDelimitedBlock(types.Fenced, content.([]interface{}), types.None)
 }
 
-FencedBlockContent <- BlankLine / FileInclude / List / BlockParagraph
+FencedBlockContent <- BlankLine / FileInclusion / List / BlockParagraph
 
 // -------------------------------------------------------------------------------------
 // Listing blocks
@@ -1231,7 +1233,7 @@ ListingBlock <- ListingBlockDelimiter content:(ListingBlockElement)* ((ListingBl
 
 ListingBlockElement <- ListingFileInclude / ListingBlockParagraph
 
-ListingFileInclude <- !ListingBlockDelimiter !EOF include:(FileInclude) {
+ListingFileInclude <- !ListingBlockDelimiter !EOF include:(FileInclusion) {
     return include, nil
 }
 
@@ -1254,7 +1256,7 @@ ListingBlockLineContent <- (Alphanums / Spaces / (!ListingBlockDelimiter !EOL  .
 // -------------------------------------------------------------------------------------
 ExampleBlockDelimiter <- "====" WS* EOL
 
-ExampleBlock <- ExampleBlockDelimiter content:(BlankLine / FileInclude / List / BlockParagraph)*  (ExampleBlockDelimiter / EOF) {
+ExampleBlock <- ExampleBlockDelimiter content:(BlankLine / FileInclusion / List / BlockParagraph)*  (ExampleBlockDelimiter / EOF) {
     return types.NewDelimitedBlock(types.Example, content.([]interface{}), types.None)
 }
 
@@ -1283,7 +1285,7 @@ QuoteBlock <- QuoteBlockDelimiter content:(QuoteBlockElement)* (QuoteBlockDelimi
 
 QuoteBlockElement <- 
     !QuoteBlockDelimiter !EOF element:(BlankLine 
-            / FileInclude
+            / FileInclusion
             / VerseBlock
             / VerseParagraph
             / ImageBlock 
@@ -1329,7 +1331,7 @@ verse:(QuoteBlockDelimiter content:(VerseBlockElement)* (QuoteBlockDelimiter / E
 VerseBlockElement <- VerseFileInclude / BlankLine / VerseBlockParagraph
 
 
-VerseFileInclude <- !QuoteBlockDelimiter !EOF include:(FileInclude) {
+VerseFileInclude <- !QuoteBlockDelimiter !EOF include:(FileInclusion) {
     return include, nil
 }
 
@@ -1354,7 +1356,7 @@ SidebarBlock <- SidebarBlockDelimiter content:(SidebarBlockContent)*  (SidebarBl
     return types.NewDelimitedBlock(types.Sidebar, content.([]interface{}), types.None)
 }
 
-SidebarBlockContent <- BlankLine / FileInclude / List / NonSidebarBlock / BlockParagraph
+SidebarBlockContent <- BlankLine / FileInclusion / List / NonSidebarBlock / BlockParagraph
 
 NonSidebarBlock <- !SidebarBlock content:(DelimitedBlock) {
     return content, nil

--- a/pkg/parser/file_inclusion_test.go
+++ b/pkg/parser/file_inclusion_test.go
@@ -566,6 +566,65 @@ include::includes/chapter-a.adoc[]
 			})
 		})
 	})
+
+	Context("missing file to include", func() {
+
+		It("should replace with string element if directory does not exist in standalone block", func() {
+			actualContent := `include::{unknown}/unknown.adoc[leveloffset=+1]`
+			expectedResult := types.Paragraph{
+				Attributes: types.ElementAttributes{},
+				Lines: []types.InlineElements{
+					{
+						types.StringElement{
+							Content: "Unresolved directive in test.adoc - include::{unknown}/unknown.adoc[leveloffset=+1]",
+						},
+					},
+				},
+			}
+			// TODO: also verify that an error was reported in the console.
+			verifyWithPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
+		})
+
+		It("should replace with string element if file is missing in standalone block", func() {
+			actualContent := `include::includes/unknown.adoc[leveloffset=+1]`
+			expectedResult := types.Paragraph{
+				Attributes: types.ElementAttributes{},
+				Lines: []types.InlineElements{
+					{
+						types.StringElement{
+							Content: "Unresolved directive in test.adoc - include::includes/unknown.adoc[leveloffset=+1]",
+						},
+					},
+				},
+			}
+			// TODO: also verify that an error was reported in the console.
+			verifyWithPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
+		})
+
+		It("should replace with string element if file is missing in delimited block", func() {
+			actualContent := `----
+include::includes/unknown.adoc[leveloffset=+1]
+----`
+			expectedResult := types.DelimitedBlock{
+				Attributes: types.ElementAttributes{},
+				Kind:       types.Listing,
+				Elements: []interface{}{
+					types.Paragraph{
+						Attributes: types.ElementAttributes{},
+						Lines: []types.InlineElements{
+							{
+								types.StringElement{
+									Content: "Unresolved directive in test.adoc - include::includes/unknown.adoc[leveloffset=+1]",
+								},
+							},
+						},
+					},
+				},
+			}
+			// TODO: also verify that an error was reported in the console.
+			verifyWithPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
+		})
+	})
 })
 
 var _ = Describe("ignore file inclusions", func() {
@@ -576,7 +635,8 @@ var _ = Describe("ignore file inclusions", func() {
 			Attributes: types.ElementAttributes{
 				types.AttrLevelOffset: "+1",
 			},
-			Path: "includes/chapter-a.adoc",
+			Path:    "includes/chapter-a.adoc",
+			RawText: `include::includes/chapter-a.adoc[leveloffset=+1]`,
 		}
 		verifyWithoutPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
 	})
@@ -594,6 +654,7 @@ var _ = Describe("ignore file inclusions", func() {
 					types.FileInclusion{
 						Attributes: types.ElementAttributes{},
 						Path:       "includes/chapter-a.adoc",
+						RawText:    `include::includes/chapter-a.adoc[]`,
 					},
 				},
 			}
@@ -611,6 +672,7 @@ include::includes/chapter-a.adoc[]
 					types.FileInclusion{
 						Attributes: types.ElementAttributes{},
 						Path:       "includes/chapter-a.adoc",
+						RawText:    `include::includes/chapter-a.adoc[]`,
 					},
 				},
 			}
@@ -628,6 +690,7 @@ include::includes/chapter-a.adoc[]
 					types.FileInclusion{
 						Attributes: types.ElementAttributes{},
 						Path:       "includes/chapter-a.adoc",
+						RawText:    `include::includes/chapter-a.adoc[]`,
 					},
 				},
 			}
@@ -645,6 +708,7 @@ ____`
 					types.FileInclusion{
 						Attributes: types.ElementAttributes{},
 						Path:       "includes/chapter-a.adoc",
+						RawText:    `include::includes/chapter-a.adoc[]`,
 					},
 				},
 			}
@@ -667,6 +731,7 @@ ____`
 					types.FileInclusion{
 						Attributes: types.ElementAttributes{},
 						Path:       "includes/chapter-a.adoc",
+						RawText:    `include::includes/chapter-a.adoc[]`,
 					},
 				},
 			}
@@ -684,6 +749,7 @@ include::includes/chapter-a.adoc[]
 					types.FileInclusion{
 						Attributes: types.ElementAttributes{},
 						Path:       "includes/chapter-a.adoc",
+						RawText:    `include::includes/chapter-a.adoc[]`,
 					},
 				},
 			}
@@ -702,6 +768,7 @@ include::includes/chapter-a.adoc[]
 					types.FileInclusion{
 						Attributes: types.ElementAttributes{},
 						Path:       "includes/chapter-a.adoc",
+						RawText:    `include::includes/chapter-a.adoc[]`,
 					},
 				},
 			}
@@ -721,7 +788,8 @@ include::includes/chapter-a.adoc[]
 							{Start: 1, End: 1},
 						},
 					},
-					Path: "includes/chapter-a.adoc",
+					Path:    "includes/chapter-a.adoc",
+					RawText: `include::includes/chapter-a.adoc[lines=1]`,
 				}
 				verifyWithoutPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
 			})
@@ -734,7 +802,8 @@ include::includes/chapter-a.adoc[]
 							{Start: 1, End: 2},
 						},
 					},
-					Path: "includes/chapter-a.adoc",
+					Path:    "includes/chapter-a.adoc",
+					RawText: `include::includes/chapter-a.adoc[lines=1..2]`,
 				}
 				verifyWithoutPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
 			})
@@ -749,7 +818,8 @@ include::includes/chapter-a.adoc[]
 							{Start: 6, End: -1},
 						},
 					},
-					Path: "includes/chapter-a.adoc",
+					Path:    "includes/chapter-a.adoc",
+					RawText: `include::includes/chapter-a.adoc[lines=1;3..4;6..-1]`,
 				}
 				verifyWithoutPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
 			})
@@ -760,7 +830,8 @@ include::includes/chapter-a.adoc[]
 					Attributes: types.ElementAttributes{
 						types.AttrLineRanges: `1;3..4;6..foo`,
 					},
-					Path: "includes/chapter-a.adoc",
+					Path:    "includes/chapter-a.adoc",
+					RawText: `include::includes/chapter-a.adoc[lines=1;3..4;6..foo]`,
 				}
 				verifyWithoutPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
 			})
@@ -775,7 +846,8 @@ include::includes/chapter-a.adoc[]
 						"3..4":  nil,
 						"6..-1": nil,
 					},
-					Path: "includes/chapter-a.adoc",
+					Path:    "includes/chapter-a.adoc",
+					RawText: `include::includes/chapter-a.adoc[lines=1,3..4,6..-1]`,
 				}
 				verifyWithoutPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
 			})
@@ -791,7 +863,8 @@ include::includes/chapter-a.adoc[]
 							{Start: 1, End: 1},
 						},
 					},
-					Path: "includes/chapter-a.adoc",
+					Path:    "includes/chapter-a.adoc",
+					RawText: `include::includes/chapter-a.adoc[lines="1"]`,
 				}
 				verifyWithoutPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
 			})
@@ -804,7 +877,8 @@ include::includes/chapter-a.adoc[]
 							{Start: 1, End: 2},
 						},
 					},
-					Path: "includes/chapter-a.adoc",
+					Path:    "includes/chapter-a.adoc",
+					RawText: `include::includes/chapter-a.adoc[lines="1..2"]`,
 				}
 				verifyWithoutPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
 			})
@@ -819,7 +893,8 @@ include::includes/chapter-a.adoc[]
 							{Start: 6, End: -1},
 						},
 					},
-					Path: "includes/chapter-a.adoc",
+					Path:    "includes/chapter-a.adoc",
+					RawText: `include::includes/chapter-a.adoc[lines="1,3..4,6..-1"]`,
 				}
 				verifyWithoutPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
 			})
@@ -832,7 +907,8 @@ include::includes/chapter-a.adoc[]
 						"3..4":               nil,
 						"6..foo":             nil,
 					},
-					Path: "includes/chapter-a.adoc",
+					Path:    "includes/chapter-a.adoc",
+					RawText: `include::includes/chapter-a.adoc[lines="1,3..4,6..foo"]`,
 				}
 				verifyWithoutPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
 			})
@@ -843,7 +919,8 @@ include::includes/chapter-a.adoc[]
 					Attributes: types.ElementAttributes{
 						types.AttrLineRanges: `"1;3..4;6..10"`,
 					},
-					Path: "includes/chapter-a.adoc",
+					Path:    "includes/chapter-a.adoc",
+					RawText: `include::includes/chapter-a.adoc[lines="1;3..4;6..10"]`,
 				}
 				verifyWithoutPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
 			})

--- a/pkg/parser/parser_suite_test.go
+++ b/pkg/parser/parser_suite_test.go
@@ -6,7 +6,7 @@ import (
 
 	"testing"
 
-	_ "github.com/bytesparadise/libasciidoc/pkg/log"
+	_ "github.com/bytesparadise/libasciidoc/testsupport"
 )
 
 func TestParser(t *testing.T) {

--- a/pkg/renderer/html5/file_inclusion_test.go
+++ b/pkg/renderer/html5/file_inclusion_test.go
@@ -484,4 +484,29 @@ last line of parent</pre>
 			verify(GinkgoT(), expectedResult, actualContent)
 		})
 	})
+
+	Context("missing file to include", func() {
+
+		It("should replace with string element if file is missing in standalone block", func() {
+			actualContent := `include::includes/unknown.adoc[leveloffset=+1]`
+			expectedResult := `<div class="paragraph">
+<p>Unresolved directive in test.adoc - include::includes/unknown.adoc[leveloffset=&#43;1]</p>
+</div>`
+			// TODO: also verify that an error was reported in the console.
+			verify(GinkgoT(), expectedResult, actualContent)
+		})
+
+		It("should replace with string element if file is missing in listing block", func() {
+			actualContent := `----
+include::includes/unknown.adoc[leveloffset=+1]
+----`
+			expectedResult := `<div class="listingblock">
+<div class="content">
+<pre>Unresolved directive in test.adoc - include::includes/unknown.adoc[leveloffset=+1]</pre>
+</div>
+</div>`
+			// TODO: also verify that an error was reported in the console.
+			verify(GinkgoT(), expectedResult, actualContent)
+		})
+	})
 })

--- a/pkg/renderer/html5/html5_suite_test.go
+++ b/pkg/renderer/html5/html5_suite_test.go
@@ -6,7 +6,7 @@ import (
 
 	"testing"
 
-	_ "github.com/bytesparadise/libasciidoc/pkg/log"
+	_ "github.com/bytesparadise/libasciidoc/testsupport"
 )
 
 func TestHtml5(t *testing.T) {

--- a/pkg/renderer/renderer_suite_test.go
+++ b/pkg/renderer/renderer_suite_test.go
@@ -6,7 +6,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	_ "github.com/bytesparadise/libasciidoc/pkg/log"
+	_ "github.com/bytesparadise/libasciidoc/testsupport"
 )
 
 func TestRenderer(t *testing.T) {

--- a/pkg/types/grammar_types.go
+++ b/pkg/types/grammar_types.go
@@ -2286,12 +2286,13 @@ func NewInlineLinkAttributes(text interface{}, otherattrs []interface{}) (Elemen
 type FileInclusion struct {
 	Attributes ElementAttributes
 	Path       string
+	RawText    string
 }
 
 var _ ElementWithAttributes = FileInclusion{}
 
 // NewFileInclusion initializes a new inline `InlineLink`
-func NewFileInclusion(path string, attributes interface{}) (FileInclusion, error) {
+func NewFileInclusion(path string, attributes interface{}, rawtext string) (FileInclusion, error) {
 	attrs, ok := attributes.(ElementAttributes)
 	// init attributes with empty 'text' attribute
 	if !ok {
@@ -2300,6 +2301,7 @@ func NewFileInclusion(path string, attributes interface{}) (FileInclusion, error
 	return FileInclusion{
 		Attributes: attrs,
 		Path:       path,
+		RawText:    rawtext,
 	}, nil
 }
 

--- a/pkg/types/types_suite_test.go
+++ b/pkg/types/types_suite_test.go
@@ -6,7 +6,7 @@ import (
 
 	"testing"
 
-	_ "github.com/bytesparadise/libasciidoc/pkg/log"
+	_ "github.com/bytesparadise/libasciidoc/testsupport"
 )
 
 func TestTypes(t *testing.T) {

--- a/test/test_suite_test.go
+++ b/test/test_suite_test.go
@@ -6,7 +6,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	_ "github.com/bytesparadise/libasciidoc/pkg/log"
+	_ "github.com/bytesparadise/libasciidoc/testsupport"
 )
 
 func TestTest(t *testing.T) {

--- a/testsupport/log_init.go
+++ b/testsupport/log_init.go
@@ -1,0 +1,38 @@
+package log
+
+import (
+	"flag"
+	"os"
+
+	logsupport "github.com/bytesparadise/libasciidoc/pkg/log"
+	log "github.com/sirupsen/logrus"
+)
+
+func init() {
+	logsupport.Setup()
+	if debugMode() {
+		log.SetLevel(log.DebugLevel)
+		log.Warn("Running test with logs in DEBUG level")
+	}
+}
+
+func debugMode() bool {
+	debugMode := false
+	flag.BoolVar(&debugMode, "debug", false, "when set, enables debug log messages")
+	if !flag.Parsed() {
+		flag.Parse()
+	}
+	// if the `-debug` flag was passed and captured by the `flag.Parse`
+	if debugMode {
+		// log.Info("`debug` flag found")
+		return debugMode
+	}
+	// otherwise, check the OS args
+	for _, arg := range os.Args {
+		if arg == "-debug" {
+			log.Info("`-debug` os env found")
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Retrieve the whole file inclusion text during parsing so it can be
included in an error message.

Also, refactor the log format and configuration, splitting the
setup in a separate package for the tests, to avoid the conflict
of flags parsing with spf13/cobra when running from CL.

Fixes #319

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>