### PR TITLE
feat(parser): support attribute in path of file to include

### DIFF
--- a/pkg/parser/asciidoc-grammar.peg
+++ b/pkg/parser/asciidoc-grammar.peg
@@ -551,8 +551,8 @@ TableOfContentsMacro <- "toc::[]" NEWLINE
 // ------------------------------------------
 // File inclusions
 // ------------------------------------------
-FileInclusion <- incl:("include::" path:(URL) inlineAttributes:(FileIncludeAttributes) { 
-        return types.NewFileInclusion(path.(string), inlineAttributes.(types.ElementAttributes), string(c.text))
+FileInclusion <- incl:("include::" path:(Location) inlineAttributes:(FileIncludeAttributes) { 
+        return types.NewFileInclusion(path.(types.Location), inlineAttributes.(types.ElementAttributes), string(c.text))
     }) WS* EOL {
     return incl.(types.FileInclusion), nil
 }
@@ -1514,13 +1514,17 @@ Dot <- "." {
 }
 
 Word <- (Alphanums / QuotedTextPrefix / ((!NEWLINE !WS !Parenthesis !"." !QuotedTextPrefix .){
-    return string(c.text), nil
+    return types.NewStringElement(string(c.text))
 })+ / "."+){ // word cannot contain parenthesis. Dots and ellipsis are treated as independent words (but will be combined afterwards)
-    return string(c.text), nil
+    return types.NewStringElement(string(c.text))
 }
 
 Spaces <- WS+ {
     return string(c.text), nil
+}
+
+Location <- elements:(URL_SCHEME? (DocumentAttributeSubstitution / Word)+) {
+    return types.NewLocation(elements.([]interface{}))
 }
 
 URL <- (Alphanums / (!NEWLINE !WS !"[" !"]"  .){
@@ -1542,7 +1546,6 @@ URL_TEXT <- (Alphanums / (!NEWLINE !"[" !"]" .){
 }
 
 URL_SCHEME <- "http://" / "https://" / "ftp://" / "irc://" / "mailto:"
-
 DIGIT <- [0-9] {
     return string(c.text), nil
 }

--- a/pkg/parser/file_inclusion_test.go
+++ b/pkg/parser/file_inclusion_test.go
@@ -625,6 +625,94 @@ include::includes/unknown.adoc[leveloffset=+1]
 			verifyWithPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
 		})
 	})
+
+	Context("inclusion with attribute in path", func() {
+
+		It("should resolve path with attribute in standaldone block", func() {
+			actualContent := `:includedir: ./includes
+			
+include::{includedir}/grandchild-include.adoc[]`
+			expectedResult := types.Document{
+				Attributes:         types.DocumentAttributes{},
+				ElementReferences:  types.ElementReferences{},
+				Footnotes:          types.Footnotes{},
+				FootnoteReferences: types.FootnoteReferences{},
+				Elements: []interface{}{
+					types.DocumentAttributeDeclaration{
+						Name:  "includedir",
+						Value: "./includes",
+					},
+					types.BlankLine{},
+					types.Paragraph{
+						Attributes: types.ElementAttributes{},
+						Lines: []types.InlineElements{
+							{
+								types.StringElement{
+									Content: "first line of grandchild",
+								},
+							},
+						},
+					},
+					types.BlankLine{},
+					types.Paragraph{
+						Attributes: types.ElementAttributes{},
+						Lines: []types.InlineElements{
+							{
+								types.StringElement{
+									Content: "last line of grandchild",
+								},
+							},
+						},
+					},
+				},
+			}
+			verifyWithPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("Document"))
+		})
+
+		It("should resolve path with attribute in delimited block", func() {
+			actualContent := `:includedir: ./includes
+
+----
+include::{includedir}/grandchild-include.adoc[]
+----`
+			expectedResult := types.Document{
+				Attributes:         types.DocumentAttributes{},
+				ElementReferences:  types.ElementReferences{},
+				Footnotes:          types.Footnotes{},
+				FootnoteReferences: types.FootnoteReferences{},
+				Elements: []interface{}{
+					types.DocumentAttributeDeclaration{
+						Name:  "includedir",
+						Value: "./includes",
+					},
+					types.BlankLine{},
+					types.DelimitedBlock{
+						Attributes: types.ElementAttributes{},
+						Kind:       types.Listing,
+						Elements: []interface{}{
+							types.Paragraph{
+								Attributes: types.ElementAttributes{},
+								Lines: []types.InlineElements{
+									{
+										types.StringElement{
+											Content: "first line of grandchild",
+										},
+									},
+									{},
+									{
+										types.StringElement{
+											Content: "last line of grandchild",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			verifyWithPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("Document"))
+		})
+	})
 })
 
 var _ = Describe("ignore file inclusions", func() {
@@ -635,7 +723,11 @@ var _ = Describe("ignore file inclusions", func() {
 			Attributes: types.ElementAttributes{
 				types.AttrLevelOffset: "+1",
 			},
-			Path:    "includes/chapter-a.adoc",
+			Location: types.Location{
+				types.StringElement{
+					Content: "includes/chapter-a.adoc",
+				},
+			},
 			RawText: `include::includes/chapter-a.adoc[leveloffset=+1]`,
 		}
 		verifyWithoutPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
@@ -653,8 +745,12 @@ var _ = Describe("ignore file inclusions", func() {
 				Elements: []interface{}{
 					types.FileInclusion{
 						Attributes: types.ElementAttributes{},
-						Path:       "includes/chapter-a.adoc",
-						RawText:    `include::includes/chapter-a.adoc[]`,
+						Location: types.Location{
+							types.StringElement{
+								Content: "includes/chapter-a.adoc",
+							},
+						},
+						RawText: `include::includes/chapter-a.adoc[]`,
 					},
 				},
 			}
@@ -671,8 +767,12 @@ include::includes/chapter-a.adoc[]
 				Elements: []interface{}{
 					types.FileInclusion{
 						Attributes: types.ElementAttributes{},
-						Path:       "includes/chapter-a.adoc",
-						RawText:    `include::includes/chapter-a.adoc[]`,
+						Location: types.Location{
+							types.StringElement{
+								Content: "includes/chapter-a.adoc",
+							},
+						},
+						RawText: `include::includes/chapter-a.adoc[]`,
 					},
 				},
 			}
@@ -689,8 +789,12 @@ include::includes/chapter-a.adoc[]
 				Elements: []interface{}{
 					types.FileInclusion{
 						Attributes: types.ElementAttributes{},
-						Path:       "includes/chapter-a.adoc",
-						RawText:    `include::includes/chapter-a.adoc[]`,
+						Location: types.Location{
+							types.StringElement{
+								Content: "includes/chapter-a.adoc",
+							},
+						},
+						RawText: `include::includes/chapter-a.adoc[]`,
 					},
 				},
 			}
@@ -707,8 +811,12 @@ ____`
 				Elements: []interface{}{
 					types.FileInclusion{
 						Attributes: types.ElementAttributes{},
-						Path:       "includes/chapter-a.adoc",
-						RawText:    `include::includes/chapter-a.adoc[]`,
+						Location: types.Location{
+							types.StringElement{
+								Content: "includes/chapter-a.adoc",
+							},
+						},
+						RawText: `include::includes/chapter-a.adoc[]`,
 					},
 				},
 			}
@@ -730,8 +838,12 @@ ____`
 				Elements: []interface{}{
 					types.FileInclusion{
 						Attributes: types.ElementAttributes{},
-						Path:       "includes/chapter-a.adoc",
-						RawText:    `include::includes/chapter-a.adoc[]`,
+						Location: types.Location{
+							types.StringElement{
+								Content: "includes/chapter-a.adoc",
+							},
+						},
+						RawText: `include::includes/chapter-a.adoc[]`,
 					},
 				},
 			}
@@ -748,8 +860,12 @@ include::includes/chapter-a.adoc[]
 				Elements: []interface{}{
 					types.FileInclusion{
 						Attributes: types.ElementAttributes{},
-						Path:       "includes/chapter-a.adoc",
-						RawText:    `include::includes/chapter-a.adoc[]`,
+						Location: types.Location{
+							types.StringElement{
+								Content: "includes/chapter-a.adoc",
+							},
+						},
+						RawText: `include::includes/chapter-a.adoc[]`,
 					},
 				},
 			}
@@ -767,8 +883,12 @@ include::includes/chapter-a.adoc[]
 				Elements: []interface{}{
 					types.FileInclusion{
 						Attributes: types.ElementAttributes{},
-						Path:       "includes/chapter-a.adoc",
-						RawText:    `include::includes/chapter-a.adoc[]`,
+						Location: types.Location{
+							types.StringElement{
+								Content: "includes/chapter-a.adoc",
+							},
+						},
+						RawText: `include::includes/chapter-a.adoc[]`,
 					},
 				},
 			}
@@ -788,7 +908,11 @@ include::includes/chapter-a.adoc[]
 							{Start: 1, End: 1},
 						},
 					},
-					Path:    "includes/chapter-a.adoc",
+					Location: types.Location{
+						types.StringElement{
+							Content: "includes/chapter-a.adoc",
+						},
+					},
 					RawText: `include::includes/chapter-a.adoc[lines=1]`,
 				}
 				verifyWithoutPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
@@ -802,7 +926,11 @@ include::includes/chapter-a.adoc[]
 							{Start: 1, End: 2},
 						},
 					},
-					Path:    "includes/chapter-a.adoc",
+					Location: types.Location{
+						types.StringElement{
+							Content: "includes/chapter-a.adoc",
+						},
+					},
 					RawText: `include::includes/chapter-a.adoc[lines=1..2]`,
 				}
 				verifyWithoutPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
@@ -818,7 +946,11 @@ include::includes/chapter-a.adoc[]
 							{Start: 6, End: -1},
 						},
 					},
-					Path:    "includes/chapter-a.adoc",
+					Location: types.Location{
+						types.StringElement{
+							Content: "includes/chapter-a.adoc",
+						},
+					},
 					RawText: `include::includes/chapter-a.adoc[lines=1;3..4;6..-1]`,
 				}
 				verifyWithoutPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
@@ -830,7 +962,11 @@ include::includes/chapter-a.adoc[]
 					Attributes: types.ElementAttributes{
 						types.AttrLineRanges: `1;3..4;6..foo`,
 					},
-					Path:    "includes/chapter-a.adoc",
+					Location: types.Location{
+						types.StringElement{
+							Content: "includes/chapter-a.adoc",
+						},
+					},
 					RawText: `include::includes/chapter-a.adoc[lines=1;3..4;6..foo]`,
 				}
 				verifyWithoutPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
@@ -846,7 +982,11 @@ include::includes/chapter-a.adoc[]
 						"3..4":  nil,
 						"6..-1": nil,
 					},
-					Path:    "includes/chapter-a.adoc",
+					Location: types.Location{
+						types.StringElement{
+							Content: "includes/chapter-a.adoc",
+						},
+					},
 					RawText: `include::includes/chapter-a.adoc[lines=1,3..4,6..-1]`,
 				}
 				verifyWithoutPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
@@ -863,7 +1003,11 @@ include::includes/chapter-a.adoc[]
 							{Start: 1, End: 1},
 						},
 					},
-					Path:    "includes/chapter-a.adoc",
+					Location: types.Location{
+						types.StringElement{
+							Content: "includes/chapter-a.adoc",
+						},
+					},
 					RawText: `include::includes/chapter-a.adoc[lines="1"]`,
 				}
 				verifyWithoutPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
@@ -877,7 +1021,11 @@ include::includes/chapter-a.adoc[]
 							{Start: 1, End: 2},
 						},
 					},
-					Path:    "includes/chapter-a.adoc",
+					Location: types.Location{
+						types.StringElement{
+							Content: "includes/chapter-a.adoc",
+						},
+					},
 					RawText: `include::includes/chapter-a.adoc[lines="1..2"]`,
 				}
 				verifyWithoutPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
@@ -893,7 +1041,11 @@ include::includes/chapter-a.adoc[]
 							{Start: 6, End: -1},
 						},
 					},
-					Path:    "includes/chapter-a.adoc",
+					Location: types.Location{
+						types.StringElement{
+							Content: "includes/chapter-a.adoc",
+						},
+					},
 					RawText: `include::includes/chapter-a.adoc[lines="1,3..4,6..-1"]`,
 				}
 				verifyWithoutPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
@@ -907,7 +1059,11 @@ include::includes/chapter-a.adoc[]
 						"3..4":               nil,
 						"6..foo":             nil,
 					},
-					Path:    "includes/chapter-a.adoc",
+					Location: types.Location{
+						types.StringElement{
+							Content: "includes/chapter-a.adoc",
+						},
+					},
 					RawText: `include::includes/chapter-a.adoc[lines="1,3..4,6..foo"]`,
 				}
 				verifyWithoutPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
@@ -919,7 +1075,11 @@ include::includes/chapter-a.adoc[]
 					Attributes: types.ElementAttributes{
 						types.AttrLineRanges: `"1;3..4;6..10"`,
 					},
-					Path:    "includes/chapter-a.adoc",
+					Location: types.Location{
+						types.StringElement{
+							Content: "includes/chapter-a.adoc",
+						},
+					},
 					RawText: `include::includes/chapter-a.adoc[lines="1;3..4;6..10"]`,
 				}
 				verifyWithoutPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))

--- a/pkg/renderer/html5/file_inclusion_test.go
+++ b/pkg/renderer/html5/file_inclusion_test.go
@@ -519,26 +519,56 @@ last line of grandchild</pre>
 
 	Context("missing file to include", func() {
 
-		It("should replace with string element if file is missing in standalone block", func() {
-			actualContent := `include::includes/unknown.adoc[leveloffset=+1]`
-			expectedResult := `<div class="paragraph">
+		Context("in standalone block", func() {
+
+			It("should replace with string element if file is missing", func() {
+
+				actualContent := `include::includes/unknown.adoc[leveloffset=+1]`
+				expectedResult := `<div class="paragraph">
 <p>Unresolved directive in test.adoc - include::includes/unknown.adoc[leveloffset=&#43;1]</p>
 </div>`
-			// TODO: also verify that an error was reported in the console.
-			verify(GinkgoT(), expectedResult, actualContent)
+				// TODO: also verify that an error was reported in the console.
+				verify(GinkgoT(), expectedResult, actualContent)
+			})
+
+			It("should replace with string element if file with attribute in path is not resolved", func() {
+
+				actualContent := `include::{includedir}/unknown.adoc[leveloffset=+1]`
+				expectedResult := `<div class="paragraph">
+<p>Unresolved directive in test.adoc - include::{includedir}/unknown.adoc[leveloffset=&#43;1]</p>
+</div>`
+				// TODO: also verify that an error was reported in the console.
+				verify(GinkgoT(), expectedResult, actualContent)
+			})
 		})
 
-		It("should replace with string element if file is missing in listing block", func() {
-			actualContent := `----
+		Context("in listing block", func() {
+
+			It("should replace with string element if file is missing", func() {
+				actualContent := `----
 include::includes/unknown.adoc[leveloffset=+1]
 ----`
-			expectedResult := `<div class="listingblock">
+				expectedResult := `<div class="listingblock">
 <div class="content">
 <pre>Unresolved directive in test.adoc - include::includes/unknown.adoc[leveloffset=+1]</pre>
 </div>
 </div>`
-			// TODO: also verify that an error was reported in the console.
-			verify(GinkgoT(), expectedResult, actualContent)
+				// TODO: also verify that an error was reported in the console.
+				verify(GinkgoT(), expectedResult, actualContent)
+			})
+
+			It("should replace with string element if file with attribute in path is not resolved", func() {
+				actualContent := `----
+include::{includedir}/unknown.adoc[leveloffset=+1]
+----`
+				expectedResult := `<div class="listingblock">
+<div class="content">
+<pre>Unresolved directive in test.adoc - include::{includedir}/unknown.adoc[leveloffset=+1]</pre>
+</div>
+</div>`
+				// TODO: also verify that an error was reported in the console.
+				verify(GinkgoT(), expectedResult, actualContent)
+			})
 		})
 	})
 })

--- a/pkg/renderer/html5/file_inclusion_test.go
+++ b/pkg/renderer/html5/file_inclusion_test.go
@@ -485,6 +485,38 @@ last line of parent</pre>
 		})
 	})
 
+	Context("inclusion with attribute in path", func() {
+
+		It("should resolve path with attribute in standaldone block", func() {
+			actualContent := `:includedir: ./includes
+			
+include::{includedir}/grandchild-include.adoc[]`
+			expectedResult := `<div class="paragraph">
+<p>first line of grandchild</p>
+</div>
+<div class="paragraph">
+<p>last line of grandchild</p>
+</div>`
+			verify(GinkgoT(), expectedResult, actualContent)
+		})
+
+		It("should resolve path with attribute in delimited block", func() {
+			actualContent := `:includedir: ./includes
+
+----
+include::{includedir}/grandchild-include.adoc[]
+----`
+			expectedResult := `<div class="listingblock">
+<div class="content">
+<pre>first line of grandchild
+
+last line of grandchild</pre>
+</div>
+</div>`
+			verify(GinkgoT(), expectedResult, actualContent)
+		})
+	})
+
 	Context("missing file to include", func() {
 
 		It("should replace with string element if file is missing in standalone block", func() {

--- a/pkg/types/grammar_types_test.go
+++ b/pkg/types/grammar_types_test.go
@@ -1562,21 +1562,50 @@ func verifyLevelOffset(expectation string, actual types.RawSectionTitlePrefix, l
 	assert.EqualValues(GinkgoT(), expectation, result)
 }
 
-var _ = Describe("file inclusions", func() {
+// var _ = Describe("file inclusions", func() {
 
-	DescribeTable("check asciidoc file",
-		func(path string, expectation bool) {
+// 	DescribeTable("check asciidoc file",
+// 		func(path string, expectation bool) {
+// 			f := types.FileInclusion{
+// 				Path: path,
+// 			}
+// 			Expect(f.IsAsciidoc()).Should(Equal(expectation))
+// 		},
+// 		Entry("foo.adoc", "foo.adoc", true),
+// 		Entry("foo.asc", "foo.asc", true),
+// 		Entry("foo.ad", "foo.ad", true),
+// 		Entry("foo.asciidoc", "foo.asciidoc", true),
+// 		Entry("foo.txt", "foo.txt", true),
+// 		Entry("foo.csv", "foo.csv", false),
+// 		Entry("foo.go", "foo.go", false),
+// 	)
+// })
+
+var _ = Describe("Location resolution", func() {
+
+	attrs := map[string]string{
+		"includedir": "includes",
+		"foo":        "bar",
+	}
+	DescribeTable("resolve URL",
+		func(location types.Location, expectation string) {
 			f := types.FileInclusion{
-				Path: path,
+				Location: location,
 			}
-			Expect(f.IsAsciidoc()).Should(Equal(expectation))
+			Expect(f.Location.Resolve(attrs)).Should(Equal(expectation))
 		},
-		Entry("foo.adoc", "foo.adoc", true),
-		Entry("foo.asc", "foo.asc", true),
-		Entry("foo.ad", "foo.ad", true),
-		Entry("foo.asciidoc", "foo.asciidoc", true),
-		Entry("foo.txt", "foo.txt", true),
-		Entry("foo.csv", "foo.csv", false),
-		Entry("foo.go", "foo.go", false),
+		Entry("includes/file.ext", types.Location{
+			types.StringElement{Content: "includes/file.ext"},
+		}, "includes/file.ext"),
+		Entry("./{includedir}/file.ext", types.Location{
+			types.StringElement{Content: "./"},
+			types.DocumentAttributeSubstitution{Name: "includedir"},
+			types.StringElement{Content: "/file.ext"},
+		}, "./includes/file.ext"),
+		Entry("./{unknown}/file.ext", types.Location{
+			types.StringElement{Content: "./"},
+			types.DocumentAttributeSubstitution{Name: "unknown"},
+			types.StringElement{Content: "/file.ext"},
+		}, "./{unknown}/file.ext"),
 	)
 })


### PR DESCRIPTION
attribute in path is resolved during preprocessing.

Fixes #317

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>