### PR TITLE
fix(parser/renderer): support quoted text in links

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ generate: prebuild-checks
 ## generate the .go file based on the asciidoc grammar
 generate-optimized:
 	@echo "generating the parser (optimized)..."
-	@pigeon -optimize-grammar -alternate-entrypoints PreparsedDocument,InlineElementsWithoutSubtitution,VerbatimBlock ./pkg/parser/asciidoc-grammar.peg > ./pkg/parser/asciidoc_parser.go
+	@pigeon -optimize-grammar -alternate-entrypoints PreparsedDocument,InlineElementsWithoutSubtitution,VerbatimBlock -o ./pkg/parser/asciidoc_parser.go ./pkg/parser/asciidoc-grammar.peg
 
 .PHONY: test
 ## run all tests excluding fixtures and vendored packages

--- a/pkg/parser/asciidoc-grammar.peg
+++ b/pkg/parser/asciidoc-grammar.peg
@@ -3,10 +3,11 @@ package parser
 
 import (
     "strconv"
+    "io"
+    "unicode"
 
     "github.com/bytesparadise/libasciidoc/pkg/types"
 
-    log "github.com/sirupsen/logrus"
     errs "github.com/pkg/errors"
 )
 
@@ -87,7 +88,7 @@ RawText <- content:((!EOL .)+ { return c.text, nil }) EOL {
 // ------------------------------------------
 FrontMatter <- YamlFrontMatter 
 
-FrontMatter <- YamlFrontMatterToken content:(YamlFrontMatterContent) YamlFrontMatterToken {
+YamlFrontMatter <- YamlFrontMatterToken content:(YamlFrontMatterContent) YamlFrontMatterToken {
     return types.NewYamlFrontMatter(content.(string))
 }
 
@@ -560,7 +561,7 @@ InlineUserMacro <- name:(UserMacroName) ":" value:(UserMacroValue) attrs:(UserMa
     return types.NewInlineUserMacro(name.(string), value.(string), attrs.(types.ElementAttributes), string(c.text))
 }
 
-UserMacroName <- (!URL_SCHEME !"." !":" !"[" !"]" !WS !EOL .)+ {
+UserMacroName <- (!"." !":" !WS !EOL .)+ {
     return string(c.text), nil
 }
 
@@ -575,7 +576,7 @@ UserMacroAttributes <- "[" attrs:(GenericAttribute)* "]" {
 // ------------------------------------------
 // File inclusions
 // ------------------------------------------
-FileInclusion <- incl:("include::" path:(Location) inlineAttributes:(FileIncludeAttributes) { 
+FileInclusion <- incl:("include::" path:(FileLocation) inlineAttributes:(FileIncludeAttributes) { 
         return types.NewFileInclusion(path.(types.Location), inlineAttributes.(types.ElementAttributes), string(c.text))
     }) WS* EOL {
     return incl.(types.FileInclusion), nil
@@ -920,7 +921,7 @@ LineBreak <- WS "+" WS* &EOL {
 // ----------------------------------------------------------------------------
 // Quoted Texts (bold, italic and monospace) including substitution prevention
 // ----------------------------------------------------------------------------
-QuotedText <- BoldText 
+QuotedText <- !WS text:(BoldText 
             / ItalicText 
             / MonospaceText 
             / SubscriptText 
@@ -930,45 +931,15 @@ QuotedText <- BoldText
             / EscapedMonospaceText 
             / EscapedSubscriptText 
             / EscapedSuperscriptText
-            / SubScriptOrSuperScriptPrefix // if a '^' or '~' is alone (ie, badly formatted superscript or subscript, then accept it as-is) 
+            / SubScriptOrSuperScriptPrefix) { // if a '^' or '~' is alone (ie, badly formatted superscript or subscript, then accept it as-is) 
+    return text, nil
+}
 
 QuotedTextPrefix <- "**" / "*" / "__" / "_" / "``" / "`" / "^" / "~"
 
 SubScriptOrSuperScriptPrefix <- "^" / "~" { // rule used withn `words` to detect superscript or subscript portions, eg in math formulae.
     return string(c.text), nil
 }
-
-BoldText <- 
-    !`\\` "**" content:(BoldTextElements) "**" { // double punctuation must be evaluated first
-        return types.NewQuotedText(types.Bold, content.([]interface{}))
-    } / !`\\` "**" content:(BoldTextElements) "*" { // unbalanced `**` vs `*` punctuation
-        result := append([]interface{}{"*"}, content.([]interface{}))
-        return types.NewQuotedText(types.Bold, result)
-    } / !`\` "*" content:(BoldTextElements) "*" !Alphanum { // single punctuation cannot be followed by a character (needs '**' to emphazise a portion of a word)
-        return types.NewQuotedText(types.Bold, content.([]interface{}))
-} 
-
-BoldTextElements <- BoldTextElement (WS* BoldTextElement)*
-
-BoldTextElement <- QuotedText
-        / InlineImage 
-        / Link 
-        / Passthrough 
-        / NonBoldText // word with quote punctuation is only accepted if nothing matched before, so we have a chance to stop
-
-NonBoldText <- (!NEWLINE !WS !"*"  !"^" !"~" .)+ { 
-    return c.text, nil
-}
-
-EscapedBoldText <- 
-    backslashes:(TwoOrMoreBackslashes) "**" content:(BoldTextElements) "**" { // double punctuation must be evaluated first
-        return types.NewEscapedQuotedText(backslashes.(string), "**", content.([]interface{}))
-    } / backslashes:(OneOrMoreBackslashes) "**" content:(BoldTextElements) "*" { // unbalanced `**` vs `*` punctuation
-        result := append([]interface{}{"*"}, content.([]interface{}))
-        return types.NewEscapedQuotedText(backslashes.(string), "*", result)
-    } / backslashes:(OneOrMoreBackslashes) "*" content:(BoldTextElements) "*" { // simple punctuation must be evaluated last
-        return types.NewEscapedQuotedText(backslashes.(string), "*", content.([]interface{}))
-} 
 
 OneOrMoreBackslashes <- `\`+ {
     return string(c.text), nil
@@ -978,67 +949,202 @@ TwoOrMoreBackslashes <- `\\` `\`* {
     return string(c.text), nil
 }
 
-ItalicText <- 
-    !`\\` "__" content:(ItalicTextElements) "__" {
-        return types.NewQuotedText(types.Italic, content.([]interface{}))
-    } / !`\\` "__" content:(ItalicTextElements) "_" { // unbalanced `__` vs `_` punctuation
-        result := append([]interface{}{"_"}, content.([]interface{}))
-        return types.NewQuotedText(types.Italic, result)
-    } / !`\` "_" content:(ItalicTextElements) "_" !Alphanum { // single punctuation cannot be followed by a character (needs '__' to emphazise a portion of a word)
-        return types.NewQuotedText(types.Italic, content.([]interface{}))
-}
+// -----------------
+// Bold text
+// -----------------
 
-ItalicTextElements <- ItalicTextElement (WS* ItalicTextElement)*
+BoldText <- DoubleQuoteBoldText / SingleQuoteBoldText
 
-ItalicTextElement <- QuotedText
+DoubleQuoteBoldText <- !`\\` "**" content:(DoubleQuoteBoldTextContent) "**" { // double punctuation must be evaluated first
+    return types.NewQuotedText(types.Bold, content.([]interface{}))
+} 
+
+DoubleQuoteBoldTextContent <- DoubleQuoteBoldTextElement (!("**") element:(WS / DoubleQuoteBoldTextElement) { // may start and end with spaces
+    return element, nil
+})*
+
+DoubleQuoteBoldTextElement <- !NEWLINE element:(SingleQuoteBoldText 
+        / ItalicText 
+        / MonospaceText
+        / SubscriptText
+        / SuperscriptText
         / InlineImage 
         / Link 
         / Passthrough 
-        / NonItalicText // word with quote punctuation is only accepted if nothing matched before, so we have a chance to stop
+        / NonDoubleQuoteBoldText) { // word with quote punctuation is only accepted if nothing matched before, so we have a chance to stop
+    return element, nil
+}
 
-NonItalicText <- (!NEWLINE !WS !"_"  !"^" !"~" .)+ { 
-    return c.text, nil
+NonDoubleQuoteBoldText <- (.) (!"**" !WS !"^" !"~" !NEWLINE .)* { 
+    return types.NewStringElement(string(c.text))
+}
+
+SingleQuoteBoldText <- !`\` !"**" "*" content:(SingleQuoteBoldTextContent) "*" { // single punctuation cannot be followed by a character (needs '**' to emphazise a portion of a word)
+    return types.NewQuotedText(types.Bold, content.([]interface{}))
+} / !`\\` "**" content:(SingleQuoteBoldTextContent) "*" { // unbalanced `**` vs `*` punctuation.
+    return types.NewQuotedText(types.Bold, append([]interface{}{types.StringElement{Content:"*"}}, content.([]interface{})...)) // include the second heading `*` as a regular StringElement in the bold content
+} 
+
+SingleQuoteBoldTextContent <- !WS SingleQuoteBoldTextElement (!("*" !Alphanum) spaces:(WS*) element:(SingleQuoteBoldTextElement) {
+    return append(spaces.([]interface{}), element), nil
+})*
+
+SingleQuoteBoldTextElement <- !NEWLINE element:(DoubleQuoteBoldText
+        / ItalicText 
+        / MonospaceText
+        / SubscriptText
+        / SuperscriptText
+        / InlineImage 
+        / Link 
+        / Passthrough 
+        / NonSingleQuoteBoldText) { // word with quote punctuation is only accepted if nothing matched before, so we have a chance to stop
+    return element, nil
+}
+
+NonSingleQuoteBoldText <- (.) (!"*" !WS !"^" !"~" !NEWLINE .)* { 
+    return types.NewStringElement(string(c.text))
+}
+
+EscapedBoldText <- 
+    backslashes:(TwoOrMoreBackslashes) "**" content:(DoubleQuoteBoldTextContent) "**" { // double punctuation must be evaluated first
+        return types.NewEscapedQuotedText(backslashes.(string), "**", content.([]interface{}))
+    } / backslashes:(OneOrMoreBackslashes) "**" content:(SingleQuoteBoldTextContent) "*" { // unbalanced `**` vs `*` punctuation
+        result := append([]interface{}{"*"}, content.([]interface{}))
+        return types.NewEscapedQuotedText(backslashes.(string), "*", result)
+    } / backslashes:(OneOrMoreBackslashes) "*" content:(SingleQuoteBoldTextContent) "*" { // simple punctuation must be evaluated last
+        return types.NewEscapedQuotedText(backslashes.(string), "*", content.([]interface{}))
+} 
+
+// -----------------
+// Italic text
+// -----------------
+
+ItalicText <- DoubleQuoteItalicText / SingleQuoteItalicText
+
+DoubleQuoteItalicText <- !`\\` "__" content:(DoubleQuoteItalicTextContent) "__" { // double punctuation must be evaluated first
+    return types.NewQuotedText(types.Italic, content.([]interface{}))
+}
+
+DoubleQuoteItalicTextContent <- DoubleQuoteItalicTextElement (!("__") element:(WS / DoubleQuoteItalicTextElement) { // may start and end with spaces
+    return element, nil
+})*
+
+DoubleQuoteItalicTextElement <- !NEWLINE element:(SingleQuoteItalicText 
+        / BoldText 
+        / MonospaceText
+        / SubscriptText
+        / SuperscriptText
+        / InlineImage 
+        / Link 
+        / Passthrough 
+        / NonDoubleQuoteItalicText) { // word with quote punctuation is only accepted if nothing matched before, so we have a chance to stop
+    return element, nil
+}
+
+NonDoubleQuoteItalicText <- (.) (!"__" !"^" !"~" !NEWLINE .)* { 
+    return types.NewStringElement(string(c.text))
+}
+
+SingleQuoteItalicText <- !`\` !"__" "_" content:(SingleQuoteItalicTextContent) "_" { // single punctuation cannot be followed by a character (needs '__' to emphazise a portion of a word)
+    return types.NewQuotedText(types.Italic, content.([]interface{}))
+} / !`\\` "__" content:(SingleQuoteItalicTextContent) "_" { // unbalanced `__` vs `_` punctuation.
+    return types.NewQuotedText(types.Italic, append([]interface{}{types.StringElement{Content:"_"}}, content.([]interface{})...)) // include the second heading `_` as a regular StringElement in the italic content
+} 
+
+SingleQuoteItalicTextContent <- !WS SingleQuoteItalicTextElement (!("_" !Alphanum) spaces:(WS*) element:(SingleQuoteItalicTextElement) {
+    return append(spaces.([]interface{}), element), nil
+})*
+
+SingleQuoteItalicTextElement <- !NEWLINE element:(DoubleQuoteItalicText
+        / BoldText 
+        / MonospaceText
+        / SubscriptText
+        / SuperscriptText
+        / InlineImage 
+        / Link 
+        / Passthrough 
+        / NonSingleQuoteItalicText) { // word with quote punctuation is only accepted if nothing matched before, so we have a chance to stop
+    return element, nil
+}
+
+NonSingleQuoteItalicText <- (.) (!"_" !WS !"^" !"~" !NEWLINE .)* { 
+    return types.NewStringElement(string(c.text))
 }
 
 EscapedItalicText <- 
-    backslashes:(TwoOrMoreBackslashes) "__" content:(ItalicTextElements) "__" { // double punctuation must be evaluated first
+    backslashes:(TwoOrMoreBackslashes) "__" content:(DoubleQuoteItalicTextContent) "__" { // double punctuation must be evaluated first
         return types.NewEscapedQuotedText(backslashes.(string), "__", content.([]interface{}))
-    } / backslashes:(OneOrMoreBackslashes) "__" content:(ItalicTextElements) "_" { // unbalanced `__` vs `_` punctuation
+    } / backslashes:(OneOrMoreBackslashes) "__" content:(SingleQuoteItalicTextContent) "_" { // unbalanced `__` vs `_` punctuation
         result := append([]interface{}{"_"}, content.([]interface{}))
         return types.NewEscapedQuotedText(backslashes.(string), "_", result)
-    } / backslashes:(OneOrMoreBackslashes) "_" content:(ItalicTextElements) "_" { // simple punctuation must be evaluated last
+    } / backslashes:(OneOrMoreBackslashes) "_" content:(SingleQuoteItalicTextContent) "_" { // simple punctuation must be evaluated last
         return types.NewEscapedQuotedText(backslashes.(string), "_", content.([]interface{}))
 } 
 
-MonospaceText <- 
-    !`\\` "``" content:(MonospaceTextElements) "``" { // double punctuation must be evaluated first
-        return types.NewQuotedText(types.Monospace, content.([]interface{}))
-    } / !`\\` "``" content:(MonospaceTextElements) "`" { // unbalanced "``" vs "`" punctuation
-        result := append([]interface{}{"`"}, content.([]interface{}))
-        return types.NewQuotedText(types.Monospace, result)
-    } / !`\` "`" content:(MonospaceTextElements) "`" !Alphanum { // single punctuation cannot be followed by a character (needs '``' to emphazise a portion of a word)
-        return types.NewQuotedText(types.Monospace, content.([]interface{}))
+// -----------------
+// Monospace text
+// -----------------
+
+MonospaceText <- DoubleQuoteMonospaceText / SingleQuoteMonospaceText
+
+DoubleQuoteMonospaceText <- !`\\` "``" content:(DoubleQuoteMonospaceTextContent) "``" { // double punctuation must be evaluated first
+    return types.NewQuotedText(types.Monospace, content.([]interface{}))
 }
 
-MonospaceTextElements <- MonospaceTextElement ((WS / NEWLINE)* MonospaceTextElement)*
+DoubleQuoteMonospaceTextContent <- DoubleQuoteMonospaceTextElement (!("``") element:(WS / DoubleQuoteMonospaceTextElement) { // may start and end with spaces
+    return element, nil
+})*
 
-MonospaceTextElement <- QuotedText 
+DoubleQuoteMonospaceTextElement <- !NEWLINE element:(SingleQuoteMonospaceText 
+        / BoldText
+        / ItalicText 
+        / SubscriptText
+        / SuperscriptText
         / InlineImage 
         / Link 
         / Passthrough 
-        / NonMonospaceText // word with quote punctuation is only accepted if nothing matched before, so we have a chance to stop
+        / NonDoubleQuoteMonospaceText) { // word with quote punctuation is only accepted if nothing matched before, so we have a chance to stop
+    return element, nil
+}
 
-NonMonospaceText <- (!WS !NEWLINE !"`" !"^" !"~" .)+ { 
-    return c.text, nil
+NonDoubleQuoteMonospaceText <- (.) (!"``" !WS !"^" !"~" !NEWLINE .)* { 
+    return types.NewStringElement(string(c.text))
+}
+
+SingleQuoteMonospaceText <- !`\` !"``" "`" content:(SingleQuoteMonospaceTextContent) "`" { // single punctuation cannot be followed by a character (needs "``" to emphazise a portion of a word)
+    return types.NewQuotedText(types.Monospace, content.([]interface{}))
+} / !`\\` "``" content:(SingleQuoteMonospaceTextContent) "`" { // unbalanced "``" vs "`" punctuation.
+    return types.NewQuotedText(types.Monospace, append([]interface{}{types.StringElement{Content:"`"}}, content.([]interface{})...)) // include the second heading "`" as a regular StringElement in the monospace content
+} 
+
+SingleQuoteMonospaceTextContent <- !WS SingleQuoteMonospaceTextElement (!("`" !Alphanum) spaces:(WS*) element:(SingleQuoteMonospaceTextElement) {
+    return append(spaces.([]interface{}), element), nil
+})*
+
+SingleQuoteMonospaceTextElement <-  element:(NEWLINE // allows multiline
+        / DoubleQuoteMonospaceText 
+        / BoldText 
+        / ItalicText
+        / SubscriptText
+        / SuperscriptText
+        / InlineImage 
+        / Link 
+        / Passthrough 
+        / NonSingleQuoteMonospaceText) { // word with quote punctuation is only accepted if nothing matched before, so we have a chance to stop
+    return element, nil
+}
+
+NonSingleQuoteMonospaceText <- (.) (!WS !"`" !"^" !"~" !NEWLINE .)* { // break at multiline
+    return types.NewStringElement(string(c.text))
 }
 
 EscapedMonospaceText <- 
-    backslashes:(TwoOrMoreBackslashes) "``" content:(MonospaceTextElements) "``" { // double punctuation must be evaluated first
+    backslashes:(TwoOrMoreBackslashes) "``" content:(DoubleQuoteMonospaceTextContent) "``" { // double punctuation must be evaluated first
         return types.NewEscapedQuotedText(backslashes.(string), "``", content.([]interface{}))
-    } / backslashes:(OneOrMoreBackslashes) "``" content:(MonospaceTextElements) "`" { // unbalanced "``" vs "`" punctuation
+    } / backslashes:(OneOrMoreBackslashes) "``" content:(SingleQuoteMonospaceTextContent) "`" { // unbalanced "``" vs "`" punctuation
         result := append([]interface{}{"`"}, content.([]interface{}))
         return types.NewEscapedQuotedText(backslashes.(string), "`", result)
-    } / backslashes:(OneOrMoreBackslashes) "`" content:(MonospaceTextElements) "`" { // simple punctuation must be evaluated last
+    } / backslashes:(OneOrMoreBackslashes) "`" content:(SingleQuoteMonospaceTextContent) "`" { // simple punctuation must be evaluated last
         return types.NewEscapedQuotedText(backslashes.(string), "`", content.([]interface{}))
 } 
 
@@ -1131,35 +1237,27 @@ Link <- link:(RelativeLink / ExternalLink) {
     return link, nil
 }
 
-ExternalLink <- url:(ExternalLinkURL) inlineAttributes:(LinkAttributes) {
-    return types.NewInlineLink(url.(string), inlineAttributes.(types.ElementAttributes))
-} / url:(ExternalLinkURL) {
-    return types.NewInlineLink(url.(string), nil)
-}
-
-ExternalLinkURL <- URL_SCHEME URL {
-    return string(c.text), nil
+ExternalLink <- url:(Location) inlineAttributes:(LinkAttributes) {
+    return types.NewInlineLink(url.(types.Location), inlineAttributes.(types.ElementAttributes))
+} / url:(Location) {
+    return types.NewInlineLink(url.(types.Location), types.ElementAttributes{})
 }
 
 // url preceeding with `link:` MUST be followed by square brackets
-RelativeLink <- "link:" url:(RelativeLinkURL) inlineAttributes:(LinkAttributes) {
-    return types.NewInlineLink(url.(string), inlineAttributes.(types.ElementAttributes))
-}
-
-RelativeLinkURL <- URL_SCHEME? URL {
-    return string(c.text), nil
+RelativeLink <- "link:" url:(FileLocation / Location) inlineAttributes:(LinkAttributes) {
+    return types.NewInlineLink(url.(types.Location), inlineAttributes.(types.ElementAttributes))
 }
 
 LinkAttributes <- "[" text:(LinkTextAttribute) ","? WS* otherattrs:(GenericAttribute)* "]" {
-    return types.NewInlineLinkAttributes(text, otherattrs.([]interface{}))
+    return types.NewInlineLinkAttributes(text.(types.InlineElements), otherattrs.([]interface{}))
 } / "[" otherattrs:(GenericAttribute)* "]" {
     return types.NewInlineLinkAttributes(nil, otherattrs.([]interface{}))
 } 
 
-LinkTextAttribute <- (Alphanums / Spaces / (!"=" !"," !"]"  .) {
-    return string(c.text), nil
-})* {
-    return string(c.text), nil
+LinkTextAttribute <- elements:(!"=" !"," !"]" (QuotedText / ((!QuotedTextPrefix .) {
+    return types.NewStringElement(string(c.text))
+})))+ {
+    return types.NewInlineElements(elements.([]interface{}))
 }
 
 // ------------------------------------------
@@ -1215,8 +1313,8 @@ FootnoteRef <- (Alphanums / Spaces / (!"," !"]" !EOL  .){
 }
 
 FootnoteContent <- elements:(!"]" !EOL WS* !InlineElementID InlineElement WS*)+  { // footnote content may span multiple lines
-        return types.NewInlineElements(elements.([]interface{}))
-    }
+    return types.NewInlineElements(elements.([]interface{}))
+}
 
 
 // ------------------------------------------------------------------------------------
@@ -1542,7 +1640,7 @@ Dot <- "." {
     return string(c.text), nil
 }
 
-Word <- (Alphanums / QuotedTextPrefix / ((!NEWLINE !WS !Parenthesis !"." !QuotedTextPrefix .){
+Word <- (Alphanums / QuotedTextPrefix / ((!NEWLINE !WS !Parenthesis !"." !QuotedTextPrefix .){ // TODO: remove check on parenthesis and dot?
     return types.NewStringElement(string(c.text))
 })+ / "."+){ // word cannot contain parenthesis. Dots and ellipsis are treated as independent words (but will be combined afterwards)
     return types.NewStringElement(string(c.text))
@@ -1552,7 +1650,11 @@ Spaces <- WS+ {
     return string(c.text), nil
 }
 
-Location <- elements:(URL_SCHEME? (DocumentAttributeSubstitution / Word)+) {
+FileLocation <- elements:(DocumentAttributeSubstitution / Word)+ {
+    return types.NewLocation(elements.([]interface{}))
+}
+
+Location <- elements:(URL_SCHEME (DocumentAttributeSubstitution / Word)+) {
     return types.NewLocation(elements.([]interface{}))
 }
 
@@ -1562,19 +1664,14 @@ URL <- (Alphanums / (!NEWLINE !WS !"[" !"]"  .){
     return string(c.text), nil
 }
 
+URL_SCHEME <- "http://" / "https://" / "ftp://" / "irc://" / "mailto:"
+
 ID <- (Alphanums / (!NEWLINE !WS !"[" !"]" !"<<" !">>" !","  .){
     return string(c.text), nil
 })+ {
     return string(c.text), nil
 }
 
-URL_TEXT <- (Alphanums / (!NEWLINE !"[" !"]" .){
-    return string(c.text), nil
-})+ {
-    return string(c.text), nil
-}
-
-URL_SCHEME <- "http://" / "https://" / "ftp://" / "irc://" / "mailto:"
 DIGIT <- [0-9] {
     return string(c.text), nil
 }

--- a/pkg/parser/bench_test.go
+++ b/pkg/parser/bench_test.go
@@ -107,7 +107,7 @@ puts "Hello, World!"
 func parseReader(content string) (parser.Stats, error) {
 	reader := strings.NewReader(content)
 	stats := parser.Stats{}
-	allOptions := make([]parser.Option, 0)
+	allOptions := []parser.Option{}
 	allOptions = append(allOptions, parser.AllowInvalidUTF8(false), parser.Statistics(&stats, "no match"))
 	if os.Getenv("DEBUG") == "true" {
 		allOptions = append(allOptions, parser.Debug(true))

--- a/pkg/parser/external_link_test.go
+++ b/pkg/parser/external_link_test.go
@@ -18,10 +18,12 @@ var _ = Describe("links", func() {
 					{
 						types.StringElement{Content: "a link to "},
 						types.InlineLink{
-							URL: "https://foo.bar",
-							Attributes: types.ElementAttributes{
-								"text": "",
+							Location: types.Location{
+								types.StringElement{
+									Content: "https://foo.bar",
+								},
 							},
+							Attributes: types.ElementAttributes{},
 						},
 					},
 				},
@@ -37,10 +39,12 @@ var _ = Describe("links", func() {
 					{
 						types.StringElement{Content: "a link to "},
 						types.InlineLink{
-							URL: "https://foo.bar",
-							Attributes: types.ElementAttributes{
-								"text": "",
+							Location: types.Location{
+								types.StringElement{
+									Content: "https://foo.bar",
+								},
 							},
+							Attributes: types.ElementAttributes{},
 						},
 					},
 				},
@@ -56,9 +60,18 @@ var _ = Describe("links", func() {
 					{
 						types.StringElement{Content: "a link to "},
 						types.InlineLink{
-							URL: "mailto:foo@bar",
+							Location: types.Location{
+								types.StringElement{
+									Content: "mailto:foo@bar",
+								},
+							},
+
 							Attributes: types.ElementAttributes{
-								"text": "the foo@bar email",
+								types.AttrInlineLinkText: types.InlineElements{
+									types.StringElement{
+										Content: "the foo@bar email",
+									},
+								},
 							},
 						},
 					},
@@ -75,10 +88,18 @@ var _ = Describe("links", func() {
 					{
 						types.StringElement{Content: "a link to "},
 						types.InlineLink{
-							URL: "mailto:foo@bar",
+							Location: types.Location{
+								types.StringElement{
+									Content: "mailto:foo@bar",
+								},
+							},
 							Attributes: types.ElementAttributes{
-								"text": "the foo@bar email",
-								"foo":  "bar",
+								types.AttrInlineLinkText: types.InlineElements{
+									types.StringElement{
+										Content: "the foo@bar email",
+									},
+								},
+								"foo": "bar",
 							},
 						},
 					},
@@ -87,25 +108,6 @@ var _ = Describe("links", func() {
 			verifyWithPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
 		})
 
-		It("external link with extra attributes only", func() {
-			actualContent := "a link to mailto:foo@bar[foo=bar]"
-			expectedResult := types.Paragraph{
-				Attributes: types.ElementAttributes{},
-				Lines: []types.InlineElements{
-					{
-						types.StringElement{Content: "a link to "},
-						types.InlineLink{
-							URL: "mailto:foo@bar",
-							Attributes: types.ElementAttributes{
-								"text": "",
-								"foo":  "bar",
-							},
-						},
-					},
-				},
-			}
-			verifyWithPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
-		})
 	})
 
 	Context("relative links", func() {
@@ -115,10 +117,12 @@ var _ = Describe("links", func() {
 			expectedResult := types.InlineElements{
 				types.StringElement{Content: "a link to "},
 				types.InlineLink{
-					URL: "foo.adoc",
-					Attributes: types.ElementAttributes{
-						"text": "",
+					Location: types.Location{
+						types.StringElement{
+							Content: "foo.adoc",
+						},
 					},
+					Attributes: types.ElementAttributes{},
 				},
 			}
 			verifyWithPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("InlineElements"))
@@ -129,9 +133,17 @@ var _ = Describe("links", func() {
 			expectedResult := types.InlineElements{
 				types.StringElement{Content: "a link to "},
 				types.InlineLink{
-					URL: "foo.adoc",
+					Location: types.Location{
+						types.StringElement{
+							Content: "foo.adoc",
+						},
+					},
 					Attributes: types.ElementAttributes{
-						"text": "foo doc",
+						types.AttrInlineLinkText: types.InlineElements{
+							types.StringElement{
+								Content: "foo doc",
+							},
+						},
 					},
 				},
 			}
@@ -143,9 +155,17 @@ var _ = Describe("links", func() {
 			expectedResult := types.InlineElements{
 				types.StringElement{Content: "a link to "},
 				types.InlineLink{
-					URL: "https://foo.bar",
+					Location: types.Location{
+						types.StringElement{
+							Content: "https://foo.bar",
+						},
+					},
 					Attributes: types.ElementAttributes{
-						"text": "foo doc",
+						types.AttrInlineLinkText: types.InlineElements{
+							types.StringElement{
+								Content: "foo doc",
+							},
+						},
 					},
 				},
 			}
@@ -157,10 +177,18 @@ var _ = Describe("links", func() {
 			expectedResult := types.InlineElements{
 				types.StringElement{Content: "a link to "},
 				types.InlineLink{
-					URL: "https://foo.bar",
+					Location: types.Location{
+						types.StringElement{
+							Content: "https://foo.bar",
+						},
+					},
 					Attributes: types.ElementAttributes{
-						"text": "foo doc",
-						"foo":  "bar",
+						types.AttrInlineLinkText: types.InlineElements{
+							types.StringElement{
+								Content: "foo doc",
+							},
+						},
+						"foo": "bar",
 					},
 				},
 			}
@@ -172,10 +200,13 @@ var _ = Describe("links", func() {
 			expectedResult := types.InlineElements{
 				types.StringElement{Content: "a link to "},
 				types.InlineLink{
-					URL: "https://foo.bar",
+					Location: types.Location{
+						types.StringElement{
+							Content: "https://foo.bar",
+						},
+					},
 					Attributes: types.ElementAttributes{
-						"text": "",
-						"foo":  "bar",
+						"foo": "bar",
 					},
 				},
 			}
@@ -191,6 +222,54 @@ var _ = Describe("links", func() {
 			}
 			verifyWithPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("InlineElements"))
 		})
+
+		It("relative link with quoted text", func() {
+			actualContent := "link:/[_a_ *b* `c`]"
+			expectedResult := types.InlineLink{
+				Location: types.Location{
+					types.StringElement{
+						Content: "/",
+					},
+				},
+				Attributes: types.ElementAttributes{
+					types.AttrInlineLinkText: types.InlineElements{
+						types.QuotedText{
+							Kind: types.Italic,
+							Elements: types.InlineElements{
+								types.StringElement{
+									Content: "a",
+								},
+							},
+						},
+						types.StringElement{
+							Content: " ",
+						},
+						types.QuotedText{
+							Kind: types.Bold,
+							Elements: types.InlineElements{
+								types.StringElement{
+									Content: "b",
+								},
+							},
+						},
+						types.StringElement{
+							Content: " ",
+						},
+						types.QuotedText{
+							Kind: types.Monospace,
+							Elements: types.InlineElements{
+								types.StringElement{
+									Content: "c",
+								},
+							},
+						},
+					},
+				},
+			}
+			// verifyWithPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("RelativeLink"), parser.Debug(true))
+			verifyWithPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("RelativeLink"))
+		})
+
 	})
 
 })

--- a/pkg/parser/footnote_test.go
+++ b/pkg/parser/footnote_test.go
@@ -51,7 +51,7 @@ var _ = Describe("footnotes", func() {
 		})
 
 		It("footnote with single-line rich content", func() {
-			actualContent := `foo footnote:[some *rich* http://foo.com[content]]`
+			actualContent := `foo footnote:[some *rich* https://foo.com[content]]`
 			footnote1 := types.Footnote{
 				ID: 0,
 				Elements: types.InlineElements{
@@ -71,9 +71,17 @@ var _ = Describe("footnotes", func() {
 					},
 					types.InlineLink{
 						Attributes: types.ElementAttributes{
-							types.AttrInlineLinkText: "content",
+							types.AttrInlineLinkText: types.InlineElements{
+								types.StringElement{
+									Content: "content",
+								},
+							},
 						},
-						URL: "http://foo.com",
+						Location: types.Location{
+							types.StringElement{
+								Content: "https://foo.com",
+							},
+						},
 					},
 				},
 			}

--- a/pkg/parser/image_test.go
+++ b/pkg/parser/image_test.go
@@ -315,7 +315,7 @@ image::appa.png[]`
 						Path: "images/foo.png",
 					},
 				}
-				verifyWithPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("InlineElements"), parser.Debug(false))
+				verifyWithPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("InlineElements"))
 			})
 
 			It("inline image with multiple other attributes only", func() {

--- a/pkg/parser/inline_elements_test.go
+++ b/pkg/parser/inline_elements_test.go
@@ -34,7 +34,6 @@ var _ = Describe("inline elements", func() {
 			},
 			types.StringElement{Content: ")"},
 		}
-
 		verifyWithPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("InlineElements"))
 	})
 

--- a/pkg/parser/quoted_text_test.go
+++ b/pkg/parser/quoted_text_test.go
@@ -43,7 +43,7 @@ var _ = Describe("quoted texts", func() {
 			verifyWithPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("QuotedText"))
 		})
 
-		It("italic text with 3 words", func() {
+		It("italic text with 3 words in single quote", func() {
 			actualContent := "_some italic content_"
 			expectedResult := types.QuotedText{
 				Kind: types.Italic,
@@ -134,20 +134,16 @@ var _ = Describe("quoted texts", func() {
 
 		It("italic text within italic text", func() {
 			actualContent := "_some _very italic_ content_"
-			expectedResult := types.QuotedText{
-				Kind: types.Italic,
-				Elements: types.InlineElements{
-					types.StringElement{Content: "some "},
-					types.QuotedText{
-						Kind: types.Italic,
-						Elements: types.InlineElements{
-							types.StringElement{Content: "very italic"},
-						},
+			expectedResult := types.InlineElements{
+				types.QuotedText{
+					Kind: types.Italic,
+					Elements: types.InlineElements{
+						types.StringElement{Content: "some _very italic"},
 					},
-					types.StringElement{Content: " content"},
 				},
+				types.StringElement{Content: " content_"},
 			}
-			verifyWithPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("QuotedText"))
+			verifyWithPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("InlineElements"))
 		})
 
 		It("subscript text attached", func() {
@@ -199,7 +195,7 @@ var _ = Describe("quoted texts", func() {
 
 	Context("Quoted text with double punctuation", func() {
 
-		It("bold text of 1 word", func() {
+		It("bold text of 1 word in double quote", func() {
 			actualContent := "**hello**"
 			expectedResult := types.QuotedText{
 				Kind: types.Bold,
@@ -210,7 +206,7 @@ var _ = Describe("quoted texts", func() {
 			verifyWithPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("QuotedText"))
 		})
 
-		It("italic text with 3 words", func() {
+		It("italic text with 3 words in double quote", func() {
 			actualContent := "__some italic content__"
 			expectedResult := types.QuotedText{
 				Kind: types.Italic,
@@ -221,7 +217,7 @@ var _ = Describe("quoted texts", func() {
 			verifyWithPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("QuotedText"))
 		})
 
-		It("monospace text with 3 words", func() {
+		It("monospace text with 3 words in double quote", func() {
 			actualContent := "``some monospace content``"
 			expectedResult := types.QuotedText{
 				Kind: types.Monospace,
@@ -418,23 +414,17 @@ var _ = Describe("quoted texts", func() {
 			verifyWithPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("InlineElements"))
 		})
 
-		It("simple-quote bold within simple-quote bold text", func() {
+		It("single-quote bold within single-quote bold text", func() {
 			// here we don't allow for bold text within bold text, to comply with the existing implementations (asciidoc and asciidoctor)
 			actualContent := "*some *nested bold* content*"
 			expectedResult := types.InlineElements{
 				types.QuotedText{
 					Kind: types.Bold,
 					Elements: types.InlineElements{
-						types.StringElement{Content: "some "},
-						types.QuotedText{
-							Kind: types.Bold,
-							Elements: types.InlineElements{
-								types.StringElement{Content: "nested bold"},
-							},
-						},
-						types.StringElement{Content: " content"},
+						types.StringElement{Content: "some *nested bold"},
 					},
 				},
+				types.StringElement{Content: " content*"},
 			}
 			verifyWithPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("InlineElements"))
 		})
@@ -447,12 +437,12 @@ var _ = Describe("quoted texts", func() {
 					Kind: types.Bold,
 					Elements: types.InlineElements{
 						types.StringElement{Content: "some "},
-						types.QuotedText{
-							Kind: types.Bold,
-							Elements: types.InlineElements{
-								types.StringElement{Content: "nested bold"},
-							},
-						},
+					},
+				},
+				types.StringElement{Content: "nested bold"},
+				types.QuotedText{
+					Kind: types.Bold,
+					Elements: types.InlineElements{
 						types.StringElement{Content: " content"},
 					},
 				},
@@ -460,7 +450,7 @@ var _ = Describe("quoted texts", func() {
 			verifyWithPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("InlineElements"))
 		})
 
-		It("simple-quote bold within double-quote bold text", func() {
+		It("single-quote bold within double-quote bold text", func() {
 			// here we don't allow for bold text within bold text, to comply with the existing implementations (asciidoc and asciidoctor)
 			actualContent := "**some *nested bold* content**"
 			expectedResult := types.InlineElements{
@@ -481,7 +471,7 @@ var _ = Describe("quoted texts", func() {
 			verifyWithPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("InlineElements"))
 		})
 
-		It("double-quote bold within simple-quote bold text", func() {
+		It("double-quote bold within single-quote bold text", func() {
 			// here we don't allow for bold text within bold text, to comply with the existing implementations (asciidoc and asciidoctor)
 			actualContent := "*some **nested bold** content*"
 			expectedResult := types.InlineElements{
@@ -502,23 +492,17 @@ var _ = Describe("quoted texts", func() {
 			verifyWithPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("InlineElements"))
 		})
 
-		It("simple-quote italic within simple-quote italic text", func() {
+		It("single-quote italic within single-quote italic text", func() {
 			// here we don't allow for italic text within italic text, to comply with the existing implementations (asciidoc and asciidoctor)
 			actualContent := "_some _nested italic_ content_"
 			expectedResult := types.InlineElements{
 				types.QuotedText{
 					Kind: types.Italic,
 					Elements: types.InlineElements{
-						types.StringElement{Content: "some "},
-						types.QuotedText{
-							Kind: types.Italic,
-							Elements: types.InlineElements{
-								types.StringElement{Content: "nested italic"},
-							},
-						},
-						types.StringElement{Content: " content"},
+						types.StringElement{Content: "some _nested italic"},
 					},
 				},
+				types.StringElement{Content: " content_"},
 			}
 			verifyWithPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("InlineElements"))
 		})
@@ -531,12 +515,12 @@ var _ = Describe("quoted texts", func() {
 					Kind: types.Italic,
 					Elements: types.InlineElements{
 						types.StringElement{Content: "some "},
-						types.QuotedText{
-							Kind: types.Italic,
-							Elements: types.InlineElements{
-								types.StringElement{Content: "nested italic"},
-							},
-						},
+					},
+				},
+				types.StringElement{Content: "nested italic"},
+				types.QuotedText{
+					Kind: types.Italic,
+					Elements: types.InlineElements{
 						types.StringElement{Content: " content"},
 					},
 				},
@@ -544,7 +528,7 @@ var _ = Describe("quoted texts", func() {
 			verifyWithPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("InlineElements"))
 		})
 
-		It("simple-quote italic within double-quote italic text", func() {
+		It("single-quote italic within double-quote italic text", func() {
 			// here we allow for italic text within italic text, to comply with the existing implementations (asciidoc and asciidoctor)
 			actualContent := "_some __nested italic__ content_"
 			expectedResult := types.InlineElements{
@@ -565,7 +549,7 @@ var _ = Describe("quoted texts", func() {
 			verifyWithPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("InlineElements"))
 		})
 
-		It("double-quote italic within simple-quote italic text", func() {
+		It("double-quote italic within single-quote italic text", func() {
 			// here we allow for italic text within italic text, to comply with the existing implementations (asciidoc and asciidoctor)
 			actualContent := "_some __nested italic__ content_"
 			expectedResult := types.InlineElements{
@@ -586,23 +570,17 @@ var _ = Describe("quoted texts", func() {
 			verifyWithPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("InlineElements"))
 		})
 
-		It("simple-quote monospace within simple-quote monospace text", func() {
+		It("single-quote monospace within single-quote monospace text", func() {
 			// here we don't allow for monospace text within monospace text, to comply with the existing implementations (asciidoc and asciidoctor)
 			actualContent := "`some `nested monospace` content`"
 			expectedResult := types.InlineElements{
 				types.QuotedText{
 					Kind: types.Monospace,
 					Elements: types.InlineElements{
-						types.StringElement{Content: "some "},
-						types.QuotedText{
-							Kind: types.Monospace,
-							Elements: types.InlineElements{
-								types.StringElement{Content: "nested monospace"},
-							},
-						},
-						types.StringElement{Content: " content"},
+						types.StringElement{Content: "some `nested monospace"},
 					},
 				},
+				types.StringElement{Content: " content`"},
 			}
 			verifyWithPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("InlineElements"))
 		})
@@ -615,12 +593,12 @@ var _ = Describe("quoted texts", func() {
 					Kind: types.Monospace,
 					Elements: types.InlineElements{
 						types.StringElement{Content: "some "},
-						types.QuotedText{
-							Kind: types.Monospace,
-							Elements: types.InlineElements{
-								types.StringElement{Content: "nested monospace"},
-							},
-						},
+					},
+				},
+				types.StringElement{Content: "nested monospace"},
+				types.QuotedText{
+					Kind: types.Monospace,
+					Elements: types.InlineElements{
 						types.StringElement{Content: " content"},
 					},
 				},
@@ -628,7 +606,7 @@ var _ = Describe("quoted texts", func() {
 			verifyWithPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("InlineElements"))
 		})
 
-		It("simple-quote monospace within double-quote monospace text", func() {
+		It("single-quote monospace within double-quote monospace text", func() {
 			// here we allow for monospace text within monospace text, to comply with the existing implementations (asciidoc and asciidoctor)
 			actualContent := "`some ``nested monospace`` content`"
 			expectedResult := types.InlineElements{
@@ -649,7 +627,7 @@ var _ = Describe("quoted texts", func() {
 			verifyWithPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("InlineElements"))
 		})
 
-		It("double-quote monospace within simple-quote monospace text", func() {
+		It("double-quote monospace within single-quote monospace text", func() {
 			// here we allow for monospace text within monospace text, to comply with the existing implementations (asciidoc and asciidoctor)
 			actualContent := "`some ``nested monospace`` content`"
 			expectedResult := types.InlineElements{
@@ -759,7 +737,7 @@ var _ = Describe("quoted texts", func() {
 			verifyWithPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("InlineElements"))
 		})
 
-		It("multiline in monospace - case 1", func() {
+		It("multiline in single quoted monospace - case 1", func() {
 			actualContent := "`a\nb`"
 			expectedResult := types.InlineElements{
 				types.QuotedText{
@@ -772,7 +750,39 @@ var _ = Describe("quoted texts", func() {
 			verifyWithPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("InlineElements"))
 		})
 
-		It("multiline in monospace - case 2", func() {
+		It("multiline in double quoted monospace - case 1", func() {
+			actualContent := "`a\nb`"
+			expectedResult := types.InlineElements{
+				types.QuotedText{
+					Kind: types.Monospace,
+					Elements: types.InlineElements{
+						types.StringElement{Content: "a\nb"},
+					},
+				},
+			}
+			verifyWithPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("InlineElements"))
+		})
+
+		It("multiline in single quoted  monospace - case 2", func() {
+			actualContent := "`a\n*b*`"
+			expectedResult := types.InlineElements{
+				types.QuotedText{
+					Kind: types.Monospace,
+					Elements: types.InlineElements{
+						types.StringElement{Content: "a\n"},
+						types.QuotedText{
+							Kind: types.Bold,
+							Elements: types.InlineElements{
+								types.StringElement{Content: "b"},
+							},
+						},
+					},
+				},
+			}
+			verifyWithPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("InlineElements"))
+		})
+
+		It("multiline in double quoted  monospace - case 2", func() {
 			actualContent := "`a\n*b*`"
 			expectedResult := types.InlineElements{
 				types.QuotedText{
@@ -800,9 +810,17 @@ var _ = Describe("quoted texts", func() {
 						types.StringElement{Content: "a "},
 						types.InlineLink{
 							Attributes: types.ElementAttributes{
-								"text": "b",
+								types.AttrInlineLinkText: types.InlineElements{
+									types.StringElement{
+										Content: "b",
+									},
+								},
 							},
-							URL: "/",
+							Location: types.Location{
+								types.StringElement{
+									Content: "/",
+								},
+							},
 						},
 					},
 				},
@@ -878,9 +896,17 @@ var _ = Describe("quoted texts", func() {
 						types.StringElement{Content: "a "},
 						types.InlineLink{
 							Attributes: types.ElementAttributes{
-								"text": "b",
+								types.AttrInlineLinkText: types.InlineElements{
+									types.StringElement{
+										Content: "b",
+									},
+								},
 							},
-							URL: "/",
+							Location: types.Location{
+								types.StringElement{
+									Content: "/",
+								},
+							},
 						},
 					},
 				},
@@ -956,9 +982,17 @@ var _ = Describe("quoted texts", func() {
 						types.StringElement{Content: "a "},
 						types.InlineLink{
 							Attributes: types.ElementAttributes{
-								"text": "b",
+								types.AttrInlineLinkText: types.InlineElements{
+									types.StringElement{
+										Content: "b",
+									},
+								},
 							},
-							URL: "/",
+							Location: types.Location{
+								types.StringElement{
+									Content: "/",
+								},
+							},
 						},
 					},
 				},
@@ -1288,7 +1322,7 @@ var _ = Describe("quoted texts", func() {
 
 			Context("without nested quoted text", func() {
 
-				It("escaped italic text with simple quote", func() {
+				It("escaped italic text with single quote", func() {
 					actualContent := `\_italic content_`
 					expectedResult := types.Paragraph{
 						Attributes: types.ElementAttributes{},
@@ -1301,7 +1335,7 @@ var _ = Describe("quoted texts", func() {
 					verifyWithPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
 				})
 
-				It("escaped italic text with simple quote and more backslashes", func() {
+				It("escaped italic text with single quote and more backslashes", func() {
 					actualContent := `\\_italic content_`
 					expectedResult := types.Paragraph{
 						Attributes: types.ElementAttributes{},
@@ -1314,7 +1348,7 @@ var _ = Describe("quoted texts", func() {
 					verifyWithPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
 				})
 
-				It("escaped italic text with double quote", func() {
+				It("escaped italic text with double quote with 2 backslashes", func() {
 					actualContent := `\\__italic content__`
 					expectedResult := types.Paragraph{
 						Attributes: types.ElementAttributes{},
@@ -1327,7 +1361,7 @@ var _ = Describe("quoted texts", func() {
 					verifyWithPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
 				})
 
-				It("escaped italic text with double quote and more backslashes", func() {
+				It("escaped italic text with double quote with 3 backslashes", func() {
 					actualContent := `\\\__italic content__`
 					expectedResult := types.Paragraph{
 						Attributes: types.ElementAttributes{},
@@ -1435,7 +1469,7 @@ var _ = Describe("quoted texts", func() {
 
 			Context("without nested quoted text", func() {
 
-				It("escaped monospace text with simple quote", func() {
+				It("escaped monospace text with single quote", func() {
 					actualContent := `\` + "`monospace content`"
 					expectedResult := types.Paragraph{
 						Attributes: types.ElementAttributes{},
@@ -1448,7 +1482,7 @@ var _ = Describe("quoted texts", func() {
 					verifyWithPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
 				})
 
-				It("escaped monospace text with simple quote and more backslashes", func() {
+				It("escaped monospace text with single quote and more backslashes", func() {
 					actualContent := `\\` + "`monospace content`"
 					expectedResult := types.Paragraph{
 						Attributes: types.ElementAttributes{},
@@ -1582,7 +1616,7 @@ var _ = Describe("quoted texts", func() {
 
 			Context("without nested quoted text", func() {
 
-				It("escaped subscript text with simple quote", func() {
+				It("escaped subscript text with single quote", func() {
 					actualContent := `\~subscriptcontent~`
 					expectedResult := types.Paragraph{
 						Attributes: types.ElementAttributes{},
@@ -1595,7 +1629,7 @@ var _ = Describe("quoted texts", func() {
 					verifyWithPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
 				})
 
-				It("escaped subscript text with simple quote and more backslashes", func() {
+				It("escaped subscript text with single quote and more backslashes", func() {
 					actualContent := `\\~subscriptcontent~`
 					expectedResult := types.Paragraph{
 						Attributes: types.ElementAttributes{},
@@ -1658,7 +1692,7 @@ var _ = Describe("quoted texts", func() {
 
 			Context("without nested quoted text", func() {
 
-				It("escaped superscript text with simple quote", func() {
+				It("escaped superscript text with single quote", func() {
 					actualContent := `\^superscriptcontent^`
 					expectedResult := types.Paragraph{
 						Attributes: types.ElementAttributes{},
@@ -1671,7 +1705,7 @@ var _ = Describe("quoted texts", func() {
 					verifyWithPreprocessing(GinkgoT(), expectedResult, actualContent, parser.Entrypoint("DocumentBlock"))
 				})
 
-				It("escaped superscript text with simple quote and more backslashes", func() {
+				It("escaped superscript text with single quote and more backslashes", func() {
 					actualContent := `\\^superscriptcontent^`
 					expectedResult := types.Paragraph{
 						Attributes: types.ElementAttributes{},

--- a/pkg/renderer/html5/attribution.go
+++ b/pkg/renderer/html5/attribution.go
@@ -20,14 +20,14 @@ func NewDelimitedBlockAttribution(b types.DelimitedBlock) Attribution {
 	return newAttribution(b.Attributes)
 }
 
-func newAttribution(attrbs types.ElementAttributes) Attribution {
+func newAttribution(attrs types.ElementAttributes) Attribution {
 	result := Attribution{}
-	if author := attrbs.GetAsString(types.AttrQuoteAuthor); author != "" {
+	if author := attrs.GetAsString(types.AttrQuoteAuthor); author != "" {
 		result.First = author
-		if title := attrbs.GetAsString(types.AttrQuoteTitle); title != "" {
+		if title := attrs.GetAsString(types.AttrQuoteTitle); title != "" {
 			result.Second = title
 		}
-	} else if title := attrbs.GetAsString(types.AttrQuoteTitle); title != "" {
+	} else if title := attrs.GetAsString(types.AttrQuoteTitle); title != "" {
 		result.First = title
 	}
 	return result

--- a/pkg/renderer/html5/document_attribute_substitution_test.go
+++ b/pkg/renderer/html5/document_attribute_substitution_test.go
@@ -86,10 +86,10 @@ author is {author}.`
 	Context("substitutions to elements", func() {
 
 		It("replace to inline link in paragraph", func() {
-			actualContent := `:quick-uri: http://foo.com/bar
+			actualContent := `:quick-uri: https://foo.com/bar
 {quick-uri}[foo]`
 			expectedResult := `<div class="paragraph">
-<p><a href="http://foo.com/bar">foo</a></p>
+<p><a href="https://foo.com/bar">foo</a></p>
 </div>`
 			verify(GinkgoT(), expectedResult, actualContent)
 		})

--- a/pkg/renderer/html5/external_link.go
+++ b/pkg/renderer/html5/external_link.go
@@ -19,20 +19,26 @@ func init() {
 
 func renderLink(ctx *renderer.Context, l types.InlineLink) ([]byte, error) { //nolint: unparam
 	result := bytes.NewBuffer(nil)
-	// text := l.Text
-	text := l.Text()
+	location := l.Location.Resolve(ctx.Document.Attributes)
+	var text []byte
 	class := ""
-	if text == "" {
-		text = l.URL
+	var err error
+	if t, ok := l.Attributes[types.AttrInlineLinkText].(types.InlineElements); ok {
+		text, err = renderElement(ctx, t)
+		if err != nil {
+			return nil, errors.Wrapf(err, "unable to render external link")
+		}
+	} else {
 		class = "bare"
+		text = []byte(location)
 	}
-	err := linkTmpl.Execute(result, struct {
+	err = linkTmpl.Execute(result, struct {
 		URL   string
 		Text  string
 		Class string
 	}{
-		URL:   l.URL,
-		Text:  text,
+		URL:   location,
+		Text:  string(text),
 		Class: class,
 	})
 	if err != nil {

--- a/pkg/renderer/html5/external_link_test.go
+++ b/pkg/renderer/html5/external_link_test.go
@@ -25,6 +25,14 @@ var _ = Describe("links", func() {
 </div>`
 			verify(GinkgoT(), expectedResult, actualContent)
 		})
+
+		It("external link with quoted text", func() {
+			actualContent := "https://foo.com[_a_ *b* `c`]"
+			expectedResult := `<div class="paragraph">
+<p><a href="https://foo.com"><em>a</em> <strong>b</strong> <code>c</code></a></p>
+</div>`
+			verify(GinkgoT(), expectedResult, actualContent)
+		})
 	})
 
 	Context("relative links", func() {
@@ -57,6 +65,14 @@ var _ = Describe("links", func() {
 			actualContent := "a link to link:foo.adoc."
 			expectedResult := `<div class="paragraph">
 <p>a link to link:foo.adoc.</p>
+</div>`
+			verify(GinkgoT(), expectedResult, actualContent)
+		})
+
+		It("relative link with quoted text", func() {
+			actualContent := "link:/[_a_ *b* `c`]"
+			expectedResult := `<div class="paragraph">
+<p><a href="/"><em>a</em> <strong>b</strong> <code>c</code></a></p>
 </div>`
 			verify(GinkgoT(), expectedResult, actualContent)
 		})

--- a/pkg/renderer/html5/footnote_test.go
+++ b/pkg/renderer/html5/footnote_test.go
@@ -26,14 +26,14 @@ var _ = Describe("footnotes", func() {
 	})
 
 	It("rich footnote in a paragraph", func() {
-		actualContent := `foo footnote:[some *rich* http://foo.com[content]]`
+		actualContent := `foo footnote:[some *rich* https://foo.com[content]]`
 		expectedResult := `<div class="paragraph">
 <p>foo <sup class="footnote">[<a id="_footnoteref_1" class="footnote" href="#_footnotedef_1" title="View footnote.">1</a>]</sup></p>
 </div>
 <div id="footnotes">
 <hr>
 <div class="footnote" id="_footnotedef_1">
-<a href="#_footnoteref_1">1</a>. some <strong>rich</strong> <a href="http://foo.com">content</a>
+<a href="#_footnoteref_1">1</a>. some <strong>rich</strong> <a href="https://foo.com">content</a>
 </div>
 </div>`
 		verify(GinkgoT(), expectedResult, actualContent)

--- a/pkg/renderer/html5/quoted_text_test.go
+++ b/pkg/renderer/html5/quoted_text_test.go
@@ -111,7 +111,7 @@ var _ = Describe("quoted texts", func() {
 
 			actualContent := "*some *nested bold* content*."
 			expectedResult := `<div class="paragraph">
-<p><strong>some <strong>nested bold</strong> content</strong>.</p>
+<p><strong>some *nested bold</strong> content*.</p>
 </div>`
 			verify(GinkgoT(), expectedResult, actualContent)
 		})

--- a/pkg/renderer/html5/renderer.go
+++ b/pkg/renderer/html5/renderer.go
@@ -145,7 +145,10 @@ func renderPlainString(ctx *renderer.Context, element interface{}) ([]byte, erro
 	case types.InlineImage:
 		return []byte(element.Attributes.GetAsString(types.AttrImageAlt)), nil
 	case types.InlineLink:
-		return []byte(element.Text()), nil
+		if alt, ok := element.Attributes[types.AttrInlineLinkText].(types.InlineElements); ok {
+			return renderPlainString(ctx, alt)
+		}
+		return []byte(element.Location.Resolve(ctx.Document.Attributes)), nil
 	case types.BlankLine:
 		return []byte("\n\n"), nil
 	case types.StringElement:

--- a/pkg/types/element_attributes.go
+++ b/pkg/types/element_attributes.go
@@ -170,8 +170,8 @@ func NewSourceAttributes(language string) (ElementAttributes, error) {
 func WithAttributes(element interface{}, attributes []interface{}) (interface{}, error) {
 	attrs := NewElementAttributes(attributes)
 	// look for custom ID
-	for attrb := range attrs {
-		if attrb == AttrID {
+	for attr := range attrs {
+		if attr == AttrID {
 			// mark custom_id flag to `true`
 			attrs[AttrCustomID] = true
 		}
@@ -258,31 +258,31 @@ func (a ElementAttributes) AddNonEmpty(key string, value interface{}) {
 // NewElementAttributes retrieves the ElementID, ElementTitle and ElementInlineLink from the given slice of attributes
 func NewElementAttributes(attributes []interface{}, extras ...ElementAttributes) ElementAttributes {
 	attrs := ElementAttributes{}
-	for _, attrb := range attributes {
-		log.Debugf("processing attribute %[1]v (%[1]T)", attrb)
-		switch attrb := attrb.(type) {
+	for _, attr := range attributes {
+		log.Debugf("processing attribute %[1]v (%[1]T)", attr)
+		switch attr := attr.(type) {
 		case []interface{}:
 			// nested case, because of the grammar syntax,
 			// eg: `attributes:(ElementAttribute* LiteralAttribute ElementAttribute*)`
 			// which is used to ensure that a `LiteralAttribute` element is set amongst the attributes
-			r := NewElementAttributes(attrb)
+			r := NewElementAttributes(attr)
 			for k, v := range r {
 				attrs[k] = v
 			}
 		case ElementAttributes:
 			// TODO: warn if attribute already exists and is overridden
-			for k, v := range attrb {
+			for k, v := range attr {
 				attrs[k] = v
 			}
 		case map[string]interface{}:
 			// TODO: warn if attribute already exists and is overridden
-			for k, v := range attrb {
+			for k, v := range attr {
 				attrs[k] = v
 			}
 		case nil:
 			// ignore
 		default:
-			log.Warnf("unexpected attributes of type: %T", attrb)
+			log.Warnf("unexpected attributes of type: %T", attr)
 		}
 	}
 	for _, extra := range extras {

--- a/pkg/types/grammar_types_test.go
+++ b/pkg/types/grammar_types_test.go
@@ -1583,7 +1583,7 @@ func verifyLevelOffset(expectation string, actual types.RawSectionTitlePrefix, l
 
 var _ = Describe("Location resolution", func() {
 
-	attrs := map[string]string{
+	attrs := types.DocumentAttributes{
 		"includedir": "includes",
 		"foo":        "bar",
 	}

--- a/pkg/types/grammar_types_utils.go
+++ b/pkg/types/grammar_types_utils.go
@@ -74,7 +74,10 @@ func NilSafe(elements []interface{}) []interface{} {
 
 func mergeElements(elements ...interface{}) InlineElements {
 	result := make([]interface{}, 0)
-	// log.Debugf("merging %d element(s):", len(elements))
+	// if log.IsLevelEnabled(log.DebugLevel) {
+	// 	log.Debugf("merging %d element(s):", len(elements))
+	// 	spew.Dump(elements)
+	// }
 	buff := bytes.NewBuffer(nil)
 	for _, element := range elements {
 		if element == nil {
@@ -104,7 +107,10 @@ func mergeElements(elements ...interface{}) InlineElements {
 	}
 	// if buff was filled because some text was found
 	result, _ = appendBuffer(result, buff)
-	// log.Debugf(" -> '%[1]v' (%[1]T)", result)
+	// if log.IsLevelEnabled(log.DebugLevel) {
+	// 	log.Debug(" merged elements:")
+	// 	spew.Dump(result)
+	// }
 	return result
 }
 


### PR DESCRIPTION
Also, significant refactoring on the parsing of quoted text
Also, when a link has no `text` attribute, then omit in the
output AST.

Fixes #356

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>