### PR TITLE
refactor(types): get rid of pointers in types

### DIFF
--- a/libasciidoc.go
+++ b/libasciidoc.go
@@ -49,7 +49,7 @@ func ConvertToHTML(ctx context.Context, r io.Reader, output io.Writer, options .
 	return convertToHTML(ctx, doc, output, options...)
 }
 
-func convertToHTML(ctx context.Context, doc *types.Document, output io.Writer, options ...renderer.Option) (map[string]interface{}, error) {
+func convertToHTML(ctx context.Context, doc types.Document, output io.Writer, options ...renderer.Option) (map[string]interface{}, error) {
 	start := time.Now()
 	rendererCtx := renderer.Wrap(ctx, doc, options...)
 	// insert tables of contents, preamble and process file inclusions

--- a/pkg/parser/asciidoc-grammar.peg
+++ b/pkg/parser/asciidoc-grammar.peg
@@ -348,7 +348,7 @@ UserMacroAttributes <- "[" attrs:(GenericAttribute)* "]" {
 FileInclusion <- incl:("include::" path:(FileLocation) inlineAttributes:(FileIncludeAttributes) { 
         return types.NewFileInclusion(path.(types.Location), inlineAttributes.(types.ElementAttributes), string(c.text))
     }) EOLS {
-    return incl.(*types.FileInclusion), nil
+    return incl.(types.FileInclusion), nil
 }
 
 FileIncludeAttributes <- "[" attrs:(LineRangesAttribute / GenericAttribute)* "]" {

--- a/pkg/parser/asciidoc_parser.go
+++ b/pkg/parser/asciidoc_parser.go
@@ -2862,32 +2862,32 @@ var g = &grammar{
 		},
 		{
 			name: "FileIncludeAttributes",
-			pos:  position{line: 354, col: 1, offset: 11916},
+			pos:  position{line: 354, col: 1, offset: 11915},
 			expr: &actionExpr{
-				pos: position{line: 354, col: 26, offset: 11941},
+				pos: position{line: 354, col: 26, offset: 11940},
 				run: (*parser).callonFileIncludeAttributes1,
 				expr: &seqExpr{
-					pos: position{line: 354, col: 26, offset: 11941},
+					pos: position{line: 354, col: 26, offset: 11940},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 354, col: 26, offset: 11941},
+							pos:        position{line: 354, col: 26, offset: 11940},
 							val:        "[",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 354, col: 30, offset: 11945},
+							pos:   position{line: 354, col: 30, offset: 11944},
 							label: "attrs",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 354, col: 36, offset: 11951},
+								pos: position{line: 354, col: 36, offset: 11950},
 								expr: &choiceExpr{
-									pos: position{line: 354, col: 37, offset: 11952},
+									pos: position{line: 354, col: 37, offset: 11951},
 									alternatives: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 354, col: 37, offset: 11952},
+											pos:  position{line: 354, col: 37, offset: 11951},
 											name: "LineRangesAttribute",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 354, col: 59, offset: 11974},
+											pos:  position{line: 354, col: 59, offset: 11973},
 											name: "GenericAttribute",
 										},
 									},
@@ -2895,7 +2895,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 354, col: 78, offset: 11993},
+							pos:        position{line: 354, col: 78, offset: 11992},
 							val:        "]",
 							ignoreCase: false,
 						},
@@ -2905,30 +2905,30 @@ var g = &grammar{
 		},
 		{
 			name: "LineRangesAttribute",
-			pos:  position{line: 358, col: 1, offset: 12063},
+			pos:  position{line: 358, col: 1, offset: 12062},
 			expr: &actionExpr{
-				pos: position{line: 358, col: 24, offset: 12086},
+				pos: position{line: 358, col: 24, offset: 12085},
 				run: (*parser).callonLineRangesAttribute1,
 				expr: &seqExpr{
-					pos: position{line: 358, col: 24, offset: 12086},
+					pos: position{line: 358, col: 24, offset: 12085},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 358, col: 24, offset: 12086},
+							pos:        position{line: 358, col: 24, offset: 12085},
 							val:        "lines=",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 358, col: 33, offset: 12095},
+							pos:   position{line: 358, col: 33, offset: 12094},
 							label: "lines",
 							expr: &ruleRefExpr{
-								pos:  position{line: 358, col: 40, offset: 12102},
+								pos:  position{line: 358, col: 40, offset: 12101},
 								name: "LineRangesAttributeValue",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 358, col: 66, offset: 12128},
+							pos: position{line: 358, col: 66, offset: 12127},
 							expr: &litMatcher{
-								pos:        position{line: 358, col: 66, offset: 12128},
+								pos:        position{line: 358, col: 66, offset: 12127},
 								val:        ",",
 								ignoreCase: false,
 							},
@@ -2939,72 +2939,72 @@ var g = &grammar{
 		},
 		{
 			name: "LineRangesAttributeValue",
-			pos:  position{line: 363, col: 1, offset: 12224},
+			pos:  position{line: 363, col: 1, offset: 12223},
 			expr: &actionExpr{
-				pos: position{line: 363, col: 29, offset: 12252},
+				pos: position{line: 363, col: 29, offset: 12251},
 				run: (*parser).callonLineRangesAttributeValue1,
 				expr: &seqExpr{
-					pos: position{line: 363, col: 29, offset: 12252},
+					pos: position{line: 363, col: 29, offset: 12251},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 363, col: 29, offset: 12252},
+							pos:   position{line: 363, col: 29, offset: 12251},
 							label: "value",
 							expr: &choiceExpr{
-								pos: position{line: 363, col: 36, offset: 12259},
+								pos: position{line: 363, col: 36, offset: 12258},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 363, col: 36, offset: 12259},
+										pos:  position{line: 363, col: 36, offset: 12258},
 										name: "MultipleRanges",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 364, col: 11, offset: 12364},
+										pos:  position{line: 364, col: 11, offset: 12363},
 										name: "MultipleQuotedRanges",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 365, col: 11, offset: 12396},
+										pos:  position{line: 365, col: 11, offset: 12395},
 										name: "MultilineRange",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 366, col: 11, offset: 12422},
+										pos:  position{line: 366, col: 11, offset: 12421},
 										name: "MultilineQuotedRange",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 367, col: 11, offset: 12454},
+										pos:  position{line: 367, col: 11, offset: 12453},
 										name: "SinglelineQuotedRange",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 368, col: 11, offset: 12486},
+										pos:  position{line: 368, col: 11, offset: 12485},
 										name: "SinglelineRange",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 369, col: 11, offset: 12513},
+										pos:  position{line: 369, col: 11, offset: 12512},
 										name: "UndefinedLineRange",
 									},
 								},
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 369, col: 31, offset: 12533},
+							pos: position{line: 369, col: 31, offset: 12532},
 							expr: &ruleRefExpr{
-								pos:  position{line: 369, col: 31, offset: 12533},
+								pos:  position{line: 369, col: 31, offset: 12532},
 								name: "WS",
 							},
 						},
 						&choiceExpr{
-							pos: position{line: 369, col: 36, offset: 12538},
+							pos: position{line: 369, col: 36, offset: 12537},
 							alternatives: []interface{}{
 								&andExpr{
-									pos: position{line: 369, col: 36, offset: 12538},
+									pos: position{line: 369, col: 36, offset: 12537},
 									expr: &litMatcher{
-										pos:        position{line: 369, col: 37, offset: 12539},
+										pos:        position{line: 369, col: 37, offset: 12538},
 										val:        ",",
 										ignoreCase: false,
 									},
 								},
 								&andExpr{
-									pos: position{line: 369, col: 43, offset: 12545},
+									pos: position{line: 369, col: 43, offset: 12544},
 									expr: &litMatcher{
-										pos:        position{line: 369, col: 44, offset: 12546},
+										pos:        position{line: 369, col: 44, offset: 12545},
 										val:        "]",
 										ignoreCase: false,
 									},
@@ -3017,58 +3017,58 @@ var g = &grammar{
 		},
 		{
 			name: "MultipleRanges",
-			pos:  position{line: 373, col: 1, offset: 12578},
+			pos:  position{line: 373, col: 1, offset: 12577},
 			expr: &actionExpr{
-				pos: position{line: 373, col: 19, offset: 12596},
+				pos: position{line: 373, col: 19, offset: 12595},
 				run: (*parser).callonMultipleRanges1,
 				expr: &seqExpr{
-					pos: position{line: 373, col: 19, offset: 12596},
+					pos: position{line: 373, col: 19, offset: 12595},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 373, col: 19, offset: 12596},
+							pos:   position{line: 373, col: 19, offset: 12595},
 							label: "first",
 							expr: &choiceExpr{
-								pos: position{line: 373, col: 26, offset: 12603},
+								pos: position{line: 373, col: 26, offset: 12602},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 373, col: 26, offset: 12603},
+										pos:  position{line: 373, col: 26, offset: 12602},
 										name: "MultilineRange",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 373, col: 43, offset: 12620},
+										pos:  position{line: 373, col: 43, offset: 12619},
 										name: "SinglelineRange",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 374, col: 5, offset: 12642},
+							pos:   position{line: 374, col: 5, offset: 12641},
 							label: "others",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 374, col: 12, offset: 12649},
+								pos: position{line: 374, col: 12, offset: 12648},
 								expr: &actionExpr{
-									pos: position{line: 374, col: 13, offset: 12650},
+									pos: position{line: 374, col: 13, offset: 12649},
 									run: (*parser).callonMultipleRanges9,
 									expr: &seqExpr{
-										pos: position{line: 374, col: 13, offset: 12650},
+										pos: position{line: 374, col: 13, offset: 12649},
 										exprs: []interface{}{
 											&litMatcher{
-												pos:        position{line: 374, col: 13, offset: 12650},
+												pos:        position{line: 374, col: 13, offset: 12649},
 												val:        ";",
 												ignoreCase: false,
 											},
 											&labeledExpr{
-												pos:   position{line: 374, col: 17, offset: 12654},
+												pos:   position{line: 374, col: 17, offset: 12653},
 												label: "other",
 												expr: &choiceExpr{
-													pos: position{line: 374, col: 24, offset: 12661},
+													pos: position{line: 374, col: 24, offset: 12660},
 													alternatives: []interface{}{
 														&ruleRefExpr{
-															pos:  position{line: 374, col: 24, offset: 12661},
+															pos:  position{line: 374, col: 24, offset: 12660},
 															name: "MultilineRange",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 374, col: 41, offset: 12678},
+															pos:  position{line: 374, col: 41, offset: 12677},
 															name: "SinglelineRange",
 														},
 													},
@@ -3085,63 +3085,63 @@ var g = &grammar{
 		},
 		{
 			name: "MultipleQuotedRanges",
-			pos:  position{line: 380, col: 1, offset: 12816},
+			pos:  position{line: 380, col: 1, offset: 12815},
 			expr: &actionExpr{
-				pos: position{line: 380, col: 25, offset: 12840},
+				pos: position{line: 380, col: 25, offset: 12839},
 				run: (*parser).callonMultipleQuotedRanges1,
 				expr: &seqExpr{
-					pos: position{line: 380, col: 25, offset: 12840},
+					pos: position{line: 380, col: 25, offset: 12839},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 380, col: 25, offset: 12840},
+							pos:        position{line: 380, col: 25, offset: 12839},
 							val:        "\"",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 380, col: 30, offset: 12845},
+							pos:   position{line: 380, col: 30, offset: 12844},
 							label: "first",
 							expr: &choiceExpr{
-								pos: position{line: 380, col: 37, offset: 12852},
+								pos: position{line: 380, col: 37, offset: 12851},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 380, col: 37, offset: 12852},
+										pos:  position{line: 380, col: 37, offset: 12851},
 										name: "MultilineRange",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 380, col: 54, offset: 12869},
+										pos:  position{line: 380, col: 54, offset: 12868},
 										name: "SinglelineRange",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 381, col: 5, offset: 12891},
+							pos:   position{line: 381, col: 5, offset: 12890},
 							label: "others",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 381, col: 12, offset: 12898},
+								pos: position{line: 381, col: 12, offset: 12897},
 								expr: &actionExpr{
-									pos: position{line: 381, col: 13, offset: 12899},
+									pos: position{line: 381, col: 13, offset: 12898},
 									run: (*parser).callonMultipleQuotedRanges10,
 									expr: &seqExpr{
-										pos: position{line: 381, col: 13, offset: 12899},
+										pos: position{line: 381, col: 13, offset: 12898},
 										exprs: []interface{}{
 											&litMatcher{
-												pos:        position{line: 381, col: 13, offset: 12899},
+												pos:        position{line: 381, col: 13, offset: 12898},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&labeledExpr{
-												pos:   position{line: 381, col: 17, offset: 12903},
+												pos:   position{line: 381, col: 17, offset: 12902},
 												label: "other",
 												expr: &choiceExpr{
-													pos: position{line: 381, col: 24, offset: 12910},
+													pos: position{line: 381, col: 24, offset: 12909},
 													alternatives: []interface{}{
 														&ruleRefExpr{
-															pos:  position{line: 381, col: 24, offset: 12910},
+															pos:  position{line: 381, col: 24, offset: 12909},
 															name: "MultilineRange",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 381, col: 41, offset: 12927},
+															pos:  position{line: 381, col: 41, offset: 12926},
 															name: "SinglelineRange",
 														},
 													},
@@ -3153,7 +3153,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 383, col: 9, offset: 12980},
+							pos:        position{line: 383, col: 9, offset: 12979},
 							val:        "\"",
 							ignoreCase: false,
 						},
@@ -3163,31 +3163,31 @@ var g = &grammar{
 		},
 		{
 			name: "MultilineRange",
-			pos:  position{line: 387, col: 1, offset: 13070},
+			pos:  position{line: 387, col: 1, offset: 13069},
 			expr: &actionExpr{
-				pos: position{line: 387, col: 19, offset: 13088},
+				pos: position{line: 387, col: 19, offset: 13087},
 				run: (*parser).callonMultilineRange1,
 				expr: &seqExpr{
-					pos: position{line: 387, col: 19, offset: 13088},
+					pos: position{line: 387, col: 19, offset: 13087},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 387, col: 19, offset: 13088},
+							pos:   position{line: 387, col: 19, offset: 13087},
 							label: "start",
 							expr: &ruleRefExpr{
-								pos:  position{line: 387, col: 26, offset: 13095},
+								pos:  position{line: 387, col: 26, offset: 13094},
 								name: "NUMBER",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 387, col: 34, offset: 13103},
+							pos:        position{line: 387, col: 34, offset: 13102},
 							val:        "..",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 387, col: 39, offset: 13108},
+							pos:   position{line: 387, col: 39, offset: 13107},
 							label: "end",
 							expr: &ruleRefExpr{
-								pos:  position{line: 387, col: 44, offset: 13113},
+								pos:  position{line: 387, col: 44, offset: 13112},
 								name: "NUMBER",
 							},
 						},
@@ -3197,41 +3197,41 @@ var g = &grammar{
 		},
 		{
 			name: "MultilineQuotedRange",
-			pos:  position{line: 391, col: 1, offset: 13206},
+			pos:  position{line: 391, col: 1, offset: 13205},
 			expr: &actionExpr{
-				pos: position{line: 391, col: 25, offset: 13230},
+				pos: position{line: 391, col: 25, offset: 13229},
 				run: (*parser).callonMultilineQuotedRange1,
 				expr: &seqExpr{
-					pos: position{line: 391, col: 25, offset: 13230},
+					pos: position{line: 391, col: 25, offset: 13229},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 391, col: 25, offset: 13230},
+							pos:        position{line: 391, col: 25, offset: 13229},
 							val:        "\"",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 391, col: 30, offset: 13235},
+							pos:   position{line: 391, col: 30, offset: 13234},
 							label: "start",
 							expr: &ruleRefExpr{
-								pos:  position{line: 391, col: 37, offset: 13242},
+								pos:  position{line: 391, col: 37, offset: 13241},
 								name: "NUMBER",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 391, col: 45, offset: 13250},
+							pos:        position{line: 391, col: 45, offset: 13249},
 							val:        "..",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 391, col: 50, offset: 13255},
+							pos:   position{line: 391, col: 50, offset: 13254},
 							label: "end",
 							expr: &ruleRefExpr{
-								pos:  position{line: 391, col: 55, offset: 13260},
+								pos:  position{line: 391, col: 55, offset: 13259},
 								name: "NUMBER",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 391, col: 63, offset: 13268},
+							pos:        position{line: 391, col: 63, offset: 13267},
 							val:        "\"",
 							ignoreCase: false,
 						},
@@ -3241,15 +3241,15 @@ var g = &grammar{
 		},
 		{
 			name: "SinglelineRange",
-			pos:  position{line: 395, col: 1, offset: 13358},
+			pos:  position{line: 395, col: 1, offset: 13357},
 			expr: &actionExpr{
-				pos: position{line: 395, col: 20, offset: 13377},
+				pos: position{line: 395, col: 20, offset: 13376},
 				run: (*parser).callonSinglelineRange1,
 				expr: &labeledExpr{
-					pos:   position{line: 395, col: 20, offset: 13377},
+					pos:   position{line: 395, col: 20, offset: 13376},
 					label: "singleline",
 					expr: &ruleRefExpr{
-						pos:  position{line: 395, col: 32, offset: 13389},
+						pos:  position{line: 395, col: 32, offset: 13388},
 						name: "NUMBER",
 					},
 				},
@@ -3257,28 +3257,28 @@ var g = &grammar{
 		},
 		{
 			name: "SinglelineQuotedRange",
-			pos:  position{line: 399, col: 1, offset: 13472},
+			pos:  position{line: 399, col: 1, offset: 13471},
 			expr: &actionExpr{
-				pos: position{line: 399, col: 26, offset: 13497},
+				pos: position{line: 399, col: 26, offset: 13496},
 				run: (*parser).callonSinglelineQuotedRange1,
 				expr: &seqExpr{
-					pos: position{line: 399, col: 26, offset: 13497},
+					pos: position{line: 399, col: 26, offset: 13496},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 399, col: 26, offset: 13497},
+							pos:        position{line: 399, col: 26, offset: 13496},
 							val:        "\"",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 399, col: 31, offset: 13502},
+							pos:   position{line: 399, col: 31, offset: 13501},
 							label: "singleline",
 							expr: &ruleRefExpr{
-								pos:  position{line: 399, col: 43, offset: 13514},
+								pos:  position{line: 399, col: 43, offset: 13513},
 								name: "NUMBER",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 399, col: 51, offset: 13522},
+							pos:        position{line: 399, col: 51, offset: 13521},
 							val:        "\"",
 							ignoreCase: false,
 						},
@@ -3288,40 +3288,40 @@ var g = &grammar{
 		},
 		{
 			name: "UndefinedLineRange",
-			pos:  position{line: 403, col: 1, offset: 13602},
+			pos:  position{line: 403, col: 1, offset: 13601},
 			expr: &actionExpr{
-				pos: position{line: 403, col: 23, offset: 13624},
+				pos: position{line: 403, col: 23, offset: 13623},
 				run: (*parser).callonUndefinedLineRange1,
 				expr: &zeroOrMoreExpr{
-					pos: position{line: 403, col: 23, offset: 13624},
+					pos: position{line: 403, col: 23, offset: 13623},
 					expr: &seqExpr{
-						pos: position{line: 403, col: 24, offset: 13625},
+						pos: position{line: 403, col: 24, offset: 13624},
 						exprs: []interface{}{
 							&notExpr{
-								pos: position{line: 403, col: 24, offset: 13625},
+								pos: position{line: 403, col: 24, offset: 13624},
 								expr: &litMatcher{
-									pos:        position{line: 403, col: 25, offset: 13626},
+									pos:        position{line: 403, col: 25, offset: 13625},
 									val:        "]",
 									ignoreCase: false,
 								},
 							},
 							&notExpr{
-								pos: position{line: 403, col: 29, offset: 13630},
+								pos: position{line: 403, col: 29, offset: 13629},
 								expr: &litMatcher{
-									pos:        position{line: 403, col: 30, offset: 13631},
+									pos:        position{line: 403, col: 30, offset: 13630},
 									val:        ",",
 									ignoreCase: false,
 								},
 							},
 							&notExpr{
-								pos: position{line: 403, col: 34, offset: 13635},
+								pos: position{line: 403, col: 34, offset: 13634},
 								expr: &ruleRefExpr{
-									pos:  position{line: 403, col: 35, offset: 13636},
+									pos:  position{line: 403, col: 35, offset: 13635},
 									name: "WS",
 								},
 							},
 							&anyMatcher{
-								line: 403, col: 38, offset: 13639,
+								line: 403, col: 38, offset: 13638,
 							},
 						},
 					},
@@ -3330,35 +3330,35 @@ var g = &grammar{
 		},
 		{
 			name: "ListItems",
-			pos:  position{line: 410, col: 1, offset: 13780},
+			pos:  position{line: 410, col: 1, offset: 13779},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 410, col: 14, offset: 13793},
+				pos: position{line: 410, col: 14, offset: 13792},
 				expr: &ruleRefExpr{
-					pos:  position{line: 410, col: 14, offset: 13793},
+					pos:  position{line: 410, col: 14, offset: 13792},
 					name: "ListItem",
 				},
 			},
 		},
 		{
 			name: "ListItem",
-			pos:  position{line: 412, col: 1, offset: 13804},
+			pos:  position{line: 412, col: 1, offset: 13803},
 			expr: &choiceExpr{
-				pos: position{line: 412, col: 13, offset: 13816},
+				pos: position{line: 412, col: 13, offset: 13815},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 412, col: 13, offset: 13816},
+						pos:  position{line: 412, col: 13, offset: 13815},
 						name: "OrderedListItem",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 412, col: 31, offset: 13834},
+						pos:  position{line: 412, col: 31, offset: 13833},
 						name: "UnorderedListItem",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 412, col: 51, offset: 13854},
+						pos:  position{line: 412, col: 51, offset: 13853},
 						name: "LabeledListItem",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 412, col: 69, offset: 13872},
+						pos:  position{line: 412, col: 69, offset: 13871},
 						name: "ContinuedListItemElement",
 					},
 				},
@@ -3366,32 +3366,32 @@ var g = &grammar{
 		},
 		{
 			name: "ListParagraph",
-			pos:  position{line: 414, col: 1, offset: 13898},
+			pos:  position{line: 414, col: 1, offset: 13897},
 			expr: &choiceExpr{
-				pos: position{line: 414, col: 18, offset: 13915},
+				pos: position{line: 414, col: 18, offset: 13914},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 414, col: 18, offset: 13915},
+						pos: position{line: 414, col: 18, offset: 13914},
 						run: (*parser).callonListParagraph2,
 						expr: &labeledExpr{
-							pos:   position{line: 414, col: 18, offset: 13915},
+							pos:   position{line: 414, col: 18, offset: 13914},
 							label: "comment",
 							expr: &ruleRefExpr{
-								pos:  position{line: 414, col: 27, offset: 13924},
+								pos:  position{line: 414, col: 27, offset: 13923},
 								name: "SingleLineComment",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 416, col: 9, offset: 13981},
+						pos: position{line: 416, col: 9, offset: 13980},
 						run: (*parser).callonListParagraph5,
 						expr: &labeledExpr{
-							pos:   position{line: 416, col: 9, offset: 13981},
+							pos:   position{line: 416, col: 9, offset: 13980},
 							label: "lines",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 416, col: 15, offset: 13987},
+								pos: position{line: 416, col: 15, offset: 13986},
 								expr: &ruleRefExpr{
-									pos:  position{line: 416, col: 16, offset: 13988},
+									pos:  position{line: 416, col: 16, offset: 13987},
 									name: "ListParagraphLine",
 								},
 							},
@@ -3402,112 +3402,112 @@ var g = &grammar{
 		},
 		{
 			name: "ListParagraphLine",
-			pos:  position{line: 420, col: 1, offset: 14080},
+			pos:  position{line: 420, col: 1, offset: 14079},
 			expr: &actionExpr{
-				pos: position{line: 420, col: 22, offset: 14101},
+				pos: position{line: 420, col: 22, offset: 14100},
 				run: (*parser).callonListParagraphLine1,
 				expr: &seqExpr{
-					pos: position{line: 420, col: 22, offset: 14101},
+					pos: position{line: 420, col: 22, offset: 14100},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 420, col: 22, offset: 14101},
+							pos: position{line: 420, col: 22, offset: 14100},
 							expr: &ruleRefExpr{
-								pos:  position{line: 420, col: 23, offset: 14102},
+								pos:  position{line: 420, col: 23, offset: 14101},
 								name: "EOF",
 							},
 						},
 						&notExpr{
-							pos: position{line: 421, col: 5, offset: 14110},
+							pos: position{line: 421, col: 5, offset: 14109},
 							expr: &ruleRefExpr{
-								pos:  position{line: 421, col: 6, offset: 14111},
+								pos:  position{line: 421, col: 6, offset: 14110},
 								name: "BlankLine",
 							},
 						},
 						&notExpr{
-							pos: position{line: 422, col: 5, offset: 14126},
+							pos: position{line: 422, col: 5, offset: 14125},
 							expr: &ruleRefExpr{
-								pos:  position{line: 422, col: 6, offset: 14127},
+								pos:  position{line: 422, col: 6, offset: 14126},
 								name: "SingleLineComment",
 							},
 						},
 						&notExpr{
-							pos: position{line: 423, col: 5, offset: 14149},
+							pos: position{line: 423, col: 5, offset: 14148},
 							expr: &ruleRefExpr{
-								pos:  position{line: 423, col: 6, offset: 14150},
+								pos:  position{line: 423, col: 6, offset: 14149},
 								name: "OrderedListItemPrefix",
 							},
 						},
 						&notExpr{
-							pos: position{line: 424, col: 5, offset: 14176},
+							pos: position{line: 424, col: 5, offset: 14175},
 							expr: &ruleRefExpr{
-								pos:  position{line: 424, col: 6, offset: 14177},
+								pos:  position{line: 424, col: 6, offset: 14176},
 								name: "UnorderedListItemPrefix",
 							},
 						},
 						&notExpr{
-							pos: position{line: 425, col: 5, offset: 14205},
+							pos: position{line: 425, col: 5, offset: 14204},
 							expr: &seqExpr{
-								pos: position{line: 425, col: 7, offset: 14207},
+								pos: position{line: 425, col: 7, offset: 14206},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 425, col: 7, offset: 14207},
+										pos:  position{line: 425, col: 7, offset: 14206},
 										name: "LabeledListItemTerm",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 425, col: 27, offset: 14227},
+										pos:  position{line: 425, col: 27, offset: 14226},
 										name: "LabeledListItemSeparator",
 									},
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 426, col: 5, offset: 14258},
+							pos: position{line: 426, col: 5, offset: 14257},
 							expr: &ruleRefExpr{
-								pos:  position{line: 426, col: 6, offset: 14259},
+								pos:  position{line: 426, col: 6, offset: 14258},
 								name: "ListItemContinuation",
 							},
 						},
 						&notExpr{
-							pos: position{line: 427, col: 5, offset: 14284},
+							pos: position{line: 427, col: 5, offset: 14283},
 							expr: &ruleRefExpr{
-								pos:  position{line: 427, col: 6, offset: 14285},
+								pos:  position{line: 427, col: 6, offset: 14284},
 								name: "ElementAttribute",
 							},
 						},
 						&notExpr{
-							pos: position{line: 428, col: 5, offset: 14306},
+							pos: position{line: 428, col: 5, offset: 14305},
 							expr: &ruleRefExpr{
-								pos:  position{line: 428, col: 6, offset: 14307},
+								pos:  position{line: 428, col: 6, offset: 14306},
 								name: "BlockDelimiter",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 429, col: 5, offset: 14326},
+							pos:   position{line: 429, col: 5, offset: 14325},
 							label: "line",
 							expr: &actionExpr{
-								pos: position{line: 430, col: 9, offset: 14341},
+								pos: position{line: 430, col: 9, offset: 14340},
 								run: (*parser).callonListParagraphLine24,
 								expr: &seqExpr{
-									pos: position{line: 430, col: 9, offset: 14341},
+									pos: position{line: 430, col: 9, offset: 14340},
 									exprs: []interface{}{
 										&labeledExpr{
-											pos:   position{line: 430, col: 9, offset: 14341},
+											pos:   position{line: 430, col: 9, offset: 14340},
 											label: "elements",
 											expr: &oneOrMoreExpr{
-												pos: position{line: 430, col: 18, offset: 14350},
+												pos: position{line: 430, col: 18, offset: 14349},
 												expr: &ruleRefExpr{
-													pos:  position{line: 430, col: 19, offset: 14351},
+													pos:  position{line: 430, col: 19, offset: 14350},
 													name: "InlineElement",
 												},
 											},
 										},
 										&labeledExpr{
-											pos:   position{line: 430, col: 35, offset: 14367},
+											pos:   position{line: 430, col: 35, offset: 14366},
 											label: "linebreak",
 											expr: &zeroOrOneExpr{
-												pos: position{line: 430, col: 45, offset: 14377},
+												pos: position{line: 430, col: 45, offset: 14376},
 												expr: &ruleRefExpr{
-													pos:  position{line: 430, col: 46, offset: 14378},
+													pos:  position{line: 430, col: 46, offset: 14377},
 													name: "LineBreak",
 												},
 											},
@@ -3517,7 +3517,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 432, col: 12, offset: 14530},
+							pos:  position{line: 432, col: 12, offset: 14529},
 							name: "EOL",
 						},
 					},
@@ -3526,17 +3526,17 @@ var g = &grammar{
 		},
 		{
 			name: "ListItemContinuation",
-			pos:  position{line: 436, col: 1, offset: 14577},
+			pos:  position{line: 436, col: 1, offset: 14576},
 			expr: &seqExpr{
-				pos: position{line: 436, col: 25, offset: 14601},
+				pos: position{line: 436, col: 25, offset: 14600},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 436, col: 25, offset: 14601},
+						pos:        position{line: 436, col: 25, offset: 14600},
 						val:        "+",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 436, col: 29, offset: 14605},
+						pos:  position{line: 436, col: 29, offset: 14604},
 						name: "EOLS",
 					},
 				},
@@ -3544,33 +3544,33 @@ var g = &grammar{
 		},
 		{
 			name: "ContinuedListItemElement",
-			pos:  position{line: 438, col: 1, offset: 14612},
+			pos:  position{line: 438, col: 1, offset: 14611},
 			expr: &actionExpr{
-				pos: position{line: 438, col: 29, offset: 14640},
+				pos: position{line: 438, col: 29, offset: 14639},
 				run: (*parser).callonContinuedListItemElement1,
 				expr: &seqExpr{
-					pos: position{line: 438, col: 29, offset: 14640},
+					pos: position{line: 438, col: 29, offset: 14639},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 438, col: 29, offset: 14640},
+							pos:   position{line: 438, col: 29, offset: 14639},
 							label: "blanklines",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 438, col: 41, offset: 14652},
+								pos: position{line: 438, col: 41, offset: 14651},
 								expr: &ruleRefExpr{
-									pos:  position{line: 438, col: 41, offset: 14652},
+									pos:  position{line: 438, col: 41, offset: 14651},
 									name: "BlankLine",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 438, col: 53, offset: 14664},
+							pos:  position{line: 438, col: 53, offset: 14663},
 							name: "ListItemContinuation",
 						},
 						&labeledExpr{
-							pos:   position{line: 438, col: 74, offset: 14685},
+							pos:   position{line: 438, col: 74, offset: 14684},
 							label: "element",
 							expr: &ruleRefExpr{
-								pos:  position{line: 438, col: 82, offset: 14693},
+								pos:  position{line: 438, col: 82, offset: 14692},
 								name: "DocumentBlock",
 							},
 						},
@@ -3580,37 +3580,37 @@ var g = &grammar{
 		},
 		{
 			name: "OrderedListItem",
-			pos:  position{line: 445, col: 1, offset: 14935},
+			pos:  position{line: 445, col: 1, offset: 14934},
 			expr: &actionExpr{
-				pos: position{line: 445, col: 20, offset: 14954},
+				pos: position{line: 445, col: 20, offset: 14953},
 				run: (*parser).callonOrderedListItem1,
 				expr: &seqExpr{
-					pos: position{line: 445, col: 20, offset: 14954},
+					pos: position{line: 445, col: 20, offset: 14953},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 445, col: 20, offset: 14954},
+							pos:   position{line: 445, col: 20, offset: 14953},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 445, col: 31, offset: 14965},
+								pos: position{line: 445, col: 31, offset: 14964},
 								expr: &ruleRefExpr{
-									pos:  position{line: 445, col: 32, offset: 14966},
+									pos:  position{line: 445, col: 32, offset: 14965},
 									name: "ElementAttributes",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 445, col: 52, offset: 14986},
+							pos:   position{line: 445, col: 52, offset: 14985},
 							label: "prefix",
 							expr: &ruleRefExpr{
-								pos:  position{line: 445, col: 60, offset: 14994},
+								pos:  position{line: 445, col: 60, offset: 14993},
 								name: "OrderedListItemPrefix",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 445, col: 83, offset: 15017},
+							pos:   position{line: 445, col: 83, offset: 15016},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 445, col: 92, offset: 15026},
+								pos:  position{line: 445, col: 92, offset: 15025},
 								name: "OrderedListItemContent",
 							},
 						},
@@ -3620,42 +3620,42 @@ var g = &grammar{
 		},
 		{
 			name: "OrderedListItemPrefix",
-			pos:  position{line: 449, col: 1, offset: 15166},
+			pos:  position{line: 449, col: 1, offset: 15165},
 			expr: &actionExpr{
-				pos: position{line: 450, col: 5, offset: 15196},
+				pos: position{line: 450, col: 5, offset: 15195},
 				run: (*parser).callonOrderedListItemPrefix1,
 				expr: &seqExpr{
-					pos: position{line: 450, col: 5, offset: 15196},
+					pos: position{line: 450, col: 5, offset: 15195},
 					exprs: []interface{}{
 						&zeroOrMoreExpr{
-							pos: position{line: 450, col: 5, offset: 15196},
+							pos: position{line: 450, col: 5, offset: 15195},
 							expr: &ruleRefExpr{
-								pos:  position{line: 450, col: 5, offset: 15196},
+								pos:  position{line: 450, col: 5, offset: 15195},
 								name: "WS",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 450, col: 9, offset: 15200},
+							pos:   position{line: 450, col: 9, offset: 15199},
 							label: "prefix",
 							expr: &choiceExpr{
-								pos: position{line: 452, col: 9, offset: 15263},
+								pos: position{line: 452, col: 9, offset: 15262},
 								alternatives: []interface{}{
 									&actionExpr{
-										pos: position{line: 452, col: 9, offset: 15263},
+										pos: position{line: 452, col: 9, offset: 15262},
 										run: (*parser).callonOrderedListItemPrefix7,
 										expr: &seqExpr{
-											pos: position{line: 452, col: 9, offset: 15263},
+											pos: position{line: 452, col: 9, offset: 15262},
 											exprs: []interface{}{
 												&labeledExpr{
-													pos:   position{line: 452, col: 9, offset: 15263},
+													pos:   position{line: 452, col: 9, offset: 15262},
 													label: "depth",
 													expr: &actionExpr{
-														pos: position{line: 452, col: 16, offset: 15270},
+														pos: position{line: 452, col: 16, offset: 15269},
 														run: (*parser).callonOrderedListItemPrefix10,
 														expr: &oneOrMoreExpr{
-															pos: position{line: 452, col: 16, offset: 15270},
+															pos: position{line: 452, col: 16, offset: 15269},
 															expr: &litMatcher{
-																pos:        position{line: 452, col: 17, offset: 15271},
+																pos:        position{line: 452, col: 17, offset: 15270},
 																val:        ".",
 																ignoreCase: false,
 															},
@@ -3663,22 +3663,22 @@ var g = &grammar{
 													},
 												},
 												&andCodeExpr{
-													pos: position{line: 456, col: 9, offset: 15371},
+													pos: position{line: 456, col: 9, offset: 15370},
 													run: (*parser).callonOrderedListItemPrefix13,
 												},
 											},
 										},
 									},
 									&actionExpr{
-										pos: position{line: 475, col: 11, offset: 16088},
+										pos: position{line: 475, col: 11, offset: 16087},
 										run: (*parser).callonOrderedListItemPrefix14,
 										expr: &seqExpr{
-											pos: position{line: 475, col: 11, offset: 16088},
+											pos: position{line: 475, col: 11, offset: 16087},
 											exprs: []interface{}{
 												&oneOrMoreExpr{
-													pos: position{line: 475, col: 11, offset: 16088},
+													pos: position{line: 475, col: 11, offset: 16087},
 													expr: &charClassMatcher{
-														pos:        position{line: 475, col: 12, offset: 16089},
+														pos:        position{line: 475, col: 12, offset: 16088},
 														val:        "[0-9]",
 														ranges:     []rune{'0', '9'},
 														ignoreCase: false,
@@ -3686,7 +3686,7 @@ var g = &grammar{
 													},
 												},
 												&litMatcher{
-													pos:        position{line: 475, col: 20, offset: 16097},
+													pos:        position{line: 475, col: 20, offset: 16096},
 													val:        ".",
 													ignoreCase: false,
 												},
@@ -3694,20 +3694,20 @@ var g = &grammar{
 										},
 									},
 									&actionExpr{
-										pos: position{line: 477, col: 13, offset: 16208},
+										pos: position{line: 477, col: 13, offset: 16207},
 										run: (*parser).callonOrderedListItemPrefix19,
 										expr: &seqExpr{
-											pos: position{line: 477, col: 13, offset: 16208},
+											pos: position{line: 477, col: 13, offset: 16207},
 											exprs: []interface{}{
 												&charClassMatcher{
-													pos:        position{line: 477, col: 14, offset: 16209},
+													pos:        position{line: 477, col: 14, offset: 16208},
 													val:        "[a-z]",
 													ranges:     []rune{'a', 'z'},
 													ignoreCase: false,
 													inverted:   false,
 												},
 												&litMatcher{
-													pos:        position{line: 477, col: 21, offset: 16216},
+													pos:        position{line: 477, col: 21, offset: 16215},
 													val:        ".",
 													ignoreCase: false,
 												},
@@ -3715,20 +3715,20 @@ var g = &grammar{
 										},
 									},
 									&actionExpr{
-										pos: position{line: 479, col: 13, offset: 16330},
+										pos: position{line: 479, col: 13, offset: 16329},
 										run: (*parser).callonOrderedListItemPrefix23,
 										expr: &seqExpr{
-											pos: position{line: 479, col: 13, offset: 16330},
+											pos: position{line: 479, col: 13, offset: 16329},
 											exprs: []interface{}{
 												&charClassMatcher{
-													pos:        position{line: 479, col: 14, offset: 16331},
+													pos:        position{line: 479, col: 14, offset: 16330},
 													val:        "[A-Z]",
 													ranges:     []rune{'A', 'Z'},
 													ignoreCase: false,
 													inverted:   false,
 												},
 												&litMatcher{
-													pos:        position{line: 479, col: 21, offset: 16338},
+													pos:        position{line: 479, col: 21, offset: 16337},
 													val:        ".",
 													ignoreCase: false,
 												},
@@ -3736,15 +3736,15 @@ var g = &grammar{
 										},
 									},
 									&actionExpr{
-										pos: position{line: 481, col: 13, offset: 16452},
+										pos: position{line: 481, col: 13, offset: 16451},
 										run: (*parser).callonOrderedListItemPrefix27,
 										expr: &seqExpr{
-											pos: position{line: 481, col: 13, offset: 16452},
+											pos: position{line: 481, col: 13, offset: 16451},
 											exprs: []interface{}{
 												&oneOrMoreExpr{
-													pos: position{line: 481, col: 13, offset: 16452},
+													pos: position{line: 481, col: 13, offset: 16451},
 													expr: &charClassMatcher{
-														pos:        position{line: 481, col: 14, offset: 16453},
+														pos:        position{line: 481, col: 14, offset: 16452},
 														val:        "[a-z]",
 														ranges:     []rune{'a', 'z'},
 														ignoreCase: false,
@@ -3752,7 +3752,7 @@ var g = &grammar{
 													},
 												},
 												&litMatcher{
-													pos:        position{line: 481, col: 22, offset: 16461},
+													pos:        position{line: 481, col: 22, offset: 16460},
 													val:        ")",
 													ignoreCase: false,
 												},
@@ -3760,15 +3760,15 @@ var g = &grammar{
 										},
 									},
 									&actionExpr{
-										pos: position{line: 483, col: 13, offset: 16575},
+										pos: position{line: 483, col: 13, offset: 16574},
 										run: (*parser).callonOrderedListItemPrefix32,
 										expr: &seqExpr{
-											pos: position{line: 483, col: 13, offset: 16575},
+											pos: position{line: 483, col: 13, offset: 16574},
 											exprs: []interface{}{
 												&oneOrMoreExpr{
-													pos: position{line: 483, col: 13, offset: 16575},
+													pos: position{line: 483, col: 13, offset: 16574},
 													expr: &charClassMatcher{
-														pos:        position{line: 483, col: 14, offset: 16576},
+														pos:        position{line: 483, col: 14, offset: 16575},
 														val:        "[A-Z]",
 														ranges:     []rune{'A', 'Z'},
 														ignoreCase: false,
@@ -3776,7 +3776,7 @@ var g = &grammar{
 													},
 												},
 												&litMatcher{
-													pos:        position{line: 483, col: 22, offset: 16584},
+													pos:        position{line: 483, col: 22, offset: 16583},
 													val:        ")",
 													ignoreCase: false,
 												},
@@ -3787,9 +3787,9 @@ var g = &grammar{
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 485, col: 12, offset: 16697},
+							pos: position{line: 485, col: 12, offset: 16696},
 							expr: &ruleRefExpr{
-								pos:  position{line: 485, col: 12, offset: 16697},
+								pos:  position{line: 485, col: 12, offset: 16696},
 								name: "WS",
 							},
 						},
@@ -3799,17 +3799,17 @@ var g = &grammar{
 		},
 		{
 			name: "OrderedListItemContent",
-			pos:  position{line: 489, col: 1, offset: 16729},
+			pos:  position{line: 489, col: 1, offset: 16728},
 			expr: &actionExpr{
-				pos: position{line: 489, col: 27, offset: 16755},
+				pos: position{line: 489, col: 27, offset: 16754},
 				run: (*parser).callonOrderedListItemContent1,
 				expr: &labeledExpr{
-					pos:   position{line: 489, col: 27, offset: 16755},
+					pos:   position{line: 489, col: 27, offset: 16754},
 					label: "elements",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 489, col: 37, offset: 16765},
+						pos: position{line: 489, col: 37, offset: 16764},
 						expr: &ruleRefExpr{
-							pos:  position{line: 489, col: 37, offset: 16765},
+							pos:  position{line: 489, col: 37, offset: 16764},
 							name: "ListParagraph",
 						},
 					},
@@ -3818,48 +3818,48 @@ var g = &grammar{
 		},
 		{
 			name: "UnorderedListItem",
-			pos:  position{line: 496, col: 1, offset: 16965},
+			pos:  position{line: 496, col: 1, offset: 16964},
 			expr: &actionExpr{
-				pos: position{line: 496, col: 22, offset: 16986},
+				pos: position{line: 496, col: 22, offset: 16985},
 				run: (*parser).callonUnorderedListItem1,
 				expr: &seqExpr{
-					pos: position{line: 496, col: 22, offset: 16986},
+					pos: position{line: 496, col: 22, offset: 16985},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 496, col: 22, offset: 16986},
+							pos:   position{line: 496, col: 22, offset: 16985},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 496, col: 33, offset: 16997},
+								pos: position{line: 496, col: 33, offset: 16996},
 								expr: &ruleRefExpr{
-									pos:  position{line: 496, col: 34, offset: 16998},
+									pos:  position{line: 496, col: 34, offset: 16997},
 									name: "ElementAttributes",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 496, col: 54, offset: 17018},
+							pos:   position{line: 496, col: 54, offset: 17017},
 							label: "prefix",
 							expr: &ruleRefExpr{
-								pos:  position{line: 496, col: 62, offset: 17026},
+								pos:  position{line: 496, col: 62, offset: 17025},
 								name: "UnorderedListItemPrefix",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 496, col: 87, offset: 17051},
+							pos:   position{line: 496, col: 87, offset: 17050},
 							label: "checkstyle",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 496, col: 98, offset: 17062},
+								pos: position{line: 496, col: 98, offset: 17061},
 								expr: &ruleRefExpr{
-									pos:  position{line: 496, col: 99, offset: 17063},
+									pos:  position{line: 496, col: 99, offset: 17062},
 									name: "UnorderedListItemCheckStyle",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 496, col: 129, offset: 17093},
+							pos:   position{line: 496, col: 129, offset: 17092},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 496, col: 138, offset: 17102},
+								pos:  position{line: 496, col: 138, offset: 17101},
 								name: "UnorderedListItemContent",
 							},
 						},
@@ -3869,42 +3869,42 @@ var g = &grammar{
 		},
 		{
 			name: "UnorderedListItemPrefix",
-			pos:  position{line: 500, col: 1, offset: 17260},
+			pos:  position{line: 500, col: 1, offset: 17259},
 			expr: &actionExpr{
-				pos: position{line: 501, col: 5, offset: 17292},
+				pos: position{line: 501, col: 5, offset: 17291},
 				run: (*parser).callonUnorderedListItemPrefix1,
 				expr: &seqExpr{
-					pos: position{line: 501, col: 5, offset: 17292},
+					pos: position{line: 501, col: 5, offset: 17291},
 					exprs: []interface{}{
 						&zeroOrMoreExpr{
-							pos: position{line: 501, col: 5, offset: 17292},
+							pos: position{line: 501, col: 5, offset: 17291},
 							expr: &ruleRefExpr{
-								pos:  position{line: 501, col: 5, offset: 17292},
+								pos:  position{line: 501, col: 5, offset: 17291},
 								name: "WS",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 501, col: 9, offset: 17296},
+							pos:   position{line: 501, col: 9, offset: 17295},
 							label: "prefix",
 							expr: &choiceExpr{
-								pos: position{line: 501, col: 17, offset: 17304},
+								pos: position{line: 501, col: 17, offset: 17303},
 								alternatives: []interface{}{
 									&actionExpr{
-										pos: position{line: 503, col: 9, offset: 17361},
+										pos: position{line: 503, col: 9, offset: 17360},
 										run: (*parser).callonUnorderedListItemPrefix7,
 										expr: &seqExpr{
-											pos: position{line: 503, col: 9, offset: 17361},
+											pos: position{line: 503, col: 9, offset: 17360},
 											exprs: []interface{}{
 												&labeledExpr{
-													pos:   position{line: 503, col: 9, offset: 17361},
+													pos:   position{line: 503, col: 9, offset: 17360},
 													label: "depth",
 													expr: &actionExpr{
-														pos: position{line: 503, col: 16, offset: 17368},
+														pos: position{line: 503, col: 16, offset: 17367},
 														run: (*parser).callonUnorderedListItemPrefix10,
 														expr: &oneOrMoreExpr{
-															pos: position{line: 503, col: 16, offset: 17368},
+															pos: position{line: 503, col: 16, offset: 17367},
 															expr: &litMatcher{
-																pos:        position{line: 503, col: 17, offset: 17369},
+																pos:        position{line: 503, col: 17, offset: 17368},
 																val:        "*",
 																ignoreCase: false,
 															},
@@ -3912,20 +3912,20 @@ var g = &grammar{
 													},
 												},
 												&andCodeExpr{
-													pos: position{line: 507, col: 9, offset: 17469},
+													pos: position{line: 507, col: 9, offset: 17468},
 													run: (*parser).callonUnorderedListItemPrefix13,
 												},
 											},
 										},
 									},
 									&labeledExpr{
-										pos:   position{line: 524, col: 14, offset: 18176},
+										pos:   position{line: 524, col: 14, offset: 18175},
 										label: "depth",
 										expr: &actionExpr{
-											pos: position{line: 524, col: 21, offset: 18183},
+											pos: position{line: 524, col: 21, offset: 18182},
 											run: (*parser).callonUnorderedListItemPrefix15,
 											expr: &litMatcher{
-												pos:        position{line: 524, col: 22, offset: 18184},
+												pos:        position{line: 524, col: 22, offset: 18183},
 												val:        "-",
 												ignoreCase: false,
 											},
@@ -3935,9 +3935,9 @@ var g = &grammar{
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 526, col: 13, offset: 18270},
+							pos: position{line: 526, col: 13, offset: 18269},
 							expr: &ruleRefExpr{
-								pos:  position{line: 526, col: 13, offset: 18270},
+								pos:  position{line: 526, col: 13, offset: 18269},
 								name: "WS",
 							},
 						},
@@ -3947,50 +3947,50 @@ var g = &grammar{
 		},
 		{
 			name: "UnorderedListItemCheckStyle",
-			pos:  position{line: 530, col: 1, offset: 18303},
+			pos:  position{line: 530, col: 1, offset: 18302},
 			expr: &actionExpr{
-				pos: position{line: 530, col: 32, offset: 18334},
+				pos: position{line: 530, col: 32, offset: 18333},
 				run: (*parser).callonUnorderedListItemCheckStyle1,
 				expr: &seqExpr{
-					pos: position{line: 530, col: 32, offset: 18334},
+					pos: position{line: 530, col: 32, offset: 18333},
 					exprs: []interface{}{
 						&andExpr{
-							pos: position{line: 530, col: 32, offset: 18334},
+							pos: position{line: 530, col: 32, offset: 18333},
 							expr: &litMatcher{
-								pos:        position{line: 530, col: 33, offset: 18335},
+								pos:        position{line: 530, col: 33, offset: 18334},
 								val:        "[",
 								ignoreCase: false,
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 530, col: 37, offset: 18339},
+							pos:   position{line: 530, col: 37, offset: 18338},
 							label: "style",
 							expr: &choiceExpr{
-								pos: position{line: 531, col: 7, offset: 18353},
+								pos: position{line: 531, col: 7, offset: 18352},
 								alternatives: []interface{}{
 									&actionExpr{
-										pos: position{line: 531, col: 7, offset: 18353},
+										pos: position{line: 531, col: 7, offset: 18352},
 										run: (*parser).callonUnorderedListItemCheckStyle7,
 										expr: &litMatcher{
-											pos:        position{line: 531, col: 7, offset: 18353},
+											pos:        position{line: 531, col: 7, offset: 18352},
 											val:        "[ ]",
 											ignoreCase: false,
 										},
 									},
 									&actionExpr{
-										pos: position{line: 532, col: 7, offset: 18398},
+										pos: position{line: 532, col: 7, offset: 18397},
 										run: (*parser).callonUnorderedListItemCheckStyle9,
 										expr: &litMatcher{
-											pos:        position{line: 532, col: 7, offset: 18398},
+											pos:        position{line: 532, col: 7, offset: 18397},
 											val:        "[*]",
 											ignoreCase: false,
 										},
 									},
 									&actionExpr{
-										pos: position{line: 533, col: 7, offset: 18441},
+										pos: position{line: 533, col: 7, offset: 18440},
 										run: (*parser).callonUnorderedListItemCheckStyle11,
 										expr: &litMatcher{
-											pos:        position{line: 533, col: 7, offset: 18441},
+											pos:        position{line: 533, col: 7, offset: 18440},
 											val:        "[x]",
 											ignoreCase: false,
 										},
@@ -3999,9 +3999,9 @@ var g = &grammar{
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 534, col: 7, offset: 18483},
+							pos: position{line: 534, col: 7, offset: 18482},
 							expr: &ruleRefExpr{
-								pos:  position{line: 534, col: 7, offset: 18483},
+								pos:  position{line: 534, col: 7, offset: 18482},
 								name: "WS",
 							},
 						},
@@ -4011,17 +4011,17 @@ var g = &grammar{
 		},
 		{
 			name: "UnorderedListItemContent",
-			pos:  position{line: 538, col: 1, offset: 18522},
+			pos:  position{line: 538, col: 1, offset: 18521},
 			expr: &actionExpr{
-				pos: position{line: 538, col: 29, offset: 18550},
+				pos: position{line: 538, col: 29, offset: 18549},
 				run: (*parser).callonUnorderedListItemContent1,
 				expr: &labeledExpr{
-					pos:   position{line: 538, col: 29, offset: 18550},
+					pos:   position{line: 538, col: 29, offset: 18549},
 					label: "elements",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 538, col: 39, offset: 18560},
+						pos: position{line: 538, col: 39, offset: 18559},
 						expr: &ruleRefExpr{
-							pos:  position{line: 538, col: 39, offset: 18560},
+							pos:  position{line: 538, col: 39, offset: 18559},
 							name: "ListParagraph",
 						},
 					},
@@ -4030,47 +4030,47 @@ var g = &grammar{
 		},
 		{
 			name: "LabeledListItem",
-			pos:  position{line: 545, col: 1, offset: 18876},
+			pos:  position{line: 545, col: 1, offset: 18875},
 			expr: &actionExpr{
-				pos: position{line: 545, col: 20, offset: 18895},
+				pos: position{line: 545, col: 20, offset: 18894},
 				run: (*parser).callonLabeledListItem1,
 				expr: &seqExpr{
-					pos: position{line: 545, col: 20, offset: 18895},
+					pos: position{line: 545, col: 20, offset: 18894},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 545, col: 20, offset: 18895},
+							pos:   position{line: 545, col: 20, offset: 18894},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 545, col: 31, offset: 18906},
+								pos: position{line: 545, col: 31, offset: 18905},
 								expr: &ruleRefExpr{
-									pos:  position{line: 545, col: 32, offset: 18907},
+									pos:  position{line: 545, col: 32, offset: 18906},
 									name: "ElementAttributes",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 545, col: 52, offset: 18927},
+							pos:   position{line: 545, col: 52, offset: 18926},
 							label: "term",
 							expr: &ruleRefExpr{
-								pos:  position{line: 545, col: 58, offset: 18933},
+								pos:  position{line: 545, col: 58, offset: 18932},
 								name: "LabeledListItemTerm",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 545, col: 79, offset: 18954},
+							pos:   position{line: 545, col: 79, offset: 18953},
 							label: "separator",
 							expr: &ruleRefExpr{
-								pos:  position{line: 545, col: 90, offset: 18965},
+								pos:  position{line: 545, col: 90, offset: 18964},
 								name: "LabeledListItemSeparator",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 545, col: 116, offset: 18991},
+							pos:   position{line: 545, col: 116, offset: 18990},
 							label: "description",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 545, col: 128, offset: 19003},
+								pos: position{line: 545, col: 128, offset: 19002},
 								expr: &ruleRefExpr{
-									pos:  position{line: 545, col: 129, offset: 19004},
+									pos:  position{line: 545, col: 129, offset: 19003},
 									name: "LabeledListItemDescription",
 								},
 							},
@@ -4081,43 +4081,43 @@ var g = &grammar{
 		},
 		{
 			name: "LabeledListItemTerm",
-			pos:  position{line: 549, col: 1, offset: 19143},
+			pos:  position{line: 549, col: 1, offset: 19142},
 			expr: &actionExpr{
-				pos: position{line: 549, col: 24, offset: 19166},
+				pos: position{line: 549, col: 24, offset: 19165},
 				run: (*parser).callonLabeledListItemTerm1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 549, col: 24, offset: 19166},
+					pos: position{line: 549, col: 24, offset: 19165},
 					expr: &choiceExpr{
-						pos: position{line: 549, col: 25, offset: 19167},
+						pos: position{line: 549, col: 25, offset: 19166},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 549, col: 25, offset: 19167},
+								pos:  position{line: 549, col: 25, offset: 19166},
 								name: "Alphanums",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 549, col: 37, offset: 19179},
+								pos:  position{line: 549, col: 37, offset: 19178},
 								name: "Spaces",
 							},
 							&seqExpr{
-								pos: position{line: 549, col: 47, offset: 19189},
+								pos: position{line: 549, col: 47, offset: 19188},
 								exprs: []interface{}{
 									&notExpr{
-										pos: position{line: 549, col: 47, offset: 19189},
+										pos: position{line: 549, col: 47, offset: 19188},
 										expr: &ruleRefExpr{
-											pos:  position{line: 549, col: 48, offset: 19190},
+											pos:  position{line: 549, col: 48, offset: 19189},
 											name: "NEWLINE",
 										},
 									},
 									&notExpr{
-										pos: position{line: 549, col: 56, offset: 19198},
+										pos: position{line: 549, col: 56, offset: 19197},
 										expr: &litMatcher{
-											pos:        position{line: 549, col: 57, offset: 19199},
+											pos:        position{line: 549, col: 57, offset: 19198},
 											val:        "::",
 											ignoreCase: false,
 										},
 									},
 									&anyMatcher{
-										line: 549, col: 62, offset: 19204,
+										line: 549, col: 62, offset: 19203,
 									},
 								},
 							},
@@ -4128,23 +4128,23 @@ var g = &grammar{
 		},
 		{
 			name: "LabeledListItemSeparator",
-			pos:  position{line: 553, col: 1, offset: 19246},
+			pos:  position{line: 553, col: 1, offset: 19245},
 			expr: &actionExpr{
-				pos: position{line: 554, col: 5, offset: 19279},
+				pos: position{line: 554, col: 5, offset: 19278},
 				run: (*parser).callonLabeledListItemSeparator1,
 				expr: &seqExpr{
-					pos: position{line: 554, col: 5, offset: 19279},
+					pos: position{line: 554, col: 5, offset: 19278},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 554, col: 5, offset: 19279},
+							pos:   position{line: 554, col: 5, offset: 19278},
 							label: "separator",
 							expr: &actionExpr{
-								pos: position{line: 554, col: 16, offset: 19290},
+								pos: position{line: 554, col: 16, offset: 19289},
 								run: (*parser).callonLabeledListItemSeparator4,
 								expr: &oneOrMoreExpr{
-									pos: position{line: 554, col: 16, offset: 19290},
+									pos: position{line: 554, col: 16, offset: 19289},
 									expr: &litMatcher{
-										pos:        position{line: 554, col: 17, offset: 19291},
+										pos:        position{line: 554, col: 17, offset: 19290},
 										val:        ":",
 										ignoreCase: false,
 									},
@@ -4152,30 +4152,30 @@ var g = &grammar{
 							},
 						},
 						&andCodeExpr{
-							pos: position{line: 557, col: 5, offset: 19349},
+							pos: position{line: 557, col: 5, offset: 19348},
 							run: (*parser).callonLabeledListItemSeparator7,
 						},
 						&choiceExpr{
-							pos: position{line: 561, col: 6, offset: 19525},
+							pos: position{line: 561, col: 6, offset: 19524},
 							alternatives: []interface{}{
 								&oneOrMoreExpr{
-									pos: position{line: 561, col: 6, offset: 19525},
+									pos: position{line: 561, col: 6, offset: 19524},
 									expr: &choiceExpr{
-										pos: position{line: 561, col: 7, offset: 19526},
+										pos: position{line: 561, col: 7, offset: 19525},
 										alternatives: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 561, col: 7, offset: 19526},
+												pos:  position{line: 561, col: 7, offset: 19525},
 												name: "WS",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 561, col: 12, offset: 19531},
+												pos:  position{line: 561, col: 12, offset: 19530},
 												name: "NEWLINE",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 561, col: 24, offset: 19543},
+									pos:  position{line: 561, col: 24, offset: 19542},
 									name: "EOL",
 								},
 							},
@@ -4186,17 +4186,17 @@ var g = &grammar{
 		},
 		{
 			name: "LabeledListItemDescription",
-			pos:  position{line: 565, col: 1, offset: 19583},
+			pos:  position{line: 565, col: 1, offset: 19582},
 			expr: &actionExpr{
-				pos: position{line: 565, col: 31, offset: 19613},
+				pos: position{line: 565, col: 31, offset: 19612},
 				run: (*parser).callonLabeledListItemDescription1,
 				expr: &labeledExpr{
-					pos:   position{line: 565, col: 31, offset: 19613},
+					pos:   position{line: 565, col: 31, offset: 19612},
 					label: "elements",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 565, col: 40, offset: 19622},
+						pos: position{line: 565, col: 40, offset: 19621},
 						expr: &ruleRefExpr{
-							pos:  position{line: 565, col: 41, offset: 19623},
+							pos:  position{line: 565, col: 41, offset: 19622},
 							name: "ListParagraph",
 						},
 					},
@@ -4205,51 +4205,51 @@ var g = &grammar{
 		},
 		{
 			name: "AdmonitionKind",
-			pos:  position{line: 572, col: 1, offset: 19814},
+			pos:  position{line: 572, col: 1, offset: 19813},
 			expr: &choiceExpr{
-				pos: position{line: 572, col: 19, offset: 19832},
+				pos: position{line: 572, col: 19, offset: 19831},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 572, col: 19, offset: 19832},
+						pos: position{line: 572, col: 19, offset: 19831},
 						run: (*parser).callonAdmonitionKind2,
 						expr: &litMatcher{
-							pos:        position{line: 572, col: 19, offset: 19832},
+							pos:        position{line: 572, col: 19, offset: 19831},
 							val:        "TIP",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 574, col: 9, offset: 19878},
+						pos: position{line: 574, col: 9, offset: 19877},
 						run: (*parser).callonAdmonitionKind4,
 						expr: &litMatcher{
-							pos:        position{line: 574, col: 9, offset: 19878},
+							pos:        position{line: 574, col: 9, offset: 19877},
 							val:        "NOTE",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 576, col: 9, offset: 19926},
+						pos: position{line: 576, col: 9, offset: 19925},
 						run: (*parser).callonAdmonitionKind6,
 						expr: &litMatcher{
-							pos:        position{line: 576, col: 9, offset: 19926},
+							pos:        position{line: 576, col: 9, offset: 19925},
 							val:        "IMPORTANT",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 578, col: 9, offset: 19984},
+						pos: position{line: 578, col: 9, offset: 19983},
 						run: (*parser).callonAdmonitionKind8,
 						expr: &litMatcher{
-							pos:        position{line: 578, col: 9, offset: 19984},
+							pos:        position{line: 578, col: 9, offset: 19983},
 							val:        "WARNING",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 580, col: 9, offset: 20038},
+						pos: position{line: 580, col: 9, offset: 20037},
 						run: (*parser).callonAdmonitionKind10,
 						expr: &litMatcher{
-							pos:        position{line: 580, col: 9, offset: 20038},
+							pos:        position{line: 580, col: 9, offset: 20037},
 							val:        "CAUTION",
 							ignoreCase: false,
 						},
@@ -4259,47 +4259,47 @@ var g = &grammar{
 		},
 		{
 			name: "Paragraph",
-			pos:  position{line: 589, col: 1, offset: 20345},
+			pos:  position{line: 589, col: 1, offset: 20344},
 			expr: &choiceExpr{
-				pos: position{line: 591, col: 5, offset: 20392},
+				pos: position{line: 591, col: 5, offset: 20391},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 591, col: 5, offset: 20392},
+						pos: position{line: 591, col: 5, offset: 20391},
 						run: (*parser).callonParagraph2,
 						expr: &seqExpr{
-							pos: position{line: 591, col: 5, offset: 20392},
+							pos: position{line: 591, col: 5, offset: 20391},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 591, col: 5, offset: 20392},
+									pos:   position{line: 591, col: 5, offset: 20391},
 									label: "attributes",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 591, col: 16, offset: 20403},
+										pos: position{line: 591, col: 16, offset: 20402},
 										expr: &ruleRefExpr{
-											pos:  position{line: 591, col: 17, offset: 20404},
+											pos:  position{line: 591, col: 17, offset: 20403},
 											name: "ElementAttributes",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 591, col: 37, offset: 20424},
+									pos:   position{line: 591, col: 37, offset: 20423},
 									label: "t",
 									expr: &ruleRefExpr{
-										pos:  position{line: 591, col: 40, offset: 20427},
+										pos:  position{line: 591, col: 40, offset: 20426},
 										name: "AdmonitionKind",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 591, col: 56, offset: 20443},
+									pos:        position{line: 591, col: 56, offset: 20442},
 									val:        ": ",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 591, col: 61, offset: 20448},
+									pos:   position{line: 591, col: 61, offset: 20447},
 									label: "lines",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 591, col: 67, offset: 20454},
+										pos: position{line: 591, col: 67, offset: 20453},
 										expr: &ruleRefExpr{
-											pos:  position{line: 591, col: 68, offset: 20455},
+											pos:  position{line: 591, col: 68, offset: 20454},
 											name: "InlineElements",
 										},
 									},
@@ -4308,29 +4308,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 595, col: 5, offset: 20647},
+						pos: position{line: 595, col: 5, offset: 20646},
 						run: (*parser).callonParagraph13,
 						expr: &seqExpr{
-							pos: position{line: 595, col: 5, offset: 20647},
+							pos: position{line: 595, col: 5, offset: 20646},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 595, col: 5, offset: 20647},
+									pos:   position{line: 595, col: 5, offset: 20646},
 									label: "attributes",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 595, col: 16, offset: 20658},
+										pos: position{line: 595, col: 16, offset: 20657},
 										expr: &ruleRefExpr{
-											pos:  position{line: 595, col: 17, offset: 20659},
+											pos:  position{line: 595, col: 17, offset: 20658},
 											name: "ElementAttributes",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 595, col: 37, offset: 20679},
+									pos:   position{line: 595, col: 37, offset: 20678},
 									label: "lines",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 595, col: 43, offset: 20685},
+										pos: position{line: 595, col: 43, offset: 20684},
 										expr: &ruleRefExpr{
-											pos:  position{line: 595, col: 44, offset: 20686},
+											pos:  position{line: 595, col: 44, offset: 20685},
 											name: "InlineElements",
 										},
 									},
@@ -4343,43 +4343,43 @@ var g = &grammar{
 		},
 		{
 			name: "SimpleParagraph",
-			pos:  position{line: 600, col: 1, offset: 20851},
+			pos:  position{line: 600, col: 1, offset: 20850},
 			expr: &actionExpr{
-				pos: position{line: 600, col: 20, offset: 20870},
+				pos: position{line: 600, col: 20, offset: 20869},
 				run: (*parser).callonSimpleParagraph1,
 				expr: &seqExpr{
-					pos: position{line: 600, col: 20, offset: 20870},
+					pos: position{line: 600, col: 20, offset: 20869},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 600, col: 20, offset: 20870},
+							pos:   position{line: 600, col: 20, offset: 20869},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 600, col: 31, offset: 20881},
+								pos: position{line: 600, col: 31, offset: 20880},
 								expr: &ruleRefExpr{
-									pos:  position{line: 600, col: 32, offset: 20882},
+									pos:  position{line: 600, col: 32, offset: 20881},
 									name: "ElementAttributes",
 								},
 							},
 						},
 						&andCodeExpr{
-							pos: position{line: 601, col: 5, offset: 20907},
+							pos: position{line: 601, col: 5, offset: 20906},
 							run: (*parser).callonSimpleParagraph6,
 						},
 						&labeledExpr{
-							pos:   position{line: 609, col: 5, offset: 21198},
+							pos:   position{line: 609, col: 5, offset: 21197},
 							label: "firstLine",
 							expr: &ruleRefExpr{
-								pos:  position{line: 609, col: 16, offset: 21209},
+								pos:  position{line: 609, col: 16, offset: 21208},
 								name: "FirstParagraphLine",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 610, col: 5, offset: 21232},
+							pos:   position{line: 610, col: 5, offset: 21231},
 							label: "otherLines",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 610, col: 16, offset: 21243},
+								pos: position{line: 610, col: 16, offset: 21242},
 								expr: &ruleRefExpr{
-									pos:  position{line: 610, col: 17, offset: 21244},
+									pos:  position{line: 610, col: 17, offset: 21243},
 									name: "OtherParagraphLine",
 								},
 							},
@@ -4390,28 +4390,28 @@ var g = &grammar{
 		},
 		{
 			name: "ParagraphLines",
-			pos:  position{line: 614, col: 1, offset: 21378},
+			pos:  position{line: 614, col: 1, offset: 21377},
 			expr: &actionExpr{
-				pos: position{line: 614, col: 19, offset: 21396},
+				pos: position{line: 614, col: 19, offset: 21395},
 				run: (*parser).callonParagraphLines1,
 				expr: &seqExpr{
-					pos: position{line: 614, col: 19, offset: 21396},
+					pos: position{line: 614, col: 19, offset: 21395},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 614, col: 19, offset: 21396},
+							pos:   position{line: 614, col: 19, offset: 21395},
 							label: "firstLine",
 							expr: &ruleRefExpr{
-								pos:  position{line: 614, col: 30, offset: 21407},
+								pos:  position{line: 614, col: 30, offset: 21406},
 								name: "FirstParagraphLine",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 614, col: 50, offset: 21427},
+							pos:   position{line: 614, col: 50, offset: 21426},
 							label: "otherLines",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 614, col: 61, offset: 21438},
+								pos: position{line: 614, col: 61, offset: 21437},
 								expr: &ruleRefExpr{
-									pos:  position{line: 614, col: 62, offset: 21439},
+									pos:  position{line: 614, col: 62, offset: 21438},
 									name: "OtherParagraphLine",
 								},
 							},
@@ -4422,43 +4422,43 @@ var g = &grammar{
 		},
 		{
 			name: "FirstParagraphLine",
-			pos:  position{line: 618, col: 1, offset: 21545},
+			pos:  position{line: 618, col: 1, offset: 21544},
 			expr: &actionExpr{
-				pos: position{line: 618, col: 23, offset: 21567},
+				pos: position{line: 618, col: 23, offset: 21566},
 				run: (*parser).callonFirstParagraphLine1,
 				expr: &seqExpr{
-					pos: position{line: 618, col: 23, offset: 21567},
+					pos: position{line: 618, col: 23, offset: 21566},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 618, col: 23, offset: 21567},
+							pos: position{line: 618, col: 23, offset: 21566},
 							expr: &seqExpr{
-								pos: position{line: 618, col: 25, offset: 21569},
+								pos: position{line: 618, col: 25, offset: 21568},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 618, col: 25, offset: 21569},
+										pos:  position{line: 618, col: 25, offset: 21568},
 										name: "LabeledListItemTerm",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 618, col: 45, offset: 21589},
+										pos:  position{line: 618, col: 45, offset: 21588},
 										name: "LabeledListItemSeparator",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 619, col: 5, offset: 21619},
+							pos:   position{line: 619, col: 5, offset: 21618},
 							label: "elements",
 							expr: &seqExpr{
-								pos: position{line: 619, col: 15, offset: 21629},
+								pos: position{line: 619, col: 15, offset: 21628},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 619, col: 15, offset: 21629},
+										pos:  position{line: 619, col: 15, offset: 21628},
 										name: "SimpleWord",
 									},
 									&zeroOrMoreExpr{
-										pos: position{line: 619, col: 26, offset: 21640},
+										pos: position{line: 619, col: 26, offset: 21639},
 										expr: &ruleRefExpr{
-											pos:  position{line: 619, col: 26, offset: 21640},
+											pos:  position{line: 619, col: 26, offset: 21639},
 											name: "InlineElement",
 										},
 									},
@@ -4466,18 +4466,18 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 619, col: 42, offset: 21656},
+							pos:   position{line: 619, col: 42, offset: 21655},
 							label: "linebreak",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 619, col: 52, offset: 21666},
+								pos: position{line: 619, col: 52, offset: 21665},
 								expr: &ruleRefExpr{
-									pos:  position{line: 619, col: 53, offset: 21667},
+									pos:  position{line: 619, col: 53, offset: 21666},
 									name: "LineBreak",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 619, col: 65, offset: 21679},
+							pos:  position{line: 619, col: 65, offset: 21678},
 							name: "EOL",
 						},
 					},
@@ -4486,15 +4486,15 @@ var g = &grammar{
 		},
 		{
 			name: "OtherParagraphLine",
-			pos:  position{line: 623, col: 1, offset: 21769},
+			pos:  position{line: 623, col: 1, offset: 21768},
 			expr: &actionExpr{
-				pos: position{line: 623, col: 23, offset: 21791},
+				pos: position{line: 623, col: 23, offset: 21790},
 				run: (*parser).callonOtherParagraphLine1,
 				expr: &labeledExpr{
-					pos:   position{line: 623, col: 23, offset: 21791},
+					pos:   position{line: 623, col: 23, offset: 21790},
 					label: "elements",
 					expr: &ruleRefExpr{
-						pos:  position{line: 623, col: 33, offset: 21801},
+						pos:  position{line: 623, col: 33, offset: 21800},
 						name: "InlineElements",
 					},
 				},
@@ -4502,51 +4502,51 @@ var g = &grammar{
 		},
 		{
 			name: "VerseParagraph",
-			pos:  position{line: 627, col: 1, offset: 21847},
+			pos:  position{line: 627, col: 1, offset: 21846},
 			expr: &choiceExpr{
-				pos: position{line: 629, col: 5, offset: 21899},
+				pos: position{line: 629, col: 5, offset: 21898},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 629, col: 5, offset: 21899},
+						pos: position{line: 629, col: 5, offset: 21898},
 						run: (*parser).callonVerseParagraph2,
 						expr: &seqExpr{
-							pos: position{line: 629, col: 5, offset: 21899},
+							pos: position{line: 629, col: 5, offset: 21898},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 629, col: 5, offset: 21899},
+									pos:   position{line: 629, col: 5, offset: 21898},
 									label: "attributes",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 629, col: 16, offset: 21910},
+										pos: position{line: 629, col: 16, offset: 21909},
 										expr: &ruleRefExpr{
-											pos:  position{line: 629, col: 17, offset: 21911},
+											pos:  position{line: 629, col: 17, offset: 21910},
 											name: "ElementAttributes",
 										},
 									},
 								},
 								&andCodeExpr{
-									pos: position{line: 630, col: 5, offset: 21935},
+									pos: position{line: 630, col: 5, offset: 21934},
 									run: (*parser).callonVerseParagraph7,
 								},
 								&labeledExpr{
-									pos:   position{line: 637, col: 5, offset: 22147},
+									pos:   position{line: 637, col: 5, offset: 22146},
 									label: "t",
 									expr: &ruleRefExpr{
-										pos:  position{line: 637, col: 8, offset: 22150},
+										pos:  position{line: 637, col: 8, offset: 22149},
 										name: "AdmonitionKind",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 637, col: 24, offset: 22166},
+									pos:        position{line: 637, col: 24, offset: 22165},
 									val:        ": ",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 637, col: 29, offset: 22171},
+									pos:   position{line: 637, col: 29, offset: 22170},
 									label: "lines",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 637, col: 35, offset: 22177},
+										pos: position{line: 637, col: 35, offset: 22176},
 										expr: &ruleRefExpr{
-											pos:  position{line: 637, col: 36, offset: 22178},
+											pos:  position{line: 637, col: 36, offset: 22177},
 											name: "InlineElements",
 										},
 									},
@@ -4555,33 +4555,33 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 641, col: 5, offset: 22370},
+						pos: position{line: 641, col: 5, offset: 22369},
 						run: (*parser).callonVerseParagraph14,
 						expr: &seqExpr{
-							pos: position{line: 641, col: 5, offset: 22370},
+							pos: position{line: 641, col: 5, offset: 22369},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 641, col: 5, offset: 22370},
+									pos:   position{line: 641, col: 5, offset: 22369},
 									label: "attributes",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 641, col: 16, offset: 22381},
+										pos: position{line: 641, col: 16, offset: 22380},
 										expr: &ruleRefExpr{
-											pos:  position{line: 641, col: 17, offset: 22382},
+											pos:  position{line: 641, col: 17, offset: 22381},
 											name: "ElementAttributes",
 										},
 									},
 								},
 								&andCodeExpr{
-									pos: position{line: 642, col: 5, offset: 22406},
+									pos: position{line: 642, col: 5, offset: 22405},
 									run: (*parser).callonVerseParagraph19,
 								},
 								&labeledExpr{
-									pos:   position{line: 649, col: 5, offset: 22618},
+									pos:   position{line: 649, col: 5, offset: 22617},
 									label: "lines",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 649, col: 11, offset: 22624},
+										pos: position{line: 649, col: 11, offset: 22623},
 										expr: &ruleRefExpr{
-											pos:  position{line: 649, col: 12, offset: 22625},
+											pos:  position{line: 649, col: 12, offset: 22624},
 											name: "InlineElements",
 										},
 									},
@@ -4594,82 +4594,82 @@ var g = &grammar{
 		},
 		{
 			name: "InlineElements",
-			pos:  position{line: 653, col: 1, offset: 22726},
+			pos:  position{line: 653, col: 1, offset: 22725},
 			expr: &actionExpr{
-				pos: position{line: 653, col: 19, offset: 22744},
+				pos: position{line: 653, col: 19, offset: 22743},
 				run: (*parser).callonInlineElements1,
 				expr: &seqExpr{
-					pos: position{line: 653, col: 19, offset: 22744},
+					pos: position{line: 653, col: 19, offset: 22743},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 653, col: 19, offset: 22744},
+							pos: position{line: 653, col: 19, offset: 22743},
 							expr: &ruleRefExpr{
-								pos:  position{line: 653, col: 20, offset: 22745},
+								pos:  position{line: 653, col: 20, offset: 22744},
 								name: "EOF",
 							},
 						},
 						&notExpr{
-							pos: position{line: 653, col: 24, offset: 22749},
+							pos: position{line: 653, col: 24, offset: 22748},
 							expr: &ruleRefExpr{
-								pos:  position{line: 653, col: 25, offset: 22750},
+								pos:  position{line: 653, col: 25, offset: 22749},
 								name: "BlankLine",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 654, col: 5, offset: 22764},
+							pos:   position{line: 654, col: 5, offset: 22763},
 							label: "elements",
 							expr: &choiceExpr{
-								pos: position{line: 654, col: 15, offset: 22774},
+								pos: position{line: 654, col: 15, offset: 22773},
 								alternatives: []interface{}{
 									&actionExpr{
-										pos: position{line: 654, col: 15, offset: 22774},
+										pos: position{line: 654, col: 15, offset: 22773},
 										run: (*parser).callonInlineElements9,
 										expr: &labeledExpr{
-											pos:   position{line: 654, col: 15, offset: 22774},
+											pos:   position{line: 654, col: 15, offset: 22773},
 											label: "comment",
 											expr: &ruleRefExpr{
-												pos:  position{line: 654, col: 24, offset: 22783},
+												pos:  position{line: 654, col: 24, offset: 22782},
 												name: "SingleLineComment",
 											},
 										},
 									},
 									&actionExpr{
-										pos: position{line: 656, col: 9, offset: 22875},
+										pos: position{line: 656, col: 9, offset: 22874},
 										run: (*parser).callonInlineElements12,
 										expr: &seqExpr{
-											pos: position{line: 656, col: 9, offset: 22875},
+											pos: position{line: 656, col: 9, offset: 22874},
 											exprs: []interface{}{
 												&notExpr{
-													pos: position{line: 656, col: 9, offset: 22875},
+													pos: position{line: 656, col: 9, offset: 22874},
 													expr: &ruleRefExpr{
-														pos:  position{line: 656, col: 10, offset: 22876},
+														pos:  position{line: 656, col: 10, offset: 22875},
 														name: "BlockDelimiter",
 													},
 												},
 												&labeledExpr{
-													pos:   position{line: 656, col: 25, offset: 22891},
+													pos:   position{line: 656, col: 25, offset: 22890},
 													label: "elements",
 													expr: &oneOrMoreExpr{
-														pos: position{line: 656, col: 34, offset: 22900},
+														pos: position{line: 656, col: 34, offset: 22899},
 														expr: &ruleRefExpr{
-															pos:  position{line: 656, col: 35, offset: 22901},
+															pos:  position{line: 656, col: 35, offset: 22900},
 															name: "InlineElement",
 														},
 													},
 												},
 												&labeledExpr{
-													pos:   position{line: 656, col: 51, offset: 22917},
+													pos:   position{line: 656, col: 51, offset: 22916},
 													label: "linebreak",
 													expr: &zeroOrOneExpr{
-														pos: position{line: 656, col: 61, offset: 22927},
+														pos: position{line: 656, col: 61, offset: 22926},
 														expr: &ruleRefExpr{
-															pos:  position{line: 656, col: 62, offset: 22928},
+															pos:  position{line: 656, col: 62, offset: 22927},
 															name: "LineBreak",
 														},
 													},
 												},
 												&ruleRefExpr{
-													pos:  position{line: 656, col: 74, offset: 22940},
+													pos:  position{line: 656, col: 74, offset: 22939},
 													name: "EOL",
 												},
 											},
@@ -4684,79 +4684,79 @@ var g = &grammar{
 		},
 		{
 			name: "InlineElement",
-			pos:  position{line: 662, col: 1, offset: 23076},
+			pos:  position{line: 662, col: 1, offset: 23075},
 			expr: &actionExpr{
-				pos: position{line: 662, col: 18, offset: 23093},
+				pos: position{line: 662, col: 18, offset: 23092},
 				run: (*parser).callonInlineElement1,
 				expr: &seqExpr{
-					pos: position{line: 662, col: 18, offset: 23093},
+					pos: position{line: 662, col: 18, offset: 23092},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 662, col: 18, offset: 23093},
+							pos: position{line: 662, col: 18, offset: 23092},
 							expr: &ruleRefExpr{
-								pos:  position{line: 662, col: 19, offset: 23094},
+								pos:  position{line: 662, col: 19, offset: 23093},
 								name: "EOL",
 							},
 						},
 						&notExpr{
-							pos: position{line: 662, col: 23, offset: 23098},
+							pos: position{line: 662, col: 23, offset: 23097},
 							expr: &ruleRefExpr{
-								pos:  position{line: 662, col: 24, offset: 23099},
+								pos:  position{line: 662, col: 24, offset: 23098},
 								name: "LineBreak",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 663, col: 5, offset: 23114},
+							pos:   position{line: 663, col: 5, offset: 23113},
 							label: "element",
 							expr: &choiceExpr{
-								pos: position{line: 663, col: 14, offset: 23123},
+								pos: position{line: 663, col: 14, offset: 23122},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 663, col: 14, offset: 23123},
+										pos:  position{line: 663, col: 14, offset: 23122},
 										name: "SimpleWord",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 664, col: 11, offset: 23144},
+										pos:  position{line: 664, col: 11, offset: 23143},
 										name: "Spaces",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 665, col: 11, offset: 23162},
+										pos:  position{line: 665, col: 11, offset: 23161},
 										name: "InlineImage",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 666, col: 11, offset: 23185},
+										pos:  position{line: 666, col: 11, offset: 23184},
 										name: "Link",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 667, col: 11, offset: 23201},
+										pos:  position{line: 667, col: 11, offset: 23200},
 										name: "Passthrough",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 668, col: 11, offset: 23224},
+										pos:  position{line: 668, col: 11, offset: 23223},
 										name: "InlineFootnote",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 669, col: 11, offset: 23250},
+										pos:  position{line: 669, col: 11, offset: 23249},
 										name: "InlineUserMacro",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 670, col: 11, offset: 23277},
+										pos:  position{line: 670, col: 11, offset: 23276},
 										name: "QuotedText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 671, col: 11, offset: 23299},
+										pos:  position{line: 671, col: 11, offset: 23298},
 										name: "CrossReference",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 672, col: 11, offset: 23325},
+										pos:  position{line: 672, col: 11, offset: 23324},
 										name: "DocumentAttributeSubstitution",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 673, col: 11, offset: 23366},
+										pos:  position{line: 673, col: 11, offset: 23365},
 										name: "InlineElementID",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 674, col: 11, offset: 23393},
+										pos:  position{line: 674, col: 11, offset: 23392},
 										name: "OtherWord",
 									},
 								},
@@ -4768,51 +4768,51 @@ var g = &grammar{
 		},
 		{
 			name: "InlineElementsWithoutSubtitution",
-			pos:  position{line: 681, col: 1, offset: 23653},
+			pos:  position{line: 681, col: 1, offset: 23652},
 			expr: &actionExpr{
-				pos: position{line: 681, col: 37, offset: 23689},
+				pos: position{line: 681, col: 37, offset: 23688},
 				run: (*parser).callonInlineElementsWithoutSubtitution1,
 				expr: &seqExpr{
-					pos: position{line: 681, col: 37, offset: 23689},
+					pos: position{line: 681, col: 37, offset: 23688},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 681, col: 37, offset: 23689},
+							pos: position{line: 681, col: 37, offset: 23688},
 							expr: &ruleRefExpr{
-								pos:  position{line: 681, col: 38, offset: 23690},
+								pos:  position{line: 681, col: 38, offset: 23689},
 								name: "BlankLine",
 							},
 						},
 						&notExpr{
-							pos: position{line: 681, col: 48, offset: 23700},
+							pos: position{line: 681, col: 48, offset: 23699},
 							expr: &ruleRefExpr{
-								pos:  position{line: 681, col: 49, offset: 23701},
+								pos:  position{line: 681, col: 49, offset: 23700},
 								name: "BlockDelimiter",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 681, col: 64, offset: 23716},
+							pos:   position{line: 681, col: 64, offset: 23715},
 							label: "elements",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 681, col: 73, offset: 23725},
+								pos: position{line: 681, col: 73, offset: 23724},
 								expr: &ruleRefExpr{
-									pos:  position{line: 681, col: 74, offset: 23726},
+									pos:  position{line: 681, col: 74, offset: 23725},
 									name: "InlineElementWithoutSubtitution",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 681, col: 108, offset: 23760},
+							pos:   position{line: 681, col: 108, offset: 23759},
 							label: "linebreak",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 681, col: 118, offset: 23770},
+								pos: position{line: 681, col: 118, offset: 23769},
 								expr: &ruleRefExpr{
-									pos:  position{line: 681, col: 119, offset: 23771},
+									pos:  position{line: 681, col: 119, offset: 23770},
 									name: "LineBreak",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 681, col: 131, offset: 23783},
+							pos:  position{line: 681, col: 131, offset: 23782},
 							name: "EOL",
 						},
 					},
@@ -4821,67 +4821,67 @@ var g = &grammar{
 		},
 		{
 			name: "InlineElementWithoutSubtitution",
-			pos:  position{line: 685, col: 1, offset: 23874},
+			pos:  position{line: 685, col: 1, offset: 23873},
 			expr: &actionExpr{
-				pos: position{line: 685, col: 36, offset: 23909},
+				pos: position{line: 685, col: 36, offset: 23908},
 				run: (*parser).callonInlineElementWithoutSubtitution1,
 				expr: &seqExpr{
-					pos: position{line: 685, col: 36, offset: 23909},
+					pos: position{line: 685, col: 36, offset: 23908},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 685, col: 36, offset: 23909},
+							pos: position{line: 685, col: 36, offset: 23908},
 							expr: &ruleRefExpr{
-								pos:  position{line: 685, col: 37, offset: 23910},
+								pos:  position{line: 685, col: 37, offset: 23909},
 								name: "EOL",
 							},
 						},
 						&notExpr{
-							pos: position{line: 685, col: 41, offset: 23914},
+							pos: position{line: 685, col: 41, offset: 23913},
 							expr: &ruleRefExpr{
-								pos:  position{line: 685, col: 42, offset: 23915},
+								pos:  position{line: 685, col: 42, offset: 23914},
 								name: "LineBreak",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 686, col: 5, offset: 23930},
+							pos:   position{line: 686, col: 5, offset: 23929},
 							label: "element",
 							expr: &choiceExpr{
-								pos: position{line: 686, col: 14, offset: 23939},
+								pos: position{line: 686, col: 14, offset: 23938},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 686, col: 14, offset: 23939},
+										pos:  position{line: 686, col: 14, offset: 23938},
 										name: "SimpleWord",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 687, col: 11, offset: 23960},
+										pos:  position{line: 687, col: 11, offset: 23959},
 										name: "Spaces",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 688, col: 11, offset: 23978},
+										pos:  position{line: 688, col: 11, offset: 23977},
 										name: "InlineImage",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 689, col: 11, offset: 24001},
+										pos:  position{line: 689, col: 11, offset: 24000},
 										name: "Link",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 690, col: 11, offset: 24017},
+										pos:  position{line: 690, col: 11, offset: 24016},
 										name: "Passthrough",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 691, col: 11, offset: 24040},
+										pos:  position{line: 691, col: 11, offset: 24039},
 										name: "QuotedText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 692, col: 11, offset: 24062},
+										pos:  position{line: 692, col: 11, offset: 24061},
 										name: "CrossReference",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 693, col: 11, offset: 24088},
+										pos:  position{line: 693, col: 11, offset: 24087},
 										name: "InlineElementID",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 694, col: 11, offset: 24114},
+										pos:  position{line: 694, col: 11, offset: 24113},
 										name: "OtherWord",
 									},
 								},
@@ -4893,31 +4893,31 @@ var g = &grammar{
 		},
 		{
 			name: "VerbatimBlock",
-			pos:  position{line: 699, col: 1, offset: 24248},
+			pos:  position{line: 699, col: 1, offset: 24247},
 			expr: &actionExpr{
-				pos: position{line: 699, col: 18, offset: 24265},
+				pos: position{line: 699, col: 18, offset: 24264},
 				run: (*parser).callonVerbatimBlock1,
 				expr: &seqExpr{
-					pos: position{line: 699, col: 18, offset: 24265},
+					pos: position{line: 699, col: 18, offset: 24264},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 699, col: 18, offset: 24265},
+							pos:   position{line: 699, col: 18, offset: 24264},
 							label: "elements",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 699, col: 27, offset: 24274},
+								pos: position{line: 699, col: 27, offset: 24273},
 								expr: &choiceExpr{
-									pos: position{line: 699, col: 28, offset: 24275},
+									pos: position{line: 699, col: 28, offset: 24274},
 									alternatives: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 699, col: 28, offset: 24275},
+											pos:  position{line: 699, col: 28, offset: 24274},
 											name: "BlankLine",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 699, col: 40, offset: 24287},
+											pos:  position{line: 699, col: 40, offset: 24286},
 											name: "FileInclusion",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 699, col: 56, offset: 24303},
+											pos:  position{line: 699, col: 56, offset: 24302},
 											name: "VerbatimParagraph",
 										},
 									},
@@ -4925,7 +4925,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 699, col: 76, offset: 24323},
+							pos:  position{line: 699, col: 76, offset: 24322},
 							name: "EOF",
 						},
 					},
@@ -4934,47 +4934,47 @@ var g = &grammar{
 		},
 		{
 			name: "VerbatimParagraph",
-			pos:  position{line: 703, col: 1, offset: 24357},
+			pos:  position{line: 703, col: 1, offset: 24356},
 			expr: &actionExpr{
-				pos: position{line: 703, col: 22, offset: 24378},
+				pos: position{line: 703, col: 22, offset: 24377},
 				run: (*parser).callonVerbatimParagraph1,
 				expr: &seqExpr{
-					pos: position{line: 703, col: 22, offset: 24378},
+					pos: position{line: 703, col: 22, offset: 24377},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 703, col: 22, offset: 24378},
+							pos:   position{line: 703, col: 22, offset: 24377},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 703, col: 33, offset: 24389},
+								pos: position{line: 703, col: 33, offset: 24388},
 								expr: &ruleRefExpr{
-									pos:  position{line: 703, col: 34, offset: 24390},
+									pos:  position{line: 703, col: 34, offset: 24389},
 									name: "ElementAttributes",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 703, col: 54, offset: 24410},
+							pos:   position{line: 703, col: 54, offset: 24409},
 							label: "lines",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 703, col: 60, offset: 24416},
+								pos: position{line: 703, col: 60, offset: 24415},
 								expr: &actionExpr{
-									pos: position{line: 703, col: 61, offset: 24417},
+									pos: position{line: 703, col: 61, offset: 24416},
 									run: (*parser).callonVerbatimParagraph8,
 									expr: &seqExpr{
-										pos: position{line: 703, col: 61, offset: 24417},
+										pos: position{line: 703, col: 61, offset: 24416},
 										exprs: []interface{}{
 											&notExpr{
-												pos: position{line: 703, col: 61, offset: 24417},
+												pos: position{line: 703, col: 61, offset: 24416},
 												expr: &ruleRefExpr{
-													pos:  position{line: 703, col: 62, offset: 24418},
+													pos:  position{line: 703, col: 62, offset: 24417},
 													name: "EOF",
 												},
 											},
 											&labeledExpr{
-												pos:   position{line: 703, col: 66, offset: 24422},
+												pos:   position{line: 703, col: 66, offset: 24421},
 												label: "line",
 												expr: &ruleRefExpr{
-													pos:  position{line: 703, col: 72, offset: 24428},
+													pos:  position{line: 703, col: 72, offset: 24427},
 													name: "VerbatimParagraphLine",
 												},
 											},
@@ -4989,51 +4989,51 @@ var g = &grammar{
 		},
 		{
 			name: "VerbatimParagraphLine",
-			pos:  position{line: 709, col: 1, offset: 24548},
+			pos:  position{line: 709, col: 1, offset: 24547},
 			expr: &actionExpr{
-				pos: position{line: 709, col: 26, offset: 24573},
+				pos: position{line: 709, col: 26, offset: 24572},
 				run: (*parser).callonVerbatimParagraphLine1,
 				expr: &seqExpr{
-					pos: position{line: 709, col: 26, offset: 24573},
+					pos: position{line: 709, col: 26, offset: 24572},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 709, col: 26, offset: 24573},
+							pos: position{line: 709, col: 26, offset: 24572},
 							expr: &ruleRefExpr{
-								pos:  position{line: 709, col: 27, offset: 24574},
+								pos:  position{line: 709, col: 27, offset: 24573},
 								name: "BlockDelimiter",
 							},
 						},
 						&notExpr{
-							pos: position{line: 709, col: 42, offset: 24589},
+							pos: position{line: 709, col: 42, offset: 24588},
 							expr: &ruleRefExpr{
-								pos:  position{line: 709, col: 43, offset: 24590},
+								pos:  position{line: 709, col: 43, offset: 24589},
 								name: "BlankLine",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 709, col: 53, offset: 24600},
+							pos:   position{line: 709, col: 53, offset: 24599},
 							label: "elements",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 709, col: 62, offset: 24609},
+								pos: position{line: 709, col: 62, offset: 24608},
 								expr: &ruleRefExpr{
-									pos:  position{line: 709, col: 63, offset: 24610},
+									pos:  position{line: 709, col: 63, offset: 24609},
 									name: "VerbatimParagraphLineElement",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 709, col: 94, offset: 24641},
+							pos:   position{line: 709, col: 94, offset: 24640},
 							label: "linebreak",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 709, col: 104, offset: 24651},
+								pos: position{line: 709, col: 104, offset: 24650},
 								expr: &ruleRefExpr{
-									pos:  position{line: 709, col: 105, offset: 24652},
+									pos:  position{line: 709, col: 105, offset: 24651},
 									name: "LineBreak",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 709, col: 117, offset: 24664},
+							pos:  position{line: 709, col: 117, offset: 24663},
 							name: "EOL",
 						},
 					},
@@ -5042,31 +5042,31 @@ var g = &grammar{
 		},
 		{
 			name: "VerbatimParagraphLineElement",
-			pos:  position{line: 713, col: 1, offset: 24755},
+			pos:  position{line: 713, col: 1, offset: 24754},
 			expr: &actionExpr{
-				pos: position{line: 713, col: 33, offset: 24787},
+				pos: position{line: 713, col: 33, offset: 24786},
 				run: (*parser).callonVerbatimParagraphLineElement1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 713, col: 33, offset: 24787},
+					pos: position{line: 713, col: 33, offset: 24786},
 					expr: &seqExpr{
-						pos: position{line: 713, col: 34, offset: 24788},
+						pos: position{line: 713, col: 34, offset: 24787},
 						exprs: []interface{}{
 							&notExpr{
-								pos: position{line: 713, col: 34, offset: 24788},
+								pos: position{line: 713, col: 34, offset: 24787},
 								expr: &ruleRefExpr{
-									pos:  position{line: 713, col: 35, offset: 24789},
+									pos:  position{line: 713, col: 35, offset: 24788},
 									name: "EOL",
 								},
 							},
 							&notExpr{
-								pos: position{line: 713, col: 39, offset: 24793},
+								pos: position{line: 713, col: 39, offset: 24792},
 								expr: &ruleRefExpr{
-									pos:  position{line: 713, col: 40, offset: 24794},
+									pos:  position{line: 713, col: 40, offset: 24793},
 									name: "LineBreak",
 								},
 							},
 							&anyMatcher{
-								line: 713, col: 50, offset: 24804,
+								line: 713, col: 50, offset: 24803,
 							},
 						},
 					},
@@ -5075,33 +5075,33 @@ var g = &grammar{
 		},
 		{
 			name: "LineBreak",
-			pos:  position{line: 720, col: 1, offset: 25028},
+			pos:  position{line: 720, col: 1, offset: 25027},
 			expr: &actionExpr{
-				pos: position{line: 720, col: 14, offset: 25041},
+				pos: position{line: 720, col: 14, offset: 25040},
 				run: (*parser).callonLineBreak1,
 				expr: &seqExpr{
-					pos: position{line: 720, col: 14, offset: 25041},
+					pos: position{line: 720, col: 14, offset: 25040},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 720, col: 14, offset: 25041},
+							pos:  position{line: 720, col: 14, offset: 25040},
 							name: "WS",
 						},
 						&litMatcher{
-							pos:        position{line: 720, col: 17, offset: 25044},
+							pos:        position{line: 720, col: 17, offset: 25043},
 							val:        "+",
 							ignoreCase: false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 720, col: 21, offset: 25048},
+							pos: position{line: 720, col: 21, offset: 25047},
 							expr: &ruleRefExpr{
-								pos:  position{line: 720, col: 21, offset: 25048},
+								pos:  position{line: 720, col: 21, offset: 25047},
 								name: "WS",
 							},
 						},
 						&andExpr{
-							pos: position{line: 720, col: 25, offset: 25052},
+							pos: position{line: 720, col: 25, offset: 25051},
 							expr: &ruleRefExpr{
-								pos:  position{line: 720, col: 26, offset: 25053},
+								pos:  position{line: 720, col: 26, offset: 25052},
 								name: "EOL",
 							},
 						},
@@ -5111,68 +5111,68 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedText",
-			pos:  position{line: 727, col: 1, offset: 25337},
+			pos:  position{line: 727, col: 1, offset: 25336},
 			expr: &actionExpr{
-				pos: position{line: 727, col: 15, offset: 25351},
+				pos: position{line: 727, col: 15, offset: 25350},
 				run: (*parser).callonQuotedText1,
 				expr: &seqExpr{
-					pos: position{line: 727, col: 15, offset: 25351},
+					pos: position{line: 727, col: 15, offset: 25350},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 727, col: 15, offset: 25351},
+							pos: position{line: 727, col: 15, offset: 25350},
 							expr: &ruleRefExpr{
-								pos:  position{line: 727, col: 16, offset: 25352},
+								pos:  position{line: 727, col: 16, offset: 25351},
 								name: "WS",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 727, col: 19, offset: 25355},
+							pos:   position{line: 727, col: 19, offset: 25354},
 							label: "text",
 							expr: &choiceExpr{
-								pos: position{line: 727, col: 25, offset: 25361},
+								pos: position{line: 727, col: 25, offset: 25360},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 727, col: 25, offset: 25361},
+										pos:  position{line: 727, col: 25, offset: 25360},
 										name: "BoldText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 728, col: 15, offset: 25385},
+										pos:  position{line: 728, col: 15, offset: 25384},
 										name: "ItalicText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 729, col: 15, offset: 25411},
+										pos:  position{line: 729, col: 15, offset: 25410},
 										name: "MonospaceText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 730, col: 15, offset: 25440},
+										pos:  position{line: 730, col: 15, offset: 25439},
 										name: "SubscriptText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 731, col: 15, offset: 25469},
+										pos:  position{line: 731, col: 15, offset: 25468},
 										name: "SuperscriptText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 732, col: 15, offset: 25500},
+										pos:  position{line: 732, col: 15, offset: 25499},
 										name: "EscapedBoldText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 733, col: 15, offset: 25531},
+										pos:  position{line: 733, col: 15, offset: 25530},
 										name: "EscapedItalicText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 734, col: 15, offset: 25564},
+										pos:  position{line: 734, col: 15, offset: 25563},
 										name: "EscapedMonospaceText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 735, col: 15, offset: 25600},
+										pos:  position{line: 735, col: 15, offset: 25599},
 										name: "EscapedSubscriptText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 736, col: 15, offset: 25636},
+										pos:  position{line: 736, col: 15, offset: 25635},
 										name: "EscapedSuperscriptText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 737, col: 15, offset: 25673},
+										pos:  position{line: 737, col: 15, offset: 25672},
 										name: "SubscriptOrSuperscriptPrefix",
 									},
 								},
@@ -5184,47 +5184,47 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedTextPrefix",
-			pos:  position{line: 741, col: 1, offset: 25827},
+			pos:  position{line: 741, col: 1, offset: 25826},
 			expr: &choiceExpr{
-				pos: position{line: 741, col: 21, offset: 25847},
+				pos: position{line: 741, col: 21, offset: 25846},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 741, col: 21, offset: 25847},
+						pos:        position{line: 741, col: 21, offset: 25846},
 						val:        "**",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 741, col: 28, offset: 25854},
+						pos:        position{line: 741, col: 28, offset: 25853},
 						val:        "*",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 741, col: 34, offset: 25860},
+						pos:        position{line: 741, col: 34, offset: 25859},
 						val:        "__",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 741, col: 41, offset: 25867},
+						pos:        position{line: 741, col: 41, offset: 25866},
 						val:        "_",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 741, col: 47, offset: 25873},
+						pos:        position{line: 741, col: 47, offset: 25872},
 						val:        "``",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 741, col: 54, offset: 25880},
+						pos:        position{line: 741, col: 54, offset: 25879},
 						val:        "`",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 741, col: 60, offset: 25886},
+						pos:        position{line: 741, col: 60, offset: 25885},
 						val:        "^",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 741, col: 66, offset: 25892},
+						pos:        position{line: 741, col: 66, offset: 25891},
 						val:        "~",
 						ignoreCase: false,
 					},
@@ -5233,20 +5233,20 @@ var g = &grammar{
 		},
 		{
 			name: "SubscriptOrSuperscriptPrefix",
-			pos:  position{line: 743, col: 1, offset: 25897},
+			pos:  position{line: 743, col: 1, offset: 25896},
 			expr: &choiceExpr{
-				pos: position{line: 743, col: 33, offset: 25929},
+				pos: position{line: 743, col: 33, offset: 25928},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 743, col: 33, offset: 25929},
+						pos:        position{line: 743, col: 33, offset: 25928},
 						val:        "^",
 						ignoreCase: false,
 					},
 					&actionExpr{
-						pos: position{line: 743, col: 39, offset: 25935},
+						pos: position{line: 743, col: 39, offset: 25934},
 						run: (*parser).callonSubscriptOrSuperscriptPrefix3,
 						expr: &litMatcher{
-							pos:        position{line: 743, col: 39, offset: 25935},
+							pos:        position{line: 743, col: 39, offset: 25934},
 							val:        "~",
 							ignoreCase: false,
 						},
@@ -5256,14 +5256,14 @@ var g = &grammar{
 		},
 		{
 			name: "OneOrMoreBackslashes",
-			pos:  position{line: 747, col: 1, offset: 26068},
+			pos:  position{line: 747, col: 1, offset: 26067},
 			expr: &actionExpr{
-				pos: position{line: 747, col: 25, offset: 26092},
+				pos: position{line: 747, col: 25, offset: 26091},
 				run: (*parser).callonOneOrMoreBackslashes1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 747, col: 25, offset: 26092},
+					pos: position{line: 747, col: 25, offset: 26091},
 					expr: &litMatcher{
-						pos:        position{line: 747, col: 25, offset: 26092},
+						pos:        position{line: 747, col: 25, offset: 26091},
 						val:        "\\",
 						ignoreCase: false,
 					},
@@ -5272,22 +5272,22 @@ var g = &grammar{
 		},
 		{
 			name: "TwoOrMoreBackslashes",
-			pos:  position{line: 751, col: 1, offset: 26133},
+			pos:  position{line: 751, col: 1, offset: 26132},
 			expr: &actionExpr{
-				pos: position{line: 751, col: 25, offset: 26157},
+				pos: position{line: 751, col: 25, offset: 26156},
 				run: (*parser).callonTwoOrMoreBackslashes1,
 				expr: &seqExpr{
-					pos: position{line: 751, col: 25, offset: 26157},
+					pos: position{line: 751, col: 25, offset: 26156},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 751, col: 25, offset: 26157},
+							pos:        position{line: 751, col: 25, offset: 26156},
 							val:        "\\\\",
 							ignoreCase: false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 751, col: 30, offset: 26162},
+							pos: position{line: 751, col: 30, offset: 26161},
 							expr: &litMatcher{
-								pos:        position{line: 751, col: 30, offset: 26162},
+								pos:        position{line: 751, col: 30, offset: 26161},
 								val:        "\\",
 								ignoreCase: false,
 							},
@@ -5298,16 +5298,16 @@ var g = &grammar{
 		},
 		{
 			name: "BoldText",
-			pos:  position{line: 759, col: 1, offset: 26259},
+			pos:  position{line: 759, col: 1, offset: 26258},
 			expr: &choiceExpr{
-				pos: position{line: 759, col: 13, offset: 26271},
+				pos: position{line: 759, col: 13, offset: 26270},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 759, col: 13, offset: 26271},
+						pos:  position{line: 759, col: 13, offset: 26270},
 						name: "DoubleQuoteBoldText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 759, col: 35, offset: 26293},
+						pos:  position{line: 759, col: 35, offset: 26292},
 						name: "SingleQuoteBoldText",
 					},
 				},
@@ -5315,36 +5315,36 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteBoldText",
-			pos:  position{line: 761, col: 1, offset: 26314},
+			pos:  position{line: 761, col: 1, offset: 26313},
 			expr: &actionExpr{
-				pos: position{line: 761, col: 24, offset: 26337},
+				pos: position{line: 761, col: 24, offset: 26336},
 				run: (*parser).callonDoubleQuoteBoldText1,
 				expr: &seqExpr{
-					pos: position{line: 761, col: 24, offset: 26337},
+					pos: position{line: 761, col: 24, offset: 26336},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 761, col: 24, offset: 26337},
+							pos: position{line: 761, col: 24, offset: 26336},
 							expr: &litMatcher{
-								pos:        position{line: 761, col: 25, offset: 26338},
+								pos:        position{line: 761, col: 25, offset: 26337},
 								val:        "\\\\",
 								ignoreCase: false,
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 761, col: 30, offset: 26343},
+							pos:        position{line: 761, col: 30, offset: 26342},
 							val:        "**",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 761, col: 35, offset: 26348},
+							pos:   position{line: 761, col: 35, offset: 26347},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 761, col: 44, offset: 26357},
+								pos:  position{line: 761, col: 44, offset: 26356},
 								name: "DoubleQuoteBoldTextContent",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 761, col: 72, offset: 26385},
+							pos:        position{line: 761, col: 72, offset: 26384},
 							val:        "**",
 							ignoreCase: false,
 						},
@@ -5354,42 +5354,42 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteBoldTextContent",
-			pos:  position{line: 765, col: 1, offset: 26510},
+			pos:  position{line: 765, col: 1, offset: 26509},
 			expr: &seqExpr{
-				pos: position{line: 765, col: 31, offset: 26540},
+				pos: position{line: 765, col: 31, offset: 26539},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 765, col: 31, offset: 26540},
+						pos:  position{line: 765, col: 31, offset: 26539},
 						name: "DoubleQuoteBoldTextElement",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 765, col: 58, offset: 26567},
+						pos: position{line: 765, col: 58, offset: 26566},
 						expr: &actionExpr{
-							pos: position{line: 765, col: 59, offset: 26568},
+							pos: position{line: 765, col: 59, offset: 26567},
 							run: (*parser).callonDoubleQuoteBoldTextContent4,
 							expr: &seqExpr{
-								pos: position{line: 765, col: 59, offset: 26568},
+								pos: position{line: 765, col: 59, offset: 26567},
 								exprs: []interface{}{
 									&notExpr{
-										pos: position{line: 765, col: 59, offset: 26568},
+										pos: position{line: 765, col: 59, offset: 26567},
 										expr: &litMatcher{
-											pos:        position{line: 765, col: 61, offset: 26570},
+											pos:        position{line: 765, col: 61, offset: 26569},
 											val:        "**",
 											ignoreCase: false,
 										},
 									},
 									&labeledExpr{
-										pos:   position{line: 765, col: 67, offset: 26576},
+										pos:   position{line: 765, col: 67, offset: 26575},
 										label: "element",
 										expr: &choiceExpr{
-											pos: position{line: 765, col: 76, offset: 26585},
+											pos: position{line: 765, col: 76, offset: 26584},
 											alternatives: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 765, col: 76, offset: 26585},
+													pos:  position{line: 765, col: 76, offset: 26584},
 													name: "WS",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 765, col: 81, offset: 26590},
+													pos:  position{line: 765, col: 81, offset: 26589},
 													name: "DoubleQuoteBoldTextElement",
 												},
 											},
@@ -5404,60 +5404,60 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteBoldTextElement",
-			pos:  position{line: 769, col: 1, offset: 26682},
+			pos:  position{line: 769, col: 1, offset: 26681},
 			expr: &actionExpr{
-				pos: position{line: 769, col: 31, offset: 26712},
+				pos: position{line: 769, col: 31, offset: 26711},
 				run: (*parser).callonDoubleQuoteBoldTextElement1,
 				expr: &seqExpr{
-					pos: position{line: 769, col: 31, offset: 26712},
+					pos: position{line: 769, col: 31, offset: 26711},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 769, col: 31, offset: 26712},
+							pos: position{line: 769, col: 31, offset: 26711},
 							expr: &ruleRefExpr{
-								pos:  position{line: 769, col: 32, offset: 26713},
+								pos:  position{line: 769, col: 32, offset: 26712},
 								name: "NEWLINE",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 769, col: 40, offset: 26721},
+							pos:   position{line: 769, col: 40, offset: 26720},
 							label: "element",
 							expr: &choiceExpr{
-								pos: position{line: 769, col: 49, offset: 26730},
+								pos: position{line: 769, col: 49, offset: 26729},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 769, col: 49, offset: 26730},
+										pos:  position{line: 769, col: 49, offset: 26729},
 										name: "SingleQuoteBoldText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 770, col: 11, offset: 26761},
+										pos:  position{line: 770, col: 11, offset: 26760},
 										name: "ItalicText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 771, col: 11, offset: 26783},
+										pos:  position{line: 771, col: 11, offset: 26782},
 										name: "MonospaceText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 772, col: 11, offset: 26807},
+										pos:  position{line: 772, col: 11, offset: 26806},
 										name: "SubscriptText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 773, col: 11, offset: 26831},
+										pos:  position{line: 773, col: 11, offset: 26830},
 										name: "SuperscriptText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 774, col: 11, offset: 26857},
+										pos:  position{line: 774, col: 11, offset: 26856},
 										name: "InlineImage",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 775, col: 11, offset: 26880},
+										pos:  position{line: 775, col: 11, offset: 26879},
 										name: "Link",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 776, col: 11, offset: 26896},
+										pos:  position{line: 776, col: 11, offset: 26895},
 										name: "Passthrough",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 777, col: 11, offset: 26919},
+										pos:  position{line: 777, col: 11, offset: 26918},
 										name: "NonDoubleQuoteBoldText",
 									},
 								},
@@ -5469,61 +5469,61 @@ var g = &grammar{
 		},
 		{
 			name: "NonDoubleQuoteBoldText",
-			pos:  position{line: 781, col: 1, offset: 27075},
+			pos:  position{line: 781, col: 1, offset: 27074},
 			expr: &actionExpr{
-				pos: position{line: 781, col: 27, offset: 27101},
+				pos: position{line: 781, col: 27, offset: 27100},
 				run: (*parser).callonNonDoubleQuoteBoldText1,
 				expr: &seqExpr{
-					pos: position{line: 781, col: 27, offset: 27101},
+					pos: position{line: 781, col: 27, offset: 27100},
 					exprs: []interface{}{
 						&anyMatcher{
-							line: 781, col: 28, offset: 27102,
+							line: 781, col: 28, offset: 27101,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 781, col: 31, offset: 27105},
+							pos: position{line: 781, col: 31, offset: 27104},
 							expr: &seqExpr{
-								pos: position{line: 781, col: 32, offset: 27106},
+								pos: position{line: 781, col: 32, offset: 27105},
 								exprs: []interface{}{
 									&notExpr{
-										pos: position{line: 781, col: 32, offset: 27106},
+										pos: position{line: 781, col: 32, offset: 27105},
 										expr: &litMatcher{
-											pos:        position{line: 781, col: 33, offset: 27107},
+											pos:        position{line: 781, col: 33, offset: 27106},
 											val:        "**",
 											ignoreCase: false,
 										},
 									},
 									&notExpr{
-										pos: position{line: 781, col: 38, offset: 27112},
+										pos: position{line: 781, col: 38, offset: 27111},
 										expr: &ruleRefExpr{
-											pos:  position{line: 781, col: 39, offset: 27113},
+											pos:  position{line: 781, col: 39, offset: 27112},
 											name: "WS",
 										},
 									},
 									&notExpr{
-										pos: position{line: 781, col: 42, offset: 27116},
+										pos: position{line: 781, col: 42, offset: 27115},
 										expr: &litMatcher{
-											pos:        position{line: 781, col: 43, offset: 27117},
+											pos:        position{line: 781, col: 43, offset: 27116},
 											val:        "^",
 											ignoreCase: false,
 										},
 									},
 									&notExpr{
-										pos: position{line: 781, col: 47, offset: 27121},
+										pos: position{line: 781, col: 47, offset: 27120},
 										expr: &litMatcher{
-											pos:        position{line: 781, col: 48, offset: 27122},
+											pos:        position{line: 781, col: 48, offset: 27121},
 											val:        "~",
 											ignoreCase: false,
 										},
 									},
 									&notExpr{
-										pos: position{line: 781, col: 52, offset: 27126},
+										pos: position{line: 781, col: 52, offset: 27125},
 										expr: &ruleRefExpr{
-											pos:  position{line: 781, col: 53, offset: 27127},
+											pos:  position{line: 781, col: 53, offset: 27126},
 											name: "NEWLINE",
 										},
 									},
 									&anyMatcher{
-										line: 781, col: 61, offset: 27135,
+										line: 781, col: 61, offset: 27134,
 									},
 								},
 							},
@@ -5534,47 +5534,47 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteBoldText",
-			pos:  position{line: 785, col: 1, offset: 27195},
+			pos:  position{line: 785, col: 1, offset: 27194},
 			expr: &choiceExpr{
-				pos: position{line: 785, col: 24, offset: 27218},
+				pos: position{line: 785, col: 24, offset: 27217},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 785, col: 24, offset: 27218},
+						pos: position{line: 785, col: 24, offset: 27217},
 						run: (*parser).callonSingleQuoteBoldText2,
 						expr: &seqExpr{
-							pos: position{line: 785, col: 24, offset: 27218},
+							pos: position{line: 785, col: 24, offset: 27217},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 785, col: 24, offset: 27218},
+									pos: position{line: 785, col: 24, offset: 27217},
 									expr: &litMatcher{
-										pos:        position{line: 785, col: 25, offset: 27219},
+										pos:        position{line: 785, col: 25, offset: 27218},
 										val:        "\\",
 										ignoreCase: false,
 									},
 								},
 								&notExpr{
-									pos: position{line: 785, col: 29, offset: 27223},
+									pos: position{line: 785, col: 29, offset: 27222},
 									expr: &litMatcher{
-										pos:        position{line: 785, col: 30, offset: 27224},
+										pos:        position{line: 785, col: 30, offset: 27223},
 										val:        "**",
 										ignoreCase: false,
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 785, col: 35, offset: 27229},
+									pos:        position{line: 785, col: 35, offset: 27228},
 									val:        "*",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 785, col: 39, offset: 27233},
+									pos:   position{line: 785, col: 39, offset: 27232},
 									label: "content",
 									expr: &ruleRefExpr{
-										pos:  position{line: 785, col: 48, offset: 27242},
+										pos:  position{line: 785, col: 48, offset: 27241},
 										name: "SingleQuoteBoldTextContent",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 785, col: 76, offset: 27270},
+									pos:        position{line: 785, col: 76, offset: 27269},
 									val:        "*",
 									ignoreCase: false,
 								},
@@ -5582,34 +5582,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 787, col: 5, offset: 27450},
+						pos: position{line: 787, col: 5, offset: 27449},
 						run: (*parser).callonSingleQuoteBoldText12,
 						expr: &seqExpr{
-							pos: position{line: 787, col: 5, offset: 27450},
+							pos: position{line: 787, col: 5, offset: 27449},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 787, col: 5, offset: 27450},
+									pos: position{line: 787, col: 5, offset: 27449},
 									expr: &litMatcher{
-										pos:        position{line: 787, col: 6, offset: 27451},
+										pos:        position{line: 787, col: 6, offset: 27450},
 										val:        "\\\\",
 										ignoreCase: false,
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 787, col: 11, offset: 27456},
+									pos:        position{line: 787, col: 11, offset: 27455},
 									val:        "**",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 787, col: 16, offset: 27461},
+									pos:   position{line: 787, col: 16, offset: 27460},
 									label: "content",
 									expr: &ruleRefExpr{
-										pos:  position{line: 787, col: 25, offset: 27470},
+										pos:  position{line: 787, col: 25, offset: 27469},
 										name: "SingleQuoteBoldTextContent",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 787, col: 53, offset: 27498},
+									pos:        position{line: 787, col: 53, offset: 27497},
 									val:        "*",
 									ignoreCase: false,
 								},
@@ -5621,43 +5621,43 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteBoldTextContent",
-			pos:  position{line: 791, col: 1, offset: 27756},
+			pos:  position{line: 791, col: 1, offset: 27755},
 			expr: &seqExpr{
-				pos: position{line: 791, col: 31, offset: 27786},
+				pos: position{line: 791, col: 31, offset: 27785},
 				exprs: []interface{}{
 					&notExpr{
-						pos: position{line: 791, col: 31, offset: 27786},
+						pos: position{line: 791, col: 31, offset: 27785},
 						expr: &ruleRefExpr{
-							pos:  position{line: 791, col: 32, offset: 27787},
+							pos:  position{line: 791, col: 32, offset: 27786},
 							name: "WS",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 791, col: 35, offset: 27790},
+						pos:  position{line: 791, col: 35, offset: 27789},
 						name: "SingleQuoteBoldTextElement",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 791, col: 62, offset: 27817},
+						pos: position{line: 791, col: 62, offset: 27816},
 						expr: &actionExpr{
-							pos: position{line: 791, col: 63, offset: 27818},
+							pos: position{line: 791, col: 63, offset: 27817},
 							run: (*parser).callonSingleQuoteBoldTextContent6,
 							expr: &seqExpr{
-								pos: position{line: 791, col: 63, offset: 27818},
+								pos: position{line: 791, col: 63, offset: 27817},
 								exprs: []interface{}{
 									&notExpr{
-										pos: position{line: 791, col: 63, offset: 27818},
+										pos: position{line: 791, col: 63, offset: 27817},
 										expr: &seqExpr{
-											pos: position{line: 791, col: 65, offset: 27820},
+											pos: position{line: 791, col: 65, offset: 27819},
 											exprs: []interface{}{
 												&litMatcher{
-													pos:        position{line: 791, col: 65, offset: 27820},
+													pos:        position{line: 791, col: 65, offset: 27819},
 													val:        "*",
 													ignoreCase: false,
 												},
 												&notExpr{
-													pos: position{line: 791, col: 69, offset: 27824},
+													pos: position{line: 791, col: 69, offset: 27823},
 													expr: &ruleRefExpr{
-														pos:  position{line: 791, col: 70, offset: 27825},
+														pos:  position{line: 791, col: 70, offset: 27824},
 														name: "Alphanum",
 													},
 												},
@@ -5665,21 +5665,21 @@ var g = &grammar{
 										},
 									},
 									&labeledExpr{
-										pos:   position{line: 791, col: 80, offset: 27835},
+										pos:   position{line: 791, col: 80, offset: 27834},
 										label: "spaces",
 										expr: &zeroOrMoreExpr{
-											pos: position{line: 791, col: 88, offset: 27843},
+											pos: position{line: 791, col: 88, offset: 27842},
 											expr: &ruleRefExpr{
-												pos:  position{line: 791, col: 88, offset: 27843},
+												pos:  position{line: 791, col: 88, offset: 27842},
 												name: "WS",
 											},
 										},
 									},
 									&labeledExpr{
-										pos:   position{line: 791, col: 93, offset: 27848},
+										pos:   position{line: 791, col: 93, offset: 27847},
 										label: "element",
 										expr: &ruleRefExpr{
-											pos:  position{line: 791, col: 102, offset: 27857},
+											pos:  position{line: 791, col: 102, offset: 27856},
 											name: "SingleQuoteBoldTextElement",
 										},
 									},
@@ -5692,60 +5692,60 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteBoldTextElement",
-			pos:  position{line: 795, col: 1, offset: 27948},
+			pos:  position{line: 795, col: 1, offset: 27947},
 			expr: &actionExpr{
-				pos: position{line: 795, col: 31, offset: 27978},
+				pos: position{line: 795, col: 31, offset: 27977},
 				run: (*parser).callonSingleQuoteBoldTextElement1,
 				expr: &seqExpr{
-					pos: position{line: 795, col: 31, offset: 27978},
+					pos: position{line: 795, col: 31, offset: 27977},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 795, col: 31, offset: 27978},
+							pos: position{line: 795, col: 31, offset: 27977},
 							expr: &ruleRefExpr{
-								pos:  position{line: 795, col: 32, offset: 27979},
+								pos:  position{line: 795, col: 32, offset: 27978},
 								name: "NEWLINE",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 795, col: 40, offset: 27987},
+							pos:   position{line: 795, col: 40, offset: 27986},
 							label: "element",
 							expr: &choiceExpr{
-								pos: position{line: 795, col: 49, offset: 27996},
+								pos: position{line: 795, col: 49, offset: 27995},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 795, col: 49, offset: 27996},
+										pos:  position{line: 795, col: 49, offset: 27995},
 										name: "DoubleQuoteBoldText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 796, col: 11, offset: 28026},
+										pos:  position{line: 796, col: 11, offset: 28025},
 										name: "ItalicText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 797, col: 11, offset: 28048},
+										pos:  position{line: 797, col: 11, offset: 28047},
 										name: "MonospaceText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 798, col: 11, offset: 28072},
+										pos:  position{line: 798, col: 11, offset: 28071},
 										name: "SubscriptText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 799, col: 11, offset: 28096},
+										pos:  position{line: 799, col: 11, offset: 28095},
 										name: "SuperscriptText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 800, col: 11, offset: 28122},
+										pos:  position{line: 800, col: 11, offset: 28121},
 										name: "InlineImage",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 801, col: 11, offset: 28145},
+										pos:  position{line: 801, col: 11, offset: 28144},
 										name: "Link",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 802, col: 11, offset: 28161},
+										pos:  position{line: 802, col: 11, offset: 28160},
 										name: "Passthrough",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 803, col: 11, offset: 28184},
+										pos:  position{line: 803, col: 11, offset: 28183},
 										name: "NonSingleQuoteBoldText",
 									},
 								},
@@ -5757,61 +5757,61 @@ var g = &grammar{
 		},
 		{
 			name: "NonSingleQuoteBoldText",
-			pos:  position{line: 807, col: 1, offset: 28340},
+			pos:  position{line: 807, col: 1, offset: 28339},
 			expr: &actionExpr{
-				pos: position{line: 807, col: 27, offset: 28366},
+				pos: position{line: 807, col: 27, offset: 28365},
 				run: (*parser).callonNonSingleQuoteBoldText1,
 				expr: &seqExpr{
-					pos: position{line: 807, col: 27, offset: 28366},
+					pos: position{line: 807, col: 27, offset: 28365},
 					exprs: []interface{}{
 						&anyMatcher{
-							line: 807, col: 28, offset: 28367,
+							line: 807, col: 28, offset: 28366,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 807, col: 31, offset: 28370},
+							pos: position{line: 807, col: 31, offset: 28369},
 							expr: &seqExpr{
-								pos: position{line: 807, col: 32, offset: 28371},
+								pos: position{line: 807, col: 32, offset: 28370},
 								exprs: []interface{}{
 									&notExpr{
-										pos: position{line: 807, col: 32, offset: 28371},
+										pos: position{line: 807, col: 32, offset: 28370},
 										expr: &litMatcher{
-											pos:        position{line: 807, col: 33, offset: 28372},
+											pos:        position{line: 807, col: 33, offset: 28371},
 											val:        "*",
 											ignoreCase: false,
 										},
 									},
 									&notExpr{
-										pos: position{line: 807, col: 37, offset: 28376},
+										pos: position{line: 807, col: 37, offset: 28375},
 										expr: &ruleRefExpr{
-											pos:  position{line: 807, col: 38, offset: 28377},
+											pos:  position{line: 807, col: 38, offset: 28376},
 											name: "WS",
 										},
 									},
 									&notExpr{
-										pos: position{line: 807, col: 41, offset: 28380},
+										pos: position{line: 807, col: 41, offset: 28379},
 										expr: &litMatcher{
-											pos:        position{line: 807, col: 42, offset: 28381},
+											pos:        position{line: 807, col: 42, offset: 28380},
 											val:        "^",
 											ignoreCase: false,
 										},
 									},
 									&notExpr{
-										pos: position{line: 807, col: 46, offset: 28385},
+										pos: position{line: 807, col: 46, offset: 28384},
 										expr: &litMatcher{
-											pos:        position{line: 807, col: 47, offset: 28386},
+											pos:        position{line: 807, col: 47, offset: 28385},
 											val:        "~",
 											ignoreCase: false,
 										},
 									},
 									&notExpr{
-										pos: position{line: 807, col: 51, offset: 28390},
+										pos: position{line: 807, col: 51, offset: 28389},
 										expr: &ruleRefExpr{
-											pos:  position{line: 807, col: 52, offset: 28391},
+											pos:  position{line: 807, col: 52, offset: 28390},
 											name: "NEWLINE",
 										},
 									},
 									&anyMatcher{
-										line: 807, col: 60, offset: 28399,
+										line: 807, col: 60, offset: 28398,
 									},
 								},
 							},
@@ -5822,39 +5822,39 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedBoldText",
-			pos:  position{line: 811, col: 1, offset: 28459},
+			pos:  position{line: 811, col: 1, offset: 28458},
 			expr: &choiceExpr{
-				pos: position{line: 812, col: 5, offset: 28483},
+				pos: position{line: 812, col: 5, offset: 28482},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 812, col: 5, offset: 28483},
+						pos: position{line: 812, col: 5, offset: 28482},
 						run: (*parser).callonEscapedBoldText2,
 						expr: &seqExpr{
-							pos: position{line: 812, col: 5, offset: 28483},
+							pos: position{line: 812, col: 5, offset: 28482},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 812, col: 5, offset: 28483},
+									pos:   position{line: 812, col: 5, offset: 28482},
 									label: "backslashes",
 									expr: &ruleRefExpr{
-										pos:  position{line: 812, col: 18, offset: 28496},
+										pos:  position{line: 812, col: 18, offset: 28495},
 										name: "TwoOrMoreBackslashes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 812, col: 40, offset: 28518},
+									pos:        position{line: 812, col: 40, offset: 28517},
 									val:        "**",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 812, col: 45, offset: 28523},
+									pos:   position{line: 812, col: 45, offset: 28522},
 									label: "content",
 									expr: &ruleRefExpr{
-										pos:  position{line: 812, col: 54, offset: 28532},
+										pos:  position{line: 812, col: 54, offset: 28531},
 										name: "DoubleQuoteBoldTextContent",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 812, col: 82, offset: 28560},
+									pos:        position{line: 812, col: 82, offset: 28559},
 									val:        "**",
 									ignoreCase: false,
 								},
@@ -5862,34 +5862,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 814, col: 9, offset: 28716},
+						pos: position{line: 814, col: 9, offset: 28715},
 						run: (*parser).callonEscapedBoldText10,
 						expr: &seqExpr{
-							pos: position{line: 814, col: 9, offset: 28716},
+							pos: position{line: 814, col: 9, offset: 28715},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 814, col: 9, offset: 28716},
+									pos:   position{line: 814, col: 9, offset: 28715},
 									label: "backslashes",
 									expr: &ruleRefExpr{
-										pos:  position{line: 814, col: 22, offset: 28729},
+										pos:  position{line: 814, col: 22, offset: 28728},
 										name: "OneOrMoreBackslashes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 814, col: 44, offset: 28751},
+									pos:        position{line: 814, col: 44, offset: 28750},
 									val:        "**",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 814, col: 49, offset: 28756},
+									pos:   position{line: 814, col: 49, offset: 28755},
 									label: "content",
 									expr: &ruleRefExpr{
-										pos:  position{line: 814, col: 58, offset: 28765},
+										pos:  position{line: 814, col: 58, offset: 28764},
 										name: "SingleQuoteBoldTextContent",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 814, col: 86, offset: 28793},
+									pos:        position{line: 814, col: 86, offset: 28792},
 									val:        "*",
 									ignoreCase: false,
 								},
@@ -5897,34 +5897,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 817, col: 9, offset: 28992},
+						pos: position{line: 817, col: 9, offset: 28991},
 						run: (*parser).callonEscapedBoldText18,
 						expr: &seqExpr{
-							pos: position{line: 817, col: 9, offset: 28992},
+							pos: position{line: 817, col: 9, offset: 28991},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 817, col: 9, offset: 28992},
+									pos:   position{line: 817, col: 9, offset: 28991},
 									label: "backslashes",
 									expr: &ruleRefExpr{
-										pos:  position{line: 817, col: 22, offset: 29005},
+										pos:  position{line: 817, col: 22, offset: 29004},
 										name: "OneOrMoreBackslashes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 817, col: 44, offset: 29027},
+									pos:        position{line: 817, col: 44, offset: 29026},
 									val:        "*",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 817, col: 48, offset: 29031},
+									pos:   position{line: 817, col: 48, offset: 29030},
 									label: "content",
 									expr: &ruleRefExpr{
-										pos:  position{line: 817, col: 57, offset: 29040},
+										pos:  position{line: 817, col: 57, offset: 29039},
 										name: "SingleQuoteBoldTextContent",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 817, col: 85, offset: 29068},
+									pos:        position{line: 817, col: 85, offset: 29067},
 									val:        "*",
 									ignoreCase: false,
 								},
@@ -5936,16 +5936,16 @@ var g = &grammar{
 		},
 		{
 			name: "ItalicText",
-			pos:  position{line: 825, col: 1, offset: 29275},
+			pos:  position{line: 825, col: 1, offset: 29274},
 			expr: &choiceExpr{
-				pos: position{line: 825, col: 15, offset: 29289},
+				pos: position{line: 825, col: 15, offset: 29288},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 825, col: 15, offset: 29289},
+						pos:  position{line: 825, col: 15, offset: 29288},
 						name: "DoubleQuoteItalicText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 825, col: 39, offset: 29313},
+						pos:  position{line: 825, col: 39, offset: 29312},
 						name: "SingleQuoteItalicText",
 					},
 				},
@@ -5953,36 +5953,36 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteItalicText",
-			pos:  position{line: 827, col: 1, offset: 29336},
+			pos:  position{line: 827, col: 1, offset: 29335},
 			expr: &actionExpr{
-				pos: position{line: 827, col: 26, offset: 29361},
+				pos: position{line: 827, col: 26, offset: 29360},
 				run: (*parser).callonDoubleQuoteItalicText1,
 				expr: &seqExpr{
-					pos: position{line: 827, col: 26, offset: 29361},
+					pos: position{line: 827, col: 26, offset: 29360},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 827, col: 26, offset: 29361},
+							pos: position{line: 827, col: 26, offset: 29360},
 							expr: &litMatcher{
-								pos:        position{line: 827, col: 27, offset: 29362},
+								pos:        position{line: 827, col: 27, offset: 29361},
 								val:        "\\\\",
 								ignoreCase: false,
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 827, col: 32, offset: 29367},
+							pos:        position{line: 827, col: 32, offset: 29366},
 							val:        "__",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 827, col: 37, offset: 29372},
+							pos:   position{line: 827, col: 37, offset: 29371},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 827, col: 46, offset: 29381},
+								pos:  position{line: 827, col: 46, offset: 29380},
 								name: "DoubleQuoteItalicTextContent",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 827, col: 76, offset: 29411},
+							pos:        position{line: 827, col: 76, offset: 29410},
 							val:        "__",
 							ignoreCase: false,
 						},
@@ -5992,42 +5992,42 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteItalicTextContent",
-			pos:  position{line: 831, col: 1, offset: 29537},
+			pos:  position{line: 831, col: 1, offset: 29536},
 			expr: &seqExpr{
-				pos: position{line: 831, col: 33, offset: 29569},
+				pos: position{line: 831, col: 33, offset: 29568},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 831, col: 33, offset: 29569},
+						pos:  position{line: 831, col: 33, offset: 29568},
 						name: "DoubleQuoteItalicTextElement",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 831, col: 62, offset: 29598},
+						pos: position{line: 831, col: 62, offset: 29597},
 						expr: &actionExpr{
-							pos: position{line: 831, col: 63, offset: 29599},
+							pos: position{line: 831, col: 63, offset: 29598},
 							run: (*parser).callonDoubleQuoteItalicTextContent4,
 							expr: &seqExpr{
-								pos: position{line: 831, col: 63, offset: 29599},
+								pos: position{line: 831, col: 63, offset: 29598},
 								exprs: []interface{}{
 									&notExpr{
-										pos: position{line: 831, col: 63, offset: 29599},
+										pos: position{line: 831, col: 63, offset: 29598},
 										expr: &litMatcher{
-											pos:        position{line: 831, col: 65, offset: 29601},
+											pos:        position{line: 831, col: 65, offset: 29600},
 											val:        "__",
 											ignoreCase: false,
 										},
 									},
 									&labeledExpr{
-										pos:   position{line: 831, col: 71, offset: 29607},
+										pos:   position{line: 831, col: 71, offset: 29606},
 										label: "element",
 										expr: &choiceExpr{
-											pos: position{line: 831, col: 80, offset: 29616},
+											pos: position{line: 831, col: 80, offset: 29615},
 											alternatives: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 831, col: 80, offset: 29616},
+													pos:  position{line: 831, col: 80, offset: 29615},
 													name: "WS",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 831, col: 85, offset: 29621},
+													pos:  position{line: 831, col: 85, offset: 29620},
 													name: "DoubleQuoteItalicTextElement",
 												},
 											},
@@ -6042,60 +6042,60 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteItalicTextElement",
-			pos:  position{line: 835, col: 1, offset: 29715},
+			pos:  position{line: 835, col: 1, offset: 29714},
 			expr: &actionExpr{
-				pos: position{line: 835, col: 33, offset: 29747},
+				pos: position{line: 835, col: 33, offset: 29746},
 				run: (*parser).callonDoubleQuoteItalicTextElement1,
 				expr: &seqExpr{
-					pos: position{line: 835, col: 33, offset: 29747},
+					pos: position{line: 835, col: 33, offset: 29746},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 835, col: 33, offset: 29747},
+							pos: position{line: 835, col: 33, offset: 29746},
 							expr: &ruleRefExpr{
-								pos:  position{line: 835, col: 34, offset: 29748},
+								pos:  position{line: 835, col: 34, offset: 29747},
 								name: "NEWLINE",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 835, col: 42, offset: 29756},
+							pos:   position{line: 835, col: 42, offset: 29755},
 							label: "element",
 							expr: &choiceExpr{
-								pos: position{line: 835, col: 51, offset: 29765},
+								pos: position{line: 835, col: 51, offset: 29764},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 835, col: 51, offset: 29765},
+										pos:  position{line: 835, col: 51, offset: 29764},
 										name: "SingleQuoteItalicText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 836, col: 11, offset: 29798},
+										pos:  position{line: 836, col: 11, offset: 29797},
 										name: "BoldText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 837, col: 11, offset: 29818},
+										pos:  position{line: 837, col: 11, offset: 29817},
 										name: "MonospaceText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 838, col: 11, offset: 29842},
+										pos:  position{line: 838, col: 11, offset: 29841},
 										name: "SubscriptText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 839, col: 11, offset: 29866},
+										pos:  position{line: 839, col: 11, offset: 29865},
 										name: "SuperscriptText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 840, col: 11, offset: 29892},
+										pos:  position{line: 840, col: 11, offset: 29891},
 										name: "InlineImage",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 841, col: 11, offset: 29915},
+										pos:  position{line: 841, col: 11, offset: 29914},
 										name: "Link",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 842, col: 11, offset: 29931},
+										pos:  position{line: 842, col: 11, offset: 29930},
 										name: "Passthrough",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 843, col: 11, offset: 29954},
+										pos:  position{line: 843, col: 11, offset: 29953},
 										name: "NonDoubleQuoteItalicText",
 									},
 								},
@@ -6107,54 +6107,54 @@ var g = &grammar{
 		},
 		{
 			name: "NonDoubleQuoteItalicText",
-			pos:  position{line: 847, col: 1, offset: 30112},
+			pos:  position{line: 847, col: 1, offset: 30111},
 			expr: &actionExpr{
-				pos: position{line: 847, col: 29, offset: 30140},
+				pos: position{line: 847, col: 29, offset: 30139},
 				run: (*parser).callonNonDoubleQuoteItalicText1,
 				expr: &seqExpr{
-					pos: position{line: 847, col: 29, offset: 30140},
+					pos: position{line: 847, col: 29, offset: 30139},
 					exprs: []interface{}{
 						&anyMatcher{
-							line: 847, col: 30, offset: 30141,
+							line: 847, col: 30, offset: 30140,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 847, col: 33, offset: 30144},
+							pos: position{line: 847, col: 33, offset: 30143},
 							expr: &seqExpr{
-								pos: position{line: 847, col: 34, offset: 30145},
+								pos: position{line: 847, col: 34, offset: 30144},
 								exprs: []interface{}{
 									&notExpr{
-										pos: position{line: 847, col: 34, offset: 30145},
+										pos: position{line: 847, col: 34, offset: 30144},
 										expr: &litMatcher{
-											pos:        position{line: 847, col: 35, offset: 30146},
+											pos:        position{line: 847, col: 35, offset: 30145},
 											val:        "__",
 											ignoreCase: false,
 										},
 									},
 									&notExpr{
-										pos: position{line: 847, col: 40, offset: 30151},
+										pos: position{line: 847, col: 40, offset: 30150},
 										expr: &litMatcher{
-											pos:        position{line: 847, col: 41, offset: 30152},
+											pos:        position{line: 847, col: 41, offset: 30151},
 											val:        "^",
 											ignoreCase: false,
 										},
 									},
 									&notExpr{
-										pos: position{line: 847, col: 45, offset: 30156},
+										pos: position{line: 847, col: 45, offset: 30155},
 										expr: &litMatcher{
-											pos:        position{line: 847, col: 46, offset: 30157},
+											pos:        position{line: 847, col: 46, offset: 30156},
 											val:        "~",
 											ignoreCase: false,
 										},
 									},
 									&notExpr{
-										pos: position{line: 847, col: 50, offset: 30161},
+										pos: position{line: 847, col: 50, offset: 30160},
 										expr: &ruleRefExpr{
-											pos:  position{line: 847, col: 51, offset: 30162},
+											pos:  position{line: 847, col: 51, offset: 30161},
 											name: "NEWLINE",
 										},
 									},
 									&anyMatcher{
-										line: 847, col: 59, offset: 30170,
+										line: 847, col: 59, offset: 30169,
 									},
 								},
 							},
@@ -6165,47 +6165,47 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteItalicText",
-			pos:  position{line: 851, col: 1, offset: 30230},
+			pos:  position{line: 851, col: 1, offset: 30229},
 			expr: &choiceExpr{
-				pos: position{line: 851, col: 26, offset: 30255},
+				pos: position{line: 851, col: 26, offset: 30254},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 851, col: 26, offset: 30255},
+						pos: position{line: 851, col: 26, offset: 30254},
 						run: (*parser).callonSingleQuoteItalicText2,
 						expr: &seqExpr{
-							pos: position{line: 851, col: 26, offset: 30255},
+							pos: position{line: 851, col: 26, offset: 30254},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 851, col: 26, offset: 30255},
+									pos: position{line: 851, col: 26, offset: 30254},
 									expr: &litMatcher{
-										pos:        position{line: 851, col: 27, offset: 30256},
+										pos:        position{line: 851, col: 27, offset: 30255},
 										val:        "\\",
 										ignoreCase: false,
 									},
 								},
 								&notExpr{
-									pos: position{line: 851, col: 31, offset: 30260},
+									pos: position{line: 851, col: 31, offset: 30259},
 									expr: &litMatcher{
-										pos:        position{line: 851, col: 32, offset: 30261},
+										pos:        position{line: 851, col: 32, offset: 30260},
 										val:        "__",
 										ignoreCase: false,
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 851, col: 37, offset: 30266},
+									pos:        position{line: 851, col: 37, offset: 30265},
 									val:        "_",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 851, col: 41, offset: 30270},
+									pos:   position{line: 851, col: 41, offset: 30269},
 									label: "content",
 									expr: &ruleRefExpr{
-										pos:  position{line: 851, col: 50, offset: 30279},
+										pos:  position{line: 851, col: 50, offset: 30278},
 										name: "SingleQuoteItalicTextContent",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 851, col: 80, offset: 30309},
+									pos:        position{line: 851, col: 80, offset: 30308},
 									val:        "_",
 									ignoreCase: false,
 								},
@@ -6213,34 +6213,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 853, col: 5, offset: 30491},
+						pos: position{line: 853, col: 5, offset: 30490},
 						run: (*parser).callonSingleQuoteItalicText12,
 						expr: &seqExpr{
-							pos: position{line: 853, col: 5, offset: 30491},
+							pos: position{line: 853, col: 5, offset: 30490},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 853, col: 5, offset: 30491},
+									pos: position{line: 853, col: 5, offset: 30490},
 									expr: &litMatcher{
-										pos:        position{line: 853, col: 6, offset: 30492},
+										pos:        position{line: 853, col: 6, offset: 30491},
 										val:        "\\\\",
 										ignoreCase: false,
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 853, col: 11, offset: 30497},
+									pos:        position{line: 853, col: 11, offset: 30496},
 									val:        "__",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 853, col: 16, offset: 30502},
+									pos:   position{line: 853, col: 16, offset: 30501},
 									label: "content",
 									expr: &ruleRefExpr{
-										pos:  position{line: 853, col: 25, offset: 30511},
+										pos:  position{line: 853, col: 25, offset: 30510},
 										name: "SingleQuoteItalicTextContent",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 853, col: 55, offset: 30541},
+									pos:        position{line: 853, col: 55, offset: 30540},
 									val:        "_",
 									ignoreCase: false,
 								},
@@ -6252,43 +6252,43 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteItalicTextContent",
-			pos:  position{line: 857, col: 1, offset: 30803},
+			pos:  position{line: 857, col: 1, offset: 30802},
 			expr: &seqExpr{
-				pos: position{line: 857, col: 33, offset: 30835},
+				pos: position{line: 857, col: 33, offset: 30834},
 				exprs: []interface{}{
 					&notExpr{
-						pos: position{line: 857, col: 33, offset: 30835},
+						pos: position{line: 857, col: 33, offset: 30834},
 						expr: &ruleRefExpr{
-							pos:  position{line: 857, col: 34, offset: 30836},
+							pos:  position{line: 857, col: 34, offset: 30835},
 							name: "WS",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 857, col: 37, offset: 30839},
+						pos:  position{line: 857, col: 37, offset: 30838},
 						name: "SingleQuoteItalicTextElement",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 857, col: 66, offset: 30868},
+						pos: position{line: 857, col: 66, offset: 30867},
 						expr: &actionExpr{
-							pos: position{line: 857, col: 67, offset: 30869},
+							pos: position{line: 857, col: 67, offset: 30868},
 							run: (*parser).callonSingleQuoteItalicTextContent6,
 							expr: &seqExpr{
-								pos: position{line: 857, col: 67, offset: 30869},
+								pos: position{line: 857, col: 67, offset: 30868},
 								exprs: []interface{}{
 									&notExpr{
-										pos: position{line: 857, col: 67, offset: 30869},
+										pos: position{line: 857, col: 67, offset: 30868},
 										expr: &seqExpr{
-											pos: position{line: 857, col: 69, offset: 30871},
+											pos: position{line: 857, col: 69, offset: 30870},
 											exprs: []interface{}{
 												&litMatcher{
-													pos:        position{line: 857, col: 69, offset: 30871},
+													pos:        position{line: 857, col: 69, offset: 30870},
 													val:        "_",
 													ignoreCase: false,
 												},
 												&notExpr{
-													pos: position{line: 857, col: 73, offset: 30875},
+													pos: position{line: 857, col: 73, offset: 30874},
 													expr: &ruleRefExpr{
-														pos:  position{line: 857, col: 74, offset: 30876},
+														pos:  position{line: 857, col: 74, offset: 30875},
 														name: "Alphanum",
 													},
 												},
@@ -6296,21 +6296,21 @@ var g = &grammar{
 										},
 									},
 									&labeledExpr{
-										pos:   position{line: 857, col: 84, offset: 30886},
+										pos:   position{line: 857, col: 84, offset: 30885},
 										label: "spaces",
 										expr: &zeroOrMoreExpr{
-											pos: position{line: 857, col: 92, offset: 30894},
+											pos: position{line: 857, col: 92, offset: 30893},
 											expr: &ruleRefExpr{
-												pos:  position{line: 857, col: 92, offset: 30894},
+												pos:  position{line: 857, col: 92, offset: 30893},
 												name: "WS",
 											},
 										},
 									},
 									&labeledExpr{
-										pos:   position{line: 857, col: 97, offset: 30899},
+										pos:   position{line: 857, col: 97, offset: 30898},
 										label: "element",
 										expr: &ruleRefExpr{
-											pos:  position{line: 857, col: 106, offset: 30908},
+											pos:  position{line: 857, col: 106, offset: 30907},
 											name: "SingleQuoteItalicTextElement",
 										},
 									},
@@ -6323,60 +6323,60 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteItalicTextElement",
-			pos:  position{line: 861, col: 1, offset: 31001},
+			pos:  position{line: 861, col: 1, offset: 31000},
 			expr: &actionExpr{
-				pos: position{line: 861, col: 33, offset: 31033},
+				pos: position{line: 861, col: 33, offset: 31032},
 				run: (*parser).callonSingleQuoteItalicTextElement1,
 				expr: &seqExpr{
-					pos: position{line: 861, col: 33, offset: 31033},
+					pos: position{line: 861, col: 33, offset: 31032},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 861, col: 33, offset: 31033},
+							pos: position{line: 861, col: 33, offset: 31032},
 							expr: &ruleRefExpr{
-								pos:  position{line: 861, col: 34, offset: 31034},
+								pos:  position{line: 861, col: 34, offset: 31033},
 								name: "NEWLINE",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 861, col: 42, offset: 31042},
+							pos:   position{line: 861, col: 42, offset: 31041},
 							label: "element",
 							expr: &choiceExpr{
-								pos: position{line: 861, col: 51, offset: 31051},
+								pos: position{line: 861, col: 51, offset: 31050},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 861, col: 51, offset: 31051},
+										pos:  position{line: 861, col: 51, offset: 31050},
 										name: "DoubleQuoteItalicText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 862, col: 11, offset: 31083},
+										pos:  position{line: 862, col: 11, offset: 31082},
 										name: "BoldText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 863, col: 11, offset: 31103},
+										pos:  position{line: 863, col: 11, offset: 31102},
 										name: "MonospaceText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 864, col: 11, offset: 31127},
+										pos:  position{line: 864, col: 11, offset: 31126},
 										name: "SubscriptText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 865, col: 11, offset: 31151},
+										pos:  position{line: 865, col: 11, offset: 31150},
 										name: "SuperscriptText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 866, col: 11, offset: 31177},
+										pos:  position{line: 866, col: 11, offset: 31176},
 										name: "InlineImage",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 867, col: 11, offset: 31200},
+										pos:  position{line: 867, col: 11, offset: 31199},
 										name: "Link",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 868, col: 11, offset: 31216},
+										pos:  position{line: 868, col: 11, offset: 31215},
 										name: "Passthrough",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 869, col: 11, offset: 31239},
+										pos:  position{line: 869, col: 11, offset: 31238},
 										name: "NonSingleQuoteItalicText",
 									},
 								},
@@ -6388,61 +6388,61 @@ var g = &grammar{
 		},
 		{
 			name: "NonSingleQuoteItalicText",
-			pos:  position{line: 873, col: 1, offset: 31397},
+			pos:  position{line: 873, col: 1, offset: 31396},
 			expr: &actionExpr{
-				pos: position{line: 873, col: 29, offset: 31425},
+				pos: position{line: 873, col: 29, offset: 31424},
 				run: (*parser).callonNonSingleQuoteItalicText1,
 				expr: &seqExpr{
-					pos: position{line: 873, col: 29, offset: 31425},
+					pos: position{line: 873, col: 29, offset: 31424},
 					exprs: []interface{}{
 						&anyMatcher{
-							line: 873, col: 30, offset: 31426,
+							line: 873, col: 30, offset: 31425,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 873, col: 33, offset: 31429},
+							pos: position{line: 873, col: 33, offset: 31428},
 							expr: &seqExpr{
-								pos: position{line: 873, col: 34, offset: 31430},
+								pos: position{line: 873, col: 34, offset: 31429},
 								exprs: []interface{}{
 									&notExpr{
-										pos: position{line: 873, col: 34, offset: 31430},
+										pos: position{line: 873, col: 34, offset: 31429},
 										expr: &litMatcher{
-											pos:        position{line: 873, col: 35, offset: 31431},
+											pos:        position{line: 873, col: 35, offset: 31430},
 											val:        "_",
 											ignoreCase: false,
 										},
 									},
 									&notExpr{
-										pos: position{line: 873, col: 39, offset: 31435},
+										pos: position{line: 873, col: 39, offset: 31434},
 										expr: &ruleRefExpr{
-											pos:  position{line: 873, col: 40, offset: 31436},
+											pos:  position{line: 873, col: 40, offset: 31435},
 											name: "WS",
 										},
 									},
 									&notExpr{
-										pos: position{line: 873, col: 43, offset: 31439},
+										pos: position{line: 873, col: 43, offset: 31438},
 										expr: &litMatcher{
-											pos:        position{line: 873, col: 44, offset: 31440},
+											pos:        position{line: 873, col: 44, offset: 31439},
 											val:        "^",
 											ignoreCase: false,
 										},
 									},
 									&notExpr{
-										pos: position{line: 873, col: 48, offset: 31444},
+										pos: position{line: 873, col: 48, offset: 31443},
 										expr: &litMatcher{
-											pos:        position{line: 873, col: 49, offset: 31445},
+											pos:        position{line: 873, col: 49, offset: 31444},
 											val:        "~",
 											ignoreCase: false,
 										},
 									},
 									&notExpr{
-										pos: position{line: 873, col: 53, offset: 31449},
+										pos: position{line: 873, col: 53, offset: 31448},
 										expr: &ruleRefExpr{
-											pos:  position{line: 873, col: 54, offset: 31450},
+											pos:  position{line: 873, col: 54, offset: 31449},
 											name: "NEWLINE",
 										},
 									},
 									&anyMatcher{
-										line: 873, col: 62, offset: 31458,
+										line: 873, col: 62, offset: 31457,
 									},
 								},
 							},
@@ -6453,39 +6453,39 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedItalicText",
-			pos:  position{line: 877, col: 1, offset: 31518},
+			pos:  position{line: 877, col: 1, offset: 31517},
 			expr: &choiceExpr{
-				pos: position{line: 878, col: 5, offset: 31544},
+				pos: position{line: 878, col: 5, offset: 31543},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 878, col: 5, offset: 31544},
+						pos: position{line: 878, col: 5, offset: 31543},
 						run: (*parser).callonEscapedItalicText2,
 						expr: &seqExpr{
-							pos: position{line: 878, col: 5, offset: 31544},
+							pos: position{line: 878, col: 5, offset: 31543},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 878, col: 5, offset: 31544},
+									pos:   position{line: 878, col: 5, offset: 31543},
 									label: "backslashes",
 									expr: &ruleRefExpr{
-										pos:  position{line: 878, col: 18, offset: 31557},
+										pos:  position{line: 878, col: 18, offset: 31556},
 										name: "TwoOrMoreBackslashes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 878, col: 40, offset: 31579},
+									pos:        position{line: 878, col: 40, offset: 31578},
 									val:        "__",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 878, col: 45, offset: 31584},
+									pos:   position{line: 878, col: 45, offset: 31583},
 									label: "content",
 									expr: &ruleRefExpr{
-										pos:  position{line: 878, col: 54, offset: 31593},
+										pos:  position{line: 878, col: 54, offset: 31592},
 										name: "DoubleQuoteItalicTextContent",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 878, col: 84, offset: 31623},
+									pos:        position{line: 878, col: 84, offset: 31622},
 									val:        "__",
 									ignoreCase: false,
 								},
@@ -6493,34 +6493,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 880, col: 9, offset: 31779},
+						pos: position{line: 880, col: 9, offset: 31778},
 						run: (*parser).callonEscapedItalicText10,
 						expr: &seqExpr{
-							pos: position{line: 880, col: 9, offset: 31779},
+							pos: position{line: 880, col: 9, offset: 31778},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 880, col: 9, offset: 31779},
+									pos:   position{line: 880, col: 9, offset: 31778},
 									label: "backslashes",
 									expr: &ruleRefExpr{
-										pos:  position{line: 880, col: 22, offset: 31792},
+										pos:  position{line: 880, col: 22, offset: 31791},
 										name: "OneOrMoreBackslashes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 880, col: 44, offset: 31814},
+									pos:        position{line: 880, col: 44, offset: 31813},
 									val:        "__",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 880, col: 49, offset: 31819},
+									pos:   position{line: 880, col: 49, offset: 31818},
 									label: "content",
 									expr: &ruleRefExpr{
-										pos:  position{line: 880, col: 58, offset: 31828},
+										pos:  position{line: 880, col: 58, offset: 31827},
 										name: "SingleQuoteItalicTextContent",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 880, col: 88, offset: 31858},
+									pos:        position{line: 880, col: 88, offset: 31857},
 									val:        "_",
 									ignoreCase: false,
 								},
@@ -6528,34 +6528,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 883, col: 9, offset: 32057},
+						pos: position{line: 883, col: 9, offset: 32056},
 						run: (*parser).callonEscapedItalicText18,
 						expr: &seqExpr{
-							pos: position{line: 883, col: 9, offset: 32057},
+							pos: position{line: 883, col: 9, offset: 32056},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 883, col: 9, offset: 32057},
+									pos:   position{line: 883, col: 9, offset: 32056},
 									label: "backslashes",
 									expr: &ruleRefExpr{
-										pos:  position{line: 883, col: 22, offset: 32070},
+										pos:  position{line: 883, col: 22, offset: 32069},
 										name: "OneOrMoreBackslashes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 883, col: 44, offset: 32092},
+									pos:        position{line: 883, col: 44, offset: 32091},
 									val:        "_",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 883, col: 48, offset: 32096},
+									pos:   position{line: 883, col: 48, offset: 32095},
 									label: "content",
 									expr: &ruleRefExpr{
-										pos:  position{line: 883, col: 57, offset: 32105},
+										pos:  position{line: 883, col: 57, offset: 32104},
 										name: "SingleQuoteItalicTextContent",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 883, col: 87, offset: 32135},
+									pos:        position{line: 883, col: 87, offset: 32134},
 									val:        "_",
 									ignoreCase: false,
 								},
@@ -6567,16 +6567,16 @@ var g = &grammar{
 		},
 		{
 			name: "MonospaceText",
-			pos:  position{line: 890, col: 1, offset: 32344},
+			pos:  position{line: 890, col: 1, offset: 32343},
 			expr: &choiceExpr{
-				pos: position{line: 890, col: 18, offset: 32361},
+				pos: position{line: 890, col: 18, offset: 32360},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 890, col: 18, offset: 32361},
+						pos:  position{line: 890, col: 18, offset: 32360},
 						name: "DoubleQuoteMonospaceText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 890, col: 45, offset: 32388},
+						pos:  position{line: 890, col: 45, offset: 32387},
 						name: "SingleQuoteMonospaceText",
 					},
 				},
@@ -6584,36 +6584,36 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteMonospaceText",
-			pos:  position{line: 892, col: 1, offset: 32414},
+			pos:  position{line: 892, col: 1, offset: 32413},
 			expr: &actionExpr{
-				pos: position{line: 892, col: 29, offset: 32442},
+				pos: position{line: 892, col: 29, offset: 32441},
 				run: (*parser).callonDoubleQuoteMonospaceText1,
 				expr: &seqExpr{
-					pos: position{line: 892, col: 29, offset: 32442},
+					pos: position{line: 892, col: 29, offset: 32441},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 892, col: 29, offset: 32442},
+							pos: position{line: 892, col: 29, offset: 32441},
 							expr: &litMatcher{
-								pos:        position{line: 892, col: 30, offset: 32443},
+								pos:        position{line: 892, col: 30, offset: 32442},
 								val:        "\\\\",
 								ignoreCase: false,
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 892, col: 35, offset: 32448},
+							pos:        position{line: 892, col: 35, offset: 32447},
 							val:        "``",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 892, col: 40, offset: 32453},
+							pos:   position{line: 892, col: 40, offset: 32452},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 892, col: 49, offset: 32462},
+								pos:  position{line: 892, col: 49, offset: 32461},
 								name: "DoubleQuoteMonospaceTextContent",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 892, col: 82, offset: 32495},
+							pos:        position{line: 892, col: 82, offset: 32494},
 							val:        "``",
 							ignoreCase: false,
 						},
@@ -6623,42 +6623,42 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteMonospaceTextContent",
-			pos:  position{line: 896, col: 1, offset: 32624},
+			pos:  position{line: 896, col: 1, offset: 32623},
 			expr: &seqExpr{
-				pos: position{line: 896, col: 36, offset: 32659},
+				pos: position{line: 896, col: 36, offset: 32658},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 896, col: 36, offset: 32659},
+						pos:  position{line: 896, col: 36, offset: 32658},
 						name: "DoubleQuoteMonospaceTextElement",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 896, col: 68, offset: 32691},
+						pos: position{line: 896, col: 68, offset: 32690},
 						expr: &actionExpr{
-							pos: position{line: 896, col: 69, offset: 32692},
+							pos: position{line: 896, col: 69, offset: 32691},
 							run: (*parser).callonDoubleQuoteMonospaceTextContent4,
 							expr: &seqExpr{
-								pos: position{line: 896, col: 69, offset: 32692},
+								pos: position{line: 896, col: 69, offset: 32691},
 								exprs: []interface{}{
 									&notExpr{
-										pos: position{line: 896, col: 69, offset: 32692},
+										pos: position{line: 896, col: 69, offset: 32691},
 										expr: &litMatcher{
-											pos:        position{line: 896, col: 71, offset: 32694},
+											pos:        position{line: 896, col: 71, offset: 32693},
 											val:        "``",
 											ignoreCase: false,
 										},
 									},
 									&labeledExpr{
-										pos:   position{line: 896, col: 77, offset: 32700},
+										pos:   position{line: 896, col: 77, offset: 32699},
 										label: "element",
 										expr: &choiceExpr{
-											pos: position{line: 896, col: 86, offset: 32709},
+											pos: position{line: 896, col: 86, offset: 32708},
 											alternatives: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 896, col: 86, offset: 32709},
+													pos:  position{line: 896, col: 86, offset: 32708},
 													name: "WS",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 896, col: 91, offset: 32714},
+													pos:  position{line: 896, col: 91, offset: 32713},
 													name: "DoubleQuoteMonospaceTextElement",
 												},
 											},
@@ -6673,60 +6673,60 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteMonospaceTextElement",
-			pos:  position{line: 900, col: 1, offset: 32811},
+			pos:  position{line: 900, col: 1, offset: 32810},
 			expr: &actionExpr{
-				pos: position{line: 900, col: 36, offset: 32846},
+				pos: position{line: 900, col: 36, offset: 32845},
 				run: (*parser).callonDoubleQuoteMonospaceTextElement1,
 				expr: &seqExpr{
-					pos: position{line: 900, col: 36, offset: 32846},
+					pos: position{line: 900, col: 36, offset: 32845},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 900, col: 36, offset: 32846},
+							pos: position{line: 900, col: 36, offset: 32845},
 							expr: &ruleRefExpr{
-								pos:  position{line: 900, col: 37, offset: 32847},
+								pos:  position{line: 900, col: 37, offset: 32846},
 								name: "NEWLINE",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 900, col: 45, offset: 32855},
+							pos:   position{line: 900, col: 45, offset: 32854},
 							label: "element",
 							expr: &choiceExpr{
-								pos: position{line: 900, col: 54, offset: 32864},
+								pos: position{line: 900, col: 54, offset: 32863},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 900, col: 54, offset: 32864},
+										pos:  position{line: 900, col: 54, offset: 32863},
 										name: "SingleQuoteMonospaceText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 901, col: 11, offset: 32900},
+										pos:  position{line: 901, col: 11, offset: 32899},
 										name: "BoldText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 902, col: 11, offset: 32919},
+										pos:  position{line: 902, col: 11, offset: 32918},
 										name: "ItalicText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 903, col: 11, offset: 32941},
+										pos:  position{line: 903, col: 11, offset: 32940},
 										name: "SubscriptText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 904, col: 11, offset: 32965},
+										pos:  position{line: 904, col: 11, offset: 32964},
 										name: "SuperscriptText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 905, col: 11, offset: 32991},
+										pos:  position{line: 905, col: 11, offset: 32990},
 										name: "InlineImage",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 906, col: 11, offset: 33014},
+										pos:  position{line: 906, col: 11, offset: 33013},
 										name: "Link",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 907, col: 11, offset: 33030},
+										pos:  position{line: 907, col: 11, offset: 33029},
 										name: "Passthrough",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 908, col: 11, offset: 33053},
+										pos:  position{line: 908, col: 11, offset: 33052},
 										name: "NonDoubleQuoteMonospaceText",
 									},
 								},
@@ -6738,61 +6738,61 @@ var g = &grammar{
 		},
 		{
 			name: "NonDoubleQuoteMonospaceText",
-			pos:  position{line: 912, col: 1, offset: 33214},
+			pos:  position{line: 912, col: 1, offset: 33213},
 			expr: &actionExpr{
-				pos: position{line: 912, col: 32, offset: 33245},
+				pos: position{line: 912, col: 32, offset: 33244},
 				run: (*parser).callonNonDoubleQuoteMonospaceText1,
 				expr: &seqExpr{
-					pos: position{line: 912, col: 32, offset: 33245},
+					pos: position{line: 912, col: 32, offset: 33244},
 					exprs: []interface{}{
 						&anyMatcher{
-							line: 912, col: 33, offset: 33246,
+							line: 912, col: 33, offset: 33245,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 912, col: 36, offset: 33249},
+							pos: position{line: 912, col: 36, offset: 33248},
 							expr: &seqExpr{
-								pos: position{line: 912, col: 37, offset: 33250},
+								pos: position{line: 912, col: 37, offset: 33249},
 								exprs: []interface{}{
 									&notExpr{
-										pos: position{line: 912, col: 37, offset: 33250},
+										pos: position{line: 912, col: 37, offset: 33249},
 										expr: &litMatcher{
-											pos:        position{line: 912, col: 38, offset: 33251},
+											pos:        position{line: 912, col: 38, offset: 33250},
 											val:        "``",
 											ignoreCase: false,
 										},
 									},
 									&notExpr{
-										pos: position{line: 912, col: 43, offset: 33256},
+										pos: position{line: 912, col: 43, offset: 33255},
 										expr: &ruleRefExpr{
-											pos:  position{line: 912, col: 44, offset: 33257},
+											pos:  position{line: 912, col: 44, offset: 33256},
 											name: "WS",
 										},
 									},
 									&notExpr{
-										pos: position{line: 912, col: 47, offset: 33260},
+										pos: position{line: 912, col: 47, offset: 33259},
 										expr: &litMatcher{
-											pos:        position{line: 912, col: 48, offset: 33261},
+											pos:        position{line: 912, col: 48, offset: 33260},
 											val:        "^",
 											ignoreCase: false,
 										},
 									},
 									&notExpr{
-										pos: position{line: 912, col: 52, offset: 33265},
+										pos: position{line: 912, col: 52, offset: 33264},
 										expr: &litMatcher{
-											pos:        position{line: 912, col: 53, offset: 33266},
+											pos:        position{line: 912, col: 53, offset: 33265},
 											val:        "~",
 											ignoreCase: false,
 										},
 									},
 									&notExpr{
-										pos: position{line: 912, col: 57, offset: 33270},
+										pos: position{line: 912, col: 57, offset: 33269},
 										expr: &ruleRefExpr{
-											pos:  position{line: 912, col: 58, offset: 33271},
+											pos:  position{line: 912, col: 58, offset: 33270},
 											name: "NEWLINE",
 										},
 									},
 									&anyMatcher{
-										line: 912, col: 66, offset: 33279,
+										line: 912, col: 66, offset: 33278,
 									},
 								},
 							},
@@ -6803,47 +6803,47 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteMonospaceText",
-			pos:  position{line: 916, col: 1, offset: 33339},
+			pos:  position{line: 916, col: 1, offset: 33338},
 			expr: &choiceExpr{
-				pos: position{line: 916, col: 29, offset: 33367},
+				pos: position{line: 916, col: 29, offset: 33366},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 916, col: 29, offset: 33367},
+						pos: position{line: 916, col: 29, offset: 33366},
 						run: (*parser).callonSingleQuoteMonospaceText2,
 						expr: &seqExpr{
-							pos: position{line: 916, col: 29, offset: 33367},
+							pos: position{line: 916, col: 29, offset: 33366},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 916, col: 29, offset: 33367},
+									pos: position{line: 916, col: 29, offset: 33366},
 									expr: &litMatcher{
-										pos:        position{line: 916, col: 30, offset: 33368},
+										pos:        position{line: 916, col: 30, offset: 33367},
 										val:        "\\",
 										ignoreCase: false,
 									},
 								},
 								&notExpr{
-									pos: position{line: 916, col: 34, offset: 33372},
+									pos: position{line: 916, col: 34, offset: 33371},
 									expr: &litMatcher{
-										pos:        position{line: 916, col: 35, offset: 33373},
+										pos:        position{line: 916, col: 35, offset: 33372},
 										val:        "``",
 										ignoreCase: false,
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 916, col: 40, offset: 33378},
+									pos:        position{line: 916, col: 40, offset: 33377},
 									val:        "`",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 916, col: 44, offset: 33382},
+									pos:   position{line: 916, col: 44, offset: 33381},
 									label: "content",
 									expr: &ruleRefExpr{
-										pos:  position{line: 916, col: 53, offset: 33391},
+										pos:  position{line: 916, col: 53, offset: 33390},
 										name: "SingleQuoteMonospaceTextContent",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 916, col: 86, offset: 33424},
+									pos:        position{line: 916, col: 86, offset: 33423},
 									val:        "`",
 									ignoreCase: false,
 								},
@@ -6851,34 +6851,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 918, col: 5, offset: 33609},
+						pos: position{line: 918, col: 5, offset: 33608},
 						run: (*parser).callonSingleQuoteMonospaceText12,
 						expr: &seqExpr{
-							pos: position{line: 918, col: 5, offset: 33609},
+							pos: position{line: 918, col: 5, offset: 33608},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 918, col: 5, offset: 33609},
+									pos: position{line: 918, col: 5, offset: 33608},
 									expr: &litMatcher{
-										pos:        position{line: 918, col: 6, offset: 33610},
+										pos:        position{line: 918, col: 6, offset: 33609},
 										val:        "\\\\",
 										ignoreCase: false,
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 918, col: 11, offset: 33615},
+									pos:        position{line: 918, col: 11, offset: 33614},
 									val:        "``",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 918, col: 16, offset: 33620},
+									pos:   position{line: 918, col: 16, offset: 33619},
 									label: "content",
 									expr: &ruleRefExpr{
-										pos:  position{line: 918, col: 25, offset: 33629},
+										pos:  position{line: 918, col: 25, offset: 33628},
 										name: "SingleQuoteMonospaceTextContent",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 918, col: 58, offset: 33662},
+									pos:        position{line: 918, col: 58, offset: 33661},
 									val:        "`",
 									ignoreCase: false,
 								},
@@ -6890,43 +6890,43 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteMonospaceTextContent",
-			pos:  position{line: 922, col: 1, offset: 33930},
+			pos:  position{line: 922, col: 1, offset: 33929},
 			expr: &seqExpr{
-				pos: position{line: 922, col: 36, offset: 33965},
+				pos: position{line: 922, col: 36, offset: 33964},
 				exprs: []interface{}{
 					&notExpr{
-						pos: position{line: 922, col: 36, offset: 33965},
+						pos: position{line: 922, col: 36, offset: 33964},
 						expr: &ruleRefExpr{
-							pos:  position{line: 922, col: 37, offset: 33966},
+							pos:  position{line: 922, col: 37, offset: 33965},
 							name: "WS",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 922, col: 40, offset: 33969},
+						pos:  position{line: 922, col: 40, offset: 33968},
 						name: "SingleQuoteMonospaceTextElement",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 922, col: 72, offset: 34001},
+						pos: position{line: 922, col: 72, offset: 34000},
 						expr: &actionExpr{
-							pos: position{line: 922, col: 73, offset: 34002},
+							pos: position{line: 922, col: 73, offset: 34001},
 							run: (*parser).callonSingleQuoteMonospaceTextContent6,
 							expr: &seqExpr{
-								pos: position{line: 922, col: 73, offset: 34002},
+								pos: position{line: 922, col: 73, offset: 34001},
 								exprs: []interface{}{
 									&notExpr{
-										pos: position{line: 922, col: 73, offset: 34002},
+										pos: position{line: 922, col: 73, offset: 34001},
 										expr: &seqExpr{
-											pos: position{line: 922, col: 75, offset: 34004},
+											pos: position{line: 922, col: 75, offset: 34003},
 											exprs: []interface{}{
 												&litMatcher{
-													pos:        position{line: 922, col: 75, offset: 34004},
+													pos:        position{line: 922, col: 75, offset: 34003},
 													val:        "`",
 													ignoreCase: false,
 												},
 												&notExpr{
-													pos: position{line: 922, col: 79, offset: 34008},
+													pos: position{line: 922, col: 79, offset: 34007},
 													expr: &ruleRefExpr{
-														pos:  position{line: 922, col: 80, offset: 34009},
+														pos:  position{line: 922, col: 80, offset: 34008},
 														name: "Alphanum",
 													},
 												},
@@ -6934,21 +6934,21 @@ var g = &grammar{
 										},
 									},
 									&labeledExpr{
-										pos:   position{line: 922, col: 90, offset: 34019},
+										pos:   position{line: 922, col: 90, offset: 34018},
 										label: "spaces",
 										expr: &zeroOrMoreExpr{
-											pos: position{line: 922, col: 98, offset: 34027},
+											pos: position{line: 922, col: 98, offset: 34026},
 											expr: &ruleRefExpr{
-												pos:  position{line: 922, col: 98, offset: 34027},
+												pos:  position{line: 922, col: 98, offset: 34026},
 												name: "WS",
 											},
 										},
 									},
 									&labeledExpr{
-										pos:   position{line: 922, col: 103, offset: 34032},
+										pos:   position{line: 922, col: 103, offset: 34031},
 										label: "element",
 										expr: &ruleRefExpr{
-											pos:  position{line: 922, col: 112, offset: 34041},
+											pos:  position{line: 922, col: 112, offset: 34040},
 											name: "SingleQuoteMonospaceTextElement",
 										},
 									},
@@ -6961,54 +6961,54 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteMonospaceTextElement",
-			pos:  position{line: 926, col: 1, offset: 34137},
+			pos:  position{line: 926, col: 1, offset: 34136},
 			expr: &actionExpr{
-				pos: position{line: 926, col: 37, offset: 34173},
+				pos: position{line: 926, col: 37, offset: 34172},
 				run: (*parser).callonSingleQuoteMonospaceTextElement1,
 				expr: &labeledExpr{
-					pos:   position{line: 926, col: 37, offset: 34173},
+					pos:   position{line: 926, col: 37, offset: 34172},
 					label: "element",
 					expr: &choiceExpr{
-						pos: position{line: 926, col: 46, offset: 34182},
+						pos: position{line: 926, col: 46, offset: 34181},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 926, col: 46, offset: 34182},
+								pos:  position{line: 926, col: 46, offset: 34181},
 								name: "NEWLINE",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 927, col: 11, offset: 34220},
+								pos:  position{line: 927, col: 11, offset: 34219},
 								name: "DoubleQuoteMonospaceText",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 928, col: 11, offset: 34256},
+								pos:  position{line: 928, col: 11, offset: 34255},
 								name: "BoldText",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 929, col: 11, offset: 34276},
+								pos:  position{line: 929, col: 11, offset: 34275},
 								name: "ItalicText",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 930, col: 11, offset: 34297},
+								pos:  position{line: 930, col: 11, offset: 34296},
 								name: "SubscriptText",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 931, col: 11, offset: 34321},
+								pos:  position{line: 931, col: 11, offset: 34320},
 								name: "SuperscriptText",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 932, col: 11, offset: 34347},
+								pos:  position{line: 932, col: 11, offset: 34346},
 								name: "InlineImage",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 933, col: 11, offset: 34370},
+								pos:  position{line: 933, col: 11, offset: 34369},
 								name: "Link",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 934, col: 11, offset: 34386},
+								pos:  position{line: 934, col: 11, offset: 34385},
 								name: "Passthrough",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 935, col: 11, offset: 34409},
+								pos:  position{line: 935, col: 11, offset: 34408},
 								name: "NonSingleQuoteMonospaceText",
 							},
 						},
@@ -7018,61 +7018,61 @@ var g = &grammar{
 		},
 		{
 			name: "NonSingleQuoteMonospaceText",
-			pos:  position{line: 939, col: 1, offset: 34570},
+			pos:  position{line: 939, col: 1, offset: 34569},
 			expr: &actionExpr{
-				pos: position{line: 939, col: 32, offset: 34601},
+				pos: position{line: 939, col: 32, offset: 34600},
 				run: (*parser).callonNonSingleQuoteMonospaceText1,
 				expr: &seqExpr{
-					pos: position{line: 939, col: 32, offset: 34601},
+					pos: position{line: 939, col: 32, offset: 34600},
 					exprs: []interface{}{
 						&anyMatcher{
-							line: 939, col: 33, offset: 34602,
+							line: 939, col: 33, offset: 34601,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 939, col: 36, offset: 34605},
+							pos: position{line: 939, col: 36, offset: 34604},
 							expr: &seqExpr{
-								pos: position{line: 939, col: 37, offset: 34606},
+								pos: position{line: 939, col: 37, offset: 34605},
 								exprs: []interface{}{
 									&notExpr{
-										pos: position{line: 939, col: 37, offset: 34606},
+										pos: position{line: 939, col: 37, offset: 34605},
 										expr: &ruleRefExpr{
-											pos:  position{line: 939, col: 38, offset: 34607},
+											pos:  position{line: 939, col: 38, offset: 34606},
 											name: "WS",
 										},
 									},
 									&notExpr{
-										pos: position{line: 939, col: 41, offset: 34610},
+										pos: position{line: 939, col: 41, offset: 34609},
 										expr: &litMatcher{
-											pos:        position{line: 939, col: 42, offset: 34611},
+											pos:        position{line: 939, col: 42, offset: 34610},
 											val:        "`",
 											ignoreCase: false,
 										},
 									},
 									&notExpr{
-										pos: position{line: 939, col: 46, offset: 34615},
+										pos: position{line: 939, col: 46, offset: 34614},
 										expr: &litMatcher{
-											pos:        position{line: 939, col: 47, offset: 34616},
+											pos:        position{line: 939, col: 47, offset: 34615},
 											val:        "^",
 											ignoreCase: false,
 										},
 									},
 									&notExpr{
-										pos: position{line: 939, col: 51, offset: 34620},
+										pos: position{line: 939, col: 51, offset: 34619},
 										expr: &litMatcher{
-											pos:        position{line: 939, col: 52, offset: 34621},
+											pos:        position{line: 939, col: 52, offset: 34620},
 											val:        "~",
 											ignoreCase: false,
 										},
 									},
 									&notExpr{
-										pos: position{line: 939, col: 56, offset: 34625},
+										pos: position{line: 939, col: 56, offset: 34624},
 										expr: &ruleRefExpr{
-											pos:  position{line: 939, col: 57, offset: 34626},
+											pos:  position{line: 939, col: 57, offset: 34625},
 											name: "NEWLINE",
 										},
 									},
 									&anyMatcher{
-										line: 939, col: 65, offset: 34634,
+										line: 939, col: 65, offset: 34633,
 									},
 								},
 							},
@@ -7083,39 +7083,39 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedMonospaceText",
-			pos:  position{line: 943, col: 1, offset: 34715},
+			pos:  position{line: 943, col: 1, offset: 34714},
 			expr: &choiceExpr{
-				pos: position{line: 944, col: 5, offset: 34744},
+				pos: position{line: 944, col: 5, offset: 34743},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 944, col: 5, offset: 34744},
+						pos: position{line: 944, col: 5, offset: 34743},
 						run: (*parser).callonEscapedMonospaceText2,
 						expr: &seqExpr{
-							pos: position{line: 944, col: 5, offset: 34744},
+							pos: position{line: 944, col: 5, offset: 34743},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 944, col: 5, offset: 34744},
+									pos:   position{line: 944, col: 5, offset: 34743},
 									label: "backslashes",
 									expr: &ruleRefExpr{
-										pos:  position{line: 944, col: 18, offset: 34757},
+										pos:  position{line: 944, col: 18, offset: 34756},
 										name: "TwoOrMoreBackslashes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 944, col: 40, offset: 34779},
+									pos:        position{line: 944, col: 40, offset: 34778},
 									val:        "``",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 944, col: 45, offset: 34784},
+									pos:   position{line: 944, col: 45, offset: 34783},
 									label: "content",
 									expr: &ruleRefExpr{
-										pos:  position{line: 944, col: 54, offset: 34793},
+										pos:  position{line: 944, col: 54, offset: 34792},
 										name: "DoubleQuoteMonospaceTextContent",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 944, col: 87, offset: 34826},
+									pos:        position{line: 944, col: 87, offset: 34825},
 									val:        "``",
 									ignoreCase: false,
 								},
@@ -7123,34 +7123,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 946, col: 9, offset: 34982},
+						pos: position{line: 946, col: 9, offset: 34981},
 						run: (*parser).callonEscapedMonospaceText10,
 						expr: &seqExpr{
-							pos: position{line: 946, col: 9, offset: 34982},
+							pos: position{line: 946, col: 9, offset: 34981},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 946, col: 9, offset: 34982},
+									pos:   position{line: 946, col: 9, offset: 34981},
 									label: "backslashes",
 									expr: &ruleRefExpr{
-										pos:  position{line: 946, col: 22, offset: 34995},
+										pos:  position{line: 946, col: 22, offset: 34994},
 										name: "OneOrMoreBackslashes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 946, col: 44, offset: 35017},
+									pos:        position{line: 946, col: 44, offset: 35016},
 									val:        "``",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 946, col: 49, offset: 35022},
+									pos:   position{line: 946, col: 49, offset: 35021},
 									label: "content",
 									expr: &ruleRefExpr{
-										pos:  position{line: 946, col: 58, offset: 35031},
+										pos:  position{line: 946, col: 58, offset: 35030},
 										name: "SingleQuoteMonospaceTextContent",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 946, col: 91, offset: 35064},
+									pos:        position{line: 946, col: 91, offset: 35063},
 									val:        "`",
 									ignoreCase: false,
 								},
@@ -7158,34 +7158,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 949, col: 9, offset: 35263},
+						pos: position{line: 949, col: 9, offset: 35262},
 						run: (*parser).callonEscapedMonospaceText18,
 						expr: &seqExpr{
-							pos: position{line: 949, col: 9, offset: 35263},
+							pos: position{line: 949, col: 9, offset: 35262},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 949, col: 9, offset: 35263},
+									pos:   position{line: 949, col: 9, offset: 35262},
 									label: "backslashes",
 									expr: &ruleRefExpr{
-										pos:  position{line: 949, col: 22, offset: 35276},
+										pos:  position{line: 949, col: 22, offset: 35275},
 										name: "OneOrMoreBackslashes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 949, col: 44, offset: 35298},
+									pos:        position{line: 949, col: 44, offset: 35297},
 									val:        "`",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 949, col: 48, offset: 35302},
+									pos:   position{line: 949, col: 48, offset: 35301},
 									label: "content",
 									expr: &ruleRefExpr{
-										pos:  position{line: 949, col: 57, offset: 35311},
+										pos:  position{line: 949, col: 57, offset: 35310},
 										name: "SingleQuoteMonospaceTextContent",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 949, col: 90, offset: 35344},
+									pos:        position{line: 949, col: 90, offset: 35343},
 									val:        "`",
 									ignoreCase: false,
 								},
@@ -7197,36 +7197,36 @@ var g = &grammar{
 		},
 		{
 			name: "SubscriptText",
-			pos:  position{line: 953, col: 1, offset: 35493},
+			pos:  position{line: 953, col: 1, offset: 35492},
 			expr: &actionExpr{
-				pos: position{line: 953, col: 18, offset: 35510},
+				pos: position{line: 953, col: 18, offset: 35509},
 				run: (*parser).callonSubscriptText1,
 				expr: &seqExpr{
-					pos: position{line: 953, col: 18, offset: 35510},
+					pos: position{line: 953, col: 18, offset: 35509},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 953, col: 18, offset: 35510},
+							pos: position{line: 953, col: 18, offset: 35509},
 							expr: &litMatcher{
-								pos:        position{line: 953, col: 19, offset: 35511},
+								pos:        position{line: 953, col: 19, offset: 35510},
 								val:        "\\",
 								ignoreCase: false,
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 953, col: 23, offset: 35515},
+							pos:        position{line: 953, col: 23, offset: 35514},
 							val:        "~",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 953, col: 27, offset: 35519},
+							pos:   position{line: 953, col: 27, offset: 35518},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 953, col: 36, offset: 35528},
+								pos:  position{line: 953, col: 36, offset: 35527},
 								name: "SubscriptTextElement",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 953, col: 58, offset: 35550},
+							pos:        position{line: 953, col: 58, offset: 35549},
 							val:        "~",
 							ignoreCase: false,
 						},
@@ -7236,16 +7236,16 @@ var g = &grammar{
 		},
 		{
 			name: "SubscriptTextElement",
-			pos:  position{line: 957, col: 1, offset: 35639},
+			pos:  position{line: 957, col: 1, offset: 35638},
 			expr: &choiceExpr{
-				pos: position{line: 957, col: 25, offset: 35663},
+				pos: position{line: 957, col: 25, offset: 35662},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 957, col: 25, offset: 35663},
+						pos:  position{line: 957, col: 25, offset: 35662},
 						name: "QuotedText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 957, col: 38, offset: 35676},
+						pos:  position{line: 957, col: 38, offset: 35675},
 						name: "NonSubscriptText",
 					},
 				},
@@ -7253,39 +7253,39 @@ var g = &grammar{
 		},
 		{
 			name: "NonSubscriptText",
-			pos:  position{line: 959, col: 1, offset: 35695},
+			pos:  position{line: 959, col: 1, offset: 35694},
 			expr: &actionExpr{
-				pos: position{line: 959, col: 21, offset: 35715},
+				pos: position{line: 959, col: 21, offset: 35714},
 				run: (*parser).callonNonSubscriptText1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 959, col: 21, offset: 35715},
+					pos: position{line: 959, col: 21, offset: 35714},
 					expr: &seqExpr{
-						pos: position{line: 959, col: 22, offset: 35716},
+						pos: position{line: 959, col: 22, offset: 35715},
 						exprs: []interface{}{
 							&notExpr{
-								pos: position{line: 959, col: 22, offset: 35716},
+								pos: position{line: 959, col: 22, offset: 35715},
 								expr: &ruleRefExpr{
-									pos:  position{line: 959, col: 23, offset: 35717},
+									pos:  position{line: 959, col: 23, offset: 35716},
 									name: "NEWLINE",
 								},
 							},
 							&notExpr{
-								pos: position{line: 959, col: 31, offset: 35725},
+								pos: position{line: 959, col: 31, offset: 35724},
 								expr: &ruleRefExpr{
-									pos:  position{line: 959, col: 32, offset: 35726},
+									pos:  position{line: 959, col: 32, offset: 35725},
 									name: "WS",
 								},
 							},
 							&notExpr{
-								pos: position{line: 959, col: 35, offset: 35729},
+								pos: position{line: 959, col: 35, offset: 35728},
 								expr: &litMatcher{
-									pos:        position{line: 959, col: 36, offset: 35730},
+									pos:        position{line: 959, col: 36, offset: 35729},
 									val:        "~",
 									ignoreCase: false,
 								},
 							},
 							&anyMatcher{
-								line: 959, col: 40, offset: 35734,
+								line: 959, col: 40, offset: 35733,
 							},
 						},
 					},
@@ -7294,36 +7294,36 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedSubscriptText",
-			pos:  position{line: 963, col: 1, offset: 35767},
+			pos:  position{line: 963, col: 1, offset: 35766},
 			expr: &actionExpr{
-				pos: position{line: 963, col: 25, offset: 35791},
+				pos: position{line: 963, col: 25, offset: 35790},
 				run: (*parser).callonEscapedSubscriptText1,
 				expr: &seqExpr{
-					pos: position{line: 963, col: 25, offset: 35791},
+					pos: position{line: 963, col: 25, offset: 35790},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 963, col: 25, offset: 35791},
+							pos:   position{line: 963, col: 25, offset: 35790},
 							label: "backslashes",
 							expr: &ruleRefExpr{
-								pos:  position{line: 963, col: 38, offset: 35804},
+								pos:  position{line: 963, col: 38, offset: 35803},
 								name: "OneOrMoreBackslashes",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 963, col: 60, offset: 35826},
+							pos:        position{line: 963, col: 60, offset: 35825},
 							val:        "~",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 963, col: 64, offset: 35830},
+							pos:   position{line: 963, col: 64, offset: 35829},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 963, col: 73, offset: 35839},
+								pos:  position{line: 963, col: 73, offset: 35838},
 								name: "SubscriptTextElement",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 963, col: 95, offset: 35861},
+							pos:        position{line: 963, col: 95, offset: 35860},
 							val:        "~",
 							ignoreCase: false,
 						},
@@ -7333,36 +7333,36 @@ var g = &grammar{
 		},
 		{
 			name: "SuperscriptText",
-			pos:  position{line: 967, col: 1, offset: 35990},
+			pos:  position{line: 967, col: 1, offset: 35989},
 			expr: &actionExpr{
-				pos: position{line: 967, col: 20, offset: 36009},
+				pos: position{line: 967, col: 20, offset: 36008},
 				run: (*parser).callonSuperscriptText1,
 				expr: &seqExpr{
-					pos: position{line: 967, col: 20, offset: 36009},
+					pos: position{line: 967, col: 20, offset: 36008},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 967, col: 20, offset: 36009},
+							pos: position{line: 967, col: 20, offset: 36008},
 							expr: &litMatcher{
-								pos:        position{line: 967, col: 21, offset: 36010},
+								pos:        position{line: 967, col: 21, offset: 36009},
 								val:        "\\",
 								ignoreCase: false,
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 967, col: 25, offset: 36014},
+							pos:        position{line: 967, col: 25, offset: 36013},
 							val:        "^",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 967, col: 29, offset: 36018},
+							pos:   position{line: 967, col: 29, offset: 36017},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 967, col: 38, offset: 36027},
+								pos:  position{line: 967, col: 38, offset: 36026},
 								name: "SuperscriptTextElement",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 967, col: 62, offset: 36051},
+							pos:        position{line: 967, col: 62, offset: 36050},
 							val:        "^",
 							ignoreCase: false,
 						},
@@ -7372,16 +7372,16 @@ var g = &grammar{
 		},
 		{
 			name: "SuperscriptTextElement",
-			pos:  position{line: 971, col: 1, offset: 36142},
+			pos:  position{line: 971, col: 1, offset: 36141},
 			expr: &choiceExpr{
-				pos: position{line: 971, col: 27, offset: 36168},
+				pos: position{line: 971, col: 27, offset: 36167},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 971, col: 27, offset: 36168},
+						pos:  position{line: 971, col: 27, offset: 36167},
 						name: "QuotedText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 971, col: 40, offset: 36181},
+						pos:  position{line: 971, col: 40, offset: 36180},
 						name: "NonSuperscriptText",
 					},
 				},
@@ -7389,39 +7389,39 @@ var g = &grammar{
 		},
 		{
 			name: "NonSuperscriptText",
-			pos:  position{line: 973, col: 1, offset: 36202},
+			pos:  position{line: 973, col: 1, offset: 36201},
 			expr: &actionExpr{
-				pos: position{line: 973, col: 23, offset: 36224},
+				pos: position{line: 973, col: 23, offset: 36223},
 				run: (*parser).callonNonSuperscriptText1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 973, col: 23, offset: 36224},
+					pos: position{line: 973, col: 23, offset: 36223},
 					expr: &seqExpr{
-						pos: position{line: 973, col: 24, offset: 36225},
+						pos: position{line: 973, col: 24, offset: 36224},
 						exprs: []interface{}{
 							&notExpr{
-								pos: position{line: 973, col: 24, offset: 36225},
+								pos: position{line: 973, col: 24, offset: 36224},
 								expr: &ruleRefExpr{
-									pos:  position{line: 973, col: 25, offset: 36226},
+									pos:  position{line: 973, col: 25, offset: 36225},
 									name: "NEWLINE",
 								},
 							},
 							&notExpr{
-								pos: position{line: 973, col: 33, offset: 36234},
+								pos: position{line: 973, col: 33, offset: 36233},
 								expr: &ruleRefExpr{
-									pos:  position{line: 973, col: 34, offset: 36235},
+									pos:  position{line: 973, col: 34, offset: 36234},
 									name: "WS",
 								},
 							},
 							&notExpr{
-								pos: position{line: 973, col: 37, offset: 36238},
+								pos: position{line: 973, col: 37, offset: 36237},
 								expr: &litMatcher{
-									pos:        position{line: 973, col: 38, offset: 36239},
+									pos:        position{line: 973, col: 38, offset: 36238},
 									val:        "^",
 									ignoreCase: false,
 								},
 							},
 							&anyMatcher{
-								line: 973, col: 42, offset: 36243,
+								line: 973, col: 42, offset: 36242,
 							},
 						},
 					},
@@ -7430,36 +7430,36 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedSuperscriptText",
-			pos:  position{line: 977, col: 1, offset: 36276},
+			pos:  position{line: 977, col: 1, offset: 36275},
 			expr: &actionExpr{
-				pos: position{line: 977, col: 27, offset: 36302},
+				pos: position{line: 977, col: 27, offset: 36301},
 				run: (*parser).callonEscapedSuperscriptText1,
 				expr: &seqExpr{
-					pos: position{line: 977, col: 27, offset: 36302},
+					pos: position{line: 977, col: 27, offset: 36301},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 977, col: 27, offset: 36302},
+							pos:   position{line: 977, col: 27, offset: 36301},
 							label: "backslashes",
 							expr: &ruleRefExpr{
-								pos:  position{line: 977, col: 40, offset: 36315},
+								pos:  position{line: 977, col: 40, offset: 36314},
 								name: "OneOrMoreBackslashes",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 977, col: 62, offset: 36337},
+							pos:        position{line: 977, col: 62, offset: 36336},
 							val:        "^",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 977, col: 66, offset: 36341},
+							pos:   position{line: 977, col: 66, offset: 36340},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 977, col: 75, offset: 36350},
+								pos:  position{line: 977, col: 75, offset: 36349},
 								name: "SuperscriptTextElement",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 977, col: 99, offset: 36374},
+							pos:        position{line: 977, col: 99, offset: 36373},
 							val:        "^",
 							ignoreCase: false,
 						},
@@ -7469,20 +7469,20 @@ var g = &grammar{
 		},
 		{
 			name: "Passthrough",
-			pos:  position{line: 984, col: 1, offset: 36610},
+			pos:  position{line: 984, col: 1, offset: 36609},
 			expr: &choiceExpr{
-				pos: position{line: 984, col: 16, offset: 36625},
+				pos: position{line: 984, col: 16, offset: 36624},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 984, col: 16, offset: 36625},
+						pos:  position{line: 984, col: 16, offset: 36624},
 						name: "TriplePlusPassthrough",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 984, col: 40, offset: 36649},
+						pos:  position{line: 984, col: 40, offset: 36648},
 						name: "SinglePlusPassthrough",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 984, col: 64, offset: 36673},
+						pos:  position{line: 984, col: 64, offset: 36672},
 						name: "PassthroughMacro",
 					},
 				},
@@ -7490,42 +7490,42 @@ var g = &grammar{
 		},
 		{
 			name: "SinglePlusPassthroughPrefix",
-			pos:  position{line: 986, col: 1, offset: 36691},
+			pos:  position{line: 986, col: 1, offset: 36690},
 			expr: &litMatcher{
-				pos:        position{line: 986, col: 32, offset: 36722},
+				pos:        position{line: 986, col: 32, offset: 36721},
 				val:        "+",
 				ignoreCase: false,
 			},
 		},
 		{
 			name: "SinglePlusPassthrough",
-			pos:  position{line: 988, col: 1, offset: 36727},
+			pos:  position{line: 988, col: 1, offset: 36726},
 			expr: &actionExpr{
-				pos: position{line: 988, col: 26, offset: 36752},
+				pos: position{line: 988, col: 26, offset: 36751},
 				run: (*parser).callonSinglePlusPassthrough1,
 				expr: &seqExpr{
-					pos: position{line: 988, col: 26, offset: 36752},
+					pos: position{line: 988, col: 26, offset: 36751},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 988, col: 26, offset: 36752},
+							pos:  position{line: 988, col: 26, offset: 36751},
 							name: "SinglePlusPassthroughPrefix",
 						},
 						&labeledExpr{
-							pos:   position{line: 988, col: 54, offset: 36780},
+							pos:   position{line: 988, col: 54, offset: 36779},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 988, col: 63, offset: 36789},
+								pos:  position{line: 988, col: 63, offset: 36788},
 								name: "SinglePlusPassthroughContent",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 988, col: 93, offset: 36819},
+							pos:  position{line: 988, col: 93, offset: 36818},
 							name: "SinglePlusPassthroughPrefix",
 						},
 						&notExpr{
-							pos: position{line: 988, col: 121, offset: 36847},
+							pos: position{line: 988, col: 121, offset: 36846},
 							expr: &ruleRefExpr{
-								pos:  position{line: 988, col: 122, offset: 36848},
+								pos:  position{line: 988, col: 122, offset: 36847},
 								name: "Alphanum",
 							},
 						},
@@ -7535,85 +7535,85 @@ var g = &grammar{
 		},
 		{
 			name: "SinglePlusPassthroughContent",
-			pos:  position{line: 992, col: 1, offset: 36947},
+			pos:  position{line: 992, col: 1, offset: 36946},
 			expr: &choiceExpr{
-				pos: position{line: 992, col: 33, offset: 36979},
+				pos: position{line: 992, col: 33, offset: 36978},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 992, col: 34, offset: 36980},
+						pos: position{line: 992, col: 34, offset: 36979},
 						run: (*parser).callonSinglePlusPassthroughContent2,
 						expr: &seqExpr{
-							pos: position{line: 992, col: 34, offset: 36980},
+							pos: position{line: 992, col: 34, offset: 36979},
 							exprs: []interface{}{
 								&seqExpr{
-									pos: position{line: 992, col: 35, offset: 36981},
+									pos: position{line: 992, col: 35, offset: 36980},
 									exprs: []interface{}{
 										&notExpr{
-											pos: position{line: 992, col: 35, offset: 36981},
+											pos: position{line: 992, col: 35, offset: 36980},
 											expr: &ruleRefExpr{
-												pos:  position{line: 992, col: 36, offset: 36982},
+												pos:  position{line: 992, col: 36, offset: 36981},
 												name: "SinglePlusPassthroughPrefix",
 											},
 										},
 										&notExpr{
-											pos: position{line: 992, col: 64, offset: 37010},
+											pos: position{line: 992, col: 64, offset: 37009},
 											expr: &ruleRefExpr{
-												pos:  position{line: 992, col: 65, offset: 37011},
+												pos:  position{line: 992, col: 65, offset: 37010},
 												name: "WS",
 											},
 										},
 										&notExpr{
-											pos: position{line: 992, col: 68, offset: 37014},
+											pos: position{line: 992, col: 68, offset: 37013},
 											expr: &ruleRefExpr{
-												pos:  position{line: 992, col: 69, offset: 37015},
+												pos:  position{line: 992, col: 69, offset: 37014},
 												name: "NEWLINE",
 											},
 										},
 										&anyMatcher{
-											line: 992, col: 77, offset: 37023,
+											line: 992, col: 77, offset: 37022,
 										},
 									},
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 992, col: 80, offset: 37026},
+									pos: position{line: 992, col: 80, offset: 37025},
 									expr: &seqExpr{
-										pos: position{line: 992, col: 81, offset: 37027},
+										pos: position{line: 992, col: 81, offset: 37026},
 										exprs: []interface{}{
 											&notExpr{
-												pos: position{line: 992, col: 81, offset: 37027},
+												pos: position{line: 992, col: 81, offset: 37026},
 												expr: &seqExpr{
-													pos: position{line: 992, col: 83, offset: 37029},
+													pos: position{line: 992, col: 83, offset: 37028},
 													exprs: []interface{}{
 														&oneOrMoreExpr{
-															pos: position{line: 992, col: 83, offset: 37029},
+															pos: position{line: 992, col: 83, offset: 37028},
 															expr: &ruleRefExpr{
-																pos:  position{line: 992, col: 83, offset: 37029},
+																pos:  position{line: 992, col: 83, offset: 37028},
 																name: "WS",
 															},
 														},
 														&ruleRefExpr{
-															pos:  position{line: 992, col: 87, offset: 37033},
+															pos:  position{line: 992, col: 87, offset: 37032},
 															name: "SinglePlusPassthroughPrefix",
 														},
 													},
 												},
 											},
 											&notExpr{
-												pos: position{line: 992, col: 116, offset: 37062},
+												pos: position{line: 992, col: 116, offset: 37061},
 												expr: &ruleRefExpr{
-													pos:  position{line: 992, col: 117, offset: 37063},
+													pos:  position{line: 992, col: 117, offset: 37062},
 													name: "SinglePlusPassthroughPrefix",
 												},
 											},
 											&notExpr{
-												pos: position{line: 992, col: 145, offset: 37091},
+												pos: position{line: 992, col: 145, offset: 37090},
 												expr: &ruleRefExpr{
-													pos:  position{line: 992, col: 146, offset: 37092},
+													pos:  position{line: 992, col: 146, offset: 37091},
 													name: "NEWLINE",
 												},
 											},
 											&anyMatcher{
-												line: 992, col: 154, offset: 37100,
+												line: 992, col: 154, offset: 37099,
 											},
 										},
 									},
@@ -7622,34 +7622,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 994, col: 7, offset: 37242},
+						pos: position{line: 994, col: 7, offset: 37241},
 						run: (*parser).callonSinglePlusPassthroughContent24,
 						expr: &seqExpr{
-							pos: position{line: 994, col: 8, offset: 37243},
+							pos: position{line: 994, col: 8, offset: 37242},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 994, col: 8, offset: 37243},
+									pos: position{line: 994, col: 8, offset: 37242},
 									expr: &ruleRefExpr{
-										pos:  position{line: 994, col: 9, offset: 37244},
+										pos:  position{line: 994, col: 9, offset: 37243},
 										name: "WS",
 									},
 								},
 								&notExpr{
-									pos: position{line: 994, col: 12, offset: 37247},
+									pos: position{line: 994, col: 12, offset: 37246},
 									expr: &ruleRefExpr{
-										pos:  position{line: 994, col: 13, offset: 37248},
+										pos:  position{line: 994, col: 13, offset: 37247},
 										name: "NEWLINE",
 									},
 								},
 								&notExpr{
-									pos: position{line: 994, col: 21, offset: 37256},
+									pos: position{line: 994, col: 21, offset: 37255},
 									expr: &ruleRefExpr{
-										pos:  position{line: 994, col: 22, offset: 37257},
+										pos:  position{line: 994, col: 22, offset: 37256},
 										name: "SinglePlusPassthroughPrefix",
 									},
 								},
 								&anyMatcher{
-									line: 994, col: 50, offset: 37285,
+									line: 994, col: 50, offset: 37284,
 								},
 							},
 						},
@@ -7659,42 +7659,42 @@ var g = &grammar{
 		},
 		{
 			name: "TriplePlusPassthroughPrefix",
-			pos:  position{line: 998, col: 1, offset: 37367},
+			pos:  position{line: 998, col: 1, offset: 37366},
 			expr: &litMatcher{
-				pos:        position{line: 998, col: 32, offset: 37398},
+				pos:        position{line: 998, col: 32, offset: 37397},
 				val:        "+++",
 				ignoreCase: false,
 			},
 		},
 		{
 			name: "TriplePlusPassthrough",
-			pos:  position{line: 1000, col: 1, offset: 37405},
+			pos:  position{line: 1000, col: 1, offset: 37404},
 			expr: &actionExpr{
-				pos: position{line: 1000, col: 26, offset: 37430},
+				pos: position{line: 1000, col: 26, offset: 37429},
 				run: (*parser).callonTriplePlusPassthrough1,
 				expr: &seqExpr{
-					pos: position{line: 1000, col: 26, offset: 37430},
+					pos: position{line: 1000, col: 26, offset: 37429},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1000, col: 26, offset: 37430},
+							pos:  position{line: 1000, col: 26, offset: 37429},
 							name: "TriplePlusPassthroughPrefix",
 						},
 						&labeledExpr{
-							pos:   position{line: 1000, col: 54, offset: 37458},
+							pos:   position{line: 1000, col: 54, offset: 37457},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1000, col: 63, offset: 37467},
+								pos:  position{line: 1000, col: 63, offset: 37466},
 								name: "TriplePlusPassthroughContent",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1000, col: 93, offset: 37497},
+							pos:  position{line: 1000, col: 93, offset: 37496},
 							name: "TriplePlusPassthroughPrefix",
 						},
 						&notExpr{
-							pos: position{line: 1000, col: 121, offset: 37525},
+							pos: position{line: 1000, col: 121, offset: 37524},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1000, col: 122, offset: 37526},
+								pos:  position{line: 1000, col: 122, offset: 37525},
 								name: "Alphanum",
 							},
 						},
@@ -7704,63 +7704,63 @@ var g = &grammar{
 		},
 		{
 			name: "TriplePlusPassthroughContent",
-			pos:  position{line: 1004, col: 1, offset: 37625},
+			pos:  position{line: 1004, col: 1, offset: 37624},
 			expr: &choiceExpr{
-				pos: position{line: 1004, col: 33, offset: 37657},
+				pos: position{line: 1004, col: 33, offset: 37656},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1004, col: 34, offset: 37658},
+						pos: position{line: 1004, col: 34, offset: 37657},
 						run: (*parser).callonTriplePlusPassthroughContent2,
 						expr: &zeroOrMoreExpr{
-							pos: position{line: 1004, col: 34, offset: 37658},
+							pos: position{line: 1004, col: 34, offset: 37657},
 							expr: &seqExpr{
-								pos: position{line: 1004, col: 35, offset: 37659},
+								pos: position{line: 1004, col: 35, offset: 37658},
 								exprs: []interface{}{
 									&notExpr{
-										pos: position{line: 1004, col: 35, offset: 37659},
+										pos: position{line: 1004, col: 35, offset: 37658},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1004, col: 36, offset: 37660},
+											pos:  position{line: 1004, col: 36, offset: 37659},
 											name: "TriplePlusPassthroughPrefix",
 										},
 									},
 									&anyMatcher{
-										line: 1004, col: 64, offset: 37688,
+										line: 1004, col: 64, offset: 37687,
 									},
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1006, col: 7, offset: 37853},
+						pos: position{line: 1006, col: 7, offset: 37852},
 						run: (*parser).callonTriplePlusPassthroughContent8,
 						expr: &zeroOrOneExpr{
-							pos: position{line: 1006, col: 7, offset: 37853},
+							pos: position{line: 1006, col: 7, offset: 37852},
 							expr: &seqExpr{
-								pos: position{line: 1006, col: 8, offset: 37854},
+								pos: position{line: 1006, col: 8, offset: 37853},
 								exprs: []interface{}{
 									&notExpr{
-										pos: position{line: 1006, col: 8, offset: 37854},
+										pos: position{line: 1006, col: 8, offset: 37853},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1006, col: 9, offset: 37855},
+											pos:  position{line: 1006, col: 9, offset: 37854},
 											name: "WS",
 										},
 									},
 									&notExpr{
-										pos: position{line: 1006, col: 12, offset: 37858},
+										pos: position{line: 1006, col: 12, offset: 37857},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1006, col: 13, offset: 37859},
+											pos:  position{line: 1006, col: 13, offset: 37858},
 											name: "NEWLINE",
 										},
 									},
 									&notExpr{
-										pos: position{line: 1006, col: 21, offset: 37867},
+										pos: position{line: 1006, col: 21, offset: 37866},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1006, col: 22, offset: 37868},
+											pos:  position{line: 1006, col: 22, offset: 37867},
 											name: "TriplePlusPassthroughPrefix",
 										},
 									},
 									&anyMatcher{
-										line: 1006, col: 50, offset: 37896,
+										line: 1006, col: 50, offset: 37895,
 									},
 								},
 							},
@@ -7771,34 +7771,34 @@ var g = &grammar{
 		},
 		{
 			name: "PassthroughMacro",
-			pos:  position{line: 1010, col: 1, offset: 37979},
+			pos:  position{line: 1010, col: 1, offset: 37978},
 			expr: &choiceExpr{
-				pos: position{line: 1010, col: 21, offset: 37999},
+				pos: position{line: 1010, col: 21, offset: 37998},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1010, col: 21, offset: 37999},
+						pos: position{line: 1010, col: 21, offset: 37998},
 						run: (*parser).callonPassthroughMacro2,
 						expr: &seqExpr{
-							pos: position{line: 1010, col: 21, offset: 37999},
+							pos: position{line: 1010, col: 21, offset: 37998},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1010, col: 21, offset: 37999},
+									pos:        position{line: 1010, col: 21, offset: 37998},
 									val:        "pass:[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1010, col: 30, offset: 38008},
+									pos:   position{line: 1010, col: 30, offset: 38007},
 									label: "content",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1010, col: 38, offset: 38016},
+										pos: position{line: 1010, col: 38, offset: 38015},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1010, col: 39, offset: 38017},
+											pos:  position{line: 1010, col: 39, offset: 38016},
 											name: "PassthroughMacroCharacter",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1010, col: 67, offset: 38045},
+									pos:        position{line: 1010, col: 67, offset: 38044},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -7806,30 +7806,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1012, col: 5, offset: 38135},
+						pos: position{line: 1012, col: 5, offset: 38134},
 						run: (*parser).callonPassthroughMacro9,
 						expr: &seqExpr{
-							pos: position{line: 1012, col: 5, offset: 38135},
+							pos: position{line: 1012, col: 5, offset: 38134},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1012, col: 5, offset: 38135},
+									pos:        position{line: 1012, col: 5, offset: 38134},
 									val:        "pass:q[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1012, col: 15, offset: 38145},
+									pos:   position{line: 1012, col: 15, offset: 38144},
 									label: "content",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1012, col: 23, offset: 38153},
+										pos: position{line: 1012, col: 23, offset: 38152},
 										expr: &choiceExpr{
-											pos: position{line: 1012, col: 24, offset: 38154},
+											pos: position{line: 1012, col: 24, offset: 38153},
 											alternatives: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 1012, col: 24, offset: 38154},
+													pos:  position{line: 1012, col: 24, offset: 38153},
 													name: "QuotedText",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1012, col: 37, offset: 38167},
+													pos:  position{line: 1012, col: 37, offset: 38166},
 													name: "PassthroughMacroCharacter",
 												},
 											},
@@ -7837,7 +7837,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1012, col: 65, offset: 38195},
+									pos:        position{line: 1012, col: 65, offset: 38194},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -7849,34 +7849,34 @@ var g = &grammar{
 		},
 		{
 			name: "PassthroughMacroCharacter",
-			pos:  position{line: 1016, col: 1, offset: 38285},
+			pos:  position{line: 1016, col: 1, offset: 38284},
 			expr: &choiceExpr{
-				pos: position{line: 1016, col: 31, offset: 38315},
+				pos: position{line: 1016, col: 31, offset: 38314},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1016, col: 31, offset: 38315},
+						pos:  position{line: 1016, col: 31, offset: 38314},
 						name: "Alphanums",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1016, col: 43, offset: 38327},
+						pos:  position{line: 1016, col: 43, offset: 38326},
 						name: "Spaces",
 					},
 					&actionExpr{
-						pos: position{line: 1016, col: 52, offset: 38336},
+						pos: position{line: 1016, col: 52, offset: 38335},
 						run: (*parser).callonPassthroughMacroCharacter4,
 						expr: &seqExpr{
-							pos: position{line: 1016, col: 53, offset: 38337},
+							pos: position{line: 1016, col: 53, offset: 38336},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1016, col: 53, offset: 38337},
+									pos: position{line: 1016, col: 53, offset: 38336},
 									expr: &litMatcher{
-										pos:        position{line: 1016, col: 54, offset: 38338},
+										pos:        position{line: 1016, col: 54, offset: 38337},
 										val:        "]",
 										ignoreCase: false,
 									},
 								},
 								&anyMatcher{
-									line: 1016, col: 58, offset: 38342,
+									line: 1016, col: 58, offset: 38341,
 								},
 							},
 						},
@@ -7886,51 +7886,51 @@ var g = &grammar{
 		},
 		{
 			name: "CrossReference",
-			pos:  position{line: 1023, col: 1, offset: 38512},
+			pos:  position{line: 1023, col: 1, offset: 38511},
 			expr: &choiceExpr{
-				pos: position{line: 1023, col: 19, offset: 38530},
+				pos: position{line: 1023, col: 19, offset: 38529},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1023, col: 19, offset: 38530},
+						pos: position{line: 1023, col: 19, offset: 38529},
 						run: (*parser).callonCrossReference2,
 						expr: &seqExpr{
-							pos: position{line: 1023, col: 19, offset: 38530},
+							pos: position{line: 1023, col: 19, offset: 38529},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1023, col: 19, offset: 38530},
+									pos:        position{line: 1023, col: 19, offset: 38529},
 									val:        "<<",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1023, col: 24, offset: 38535},
+									pos:   position{line: 1023, col: 24, offset: 38534},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1023, col: 28, offset: 38539},
+										pos:  position{line: 1023, col: 28, offset: 38538},
 										name: "ID",
 									},
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1023, col: 32, offset: 38543},
+									pos: position{line: 1023, col: 32, offset: 38542},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1023, col: 32, offset: 38543},
+										pos:  position{line: 1023, col: 32, offset: 38542},
 										name: "WS",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1023, col: 36, offset: 38547},
+									pos:        position{line: 1023, col: 36, offset: 38546},
 									val:        ",",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1023, col: 40, offset: 38551},
+									pos:   position{line: 1023, col: 40, offset: 38550},
 									label: "label",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1023, col: 47, offset: 38558},
+										pos:  position{line: 1023, col: 47, offset: 38557},
 										name: "CrossReferenceLabel",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1023, col: 68, offset: 38579},
+									pos:        position{line: 1023, col: 68, offset: 38578},
 									val:        ">>",
 									ignoreCase: false,
 								},
@@ -7938,26 +7938,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1025, col: 5, offset: 38654},
+						pos: position{line: 1025, col: 5, offset: 38653},
 						run: (*parser).callonCrossReference13,
 						expr: &seqExpr{
-							pos: position{line: 1025, col: 5, offset: 38654},
+							pos: position{line: 1025, col: 5, offset: 38653},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1025, col: 5, offset: 38654},
+									pos:        position{line: 1025, col: 5, offset: 38653},
 									val:        "<<",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1025, col: 10, offset: 38659},
+									pos:   position{line: 1025, col: 10, offset: 38658},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1025, col: 14, offset: 38663},
+										pos:  position{line: 1025, col: 14, offset: 38662},
 										name: "ID",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1025, col: 18, offset: 38667},
+									pos:        position{line: 1025, col: 18, offset: 38666},
 									val:        ">>",
 									ignoreCase: false,
 								},
@@ -7969,36 +7969,36 @@ var g = &grammar{
 		},
 		{
 			name: "CrossReferenceLabel",
-			pos:  position{line: 1029, col: 1, offset: 38730},
+			pos:  position{line: 1029, col: 1, offset: 38729},
 			expr: &actionExpr{
-				pos: position{line: 1029, col: 24, offset: 38753},
+				pos: position{line: 1029, col: 24, offset: 38752},
 				run: (*parser).callonCrossReferenceLabel1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1029, col: 24, offset: 38753},
+					pos: position{line: 1029, col: 24, offset: 38752},
 					expr: &choiceExpr{
-						pos: position{line: 1029, col: 25, offset: 38754},
+						pos: position{line: 1029, col: 25, offset: 38753},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 1029, col: 25, offset: 38754},
+								pos:  position{line: 1029, col: 25, offset: 38753},
 								name: "Alphanums",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1029, col: 37, offset: 38766},
+								pos:  position{line: 1029, col: 37, offset: 38765},
 								name: "Spaces",
 							},
 							&seqExpr{
-								pos: position{line: 1029, col: 47, offset: 38776},
+								pos: position{line: 1029, col: 47, offset: 38775},
 								exprs: []interface{}{
 									&notExpr{
-										pos: position{line: 1029, col: 47, offset: 38776},
+										pos: position{line: 1029, col: 47, offset: 38775},
 										expr: &litMatcher{
-											pos:        position{line: 1029, col: 48, offset: 38777},
+											pos:        position{line: 1029, col: 48, offset: 38776},
 											val:        ">>",
 											ignoreCase: false,
 										},
 									},
 									&anyMatcher{
-										line: 1029, col: 54, offset: 38783,
+										line: 1029, col: 54, offset: 38782,
 									},
 								},
 							},
@@ -8009,22 +8009,22 @@ var g = &grammar{
 		},
 		{
 			name: "Link",
-			pos:  position{line: 1036, col: 1, offset: 38925},
+			pos:  position{line: 1036, col: 1, offset: 38924},
 			expr: &actionExpr{
-				pos: position{line: 1036, col: 9, offset: 38933},
+				pos: position{line: 1036, col: 9, offset: 38932},
 				run: (*parser).callonLink1,
 				expr: &labeledExpr{
-					pos:   position{line: 1036, col: 9, offset: 38933},
+					pos:   position{line: 1036, col: 9, offset: 38932},
 					label: "link",
 					expr: &choiceExpr{
-						pos: position{line: 1036, col: 15, offset: 38939},
+						pos: position{line: 1036, col: 15, offset: 38938},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 1036, col: 15, offset: 38939},
+								pos:  position{line: 1036, col: 15, offset: 38938},
 								name: "RelativeLink",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1036, col: 30, offset: 38954},
+								pos:  position{line: 1036, col: 30, offset: 38953},
 								name: "ExternalLink",
 							},
 						},
@@ -8034,40 +8034,40 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeLink",
-			pos:  position{line: 1041, col: 1, offset: 39061},
+			pos:  position{line: 1041, col: 1, offset: 39060},
 			expr: &actionExpr{
-				pos: position{line: 1041, col: 17, offset: 39077},
+				pos: position{line: 1041, col: 17, offset: 39076},
 				run: (*parser).callonRelativeLink1,
 				expr: &seqExpr{
-					pos: position{line: 1041, col: 17, offset: 39077},
+					pos: position{line: 1041, col: 17, offset: 39076},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1041, col: 17, offset: 39077},
+							pos:        position{line: 1041, col: 17, offset: 39076},
 							val:        "link:",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1041, col: 25, offset: 39085},
+							pos:   position{line: 1041, col: 25, offset: 39084},
 							label: "url",
 							expr: &choiceExpr{
-								pos: position{line: 1041, col: 30, offset: 39090},
+								pos: position{line: 1041, col: 30, offset: 39089},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1041, col: 30, offset: 39090},
+										pos:  position{line: 1041, col: 30, offset: 39089},
 										name: "Location",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1041, col: 41, offset: 39101},
+										pos:  position{line: 1041, col: 41, offset: 39100},
 										name: "FileLocation",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1041, col: 55, offset: 39115},
+							pos:   position{line: 1041, col: 55, offset: 39114},
 							label: "inlineAttributes",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1041, col: 73, offset: 39133},
+								pos:  position{line: 1041, col: 73, offset: 39132},
 								name: "LinkAttributes",
 							},
 						},
@@ -8077,28 +8077,28 @@ var g = &grammar{
 		},
 		{
 			name: "ExternalLink",
-			pos:  position{line: 1045, col: 1, offset: 39251},
+			pos:  position{line: 1045, col: 1, offset: 39250},
 			expr: &actionExpr{
-				pos: position{line: 1045, col: 17, offset: 39267},
+				pos: position{line: 1045, col: 17, offset: 39266},
 				run: (*parser).callonExternalLink1,
 				expr: &seqExpr{
-					pos: position{line: 1045, col: 17, offset: 39267},
+					pos: position{line: 1045, col: 17, offset: 39266},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1045, col: 17, offset: 39267},
+							pos:   position{line: 1045, col: 17, offset: 39266},
 							label: "url",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1045, col: 22, offset: 39272},
+								pos:  position{line: 1045, col: 22, offset: 39271},
 								name: "Location",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1045, col: 32, offset: 39282},
+							pos:   position{line: 1045, col: 32, offset: 39281},
 							label: "inlineAttributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1045, col: 49, offset: 39299},
+								pos: position{line: 1045, col: 49, offset: 39298},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1045, col: 50, offset: 39300},
+									pos:  position{line: 1045, col: 50, offset: 39299},
 									name: "LinkAttributes",
 								},
 							},
@@ -8109,57 +8109,57 @@ var g = &grammar{
 		},
 		{
 			name: "LinkAttributes",
-			pos:  position{line: 1049, col: 1, offset: 39393},
+			pos:  position{line: 1049, col: 1, offset: 39392},
 			expr: &actionExpr{
-				pos: position{line: 1049, col: 19, offset: 39411},
+				pos: position{line: 1049, col: 19, offset: 39410},
 				run: (*parser).callonLinkAttributes1,
 				expr: &seqExpr{
-					pos: position{line: 1049, col: 19, offset: 39411},
+					pos: position{line: 1049, col: 19, offset: 39410},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1049, col: 19, offset: 39411},
+							pos:        position{line: 1049, col: 19, offset: 39410},
 							val:        "[",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1049, col: 23, offset: 39415},
+							pos:   position{line: 1049, col: 23, offset: 39414},
 							label: "text",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1049, col: 28, offset: 39420},
+								pos: position{line: 1049, col: 28, offset: 39419},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1049, col: 29, offset: 39421},
+									pos:  position{line: 1049, col: 29, offset: 39420},
 									name: "LinkTextAttribute",
 								},
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 1049, col: 49, offset: 39441},
+							pos: position{line: 1049, col: 49, offset: 39440},
 							expr: &litMatcher{
-								pos:        position{line: 1049, col: 49, offset: 39441},
+								pos:        position{line: 1049, col: 49, offset: 39440},
 								val:        ",",
 								ignoreCase: false,
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1049, col: 54, offset: 39446},
+							pos: position{line: 1049, col: 54, offset: 39445},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1049, col: 54, offset: 39446},
+								pos:  position{line: 1049, col: 54, offset: 39445},
 								name: "WS",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1049, col: 58, offset: 39450},
+							pos:   position{line: 1049, col: 58, offset: 39449},
 							label: "otherattrs",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1049, col: 69, offset: 39461},
+								pos: position{line: 1049, col: 69, offset: 39460},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1049, col: 70, offset: 39462},
+									pos:  position{line: 1049, col: 70, offset: 39461},
 									name: "GenericAttribute",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1049, col: 89, offset: 39481},
+							pos:        position{line: 1049, col: 89, offset: 39480},
 							val:        "]",
 							ignoreCase: false,
 						},
@@ -8169,75 +8169,75 @@ var g = &grammar{
 		},
 		{
 			name: "LinkTextAttribute",
-			pos:  position{line: 1053, col: 1, offset: 39566},
+			pos:  position{line: 1053, col: 1, offset: 39565},
 			expr: &actionExpr{
-				pos: position{line: 1053, col: 22, offset: 39587},
+				pos: position{line: 1053, col: 22, offset: 39586},
 				run: (*parser).callonLinkTextAttribute1,
 				expr: &seqExpr{
-					pos: position{line: 1053, col: 22, offset: 39587},
+					pos: position{line: 1053, col: 22, offset: 39586},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1053, col: 22, offset: 39587},
+							pos:   position{line: 1053, col: 22, offset: 39586},
 							label: "elements",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1053, col: 31, offset: 39596},
+								pos: position{line: 1053, col: 31, offset: 39595},
 								expr: &seqExpr{
-									pos: position{line: 1053, col: 32, offset: 39597},
+									pos: position{line: 1053, col: 32, offset: 39596},
 									exprs: []interface{}{
 										&notExpr{
-											pos: position{line: 1053, col: 32, offset: 39597},
+											pos: position{line: 1053, col: 32, offset: 39596},
 											expr: &litMatcher{
-												pos:        position{line: 1053, col: 33, offset: 39598},
+												pos:        position{line: 1053, col: 33, offset: 39597},
 												val:        "=",
 												ignoreCase: false,
 											},
 										},
 										&notExpr{
-											pos: position{line: 1053, col: 37, offset: 39602},
+											pos: position{line: 1053, col: 37, offset: 39601},
 											expr: &litMatcher{
-												pos:        position{line: 1053, col: 38, offset: 39603},
+												pos:        position{line: 1053, col: 38, offset: 39602},
 												val:        ",",
 												ignoreCase: false,
 											},
 										},
 										&notExpr{
-											pos: position{line: 1053, col: 42, offset: 39607},
+											pos: position{line: 1053, col: 42, offset: 39606},
 											expr: &litMatcher{
-												pos:        position{line: 1053, col: 43, offset: 39608},
+												pos:        position{line: 1053, col: 43, offset: 39607},
 												val:        "]",
 												ignoreCase: false,
 											},
 										},
 										&choiceExpr{
-											pos: position{line: 1053, col: 48, offset: 39613},
+											pos: position{line: 1053, col: 48, offset: 39612},
 											alternatives: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 1053, col: 48, offset: 39613},
+													pos:  position{line: 1053, col: 48, offset: 39612},
 													name: "QuotedText",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1053, col: 61, offset: 39626},
+													pos:  position{line: 1053, col: 61, offset: 39625},
 													name: "SimpleWord",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1053, col: 74, offset: 39639},
+													pos:  position{line: 1053, col: 74, offset: 39638},
 													name: "Spaces",
 												},
 												&actionExpr{
-													pos: position{line: 1053, col: 84, offset: 39649},
+													pos: position{line: 1053, col: 84, offset: 39648},
 													run: (*parser).callonLinkTextAttribute16,
 													expr: &seqExpr{
-														pos: position{line: 1053, col: 85, offset: 39650},
+														pos: position{line: 1053, col: 85, offset: 39649},
 														exprs: []interface{}{
 															&notExpr{
-																pos: position{line: 1053, col: 85, offset: 39650},
+																pos: position{line: 1053, col: 85, offset: 39649},
 																expr: &ruleRefExpr{
-																	pos:  position{line: 1053, col: 86, offset: 39651},
+																	pos:  position{line: 1053, col: 86, offset: 39650},
 																	name: "QuotedTextPrefix",
 																},
 															},
 															&anyMatcher{
-																line: 1053, col: 103, offset: 39668,
+																line: 1053, col: 103, offset: 39667,
 															},
 														},
 													},
@@ -8249,11 +8249,11 @@ var g = &grammar{
 							},
 						},
 						&andExpr{
-							pos: position{line: 1055, col: 7, offset: 39729},
+							pos: position{line: 1055, col: 7, offset: 39728},
 							expr: &notExpr{
-								pos: position{line: 1055, col: 9, offset: 39731},
+								pos: position{line: 1055, col: 9, offset: 39730},
 								expr: &litMatcher{
-									pos:        position{line: 1055, col: 10, offset: 39732},
+									pos:        position{line: 1055, col: 10, offset: 39731},
 									val:        "=",
 									ignoreCase: false,
 								},
@@ -8265,47 +8265,47 @@ var g = &grammar{
 		},
 		{
 			name: "ImageBlock",
-			pos:  position{line: 1062, col: 1, offset: 39905},
+			pos:  position{line: 1062, col: 1, offset: 39904},
 			expr: &actionExpr{
-				pos: position{line: 1062, col: 15, offset: 39919},
+				pos: position{line: 1062, col: 15, offset: 39918},
 				run: (*parser).callonImageBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1062, col: 15, offset: 39919},
+					pos: position{line: 1062, col: 15, offset: 39918},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1062, col: 15, offset: 39919},
+							pos:   position{line: 1062, col: 15, offset: 39918},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1062, col: 26, offset: 39930},
+								pos: position{line: 1062, col: 26, offset: 39929},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1062, col: 27, offset: 39931},
+									pos:  position{line: 1062, col: 27, offset: 39930},
 									name: "ElementAttributes",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1062, col: 47, offset: 39951},
+							pos:        position{line: 1062, col: 47, offset: 39950},
 							val:        "image::",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1062, col: 57, offset: 39961},
+							pos:   position{line: 1062, col: 57, offset: 39960},
 							label: "path",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1062, col: 63, offset: 39967},
+								pos:  position{line: 1062, col: 63, offset: 39966},
 								name: "URL",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1062, col: 68, offset: 39972},
+							pos:   position{line: 1062, col: 68, offset: 39971},
 							label: "inlineAttributes",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1062, col: 86, offset: 39990},
+								pos:  position{line: 1062, col: 86, offset: 39989},
 								name: "ImageAttributes",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1062, col: 103, offset: 40007},
+							pos:  position{line: 1062, col: 103, offset: 40006},
 							name: "EOLS",
 						},
 					},
@@ -8314,39 +8314,39 @@ var g = &grammar{
 		},
 		{
 			name: "InlineImage",
-			pos:  position{line: 1066, col: 1, offset: 40119},
+			pos:  position{line: 1066, col: 1, offset: 40118},
 			expr: &actionExpr{
-				pos: position{line: 1066, col: 16, offset: 40134},
+				pos: position{line: 1066, col: 16, offset: 40133},
 				run: (*parser).callonInlineImage1,
 				expr: &seqExpr{
-					pos: position{line: 1066, col: 16, offset: 40134},
+					pos: position{line: 1066, col: 16, offset: 40133},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1066, col: 16, offset: 40134},
+							pos:        position{line: 1066, col: 16, offset: 40133},
 							val:        "image:",
 							ignoreCase: false,
 						},
 						&notExpr{
-							pos: position{line: 1066, col: 25, offset: 40143},
+							pos: position{line: 1066, col: 25, offset: 40142},
 							expr: &litMatcher{
-								pos:        position{line: 1066, col: 26, offset: 40144},
+								pos:        position{line: 1066, col: 26, offset: 40143},
 								val:        ":",
 								ignoreCase: false,
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1066, col: 30, offset: 40148},
+							pos:   position{line: 1066, col: 30, offset: 40147},
 							label: "path",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1066, col: 36, offset: 40154},
+								pos:  position{line: 1066, col: 36, offset: 40153},
 								name: "URL",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1066, col: 41, offset: 40159},
+							pos:   position{line: 1066, col: 41, offset: 40158},
 							label: "inlineAttributes",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1066, col: 59, offset: 40177},
+								pos:  position{line: 1066, col: 59, offset: 40176},
 								name: "ImageAttributes",
 							},
 						},
@@ -8356,95 +8356,95 @@ var g = &grammar{
 		},
 		{
 			name: "ImageAttributes",
-			pos:  position{line: 1070, col: 1, offset: 40290},
+			pos:  position{line: 1070, col: 1, offset: 40289},
 			expr: &actionExpr{
-				pos: position{line: 1070, col: 20, offset: 40309},
+				pos: position{line: 1070, col: 20, offset: 40308},
 				run: (*parser).callonImageAttributes1,
 				expr: &seqExpr{
-					pos: position{line: 1070, col: 20, offset: 40309},
+					pos: position{line: 1070, col: 20, offset: 40308},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1070, col: 20, offset: 40309},
+							pos:        position{line: 1070, col: 20, offset: 40308},
 							val:        "[",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1070, col: 24, offset: 40313},
+							pos:   position{line: 1070, col: 24, offset: 40312},
 							label: "alt",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1070, col: 28, offset: 40317},
+								pos: position{line: 1070, col: 28, offset: 40316},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1070, col: 29, offset: 40318},
+									pos:  position{line: 1070, col: 29, offset: 40317},
 									name: "AttributeValue",
 								},
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 1070, col: 46, offset: 40335},
+							pos: position{line: 1070, col: 46, offset: 40334},
 							expr: &litMatcher{
-								pos:        position{line: 1070, col: 46, offset: 40335},
+								pos:        position{line: 1070, col: 46, offset: 40334},
 								val:        ",",
 								ignoreCase: false,
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1070, col: 51, offset: 40340},
+							pos:   position{line: 1070, col: 51, offset: 40339},
 							label: "width",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1070, col: 57, offset: 40346},
+								pos: position{line: 1070, col: 57, offset: 40345},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1070, col: 58, offset: 40347},
+									pos:  position{line: 1070, col: 58, offset: 40346},
 									name: "AttributeValue",
 								},
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 1070, col: 75, offset: 40364},
+							pos: position{line: 1070, col: 75, offset: 40363},
 							expr: &litMatcher{
-								pos:        position{line: 1070, col: 75, offset: 40364},
+								pos:        position{line: 1070, col: 75, offset: 40363},
 								val:        ",",
 								ignoreCase: false,
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1070, col: 80, offset: 40369},
+							pos:   position{line: 1070, col: 80, offset: 40368},
 							label: "height",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1070, col: 87, offset: 40376},
+								pos: position{line: 1070, col: 87, offset: 40375},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1070, col: 88, offset: 40377},
+									pos:  position{line: 1070, col: 88, offset: 40376},
 									name: "AttributeValue",
 								},
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 1070, col: 105, offset: 40394},
+							pos: position{line: 1070, col: 105, offset: 40393},
 							expr: &litMatcher{
-								pos:        position{line: 1070, col: 105, offset: 40394},
+								pos:        position{line: 1070, col: 105, offset: 40393},
 								val:        ",",
 								ignoreCase: false,
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1070, col: 110, offset: 40399},
+							pos: position{line: 1070, col: 110, offset: 40398},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1070, col: 110, offset: 40399},
+								pos:  position{line: 1070, col: 110, offset: 40398},
 								name: "WS",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1070, col: 114, offset: 40403},
+							pos:   position{line: 1070, col: 114, offset: 40402},
 							label: "otherattrs",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1070, col: 125, offset: 40414},
+								pos: position{line: 1070, col: 125, offset: 40413},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1070, col: 126, offset: 40415},
+									pos:  position{line: 1070, col: 126, offset: 40414},
 									name: "GenericAttribute",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1070, col: 145, offset: 40434},
+							pos:        position{line: 1070, col: 145, offset: 40433},
 							val:        "]",
 							ignoreCase: false,
 						},
@@ -8454,31 +8454,31 @@ var g = &grammar{
 		},
 		{
 			name: "InlineFootnote",
-			pos:  position{line: 1077, col: 1, offset: 40724},
+			pos:  position{line: 1077, col: 1, offset: 40723},
 			expr: &choiceExpr{
-				pos: position{line: 1077, col: 19, offset: 40742},
+				pos: position{line: 1077, col: 19, offset: 40741},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1077, col: 19, offset: 40742},
+						pos: position{line: 1077, col: 19, offset: 40741},
 						run: (*parser).callonInlineFootnote2,
 						expr: &seqExpr{
-							pos: position{line: 1077, col: 19, offset: 40742},
+							pos: position{line: 1077, col: 19, offset: 40741},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1077, col: 19, offset: 40742},
+									pos:        position{line: 1077, col: 19, offset: 40741},
 									val:        "footnote:[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1077, col: 32, offset: 40755},
+									pos:   position{line: 1077, col: 32, offset: 40754},
 									label: "content",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1077, col: 41, offset: 40764},
+										pos:  position{line: 1077, col: 41, offset: 40763},
 										name: "FootnoteContent",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1077, col: 58, offset: 40781},
+									pos:        position{line: 1077, col: 58, offset: 40780},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -8486,39 +8486,39 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1079, col: 5, offset: 40856},
+						pos: position{line: 1079, col: 5, offset: 40855},
 						run: (*parser).callonInlineFootnote8,
 						expr: &seqExpr{
-							pos: position{line: 1079, col: 5, offset: 40856},
+							pos: position{line: 1079, col: 5, offset: 40855},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1079, col: 5, offset: 40856},
+									pos:        position{line: 1079, col: 5, offset: 40855},
 									val:        "footnoteref:[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1079, col: 21, offset: 40872},
+									pos:   position{line: 1079, col: 21, offset: 40871},
 									label: "ref",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1079, col: 26, offset: 40877},
+										pos:  position{line: 1079, col: 26, offset: 40876},
 										name: "FootnoteRef",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1079, col: 39, offset: 40890},
+									pos:        position{line: 1079, col: 39, offset: 40889},
 									val:        ",",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1079, col: 43, offset: 40894},
+									pos:   position{line: 1079, col: 43, offset: 40893},
 									label: "content",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1079, col: 52, offset: 40903},
+										pos:  position{line: 1079, col: 52, offset: 40902},
 										name: "FootnoteContent",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1079, col: 69, offset: 40920},
+									pos:        position{line: 1079, col: 69, offset: 40919},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -8526,26 +8526,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1081, col: 5, offset: 41005},
+						pos: position{line: 1081, col: 5, offset: 41004},
 						run: (*parser).callonInlineFootnote17,
 						expr: &seqExpr{
-							pos: position{line: 1081, col: 5, offset: 41005},
+							pos: position{line: 1081, col: 5, offset: 41004},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1081, col: 5, offset: 41005},
+									pos:        position{line: 1081, col: 5, offset: 41004},
 									val:        "footnoteref:[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1081, col: 21, offset: 41021},
+									pos:   position{line: 1081, col: 21, offset: 41020},
 									label: "ref",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1081, col: 26, offset: 41026},
+										pos:  position{line: 1081, col: 26, offset: 41025},
 										name: "FootnoteRef",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1081, col: 39, offset: 41039},
+									pos:        position{line: 1081, col: 39, offset: 41038},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -8557,51 +8557,51 @@ var g = &grammar{
 		},
 		{
 			name: "FootnoteRef",
-			pos:  position{line: 1085, col: 1, offset: 41154},
+			pos:  position{line: 1085, col: 1, offset: 41153},
 			expr: &actionExpr{
-				pos: position{line: 1085, col: 16, offset: 41169},
+				pos: position{line: 1085, col: 16, offset: 41168},
 				run: (*parser).callonFootnoteRef1,
 				expr: &zeroOrMoreExpr{
-					pos: position{line: 1085, col: 16, offset: 41169},
+					pos: position{line: 1085, col: 16, offset: 41168},
 					expr: &choiceExpr{
-						pos: position{line: 1085, col: 17, offset: 41170},
+						pos: position{line: 1085, col: 17, offset: 41169},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 1085, col: 17, offset: 41170},
+								pos:  position{line: 1085, col: 17, offset: 41169},
 								name: "Alphanums",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1085, col: 29, offset: 41182},
+								pos:  position{line: 1085, col: 29, offset: 41181},
 								name: "Spaces",
 							},
 							&seqExpr{
-								pos: position{line: 1085, col: 39, offset: 41192},
+								pos: position{line: 1085, col: 39, offset: 41191},
 								exprs: []interface{}{
 									&notExpr{
-										pos: position{line: 1085, col: 39, offset: 41192},
+										pos: position{line: 1085, col: 39, offset: 41191},
 										expr: &litMatcher{
-											pos:        position{line: 1085, col: 40, offset: 41193},
+											pos:        position{line: 1085, col: 40, offset: 41192},
 											val:        ",",
 											ignoreCase: false,
 										},
 									},
 									&notExpr{
-										pos: position{line: 1085, col: 44, offset: 41197},
+										pos: position{line: 1085, col: 44, offset: 41196},
 										expr: &litMatcher{
-											pos:        position{line: 1085, col: 45, offset: 41198},
+											pos:        position{line: 1085, col: 45, offset: 41197},
 											val:        "]",
 											ignoreCase: false,
 										},
 									},
 									&notExpr{
-										pos: position{line: 1085, col: 49, offset: 41202},
+										pos: position{line: 1085, col: 49, offset: 41201},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1085, col: 50, offset: 41203},
+											pos:  position{line: 1085, col: 50, offset: 41202},
 											name: "EOL",
 										},
 									},
 									&anyMatcher{
-										line: 1085, col: 55, offset: 41208,
+										line: 1085, col: 55, offset: 41207,
 									},
 								},
 							},
@@ -8612,55 +8612,55 @@ var g = &grammar{
 		},
 		{
 			name: "FootnoteContent",
-			pos:  position{line: 1089, col: 1, offset: 41293},
+			pos:  position{line: 1089, col: 1, offset: 41292},
 			expr: &actionExpr{
-				pos: position{line: 1089, col: 20, offset: 41312},
+				pos: position{line: 1089, col: 20, offset: 41311},
 				run: (*parser).callonFootnoteContent1,
 				expr: &labeledExpr{
-					pos:   position{line: 1089, col: 20, offset: 41312},
+					pos:   position{line: 1089, col: 20, offset: 41311},
 					label: "elements",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 1089, col: 29, offset: 41321},
+						pos: position{line: 1089, col: 29, offset: 41320},
 						expr: &seqExpr{
-							pos: position{line: 1089, col: 30, offset: 41322},
+							pos: position{line: 1089, col: 30, offset: 41321},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1089, col: 30, offset: 41322},
+									pos: position{line: 1089, col: 30, offset: 41321},
 									expr: &litMatcher{
-										pos:        position{line: 1089, col: 31, offset: 41323},
+										pos:        position{line: 1089, col: 31, offset: 41322},
 										val:        "]",
 										ignoreCase: false,
 									},
 								},
 								&notExpr{
-									pos: position{line: 1089, col: 35, offset: 41327},
+									pos: position{line: 1089, col: 35, offset: 41326},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1089, col: 36, offset: 41328},
+										pos:  position{line: 1089, col: 36, offset: 41327},
 										name: "EOL",
 									},
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1089, col: 40, offset: 41332},
+									pos: position{line: 1089, col: 40, offset: 41331},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1089, col: 40, offset: 41332},
+										pos:  position{line: 1089, col: 40, offset: 41331},
 										name: "WS",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1089, col: 44, offset: 41336},
+									pos: position{line: 1089, col: 44, offset: 41335},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1089, col: 45, offset: 41337},
+										pos:  position{line: 1089, col: 45, offset: 41336},
 										name: "InlineElementID",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1089, col: 61, offset: 41353},
+									pos:  position{line: 1089, col: 61, offset: 41352},
 									name: "InlineElement",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1089, col: 75, offset: 41367},
+									pos: position{line: 1089, col: 75, offset: 41366},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1089, col: 75, offset: 41367},
+										pos:  position{line: 1089, col: 75, offset: 41366},
 										name: "WS",
 									},
 								},
@@ -8672,60 +8672,60 @@ var g = &grammar{
 		},
 		{
 			name: "DelimitedBlock",
-			pos:  position{line: 1096, col: 1, offset: 41681},
+			pos:  position{line: 1096, col: 1, offset: 41680},
 			expr: &actionExpr{
-				pos: position{line: 1096, col: 19, offset: 41699},
+				pos: position{line: 1096, col: 19, offset: 41698},
 				run: (*parser).callonDelimitedBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1096, col: 19, offset: 41699},
+					pos: position{line: 1096, col: 19, offset: 41698},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1096, col: 19, offset: 41699},
+							pos: position{line: 1096, col: 19, offset: 41698},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1096, col: 20, offset: 41700},
+								pos:  position{line: 1096, col: 20, offset: 41699},
 								name: "Alphanum",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1097, col: 5, offset: 41729},
+							pos:   position{line: 1097, col: 5, offset: 41728},
 							label: "block",
 							expr: &choiceExpr{
-								pos: position{line: 1097, col: 12, offset: 41736},
+								pos: position{line: 1097, col: 12, offset: 41735},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1097, col: 12, offset: 41736},
+										pos:  position{line: 1097, col: 12, offset: 41735},
 										name: "FencedBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1098, col: 11, offset: 41759},
+										pos:  position{line: 1098, col: 11, offset: 41758},
 										name: "ListingBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1099, col: 11, offset: 41783},
+										pos:  position{line: 1099, col: 11, offset: 41782},
 										name: "ExampleBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1100, col: 11, offset: 41807},
+										pos:  position{line: 1100, col: 11, offset: 41806},
 										name: "VerseBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1101, col: 11, offset: 41829},
+										pos:  position{line: 1101, col: 11, offset: 41828},
 										name: "QuoteBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1102, col: 11, offset: 41851},
+										pos:  position{line: 1102, col: 11, offset: 41850},
 										name: "SidebarBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1103, col: 11, offset: 41874},
+										pos:  position{line: 1103, col: 11, offset: 41873},
 										name: "SingleLineComment",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1104, col: 11, offset: 41902},
+										pos:  position{line: 1104, col: 11, offset: 41901},
 										name: "Table",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1105, col: 11, offset: 41918},
+										pos:  position{line: 1105, col: 11, offset: 41917},
 										name: "CommentBlock",
 									},
 								},
@@ -8737,36 +8737,36 @@ var g = &grammar{
 		},
 		{
 			name: "BlockDelimiter",
-			pos:  position{line: 1109, col: 1, offset: 41959},
+			pos:  position{line: 1109, col: 1, offset: 41958},
 			expr: &choiceExpr{
-				pos: position{line: 1109, col: 19, offset: 41977},
+				pos: position{line: 1109, col: 19, offset: 41976},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1109, col: 19, offset: 41977},
+						pos:  position{line: 1109, col: 19, offset: 41976},
 						name: "LiteralBlockDelimiter",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1110, col: 19, offset: 42018},
+						pos:  position{line: 1110, col: 19, offset: 42017},
 						name: "FencedBlockDelimiter",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1111, col: 19, offset: 42058},
+						pos:  position{line: 1111, col: 19, offset: 42057},
 						name: "ListingBlockDelimiter",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1112, col: 19, offset: 42099},
+						pos:  position{line: 1112, col: 19, offset: 42098},
 						name: "ExampleBlockDelimiter",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1113, col: 19, offset: 42140},
+						pos:  position{line: 1113, col: 19, offset: 42139},
 						name: "CommentBlockDelimiter",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1114, col: 19, offset: 42181},
+						pos:  position{line: 1114, col: 19, offset: 42180},
 						name: "QuoteBlockDelimiter",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1115, col: 19, offset: 42219},
+						pos:  position{line: 1115, col: 19, offset: 42218},
 						name: "SidebarBlockDelimiter",
 					},
 				},
@@ -8774,17 +8774,17 @@ var g = &grammar{
 		},
 		{
 			name: "FencedBlockDelimiter",
-			pos:  position{line: 1121, col: 1, offset: 42438},
+			pos:  position{line: 1121, col: 1, offset: 42437},
 			expr: &seqExpr{
-				pos: position{line: 1121, col: 25, offset: 42462},
+				pos: position{line: 1121, col: 25, offset: 42461},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1121, col: 25, offset: 42462},
+						pos:        position{line: 1121, col: 25, offset: 42461},
 						val:        "```",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1121, col: 31, offset: 42468},
+						pos:  position{line: 1121, col: 31, offset: 42467},
 						name: "EOLS",
 					},
 				},
@@ -8792,48 +8792,48 @@ var g = &grammar{
 		},
 		{
 			name: "FencedBlock",
-			pos:  position{line: 1123, col: 1, offset: 42474},
+			pos:  position{line: 1123, col: 1, offset: 42473},
 			expr: &actionExpr{
-				pos: position{line: 1123, col: 16, offset: 42489},
+				pos: position{line: 1123, col: 16, offset: 42488},
 				run: (*parser).callonFencedBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1123, col: 16, offset: 42489},
+					pos: position{line: 1123, col: 16, offset: 42488},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1123, col: 16, offset: 42489},
+							pos:   position{line: 1123, col: 16, offset: 42488},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1123, col: 27, offset: 42500},
+								pos: position{line: 1123, col: 27, offset: 42499},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1123, col: 28, offset: 42501},
+									pos:  position{line: 1123, col: 28, offset: 42500},
 									name: "ElementAttributes",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1123, col: 48, offset: 42521},
+							pos:  position{line: 1123, col: 48, offset: 42520},
 							name: "FencedBlockDelimiter",
 						},
 						&labeledExpr{
-							pos:   position{line: 1123, col: 69, offset: 42542},
+							pos:   position{line: 1123, col: 69, offset: 42541},
 							label: "content",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1123, col: 77, offset: 42550},
+								pos: position{line: 1123, col: 77, offset: 42549},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1123, col: 78, offset: 42551},
+									pos:  position{line: 1123, col: 78, offset: 42550},
 									name: "FencedBlockContent",
 								},
 							},
 						},
 						&choiceExpr{
-							pos: position{line: 1123, col: 100, offset: 42573},
+							pos: position{line: 1123, col: 100, offset: 42572},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 1123, col: 100, offset: 42573},
+									pos:  position{line: 1123, col: 100, offset: 42572},
 									name: "FencedBlockDelimiter",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1123, col: 123, offset: 42596},
+									pos:  position{line: 1123, col: 123, offset: 42595},
 									name: "EOF",
 								},
 							},
@@ -8844,24 +8844,24 @@ var g = &grammar{
 		},
 		{
 			name: "FencedBlockContent",
-			pos:  position{line: 1127, col: 1, offset: 42704},
+			pos:  position{line: 1127, col: 1, offset: 42703},
 			expr: &choiceExpr{
-				pos: position{line: 1127, col: 23, offset: 42726},
+				pos: position{line: 1127, col: 23, offset: 42725},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1127, col: 23, offset: 42726},
+						pos:  position{line: 1127, col: 23, offset: 42725},
 						name: "BlankLine",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1127, col: 35, offset: 42738},
+						pos:  position{line: 1127, col: 35, offset: 42737},
 						name: "FileInclusion",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1127, col: 51, offset: 42754},
+						pos:  position{line: 1127, col: 51, offset: 42753},
 						name: "ListItem",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1127, col: 62, offset: 42765},
+						pos:  position{line: 1127, col: 62, offset: 42764},
 						name: "FencedBlockParagraph",
 					},
 				},
@@ -8869,17 +8869,17 @@ var g = &grammar{
 		},
 		{
 			name: "FencedBlockParagraph",
-			pos:  position{line: 1130, col: 1, offset: 42805},
+			pos:  position{line: 1130, col: 1, offset: 42804},
 			expr: &actionExpr{
-				pos: position{line: 1130, col: 25, offset: 42829},
+				pos: position{line: 1130, col: 25, offset: 42828},
 				run: (*parser).callonFencedBlockParagraph1,
 				expr: &labeledExpr{
-					pos:   position{line: 1130, col: 25, offset: 42829},
+					pos:   position{line: 1130, col: 25, offset: 42828},
 					label: "lines",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 1130, col: 31, offset: 42835},
+						pos: position{line: 1130, col: 31, offset: 42834},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1130, col: 32, offset: 42836},
+							pos:  position{line: 1130, col: 32, offset: 42835},
 							name: "FencedBlockParagraphLine",
 						},
 					},
@@ -8888,32 +8888,32 @@ var g = &grammar{
 		},
 		{
 			name: "FencedBlockParagraphLine",
-			pos:  position{line: 1134, col: 1, offset: 42949},
+			pos:  position{line: 1134, col: 1, offset: 42948},
 			expr: &actionExpr{
-				pos: position{line: 1134, col: 29, offset: 42977},
+				pos: position{line: 1134, col: 29, offset: 42976},
 				run: (*parser).callonFencedBlockParagraphLine1,
 				expr: &seqExpr{
-					pos: position{line: 1134, col: 29, offset: 42977},
+					pos: position{line: 1134, col: 29, offset: 42976},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1134, col: 29, offset: 42977},
+							pos: position{line: 1134, col: 29, offset: 42976},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1134, col: 30, offset: 42978},
+								pos:  position{line: 1134, col: 30, offset: 42977},
 								name: "FencedBlockDelimiter",
 							},
 						},
 						&notExpr{
-							pos: position{line: 1134, col: 51, offset: 42999},
+							pos: position{line: 1134, col: 51, offset: 42998},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1134, col: 52, offset: 43000},
+								pos:  position{line: 1134, col: 52, offset: 42999},
 								name: "BlankLine",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1134, col: 62, offset: 43010},
+							pos:   position{line: 1134, col: 62, offset: 43009},
 							label: "line",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1134, col: 68, offset: 43016},
+								pos:  position{line: 1134, col: 68, offset: 43015},
 								name: "InlineElements",
 							},
 						},
@@ -8923,17 +8923,17 @@ var g = &grammar{
 		},
 		{
 			name: "ListingBlockDelimiter",
-			pos:  position{line: 1141, col: 1, offset: 43254},
+			pos:  position{line: 1141, col: 1, offset: 43253},
 			expr: &seqExpr{
-				pos: position{line: 1141, col: 26, offset: 43279},
+				pos: position{line: 1141, col: 26, offset: 43278},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1141, col: 26, offset: 43279},
+						pos:        position{line: 1141, col: 26, offset: 43278},
 						val:        "----",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1141, col: 33, offset: 43286},
+						pos:  position{line: 1141, col: 33, offset: 43285},
 						name: "EOLS",
 					},
 				},
@@ -8941,48 +8941,48 @@ var g = &grammar{
 		},
 		{
 			name: "ListingBlock",
-			pos:  position{line: 1144, col: 1, offset: 43327},
+			pos:  position{line: 1144, col: 1, offset: 43326},
 			expr: &actionExpr{
-				pos: position{line: 1144, col: 17, offset: 43343},
+				pos: position{line: 1144, col: 17, offset: 43342},
 				run: (*parser).callonListingBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1144, col: 17, offset: 43343},
+					pos: position{line: 1144, col: 17, offset: 43342},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1144, col: 17, offset: 43343},
+							pos:   position{line: 1144, col: 17, offset: 43342},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1144, col: 28, offset: 43354},
+								pos: position{line: 1144, col: 28, offset: 43353},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1144, col: 29, offset: 43355},
+									pos:  position{line: 1144, col: 29, offset: 43354},
 									name: "ElementAttributes",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1144, col: 49, offset: 43375},
+							pos:  position{line: 1144, col: 49, offset: 43374},
 							name: "ListingBlockDelimiter",
 						},
 						&labeledExpr{
-							pos:   position{line: 1144, col: 71, offset: 43397},
+							pos:   position{line: 1144, col: 71, offset: 43396},
 							label: "content",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1144, col: 79, offset: 43405},
+								pos: position{line: 1144, col: 79, offset: 43404},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1144, col: 80, offset: 43406},
+									pos:  position{line: 1144, col: 80, offset: 43405},
 									name: "ListingBlockElement",
 								},
 							},
 						},
 						&choiceExpr{
-							pos: position{line: 1144, col: 103, offset: 43429},
+							pos: position{line: 1144, col: 103, offset: 43428},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 1144, col: 103, offset: 43429},
+									pos:  position{line: 1144, col: 103, offset: 43428},
 									name: "ListingBlockDelimiter",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1144, col: 127, offset: 43453},
+									pos:  position{line: 1144, col: 127, offset: 43452},
 									name: "EOF",
 								},
 							},
@@ -8993,16 +8993,16 @@ var g = &grammar{
 		},
 		{
 			name: "ListingBlockElement",
-			pos:  position{line: 1148, col: 1, offset: 43562},
+			pos:  position{line: 1148, col: 1, offset: 43561},
 			expr: &choiceExpr{
-				pos: position{line: 1148, col: 24, offset: 43585},
+				pos: position{line: 1148, col: 24, offset: 43584},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1148, col: 24, offset: 43585},
+						pos:  position{line: 1148, col: 24, offset: 43584},
 						name: "FileInclusion",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1148, col: 40, offset: 43601},
+						pos:  position{line: 1148, col: 40, offset: 43600},
 						name: "ListingBlockParagraph",
 					},
 				},
@@ -9010,17 +9010,17 @@ var g = &grammar{
 		},
 		{
 			name: "ListingBlockParagraph",
-			pos:  position{line: 1150, col: 1, offset: 43624},
+			pos:  position{line: 1150, col: 1, offset: 43623},
 			expr: &actionExpr{
-				pos: position{line: 1150, col: 26, offset: 43649},
+				pos: position{line: 1150, col: 26, offset: 43648},
 				run: (*parser).callonListingBlockParagraph1,
 				expr: &labeledExpr{
-					pos:   position{line: 1150, col: 26, offset: 43649},
+					pos:   position{line: 1150, col: 26, offset: 43648},
 					label: "lines",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 1150, col: 32, offset: 43655},
+						pos: position{line: 1150, col: 32, offset: 43654},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1150, col: 33, offset: 43656},
+							pos:  position{line: 1150, col: 33, offset: 43655},
 							name: "ListingBlockParagraphLine",
 						},
 					},
@@ -9029,61 +9029,61 @@ var g = &grammar{
 		},
 		{
 			name: "ListingBlockParagraphLine",
-			pos:  position{line: 1154, col: 1, offset: 43775},
+			pos:  position{line: 1154, col: 1, offset: 43774},
 			expr: &actionExpr{
-				pos: position{line: 1154, col: 30, offset: 43804},
+				pos: position{line: 1154, col: 30, offset: 43803},
 				run: (*parser).callonListingBlockParagraphLine1,
 				expr: &seqExpr{
-					pos: position{line: 1154, col: 30, offset: 43804},
+					pos: position{line: 1154, col: 30, offset: 43803},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1154, col: 30, offset: 43804},
+							pos: position{line: 1154, col: 30, offset: 43803},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1154, col: 31, offset: 43805},
+								pos:  position{line: 1154, col: 31, offset: 43804},
 								name: "ListingBlockDelimiter",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1154, col: 53, offset: 43827},
+							pos:   position{line: 1154, col: 53, offset: 43826},
 							label: "line",
 							expr: &actionExpr{
-								pos: position{line: 1154, col: 59, offset: 43833},
+								pos: position{line: 1154, col: 59, offset: 43832},
 								run: (*parser).callonListingBlockParagraphLine6,
 								expr: &seqExpr{
-									pos: position{line: 1154, col: 59, offset: 43833},
+									pos: position{line: 1154, col: 59, offset: 43832},
 									exprs: []interface{}{
 										&notExpr{
-											pos: position{line: 1154, col: 59, offset: 43833},
+											pos: position{line: 1154, col: 59, offset: 43832},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1154, col: 60, offset: 43834},
+												pos:  position{line: 1154, col: 60, offset: 43833},
 												name: "EOF",
 											},
 										},
 										&zeroOrMoreExpr{
-											pos: position{line: 1154, col: 64, offset: 43838},
+											pos: position{line: 1154, col: 64, offset: 43837},
 											expr: &choiceExpr{
-												pos: position{line: 1154, col: 65, offset: 43839},
+												pos: position{line: 1154, col: 65, offset: 43838},
 												alternatives: []interface{}{
 													&ruleRefExpr{
-														pos:  position{line: 1154, col: 65, offset: 43839},
+														pos:  position{line: 1154, col: 65, offset: 43838},
 														name: "Alphanums",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1154, col: 77, offset: 43851},
+														pos:  position{line: 1154, col: 77, offset: 43850},
 														name: "Spaces",
 													},
 													&seqExpr{
-														pos: position{line: 1154, col: 87, offset: 43861},
+														pos: position{line: 1154, col: 87, offset: 43860},
 														exprs: []interface{}{
 															&notExpr{
-																pos: position{line: 1154, col: 87, offset: 43861},
+																pos: position{line: 1154, col: 87, offset: 43860},
 																expr: &ruleRefExpr{
-																	pos:  position{line: 1154, col: 88, offset: 43862},
+																	pos:  position{line: 1154, col: 88, offset: 43861},
 																	name: "EOL",
 																},
 															},
 															&anyMatcher{
-																line: 1154, col: 92, offset: 43866,
+																line: 1154, col: 92, offset: 43865,
 															},
 														},
 													},
@@ -9095,7 +9095,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1154, col: 128, offset: 43902},
+							pos:  position{line: 1154, col: 128, offset: 43901},
 							name: "EOL",
 						},
 					},
@@ -9104,17 +9104,17 @@ var g = &grammar{
 		},
 		{
 			name: "ExampleBlockDelimiter",
-			pos:  position{line: 1161, col: 1, offset: 44228},
+			pos:  position{line: 1161, col: 1, offset: 44227},
 			expr: &seqExpr{
-				pos: position{line: 1161, col: 26, offset: 44253},
+				pos: position{line: 1161, col: 26, offset: 44252},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1161, col: 26, offset: 44253},
+						pos:        position{line: 1161, col: 26, offset: 44252},
 						val:        "====",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1161, col: 33, offset: 44260},
+						pos:  position{line: 1161, col: 33, offset: 44259},
 						name: "EOLS",
 					},
 				},
@@ -9122,50 +9122,50 @@ var g = &grammar{
 		},
 		{
 			name: "ExampleBlock",
-			pos:  position{line: 1163, col: 1, offset: 44266},
+			pos:  position{line: 1163, col: 1, offset: 44265},
 			expr: &actionExpr{
-				pos: position{line: 1163, col: 17, offset: 44282},
+				pos: position{line: 1163, col: 17, offset: 44281},
 				run: (*parser).callonExampleBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1163, col: 17, offset: 44282},
+					pos: position{line: 1163, col: 17, offset: 44281},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1163, col: 17, offset: 44282},
+							pos:   position{line: 1163, col: 17, offset: 44281},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1163, col: 28, offset: 44293},
+								pos: position{line: 1163, col: 28, offset: 44292},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1163, col: 29, offset: 44294},
+									pos:  position{line: 1163, col: 29, offset: 44293},
 									name: "ElementAttributes",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1163, col: 49, offset: 44314},
+							pos:  position{line: 1163, col: 49, offset: 44313},
 							name: "ExampleBlockDelimiter",
 						},
 						&labeledExpr{
-							pos:   position{line: 1163, col: 71, offset: 44336},
+							pos:   position{line: 1163, col: 71, offset: 44335},
 							label: "content",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1163, col: 79, offset: 44344},
+								pos: position{line: 1163, col: 79, offset: 44343},
 								expr: &choiceExpr{
-									pos: position{line: 1163, col: 80, offset: 44345},
+									pos: position{line: 1163, col: 80, offset: 44344},
 									alternatives: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 1163, col: 80, offset: 44345},
+											pos:  position{line: 1163, col: 80, offset: 44344},
 											name: "BlankLine",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1163, col: 92, offset: 44357},
+											pos:  position{line: 1163, col: 92, offset: 44356},
 											name: "FileInclusion",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1163, col: 108, offset: 44373},
+											pos:  position{line: 1163, col: 108, offset: 44372},
 											name: "ListItem",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1163, col: 119, offset: 44384},
+											pos:  position{line: 1163, col: 119, offset: 44383},
 											name: "ExampleBlockParagraph",
 										},
 									},
@@ -9173,14 +9173,14 @@ var g = &grammar{
 							},
 						},
 						&choiceExpr{
-							pos: position{line: 1163, col: 145, offset: 44410},
+							pos: position{line: 1163, col: 145, offset: 44409},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 1163, col: 145, offset: 44410},
+									pos:  position{line: 1163, col: 145, offset: 44409},
 									name: "ExampleBlockDelimiter",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1163, col: 169, offset: 44434},
+									pos:  position{line: 1163, col: 169, offset: 44433},
 									name: "EOF",
 								},
 							},
@@ -9191,17 +9191,17 @@ var g = &grammar{
 		},
 		{
 			name: "ExampleBlockParagraph",
-			pos:  position{line: 1168, col: 1, offset: 44561},
+			pos:  position{line: 1168, col: 1, offset: 44560},
 			expr: &actionExpr{
-				pos: position{line: 1168, col: 26, offset: 44586},
+				pos: position{line: 1168, col: 26, offset: 44585},
 				run: (*parser).callonExampleBlockParagraph1,
 				expr: &labeledExpr{
-					pos:   position{line: 1168, col: 26, offset: 44586},
+					pos:   position{line: 1168, col: 26, offset: 44585},
 					label: "lines",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 1168, col: 32, offset: 44592},
+						pos: position{line: 1168, col: 32, offset: 44591},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1168, col: 33, offset: 44593},
+							pos:  position{line: 1168, col: 33, offset: 44592},
 							name: "ExampleBlockParagraphLine",
 						},
 					},
@@ -9210,32 +9210,32 @@ var g = &grammar{
 		},
 		{
 			name: "ExampleBlockParagraphLine",
-			pos:  position{line: 1172, col: 1, offset: 44707},
+			pos:  position{line: 1172, col: 1, offset: 44706},
 			expr: &actionExpr{
-				pos: position{line: 1172, col: 30, offset: 44736},
+				pos: position{line: 1172, col: 30, offset: 44735},
 				run: (*parser).callonExampleBlockParagraphLine1,
 				expr: &seqExpr{
-					pos: position{line: 1172, col: 30, offset: 44736},
+					pos: position{line: 1172, col: 30, offset: 44735},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1172, col: 30, offset: 44736},
+							pos: position{line: 1172, col: 30, offset: 44735},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1172, col: 31, offset: 44737},
+								pos:  position{line: 1172, col: 31, offset: 44736},
 								name: "ExampleBlockDelimiter",
 							},
 						},
 						&notExpr{
-							pos: position{line: 1172, col: 53, offset: 44759},
+							pos: position{line: 1172, col: 53, offset: 44758},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1172, col: 54, offset: 44760},
+								pos:  position{line: 1172, col: 54, offset: 44759},
 								name: "BlankLine",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1172, col: 64, offset: 44770},
+							pos:   position{line: 1172, col: 64, offset: 44769},
 							label: "line",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1172, col: 70, offset: 44776},
+								pos:  position{line: 1172, col: 70, offset: 44775},
 								name: "InlineElements",
 							},
 						},
@@ -9245,17 +9245,17 @@ var g = &grammar{
 		},
 		{
 			name: "QuoteBlockDelimiter",
-			pos:  position{line: 1179, col: 1, offset: 45012},
+			pos:  position{line: 1179, col: 1, offset: 45011},
 			expr: &seqExpr{
-				pos: position{line: 1179, col: 24, offset: 45035},
+				pos: position{line: 1179, col: 24, offset: 45034},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1179, col: 24, offset: 45035},
+						pos:        position{line: 1179, col: 24, offset: 45034},
 						val:        "____",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1179, col: 31, offset: 45042},
+						pos:  position{line: 1179, col: 31, offset: 45041},
 						name: "EOLS",
 					},
 				},
@@ -9263,48 +9263,48 @@ var g = &grammar{
 		},
 		{
 			name: "QuoteBlock",
-			pos:  position{line: 1181, col: 1, offset: 45073},
+			pos:  position{line: 1181, col: 1, offset: 45072},
 			expr: &actionExpr{
-				pos: position{line: 1181, col: 15, offset: 45087},
+				pos: position{line: 1181, col: 15, offset: 45086},
 				run: (*parser).callonQuoteBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1181, col: 15, offset: 45087},
+					pos: position{line: 1181, col: 15, offset: 45086},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1181, col: 15, offset: 45087},
+							pos:   position{line: 1181, col: 15, offset: 45086},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1181, col: 26, offset: 45098},
+								pos: position{line: 1181, col: 26, offset: 45097},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1181, col: 27, offset: 45099},
+									pos:  position{line: 1181, col: 27, offset: 45098},
 									name: "ElementAttributes",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1181, col: 47, offset: 45119},
+							pos:  position{line: 1181, col: 47, offset: 45118},
 							name: "QuoteBlockDelimiter",
 						},
 						&labeledExpr{
-							pos:   position{line: 1181, col: 67, offset: 45139},
+							pos:   position{line: 1181, col: 67, offset: 45138},
 							label: "content",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1181, col: 75, offset: 45147},
+								pos: position{line: 1181, col: 75, offset: 45146},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1181, col: 76, offset: 45148},
+									pos:  position{line: 1181, col: 76, offset: 45147},
 									name: "QuoteBlockElement",
 								},
 							},
 						},
 						&choiceExpr{
-							pos: position{line: 1181, col: 97, offset: 45169},
+							pos: position{line: 1181, col: 97, offset: 45168},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 1181, col: 97, offset: 45169},
+									pos:  position{line: 1181, col: 97, offset: 45168},
 									name: "QuoteBlockDelimiter",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1181, col: 119, offset: 45191},
+									pos:  position{line: 1181, col: 119, offset: 45190},
 									name: "EOF",
 								},
 							},
@@ -9315,99 +9315,99 @@ var g = &grammar{
 		},
 		{
 			name: "QuoteBlockElement",
-			pos:  position{line: 1185, col: 1, offset: 45298},
+			pos:  position{line: 1185, col: 1, offset: 45297},
 			expr: &actionExpr{
-				pos: position{line: 1186, col: 5, offset: 45324},
+				pos: position{line: 1186, col: 5, offset: 45323},
 				run: (*parser).callonQuoteBlockElement1,
 				expr: &seqExpr{
-					pos: position{line: 1186, col: 5, offset: 45324},
+					pos: position{line: 1186, col: 5, offset: 45323},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1186, col: 5, offset: 45324},
+							pos: position{line: 1186, col: 5, offset: 45323},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1186, col: 6, offset: 45325},
+								pos:  position{line: 1186, col: 6, offset: 45324},
 								name: "QuoteBlockDelimiter",
 							},
 						},
 						&notExpr{
-							pos: position{line: 1186, col: 26, offset: 45345},
+							pos: position{line: 1186, col: 26, offset: 45344},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1186, col: 27, offset: 45346},
+								pos:  position{line: 1186, col: 27, offset: 45345},
 								name: "EOF",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1186, col: 31, offset: 45350},
+							pos:   position{line: 1186, col: 31, offset: 45349},
 							label: "element",
 							expr: &choiceExpr{
-								pos: position{line: 1186, col: 40, offset: 45359},
+								pos: position{line: 1186, col: 40, offset: 45358},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1186, col: 40, offset: 45359},
+										pos:  position{line: 1186, col: 40, offset: 45358},
 										name: "BlankLine",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1187, col: 15, offset: 45384},
+										pos:  position{line: 1187, col: 15, offset: 45383},
 										name: "FileInclusion",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1188, col: 15, offset: 45412},
+										pos:  position{line: 1188, col: 15, offset: 45411},
 										name: "ImageBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1189, col: 15, offset: 45438},
+										pos:  position{line: 1189, col: 15, offset: 45437},
 										name: "ListItem",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1190, col: 15, offset: 45461},
+										pos:  position{line: 1190, col: 15, offset: 45460},
 										name: "FencedBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1191, col: 15, offset: 45487},
+										pos:  position{line: 1191, col: 15, offset: 45486},
 										name: "ListingBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1192, col: 15, offset: 45514},
+										pos:  position{line: 1192, col: 15, offset: 45513},
 										name: "ExampleBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1193, col: 15, offset: 45541},
+										pos:  position{line: 1193, col: 15, offset: 45540},
 										name: "CommentBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1194, col: 15, offset: 45568},
+										pos:  position{line: 1194, col: 15, offset: 45567},
 										name: "SingleLineComment",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1195, col: 15, offset: 45600},
+										pos:  position{line: 1195, col: 15, offset: 45599},
 										name: "QuoteBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1196, col: 15, offset: 45626},
+										pos:  position{line: 1196, col: 15, offset: 45625},
 										name: "SidebarBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1197, col: 15, offset: 45653},
+										pos:  position{line: 1197, col: 15, offset: 45652},
 										name: "Table",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1198, col: 15, offset: 45674},
+										pos:  position{line: 1198, col: 15, offset: 45673},
 										name: "LiteralBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1199, col: 15, offset: 45702},
+										pos:  position{line: 1199, col: 15, offset: 45701},
 										name: "DocumentAttributeDeclaration",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1200, col: 15, offset: 45746},
+										pos:  position{line: 1200, col: 15, offset: 45745},
 										name: "DocumentAttributeReset",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1201, col: 15, offset: 45784},
+										pos:  position{line: 1201, col: 15, offset: 45783},
 										name: "TableOfContentsMacro",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1202, col: 15, offset: 45819},
+										pos:  position{line: 1202, col: 15, offset: 45818},
 										name: "QuoteBlockParagraph",
 									},
 								},
@@ -9419,17 +9419,17 @@ var g = &grammar{
 		},
 		{
 			name: "QuoteBlockParagraph",
-			pos:  position{line: 1206, col: 1, offset: 45878},
+			pos:  position{line: 1206, col: 1, offset: 45877},
 			expr: &actionExpr{
-				pos: position{line: 1206, col: 24, offset: 45901},
+				pos: position{line: 1206, col: 24, offset: 45900},
 				run: (*parser).callonQuoteBlockParagraph1,
 				expr: &labeledExpr{
-					pos:   position{line: 1206, col: 24, offset: 45901},
+					pos:   position{line: 1206, col: 24, offset: 45900},
 					label: "lines",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 1206, col: 30, offset: 45907},
+						pos: position{line: 1206, col: 30, offset: 45906},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1206, col: 31, offset: 45908},
+							pos:  position{line: 1206, col: 31, offset: 45907},
 							name: "InlineElements",
 						},
 					},
@@ -9438,49 +9438,49 @@ var g = &grammar{
 		},
 		{
 			name: "VerseBlock",
-			pos:  position{line: 1215, col: 1, offset: 46254},
+			pos:  position{line: 1215, col: 1, offset: 46253},
 			expr: &actionExpr{
-				pos: position{line: 1215, col: 15, offset: 46268},
+				pos: position{line: 1215, col: 15, offset: 46267},
 				run: (*parser).callonVerseBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1215, col: 15, offset: 46268},
+					pos: position{line: 1215, col: 15, offset: 46267},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1215, col: 15, offset: 46268},
+							pos:   position{line: 1215, col: 15, offset: 46267},
 							label: "attributes",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1215, col: 27, offset: 46280},
+								pos:  position{line: 1215, col: 27, offset: 46279},
 								name: "ElementAttributes",
 							},
 						},
 						&andCodeExpr{
-							pos: position{line: 1216, col: 5, offset: 46304},
+							pos: position{line: 1216, col: 5, offset: 46303},
 							run: (*parser).callonVerseBlock5,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1220, col: 5, offset: 46490},
+							pos:  position{line: 1220, col: 5, offset: 46489},
 							name: "QuoteBlockDelimiter",
 						},
 						&labeledExpr{
-							pos:   position{line: 1220, col: 25, offset: 46510},
+							pos:   position{line: 1220, col: 25, offset: 46509},
 							label: "content",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1220, col: 33, offset: 46518},
+								pos: position{line: 1220, col: 33, offset: 46517},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1220, col: 34, offset: 46519},
+									pos:  position{line: 1220, col: 34, offset: 46518},
 									name: "VerseBlockElement",
 								},
 							},
 						},
 						&choiceExpr{
-							pos: position{line: 1220, col: 55, offset: 46540},
+							pos: position{line: 1220, col: 55, offset: 46539},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 1220, col: 55, offset: 46540},
+									pos:  position{line: 1220, col: 55, offset: 46539},
 									name: "QuoteBlockDelimiter",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1220, col: 77, offset: 46562},
+									pos:  position{line: 1220, col: 77, offset: 46561},
 									name: "EOF",
 								},
 							},
@@ -9491,20 +9491,20 @@ var g = &grammar{
 		},
 		{
 			name: "VerseBlockElement",
-			pos:  position{line: 1224, col: 1, offset: 46677},
+			pos:  position{line: 1224, col: 1, offset: 46676},
 			expr: &choiceExpr{
-				pos: position{line: 1224, col: 22, offset: 46698},
+				pos: position{line: 1224, col: 22, offset: 46697},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1224, col: 22, offset: 46698},
+						pos:  position{line: 1224, col: 22, offset: 46697},
 						name: "VerseFileInclude",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1224, col: 41, offset: 46717},
+						pos:  position{line: 1224, col: 41, offset: 46716},
 						name: "BlankLine",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1224, col: 53, offset: 46729},
+						pos:  position{line: 1224, col: 53, offset: 46728},
 						name: "VerseBlockParagraph",
 					},
 				},
@@ -9512,25 +9512,25 @@ var g = &grammar{
 		},
 		{
 			name: "VerseFileInclude",
-			pos:  position{line: 1226, col: 1, offset: 46750},
+			pos:  position{line: 1226, col: 1, offset: 46749},
 			expr: &actionExpr{
-				pos: position{line: 1226, col: 21, offset: 46770},
+				pos: position{line: 1226, col: 21, offset: 46769},
 				run: (*parser).callonVerseFileInclude1,
 				expr: &seqExpr{
-					pos: position{line: 1226, col: 21, offset: 46770},
+					pos: position{line: 1226, col: 21, offset: 46769},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1226, col: 21, offset: 46770},
+							pos: position{line: 1226, col: 21, offset: 46769},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1226, col: 22, offset: 46771},
+								pos:  position{line: 1226, col: 22, offset: 46770},
 								name: "QuoteBlockDelimiter",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1226, col: 42, offset: 46791},
+							pos:   position{line: 1226, col: 42, offset: 46790},
 							label: "include",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1226, col: 51, offset: 46800},
+								pos:  position{line: 1226, col: 51, offset: 46799},
 								name: "FileInclusion",
 							},
 						},
@@ -9540,17 +9540,17 @@ var g = &grammar{
 		},
 		{
 			name: "VerseBlockParagraph",
-			pos:  position{line: 1231, col: 1, offset: 46862},
+			pos:  position{line: 1231, col: 1, offset: 46861},
 			expr: &actionExpr{
-				pos: position{line: 1231, col: 24, offset: 46885},
+				pos: position{line: 1231, col: 24, offset: 46884},
 				run: (*parser).callonVerseBlockParagraph1,
 				expr: &labeledExpr{
-					pos:   position{line: 1231, col: 24, offset: 46885},
+					pos:   position{line: 1231, col: 24, offset: 46884},
 					label: "lines",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 1231, col: 30, offset: 46891},
+						pos: position{line: 1231, col: 30, offset: 46890},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1231, col: 31, offset: 46892},
+							pos:  position{line: 1231, col: 31, offset: 46891},
 							name: "VerseBlockParagraphLine",
 						},
 					},
@@ -9559,49 +9559,49 @@ var g = &grammar{
 		},
 		{
 			name: "VerseBlockParagraphLine",
-			pos:  position{line: 1235, col: 1, offset: 46982},
+			pos:  position{line: 1235, col: 1, offset: 46981},
 			expr: &actionExpr{
-				pos: position{line: 1235, col: 28, offset: 47009},
+				pos: position{line: 1235, col: 28, offset: 47008},
 				run: (*parser).callonVerseBlockParagraphLine1,
 				expr: &seqExpr{
-					pos: position{line: 1235, col: 28, offset: 47009},
+					pos: position{line: 1235, col: 28, offset: 47008},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1235, col: 28, offset: 47009},
+							pos: position{line: 1235, col: 28, offset: 47008},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1235, col: 29, offset: 47010},
+								pos:  position{line: 1235, col: 29, offset: 47009},
 								name: "QuoteBlockDelimiter",
 							},
 						},
 						&notExpr{
-							pos: position{line: 1235, col: 49, offset: 47030},
+							pos: position{line: 1235, col: 49, offset: 47029},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1235, col: 50, offset: 47031},
+								pos:  position{line: 1235, col: 50, offset: 47030},
 								name: "BlankLine",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1235, col: 60, offset: 47041},
+							pos:   position{line: 1235, col: 60, offset: 47040},
 							label: "line",
 							expr: &actionExpr{
-								pos: position{line: 1235, col: 66, offset: 47047},
+								pos: position{line: 1235, col: 66, offset: 47046},
 								run: (*parser).callonVerseBlockParagraphLine8,
 								expr: &seqExpr{
-									pos: position{line: 1235, col: 66, offset: 47047},
+									pos: position{line: 1235, col: 66, offset: 47046},
 									exprs: []interface{}{
 										&labeledExpr{
-											pos:   position{line: 1235, col: 66, offset: 47047},
+											pos:   position{line: 1235, col: 66, offset: 47046},
 											label: "elements",
 											expr: &oneOrMoreExpr{
-												pos: position{line: 1235, col: 75, offset: 47056},
+												pos: position{line: 1235, col: 75, offset: 47055},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1235, col: 76, offset: 47057},
+													pos:  position{line: 1235, col: 76, offset: 47056},
 													name: "VerseBlockParagraphLineElement",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1235, col: 109, offset: 47090},
+											pos:  position{line: 1235, col: 109, offset: 47089},
 											name: "EOL",
 										},
 									},
@@ -9614,75 +9614,75 @@ var g = &grammar{
 		},
 		{
 			name: "VerseBlockParagraphLineElement",
-			pos:  position{line: 1241, col: 1, offset: 47186},
+			pos:  position{line: 1241, col: 1, offset: 47185},
 			expr: &actionExpr{
-				pos: position{line: 1241, col: 35, offset: 47220},
+				pos: position{line: 1241, col: 35, offset: 47219},
 				run: (*parser).callonVerseBlockParagraphLineElement1,
 				expr: &seqExpr{
-					pos: position{line: 1241, col: 35, offset: 47220},
+					pos: position{line: 1241, col: 35, offset: 47219},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1241, col: 35, offset: 47220},
+							pos: position{line: 1241, col: 35, offset: 47219},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1241, col: 36, offset: 47221},
+								pos:  position{line: 1241, col: 36, offset: 47220},
 								name: "EOL",
 							},
 						},
 						&notExpr{
-							pos: position{line: 1241, col: 40, offset: 47225},
+							pos: position{line: 1241, col: 40, offset: 47224},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1241, col: 41, offset: 47226},
+								pos:  position{line: 1241, col: 41, offset: 47225},
 								name: "LineBreak",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1242, col: 5, offset: 47241},
+							pos:   position{line: 1242, col: 5, offset: 47240},
 							label: "element",
 							expr: &choiceExpr{
-								pos: position{line: 1242, col: 14, offset: 47250},
+								pos: position{line: 1242, col: 14, offset: 47249},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1242, col: 14, offset: 47250},
+										pos:  position{line: 1242, col: 14, offset: 47249},
 										name: "Spaces",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1243, col: 11, offset: 47268},
+										pos:  position{line: 1243, col: 11, offset: 47267},
 										name: "InlineImage",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1244, col: 11, offset: 47291},
+										pos:  position{line: 1244, col: 11, offset: 47290},
 										name: "Link",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1245, col: 11, offset: 47307},
+										pos:  position{line: 1245, col: 11, offset: 47306},
 										name: "Passthrough",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1246, col: 11, offset: 47330},
+										pos:  position{line: 1246, col: 11, offset: 47329},
 										name: "InlineFootnote",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1247, col: 11, offset: 47356},
+										pos:  position{line: 1247, col: 11, offset: 47355},
 										name: "InlineUserMacro",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1248, col: 11, offset: 47383},
+										pos:  position{line: 1248, col: 11, offset: 47382},
 										name: "QuotedText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1249, col: 11, offset: 47405},
+										pos:  position{line: 1249, col: 11, offset: 47404},
 										name: "CrossReference",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1250, col: 11, offset: 47431},
+										pos:  position{line: 1250, col: 11, offset: 47430},
 										name: "DocumentAttributeSubstitution",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1251, col: 11, offset: 47472},
+										pos:  position{line: 1251, col: 11, offset: 47471},
 										name: "InlineElementID",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1252, col: 11, offset: 47499},
+										pos:  position{line: 1252, col: 11, offset: 47498},
 										name: "OtherWord",
 									},
 								},
@@ -9694,17 +9694,17 @@ var g = &grammar{
 		},
 		{
 			name: "SidebarBlockDelimiter",
-			pos:  position{line: 1259, col: 1, offset: 47729},
+			pos:  position{line: 1259, col: 1, offset: 47728},
 			expr: &seqExpr{
-				pos: position{line: 1259, col: 26, offset: 47754},
+				pos: position{line: 1259, col: 26, offset: 47753},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1259, col: 26, offset: 47754},
+						pos:        position{line: 1259, col: 26, offset: 47753},
 						val:        "****",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1259, col: 33, offset: 47761},
+						pos:  position{line: 1259, col: 33, offset: 47760},
 						name: "EOLS",
 					},
 				},
@@ -9712,48 +9712,48 @@ var g = &grammar{
 		},
 		{
 			name: "SidebarBlock",
-			pos:  position{line: 1261, col: 1, offset: 47767},
+			pos:  position{line: 1261, col: 1, offset: 47766},
 			expr: &actionExpr{
-				pos: position{line: 1261, col: 17, offset: 47783},
+				pos: position{line: 1261, col: 17, offset: 47782},
 				run: (*parser).callonSidebarBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1261, col: 17, offset: 47783},
+					pos: position{line: 1261, col: 17, offset: 47782},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1261, col: 17, offset: 47783},
+							pos:   position{line: 1261, col: 17, offset: 47782},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1261, col: 28, offset: 47794},
+								pos: position{line: 1261, col: 28, offset: 47793},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1261, col: 29, offset: 47795},
+									pos:  position{line: 1261, col: 29, offset: 47794},
 									name: "ElementAttributes",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1261, col: 49, offset: 47815},
+							pos:  position{line: 1261, col: 49, offset: 47814},
 							name: "SidebarBlockDelimiter",
 						},
 						&labeledExpr{
-							pos:   position{line: 1261, col: 71, offset: 47837},
+							pos:   position{line: 1261, col: 71, offset: 47836},
 							label: "content",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1261, col: 79, offset: 47845},
+								pos: position{line: 1261, col: 79, offset: 47844},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1261, col: 80, offset: 47846},
+									pos:  position{line: 1261, col: 80, offset: 47845},
 									name: "SidebarBlockContent",
 								},
 							},
 						},
 						&choiceExpr{
-							pos: position{line: 1261, col: 104, offset: 47870},
+							pos: position{line: 1261, col: 104, offset: 47869},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 1261, col: 104, offset: 47870},
+									pos:  position{line: 1261, col: 104, offset: 47869},
 									name: "SidebarBlockDelimiter",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1261, col: 128, offset: 47894},
+									pos:  position{line: 1261, col: 128, offset: 47893},
 									name: "EOF",
 								},
 							},
@@ -9764,28 +9764,28 @@ var g = &grammar{
 		},
 		{
 			name: "SidebarBlockContent",
-			pos:  position{line: 1265, col: 1, offset: 48003},
+			pos:  position{line: 1265, col: 1, offset: 48002},
 			expr: &choiceExpr{
-				pos: position{line: 1265, col: 24, offset: 48026},
+				pos: position{line: 1265, col: 24, offset: 48025},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1265, col: 24, offset: 48026},
+						pos:  position{line: 1265, col: 24, offset: 48025},
 						name: "BlankLine",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1265, col: 36, offset: 48038},
+						pos:  position{line: 1265, col: 36, offset: 48037},
 						name: "FileInclusion",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1265, col: 52, offset: 48054},
+						pos:  position{line: 1265, col: 52, offset: 48053},
 						name: "ListItem",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1265, col: 63, offset: 48065},
+						pos:  position{line: 1265, col: 63, offset: 48064},
 						name: "NonSidebarBlock",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1265, col: 81, offset: 48083},
+						pos:  position{line: 1265, col: 81, offset: 48082},
 						name: "SidebarBlockParagraph",
 					},
 				},
@@ -9793,25 +9793,25 @@ var g = &grammar{
 		},
 		{
 			name: "NonSidebarBlock",
-			pos:  position{line: 1267, col: 1, offset: 48106},
+			pos:  position{line: 1267, col: 1, offset: 48105},
 			expr: &actionExpr{
-				pos: position{line: 1267, col: 20, offset: 48125},
+				pos: position{line: 1267, col: 20, offset: 48124},
 				run: (*parser).callonNonSidebarBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1267, col: 20, offset: 48125},
+					pos: position{line: 1267, col: 20, offset: 48124},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1267, col: 20, offset: 48125},
+							pos: position{line: 1267, col: 20, offset: 48124},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1267, col: 21, offset: 48126},
+								pos:  position{line: 1267, col: 21, offset: 48125},
 								name: "SidebarBlock",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1267, col: 34, offset: 48139},
+							pos:   position{line: 1267, col: 34, offset: 48138},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1267, col: 43, offset: 48148},
+								pos:  position{line: 1267, col: 43, offset: 48147},
 								name: "DelimitedBlock",
 							},
 						},
@@ -9821,17 +9821,17 @@ var g = &grammar{
 		},
 		{
 			name: "SidebarBlockParagraph",
-			pos:  position{line: 1272, col: 1, offset: 48211},
+			pos:  position{line: 1272, col: 1, offset: 48210},
 			expr: &actionExpr{
-				pos: position{line: 1272, col: 26, offset: 48236},
+				pos: position{line: 1272, col: 26, offset: 48235},
 				run: (*parser).callonSidebarBlockParagraph1,
 				expr: &labeledExpr{
-					pos:   position{line: 1272, col: 26, offset: 48236},
+					pos:   position{line: 1272, col: 26, offset: 48235},
 					label: "lines",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 1272, col: 32, offset: 48242},
+						pos: position{line: 1272, col: 32, offset: 48241},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1272, col: 33, offset: 48243},
+							pos:  position{line: 1272, col: 33, offset: 48242},
 							name: "SidebarBlockParagraphLine",
 						},
 					},
@@ -9840,32 +9840,32 @@ var g = &grammar{
 		},
 		{
 			name: "SidebarBlockParagraphLine",
-			pos:  position{line: 1276, col: 1, offset: 48357},
+			pos:  position{line: 1276, col: 1, offset: 48356},
 			expr: &actionExpr{
-				pos: position{line: 1276, col: 30, offset: 48386},
+				pos: position{line: 1276, col: 30, offset: 48385},
 				run: (*parser).callonSidebarBlockParagraphLine1,
 				expr: &seqExpr{
-					pos: position{line: 1276, col: 30, offset: 48386},
+					pos: position{line: 1276, col: 30, offset: 48385},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1276, col: 30, offset: 48386},
+							pos: position{line: 1276, col: 30, offset: 48385},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1276, col: 31, offset: 48387},
+								pos:  position{line: 1276, col: 31, offset: 48386},
 								name: "SidebarBlockDelimiter",
 							},
 						},
 						&notExpr{
-							pos: position{line: 1276, col: 53, offset: 48409},
+							pos: position{line: 1276, col: 53, offset: 48408},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1276, col: 54, offset: 48410},
+								pos:  position{line: 1276, col: 54, offset: 48409},
 								name: "BlankLine",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1276, col: 64, offset: 48420},
+							pos:   position{line: 1276, col: 64, offset: 48419},
 							label: "line",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1276, col: 70, offset: 48426},
+								pos:  position{line: 1276, col: 70, offset: 48425},
 								name: "InlineElements",
 							},
 						},
@@ -9875,59 +9875,59 @@ var g = &grammar{
 		},
 		{
 			name: "Table",
-			pos:  position{line: 1284, col: 1, offset: 48657},
+			pos:  position{line: 1284, col: 1, offset: 48656},
 			expr: &actionExpr{
-				pos: position{line: 1284, col: 10, offset: 48666},
+				pos: position{line: 1284, col: 10, offset: 48665},
 				run: (*parser).callonTable1,
 				expr: &seqExpr{
-					pos: position{line: 1284, col: 10, offset: 48666},
+					pos: position{line: 1284, col: 10, offset: 48665},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1284, col: 10, offset: 48666},
+							pos:   position{line: 1284, col: 10, offset: 48665},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1284, col: 21, offset: 48677},
+								pos: position{line: 1284, col: 21, offset: 48676},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1284, col: 22, offset: 48678},
+									pos:  position{line: 1284, col: 22, offset: 48677},
 									name: "ElementAttributes",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1284, col: 42, offset: 48698},
+							pos:  position{line: 1284, col: 42, offset: 48697},
 							name: "TableDelimiter",
 						},
 						&labeledExpr{
-							pos:   position{line: 1285, col: 5, offset: 48717},
+							pos:   position{line: 1285, col: 5, offset: 48716},
 							label: "header",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1285, col: 12, offset: 48724},
+								pos: position{line: 1285, col: 12, offset: 48723},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1285, col: 13, offset: 48725},
+									pos:  position{line: 1285, col: 13, offset: 48724},
 									name: "TableLineHeader",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1286, col: 5, offset: 48747},
+							pos:   position{line: 1286, col: 5, offset: 48746},
 							label: "lines",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1286, col: 11, offset: 48753},
+								pos: position{line: 1286, col: 11, offset: 48752},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1286, col: 12, offset: 48754},
+									pos:  position{line: 1286, col: 12, offset: 48753},
 									name: "TableLine",
 								},
 							},
 						},
 						&choiceExpr{
-							pos: position{line: 1287, col: 6, offset: 48771},
+							pos: position{line: 1287, col: 6, offset: 48770},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 1287, col: 6, offset: 48771},
+									pos:  position{line: 1287, col: 6, offset: 48770},
 									name: "TableDelimiter",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1287, col: 23, offset: 48788},
+									pos:  position{line: 1287, col: 23, offset: 48787},
 									name: "EOF",
 								},
 							},
@@ -9938,19 +9938,19 @@ var g = &grammar{
 		},
 		{
 			name: "TableCellSeparator",
-			pos:  position{line: 1291, col: 1, offset: 48903},
+			pos:  position{line: 1291, col: 1, offset: 48902},
 			expr: &seqExpr{
-				pos: position{line: 1291, col: 23, offset: 48925},
+				pos: position{line: 1291, col: 23, offset: 48924},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1291, col: 23, offset: 48925},
+						pos:        position{line: 1291, col: 23, offset: 48924},
 						val:        "|",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1291, col: 27, offset: 48929},
+						pos: position{line: 1291, col: 27, offset: 48928},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1291, col: 27, offset: 48929},
+							pos:  position{line: 1291, col: 27, offset: 48928},
 							name: "WS",
 						},
 					},
@@ -9959,17 +9959,17 @@ var g = &grammar{
 		},
 		{
 			name: "TableDelimiter",
-			pos:  position{line: 1293, col: 1, offset: 48934},
+			pos:  position{line: 1293, col: 1, offset: 48933},
 			expr: &seqExpr{
-				pos: position{line: 1293, col: 19, offset: 48952},
+				pos: position{line: 1293, col: 19, offset: 48951},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1293, col: 19, offset: 48952},
+						pos:        position{line: 1293, col: 19, offset: 48951},
 						val:        "|===",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1293, col: 26, offset: 48959},
+						pos:  position{line: 1293, col: 26, offset: 48958},
 						name: "EOLS",
 					},
 				},
@@ -9977,37 +9977,37 @@ var g = &grammar{
 		},
 		{
 			name: "TableLineHeader",
-			pos:  position{line: 1296, col: 1, offset: 49028},
+			pos:  position{line: 1296, col: 1, offset: 49027},
 			expr: &actionExpr{
-				pos: position{line: 1296, col: 20, offset: 49047},
+				pos: position{line: 1296, col: 20, offset: 49046},
 				run: (*parser).callonTableLineHeader1,
 				expr: &seqExpr{
-					pos: position{line: 1296, col: 20, offset: 49047},
+					pos: position{line: 1296, col: 20, offset: 49046},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1296, col: 20, offset: 49047},
+							pos: position{line: 1296, col: 20, offset: 49046},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1296, col: 21, offset: 49048},
+								pos:  position{line: 1296, col: 21, offset: 49047},
 								name: "TableDelimiter",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1296, col: 36, offset: 49063},
+							pos:   position{line: 1296, col: 36, offset: 49062},
 							label: "cells",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1296, col: 42, offset: 49069},
+								pos: position{line: 1296, col: 42, offset: 49068},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1296, col: 43, offset: 49070},
+									pos:  position{line: 1296, col: 43, offset: 49069},
 									name: "TableCell",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1296, col: 55, offset: 49082},
+							pos:  position{line: 1296, col: 55, offset: 49081},
 							name: "EOL",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1296, col: 59, offset: 49086},
+							pos:  position{line: 1296, col: 59, offset: 49085},
 							name: "BlankLine",
 						},
 					},
@@ -10016,39 +10016,39 @@ var g = &grammar{
 		},
 		{
 			name: "TableLine",
-			pos:  position{line: 1300, col: 1, offset: 49154},
+			pos:  position{line: 1300, col: 1, offset: 49153},
 			expr: &actionExpr{
-				pos: position{line: 1300, col: 14, offset: 49167},
+				pos: position{line: 1300, col: 14, offset: 49166},
 				run: (*parser).callonTableLine1,
 				expr: &seqExpr{
-					pos: position{line: 1300, col: 14, offset: 49167},
+					pos: position{line: 1300, col: 14, offset: 49166},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1300, col: 14, offset: 49167},
+							pos: position{line: 1300, col: 14, offset: 49166},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1300, col: 15, offset: 49168},
+								pos:  position{line: 1300, col: 15, offset: 49167},
 								name: "TableDelimiter",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1300, col: 30, offset: 49183},
+							pos:   position{line: 1300, col: 30, offset: 49182},
 							label: "cells",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1300, col: 36, offset: 49189},
+								pos: position{line: 1300, col: 36, offset: 49188},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1300, col: 37, offset: 49190},
+									pos:  position{line: 1300, col: 37, offset: 49189},
 									name: "TableCell",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1300, col: 49, offset: 49202},
+							pos:  position{line: 1300, col: 49, offset: 49201},
 							name: "EOL",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1300, col: 53, offset: 49206},
+							pos: position{line: 1300, col: 53, offset: 49205},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1300, col: 53, offset: 49206},
+								pos:  position{line: 1300, col: 53, offset: 49205},
 								name: "BlankLine",
 							},
 						},
@@ -10058,54 +10058,54 @@ var g = &grammar{
 		},
 		{
 			name: "TableCell",
-			pos:  position{line: 1304, col: 1, offset: 49275},
+			pos:  position{line: 1304, col: 1, offset: 49274},
 			expr: &actionExpr{
-				pos: position{line: 1304, col: 14, offset: 49288},
+				pos: position{line: 1304, col: 14, offset: 49287},
 				run: (*parser).callonTableCell1,
 				expr: &seqExpr{
-					pos: position{line: 1304, col: 14, offset: 49288},
+					pos: position{line: 1304, col: 14, offset: 49287},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1304, col: 14, offset: 49288},
+							pos:  position{line: 1304, col: 14, offset: 49287},
 							name: "TableCellSeparator",
 						},
 						&labeledExpr{
-							pos:   position{line: 1304, col: 33, offset: 49307},
+							pos:   position{line: 1304, col: 33, offset: 49306},
 							label: "elements",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1304, col: 42, offset: 49316},
+								pos: position{line: 1304, col: 42, offset: 49315},
 								expr: &seqExpr{
-									pos: position{line: 1304, col: 43, offset: 49317},
+									pos: position{line: 1304, col: 43, offset: 49316},
 									exprs: []interface{}{
 										&notExpr{
-											pos: position{line: 1304, col: 43, offset: 49317},
+											pos: position{line: 1304, col: 43, offset: 49316},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1304, col: 44, offset: 49318},
+												pos:  position{line: 1304, col: 44, offset: 49317},
 												name: "TableCellSeparator",
 											},
 										},
 										&notExpr{
-											pos: position{line: 1304, col: 63, offset: 49337},
+											pos: position{line: 1304, col: 63, offset: 49336},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1304, col: 64, offset: 49338},
+												pos:  position{line: 1304, col: 64, offset: 49337},
 												name: "EOL",
 											},
 										},
 										&zeroOrMoreExpr{
-											pos: position{line: 1304, col: 68, offset: 49342},
+											pos: position{line: 1304, col: 68, offset: 49341},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1304, col: 68, offset: 49342},
+												pos:  position{line: 1304, col: 68, offset: 49341},
 												name: "WS",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1304, col: 72, offset: 49346},
+											pos:  position{line: 1304, col: 72, offset: 49345},
 											name: "InlineElement",
 										},
 										&zeroOrMoreExpr{
-											pos: position{line: 1304, col: 86, offset: 49360},
+											pos: position{line: 1304, col: 86, offset: 49359},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1304, col: 86, offset: 49360},
+												pos:  position{line: 1304, col: 86, offset: 49359},
 												name: "WS",
 											},
 										},
@@ -10119,66 +10119,66 @@ var g = &grammar{
 		},
 		{
 			name: "CommentBlockDelimiter",
-			pos:  position{line: 1311, col: 1, offset: 49606},
+			pos:  position{line: 1311, col: 1, offset: 49605},
 			expr: &litMatcher{
-				pos:        position{line: 1311, col: 26, offset: 49631},
+				pos:        position{line: 1311, col: 26, offset: 49630},
 				val:        "////",
 				ignoreCase: false,
 			},
 		},
 		{
 			name: "CommentBlock",
-			pos:  position{line: 1313, col: 1, offset: 49639},
+			pos:  position{line: 1313, col: 1, offset: 49638},
 			expr: &actionExpr{
-				pos: position{line: 1313, col: 17, offset: 49655},
+				pos: position{line: 1313, col: 17, offset: 49654},
 				run: (*parser).callonCommentBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1313, col: 17, offset: 49655},
+					pos: position{line: 1313, col: 17, offset: 49654},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1313, col: 17, offset: 49655},
+							pos:  position{line: 1313, col: 17, offset: 49654},
 							name: "CommentBlockDelimiter",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1313, col: 39, offset: 49677},
+							pos: position{line: 1313, col: 39, offset: 49676},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1313, col: 39, offset: 49677},
+								pos:  position{line: 1313, col: 39, offset: 49676},
 								name: "WS",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1313, col: 43, offset: 49681},
+							pos:  position{line: 1313, col: 43, offset: 49680},
 							name: "NEWLINE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1313, col: 51, offset: 49689},
+							pos:   position{line: 1313, col: 51, offset: 49688},
 							label: "content",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1313, col: 59, offset: 49697},
+								pos: position{line: 1313, col: 59, offset: 49696},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1313, col: 60, offset: 49698},
+									pos:  position{line: 1313, col: 60, offset: 49697},
 									name: "CommentBlockLine",
 								},
 							},
 						},
 						&choiceExpr{
-							pos: position{line: 1313, col: 81, offset: 49719},
+							pos: position{line: 1313, col: 81, offset: 49718},
 							alternatives: []interface{}{
 								&seqExpr{
-									pos: position{line: 1313, col: 82, offset: 49720},
+									pos: position{line: 1313, col: 82, offset: 49719},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 1313, col: 82, offset: 49720},
+											pos:  position{line: 1313, col: 82, offset: 49719},
 											name: "CommentBlockDelimiter",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1313, col: 104, offset: 49742},
+											pos:  position{line: 1313, col: 104, offset: 49741},
 											name: "EOLS",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1313, col: 112, offset: 49750},
+									pos:  position{line: 1313, col: 112, offset: 49749},
 									name: "EOF",
 								},
 							},
@@ -10189,45 +10189,45 @@ var g = &grammar{
 		},
 		{
 			name: "CommentBlockLine",
-			pos:  position{line: 1317, col: 1, offset: 49856},
+			pos:  position{line: 1317, col: 1, offset: 49855},
 			expr: &actionExpr{
-				pos: position{line: 1317, col: 21, offset: 49876},
+				pos: position{line: 1317, col: 21, offset: 49875},
 				run: (*parser).callonCommentBlockLine1,
 				expr: &seqExpr{
-					pos: position{line: 1317, col: 21, offset: 49876},
+					pos: position{line: 1317, col: 21, offset: 49875},
 					exprs: []interface{}{
 						&zeroOrMoreExpr{
-							pos: position{line: 1317, col: 21, offset: 49876},
+							pos: position{line: 1317, col: 21, offset: 49875},
 							expr: &choiceExpr{
-								pos: position{line: 1317, col: 22, offset: 49877},
+								pos: position{line: 1317, col: 22, offset: 49876},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1317, col: 22, offset: 49877},
+										pos:  position{line: 1317, col: 22, offset: 49876},
 										name: "Alphanums",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1317, col: 34, offset: 49889},
+										pos:  position{line: 1317, col: 34, offset: 49888},
 										name: "Spaces",
 									},
 									&seqExpr{
-										pos: position{line: 1317, col: 44, offset: 49899},
+										pos: position{line: 1317, col: 44, offset: 49898},
 										exprs: []interface{}{
 											&notExpr{
-												pos: position{line: 1317, col: 44, offset: 49899},
+												pos: position{line: 1317, col: 44, offset: 49898},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1317, col: 45, offset: 49900},
+													pos:  position{line: 1317, col: 45, offset: 49899},
 													name: "CommentBlockDelimiter",
 												},
 											},
 											&notExpr{
-												pos: position{line: 1317, col: 67, offset: 49922},
+												pos: position{line: 1317, col: 67, offset: 49921},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1317, col: 68, offset: 49923},
+													pos:  position{line: 1317, col: 68, offset: 49922},
 													name: "EOL",
 												},
 											},
 											&anyMatcher{
-												line: 1317, col: 73, offset: 49928,
+												line: 1317, col: 73, offset: 49927,
 											},
 										},
 									},
@@ -10235,7 +10235,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1317, col: 78, offset: 49933},
+							pos:  position{line: 1317, col: 78, offset: 49932},
 							name: "EOL",
 						},
 					},
@@ -10244,42 +10244,42 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineComment",
-			pos:  position{line: 1321, col: 1, offset: 49973},
+			pos:  position{line: 1321, col: 1, offset: 49972},
 			expr: &actionExpr{
-				pos: position{line: 1321, col: 22, offset: 49994},
+				pos: position{line: 1321, col: 22, offset: 49993},
 				run: (*parser).callonSingleLineComment1,
 				expr: &seqExpr{
-					pos: position{line: 1321, col: 22, offset: 49994},
+					pos: position{line: 1321, col: 22, offset: 49993},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1321, col: 22, offset: 49994},
+							pos: position{line: 1321, col: 22, offset: 49993},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1321, col: 23, offset: 49995},
+								pos:  position{line: 1321, col: 23, offset: 49994},
 								name: "CommentBlockDelimiter",
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1321, col: 45, offset: 50017},
+							pos: position{line: 1321, col: 45, offset: 50016},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1321, col: 45, offset: 50017},
+								pos:  position{line: 1321, col: 45, offset: 50016},
 								name: "WS",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1321, col: 49, offset: 50021},
+							pos:        position{line: 1321, col: 49, offset: 50020},
 							val:        "//",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1321, col: 54, offset: 50026},
+							pos:   position{line: 1321, col: 54, offset: 50025},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1321, col: 63, offset: 50035},
+								pos:  position{line: 1321, col: 63, offset: 50034},
 								name: "SingleLineCommentContent",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1321, col: 89, offset: 50061},
+							pos:  position{line: 1321, col: 89, offset: 50060},
 							name: "EOL",
 						},
 					},
@@ -10288,35 +10288,35 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineCommentContent",
-			pos:  position{line: 1325, col: 1, offset: 50126},
+			pos:  position{line: 1325, col: 1, offset: 50125},
 			expr: &actionExpr{
-				pos: position{line: 1325, col: 29, offset: 50154},
+				pos: position{line: 1325, col: 29, offset: 50153},
 				run: (*parser).callonSingleLineCommentContent1,
 				expr: &zeroOrMoreExpr{
-					pos: position{line: 1325, col: 29, offset: 50154},
+					pos: position{line: 1325, col: 29, offset: 50153},
 					expr: &choiceExpr{
-						pos: position{line: 1325, col: 30, offset: 50155},
+						pos: position{line: 1325, col: 30, offset: 50154},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 1325, col: 30, offset: 50155},
+								pos:  position{line: 1325, col: 30, offset: 50154},
 								name: "Alphanums",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1325, col: 42, offset: 50167},
+								pos:  position{line: 1325, col: 42, offset: 50166},
 								name: "Spaces",
 							},
 							&seqExpr{
-								pos: position{line: 1325, col: 52, offset: 50177},
+								pos: position{line: 1325, col: 52, offset: 50176},
 								exprs: []interface{}{
 									&notExpr{
-										pos: position{line: 1325, col: 52, offset: 50177},
+										pos: position{line: 1325, col: 52, offset: 50176},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1325, col: 53, offset: 50178},
+											pos:  position{line: 1325, col: 53, offset: 50177},
 											name: "EOL",
 										},
 									},
 									&anyMatcher{
-										line: 1325, col: 58, offset: 50183,
+										line: 1325, col: 58, offset: 50182,
 									},
 								},
 							},
@@ -10327,20 +10327,20 @@ var g = &grammar{
 		},
 		{
 			name: "LiteralBlock",
-			pos:  position{line: 1333, col: 1, offset: 50492},
+			pos:  position{line: 1333, col: 1, offset: 50491},
 			expr: &choiceExpr{
-				pos: position{line: 1333, col: 17, offset: 50508},
+				pos: position{line: 1333, col: 17, offset: 50507},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1333, col: 17, offset: 50508},
+						pos:  position{line: 1333, col: 17, offset: 50507},
 						name: "ParagraphWithLiteralAttribute",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1333, col: 49, offset: 50540},
+						pos:  position{line: 1333, col: 49, offset: 50539},
 						name: "ParagraphWithHeadingSpaces",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1333, col: 78, offset: 50569},
+						pos:  position{line: 1333, col: 78, offset: 50568},
 						name: "ParagraphWithLiteralBlockDelimiter",
 					},
 				},
@@ -10348,38 +10348,38 @@ var g = &grammar{
 		},
 		{
 			name: "LiteralBlockDelimiter",
-			pos:  position{line: 1335, col: 1, offset: 50605},
+			pos:  position{line: 1335, col: 1, offset: 50604},
 			expr: &litMatcher{
-				pos:        position{line: 1335, col: 26, offset: 50630},
+				pos:        position{line: 1335, col: 26, offset: 50629},
 				val:        "....",
 				ignoreCase: false,
 			},
 		},
 		{
 			name: "ParagraphWithHeadingSpaces",
-			pos:  position{line: 1338, col: 1, offset: 50702},
+			pos:  position{line: 1338, col: 1, offset: 50701},
 			expr: &actionExpr{
-				pos: position{line: 1338, col: 31, offset: 50732},
+				pos: position{line: 1338, col: 31, offset: 50731},
 				run: (*parser).callonParagraphWithHeadingSpaces1,
 				expr: &seqExpr{
-					pos: position{line: 1338, col: 31, offset: 50732},
+					pos: position{line: 1338, col: 31, offset: 50731},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1338, col: 31, offset: 50732},
+							pos:   position{line: 1338, col: 31, offset: 50731},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1338, col: 42, offset: 50743},
+								pos: position{line: 1338, col: 42, offset: 50742},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1338, col: 43, offset: 50744},
+									pos:  position{line: 1338, col: 43, offset: 50743},
 									name: "ElementAttributes",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1338, col: 63, offset: 50764},
+							pos:   position{line: 1338, col: 63, offset: 50763},
 							label: "lines",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1338, col: 70, offset: 50771},
+								pos:  position{line: 1338, col: 70, offset: 50770},
 								name: "ParagraphWithHeadingSpacesLines",
 							},
 						},
@@ -10389,54 +10389,54 @@ var g = &grammar{
 		},
 		{
 			name: "ParagraphWithHeadingSpacesLines",
-			pos:  position{line: 1343, col: 1, offset: 51001},
+			pos:  position{line: 1343, col: 1, offset: 51000},
 			expr: &actionExpr{
-				pos: position{line: 1344, col: 5, offset: 51041},
+				pos: position{line: 1344, col: 5, offset: 51040},
 				run: (*parser).callonParagraphWithHeadingSpacesLines1,
 				expr: &seqExpr{
-					pos: position{line: 1344, col: 5, offset: 51041},
+					pos: position{line: 1344, col: 5, offset: 51040},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1344, col: 5, offset: 51041},
+							pos:   position{line: 1344, col: 5, offset: 51040},
 							label: "firstLine",
 							expr: &actionExpr{
-								pos: position{line: 1344, col: 16, offset: 51052},
+								pos: position{line: 1344, col: 16, offset: 51051},
 								run: (*parser).callonParagraphWithHeadingSpacesLines4,
 								expr: &seqExpr{
-									pos: position{line: 1344, col: 16, offset: 51052},
+									pos: position{line: 1344, col: 16, offset: 51051},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 1344, col: 16, offset: 51052},
+											pos:  position{line: 1344, col: 16, offset: 51051},
 											name: "WS",
 										},
 										&oneOrMoreExpr{
-											pos: position{line: 1344, col: 19, offset: 51055},
+											pos: position{line: 1344, col: 19, offset: 51054},
 											expr: &choiceExpr{
-												pos: position{line: 1344, col: 20, offset: 51056},
+												pos: position{line: 1344, col: 20, offset: 51055},
 												alternatives: []interface{}{
 													&ruleRefExpr{
-														pos:  position{line: 1344, col: 20, offset: 51056},
+														pos:  position{line: 1344, col: 20, offset: 51055},
 														name: "Alphanums",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1344, col: 32, offset: 51068},
+														pos:  position{line: 1344, col: 32, offset: 51067},
 														name: "Spaces",
 													},
 													&actionExpr{
-														pos: position{line: 1344, col: 41, offset: 51077},
+														pos: position{line: 1344, col: 41, offset: 51076},
 														run: (*parser).callonParagraphWithHeadingSpacesLines11,
 														expr: &seqExpr{
-															pos: position{line: 1344, col: 42, offset: 51078},
+															pos: position{line: 1344, col: 42, offset: 51077},
 															exprs: []interface{}{
 																&notExpr{
-																	pos: position{line: 1344, col: 42, offset: 51078},
+																	pos: position{line: 1344, col: 42, offset: 51077},
 																	expr: &ruleRefExpr{
-																		pos:  position{line: 1344, col: 43, offset: 51079},
+																		pos:  position{line: 1344, col: 43, offset: 51078},
 																		name: "EOL",
 																	},
 																},
 																&anyMatcher{
-																	line: 1344, col: 48, offset: 51084,
+																	line: 1344, col: 48, offset: 51083,
 																},
 															},
 														},
@@ -10449,58 +10449,58 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1348, col: 8, offset: 51175},
+							pos:  position{line: 1348, col: 8, offset: 51174},
 							name: "EOL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1349, col: 5, offset: 51238},
+							pos:   position{line: 1349, col: 5, offset: 51237},
 							label: "otherLines",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1349, col: 16, offset: 51249},
+								pos: position{line: 1349, col: 16, offset: 51248},
 								expr: &actionExpr{
-									pos: position{line: 1350, col: 9, offset: 51259},
+									pos: position{line: 1350, col: 9, offset: 51258},
 									run: (*parser).callonParagraphWithHeadingSpacesLines19,
 									expr: &seqExpr{
-										pos: position{line: 1350, col: 9, offset: 51259},
+										pos: position{line: 1350, col: 9, offset: 51258},
 										exprs: []interface{}{
 											&notExpr{
-												pos: position{line: 1350, col: 9, offset: 51259},
+												pos: position{line: 1350, col: 9, offset: 51258},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1350, col: 10, offset: 51260},
+													pos:  position{line: 1350, col: 10, offset: 51259},
 													name: "BlankLine",
 												},
 											},
 											&labeledExpr{
-												pos:   position{line: 1351, col: 9, offset: 51279},
+												pos:   position{line: 1351, col: 9, offset: 51278},
 												label: "otherLine",
 												expr: &actionExpr{
-													pos: position{line: 1351, col: 20, offset: 51290},
+													pos: position{line: 1351, col: 20, offset: 51289},
 													run: (*parser).callonParagraphWithHeadingSpacesLines24,
 													expr: &oneOrMoreExpr{
-														pos: position{line: 1351, col: 20, offset: 51290},
+														pos: position{line: 1351, col: 20, offset: 51289},
 														expr: &choiceExpr{
-															pos: position{line: 1351, col: 21, offset: 51291},
+															pos: position{line: 1351, col: 21, offset: 51290},
 															alternatives: []interface{}{
 																&ruleRefExpr{
-																	pos:  position{line: 1351, col: 21, offset: 51291},
+																	pos:  position{line: 1351, col: 21, offset: 51290},
 																	name: "Alphanums",
 																},
 																&ruleRefExpr{
-																	pos:  position{line: 1351, col: 33, offset: 51303},
+																	pos:  position{line: 1351, col: 33, offset: 51302},
 																	name: "Spaces",
 																},
 																&seqExpr{
-																	pos: position{line: 1351, col: 43, offset: 51313},
+																	pos: position{line: 1351, col: 43, offset: 51312},
 																	exprs: []interface{}{
 																		&notExpr{
-																			pos: position{line: 1351, col: 43, offset: 51313},
+																			pos: position{line: 1351, col: 43, offset: 51312},
 																			expr: &ruleRefExpr{
-																				pos:  position{line: 1351, col: 44, offset: 51314},
+																				pos:  position{line: 1351, col: 44, offset: 51313},
 																				name: "EOL",
 																			},
 																		},
 																		&anyMatcher{
-																			line: 1351, col: 49, offset: 51319,
+																			line: 1351, col: 49, offset: 51318,
 																		},
 																	},
 																},
@@ -10510,7 +10510,7 @@ var g = &grammar{
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1353, col: 12, offset: 51376},
+												pos:  position{line: 1353, col: 12, offset: 51375},
 												name: "EOL",
 											},
 										},
@@ -10524,65 +10524,65 @@ var g = &grammar{
 		},
 		{
 			name: "ParagraphWithLiteralBlockDelimiter",
-			pos:  position{line: 1360, col: 1, offset: 51606},
+			pos:  position{line: 1360, col: 1, offset: 51605},
 			expr: &actionExpr{
-				pos: position{line: 1360, col: 39, offset: 51644},
+				pos: position{line: 1360, col: 39, offset: 51643},
 				run: (*parser).callonParagraphWithLiteralBlockDelimiter1,
 				expr: &seqExpr{
-					pos: position{line: 1360, col: 39, offset: 51644},
+					pos: position{line: 1360, col: 39, offset: 51643},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1360, col: 39, offset: 51644},
+							pos:   position{line: 1360, col: 39, offset: 51643},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1360, col: 50, offset: 51655},
+								pos: position{line: 1360, col: 50, offset: 51654},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1360, col: 51, offset: 51656},
+									pos:  position{line: 1360, col: 51, offset: 51655},
 									name: "ElementAttributes",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1361, col: 9, offset: 51684},
+							pos:  position{line: 1361, col: 9, offset: 51683},
 							name: "LiteralBlockDelimiter",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1361, col: 31, offset: 51706},
+							pos: position{line: 1361, col: 31, offset: 51705},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1361, col: 31, offset: 51706},
+								pos:  position{line: 1361, col: 31, offset: 51705},
 								name: "WS",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1361, col: 35, offset: 51710},
+							pos:  position{line: 1361, col: 35, offset: 51709},
 							name: "NEWLINE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1361, col: 43, offset: 51718},
+							pos:   position{line: 1361, col: 43, offset: 51717},
 							label: "lines",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1361, col: 50, offset: 51725},
+								pos:  position{line: 1361, col: 50, offset: 51724},
 								name: "ParagraphWithLiteralBlockDelimiterLines",
 							},
 						},
 						&choiceExpr{
-							pos: position{line: 1361, col: 92, offset: 51767},
+							pos: position{line: 1361, col: 92, offset: 51766},
 							alternatives: []interface{}{
 								&seqExpr{
-									pos: position{line: 1361, col: 93, offset: 51768},
+									pos: position{line: 1361, col: 93, offset: 51767},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 1361, col: 93, offset: 51768},
+											pos:  position{line: 1361, col: 93, offset: 51767},
 											name: "LiteralBlockDelimiter",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1361, col: 115, offset: 51790},
+											pos:  position{line: 1361, col: 115, offset: 51789},
 											name: "EOLS",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1361, col: 123, offset: 51798},
+									pos:  position{line: 1361, col: 123, offset: 51797},
 									name: "EOF",
 								},
 							},
@@ -10593,17 +10593,17 @@ var g = &grammar{
 		},
 		{
 			name: "ParagraphWithLiteralBlockDelimiterLines",
-			pos:  position{line: 1366, col: 1, offset: 51957},
+			pos:  position{line: 1366, col: 1, offset: 51956},
 			expr: &actionExpr{
-				pos: position{line: 1366, col: 44, offset: 52000},
+				pos: position{line: 1366, col: 44, offset: 51999},
 				run: (*parser).callonParagraphWithLiteralBlockDelimiterLines1,
 				expr: &labeledExpr{
-					pos:   position{line: 1366, col: 44, offset: 52000},
+					pos:   position{line: 1366, col: 44, offset: 51999},
 					label: "lines",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 1366, col: 50, offset: 52006},
+						pos: position{line: 1366, col: 50, offset: 52005},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1366, col: 51, offset: 52007},
+							pos:  position{line: 1366, col: 51, offset: 52006},
 							name: "ParagraphWithLiteralBlockDelimiterLine",
 						},
 					},
@@ -10612,51 +10612,51 @@ var g = &grammar{
 		},
 		{
 			name: "ParagraphWithLiteralBlockDelimiterLine",
-			pos:  position{line: 1370, col: 1, offset: 52091},
+			pos:  position{line: 1370, col: 1, offset: 52090},
 			expr: &actionExpr{
-				pos: position{line: 1371, col: 5, offset: 52146},
+				pos: position{line: 1371, col: 5, offset: 52145},
 				run: (*parser).callonParagraphWithLiteralBlockDelimiterLine1,
 				expr: &seqExpr{
-					pos: position{line: 1371, col: 5, offset: 52146},
+					pos: position{line: 1371, col: 5, offset: 52145},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1371, col: 5, offset: 52146},
+							pos:   position{line: 1371, col: 5, offset: 52145},
 							label: "line",
 							expr: &actionExpr{
-								pos: position{line: 1371, col: 11, offset: 52152},
+								pos: position{line: 1371, col: 11, offset: 52151},
 								run: (*parser).callonParagraphWithLiteralBlockDelimiterLine4,
 								expr: &zeroOrMoreExpr{
-									pos: position{line: 1371, col: 11, offset: 52152},
+									pos: position{line: 1371, col: 11, offset: 52151},
 									expr: &choiceExpr{
-										pos: position{line: 1371, col: 12, offset: 52153},
+										pos: position{line: 1371, col: 12, offset: 52152},
 										alternatives: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1371, col: 12, offset: 52153},
+												pos:  position{line: 1371, col: 12, offset: 52152},
 												name: "Alphanums",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1371, col: 24, offset: 52165},
+												pos:  position{line: 1371, col: 24, offset: 52164},
 												name: "Spaces",
 											},
 											&seqExpr{
-												pos: position{line: 1371, col: 34, offset: 52175},
+												pos: position{line: 1371, col: 34, offset: 52174},
 												exprs: []interface{}{
 													&notExpr{
-														pos: position{line: 1371, col: 34, offset: 52175},
+														pos: position{line: 1371, col: 34, offset: 52174},
 														expr: &ruleRefExpr{
-															pos:  position{line: 1371, col: 35, offset: 52176},
+															pos:  position{line: 1371, col: 35, offset: 52175},
 															name: "LiteralBlockDelimiter",
 														},
 													},
 													&notExpr{
-														pos: position{line: 1371, col: 57, offset: 52198},
+														pos: position{line: 1371, col: 57, offset: 52197},
 														expr: &ruleRefExpr{
-															pos:  position{line: 1371, col: 58, offset: 52199},
+															pos:  position{line: 1371, col: 58, offset: 52198},
 															name: "EOL",
 														},
 													},
 													&anyMatcher{
-														line: 1371, col: 62, offset: 52203,
+														line: 1371, col: 62, offset: 52202,
 													},
 												},
 											},
@@ -10666,7 +10666,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1373, col: 8, offset: 52252},
+							pos:  position{line: 1373, col: 8, offset: 52251},
 							name: "EOL",
 						},
 					},
@@ -10675,33 +10675,33 @@ var g = &grammar{
 		},
 		{
 			name: "ParagraphWithLiteralAttribute",
-			pos:  position{line: 1378, col: 1, offset: 52378},
+			pos:  position{line: 1378, col: 1, offset: 52377},
 			expr: &actionExpr{
-				pos: position{line: 1379, col: 5, offset: 52416},
+				pos: position{line: 1379, col: 5, offset: 52415},
 				run: (*parser).callonParagraphWithLiteralAttribute1,
 				expr: &seqExpr{
-					pos: position{line: 1379, col: 5, offset: 52416},
+					pos: position{line: 1379, col: 5, offset: 52415},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1379, col: 5, offset: 52416},
+							pos:   position{line: 1379, col: 5, offset: 52415},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1379, col: 16, offset: 52427},
+								pos: position{line: 1379, col: 16, offset: 52426},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1379, col: 17, offset: 52428},
+									pos:  position{line: 1379, col: 17, offset: 52427},
 									name: "ElementAttributes",
 								},
 							},
 						},
 						&andCodeExpr{
-							pos: position{line: 1380, col: 5, offset: 52452},
+							pos: position{line: 1380, col: 5, offset: 52451},
 							run: (*parser).callonParagraphWithLiteralAttribute6,
 						},
 						&labeledExpr{
-							pos:   position{line: 1387, col: 5, offset: 52666},
+							pos:   position{line: 1387, col: 5, offset: 52665},
 							label: "lines",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1387, col: 12, offset: 52673},
+								pos:  position{line: 1387, col: 12, offset: 52672},
 								name: "ParagraphWithLiteralAttributeLines",
 							},
 						},
@@ -10711,12 +10711,12 @@ var g = &grammar{
 		},
 		{
 			name: "LiteralKind",
-			pos:  position{line: 1391, col: 1, offset: 52823},
+			pos:  position{line: 1391, col: 1, offset: 52822},
 			expr: &actionExpr{
-				pos: position{line: 1391, col: 16, offset: 52838},
+				pos: position{line: 1391, col: 16, offset: 52837},
 				run: (*parser).callonLiteralKind1,
 				expr: &litMatcher{
-					pos:        position{line: 1391, col: 16, offset: 52838},
+					pos:        position{line: 1391, col: 16, offset: 52837},
 					val:        "literal",
 					ignoreCase: false,
 				},
@@ -10724,17 +10724,17 @@ var g = &grammar{
 		},
 		{
 			name: "ParagraphWithLiteralAttributeLines",
-			pos:  position{line: 1396, col: 1, offset: 52921},
+			pos:  position{line: 1396, col: 1, offset: 52920},
 			expr: &actionExpr{
-				pos: position{line: 1396, col: 39, offset: 52959},
+				pos: position{line: 1396, col: 39, offset: 52958},
 				run: (*parser).callonParagraphWithLiteralAttributeLines1,
 				expr: &labeledExpr{
-					pos:   position{line: 1396, col: 39, offset: 52959},
+					pos:   position{line: 1396, col: 39, offset: 52958},
 					label: "lines",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 1396, col: 45, offset: 52965},
+						pos: position{line: 1396, col: 45, offset: 52964},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1396, col: 46, offset: 52966},
+							pos:  position{line: 1396, col: 46, offset: 52965},
 							name: "ParagraphWithLiteralAttributeLine",
 						},
 					},
@@ -10743,54 +10743,54 @@ var g = &grammar{
 		},
 		{
 			name: "ParagraphWithLiteralAttributeLine",
-			pos:  position{line: 1400, col: 1, offset: 53046},
+			pos:  position{line: 1400, col: 1, offset: 53045},
 			expr: &actionExpr{
-				pos: position{line: 1400, col: 38, offset: 53083},
+				pos: position{line: 1400, col: 38, offset: 53082},
 				run: (*parser).callonParagraphWithLiteralAttributeLine1,
 				expr: &seqExpr{
-					pos: position{line: 1400, col: 38, offset: 53083},
+					pos: position{line: 1400, col: 38, offset: 53082},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1400, col: 38, offset: 53083},
+							pos:   position{line: 1400, col: 38, offset: 53082},
 							label: "line",
 							expr: &actionExpr{
-								pos: position{line: 1400, col: 44, offset: 53089},
+								pos: position{line: 1400, col: 44, offset: 53088},
 								run: (*parser).callonParagraphWithLiteralAttributeLine4,
 								expr: &seqExpr{
-									pos: position{line: 1400, col: 44, offset: 53089},
+									pos: position{line: 1400, col: 44, offset: 53088},
 									exprs: []interface{}{
 										&notExpr{
-											pos: position{line: 1400, col: 44, offset: 53089},
+											pos: position{line: 1400, col: 44, offset: 53088},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1400, col: 46, offset: 53091},
+												pos:  position{line: 1400, col: 46, offset: 53090},
 												name: "BlankLine",
 											},
 										},
 										&oneOrMoreExpr{
-											pos: position{line: 1400, col: 57, offset: 53102},
+											pos: position{line: 1400, col: 57, offset: 53101},
 											expr: &choiceExpr{
-												pos: position{line: 1400, col: 58, offset: 53103},
+												pos: position{line: 1400, col: 58, offset: 53102},
 												alternatives: []interface{}{
 													&ruleRefExpr{
-														pos:  position{line: 1400, col: 58, offset: 53103},
+														pos:  position{line: 1400, col: 58, offset: 53102},
 														name: "Alphanums",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1400, col: 70, offset: 53115},
+														pos:  position{line: 1400, col: 70, offset: 53114},
 														name: "Spaces",
 													},
 													&seqExpr{
-														pos: position{line: 1400, col: 80, offset: 53125},
+														pos: position{line: 1400, col: 80, offset: 53124},
 														exprs: []interface{}{
 															&notExpr{
-																pos: position{line: 1400, col: 80, offset: 53125},
+																pos: position{line: 1400, col: 80, offset: 53124},
 																expr: &ruleRefExpr{
-																	pos:  position{line: 1400, col: 81, offset: 53126},
+																	pos:  position{line: 1400, col: 81, offset: 53125},
 																	name: "EOL",
 																},
 															},
 															&anyMatcher{
-																line: 1400, col: 86, offset: 53131,
+																line: 1400, col: 86, offset: 53130,
 															},
 														},
 													},
@@ -10802,7 +10802,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1402, col: 4, offset: 53172},
+							pos:  position{line: 1402, col: 4, offset: 53171},
 							name: "EOL",
 						},
 					},
@@ -10811,22 +10811,22 @@ var g = &grammar{
 		},
 		{
 			name: "BlankLine",
-			pos:  position{line: 1409, col: 1, offset: 53344},
+			pos:  position{line: 1409, col: 1, offset: 53343},
 			expr: &actionExpr{
-				pos: position{line: 1409, col: 14, offset: 53357},
+				pos: position{line: 1409, col: 14, offset: 53356},
 				run: (*parser).callonBlankLine1,
 				expr: &seqExpr{
-					pos: position{line: 1409, col: 14, offset: 53357},
+					pos: position{line: 1409, col: 14, offset: 53356},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1409, col: 14, offset: 53357},
+							pos: position{line: 1409, col: 14, offset: 53356},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1409, col: 15, offset: 53358},
+								pos:  position{line: 1409, col: 15, offset: 53357},
 								name: "EOF",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1409, col: 19, offset: 53362},
+							pos:  position{line: 1409, col: 19, offset: 53361},
 							name: "EOLS",
 						},
 					},
@@ -10835,9 +10835,9 @@ var g = &grammar{
 		},
 		{
 			name: "Alphanum",
-			pos:  position{line: 1416, col: 1, offset: 53510},
+			pos:  position{line: 1416, col: 1, offset: 53509},
 			expr: &charClassMatcher{
-				pos:        position{line: 1416, col: 13, offset: 53522},
+				pos:        position{line: 1416, col: 13, offset: 53521},
 				val:        "[\\pL0-9]",
 				ranges:     []rune{'0', '9'},
 				classes:    []*unicode.RangeTable{rangeTable("L")},
@@ -10847,27 +10847,27 @@ var g = &grammar{
 		},
 		{
 			name: "Parenthesis",
-			pos:  position{line: 1418, col: 1, offset: 53532},
+			pos:  position{line: 1418, col: 1, offset: 53531},
 			expr: &choiceExpr{
-				pos: position{line: 1418, col: 16, offset: 53547},
+				pos: position{line: 1418, col: 16, offset: 53546},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1418, col: 16, offset: 53547},
+						pos:        position{line: 1418, col: 16, offset: 53546},
 						val:        "(",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1418, col: 22, offset: 53553},
+						pos:        position{line: 1418, col: 22, offset: 53552},
 						val:        ")",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1418, col: 28, offset: 53559},
+						pos:        position{line: 1418, col: 28, offset: 53558},
 						val:        "[",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1418, col: 34, offset: 53565},
+						pos:        position{line: 1418, col: 34, offset: 53564},
 						val:        "]",
 						ignoreCase: false,
 					},
@@ -10876,11 +10876,11 @@ var g = &grammar{
 		},
 		{
 			name: "Alphanums",
-			pos:  position{line: 1420, col: 1, offset: 53570},
+			pos:  position{line: 1420, col: 1, offset: 53569},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 1420, col: 14, offset: 53583},
+				pos: position{line: 1420, col: 14, offset: 53582},
 				expr: &charClassMatcher{
-					pos:        position{line: 1420, col: 14, offset: 53583},
+					pos:        position{line: 1420, col: 14, offset: 53582},
 					val:        "[\\pL0-9]",
 					ranges:     []rune{'0', '9'},
 					classes:    []*unicode.RangeTable{rangeTable("L")},
@@ -10891,37 +10891,37 @@ var g = &grammar{
 		},
 		{
 			name: "Dot",
-			pos:  position{line: 1422, col: 1, offset: 53594},
+			pos:  position{line: 1422, col: 1, offset: 53593},
 			expr: &litMatcher{
-				pos:        position{line: 1422, col: 8, offset: 53601},
+				pos:        position{line: 1422, col: 8, offset: 53600},
 				val:        ".",
 				ignoreCase: false,
 			},
 		},
 		{
 			name: "SimpleWord",
-			pos:  position{line: 1424, col: 1, offset: 53606},
+			pos:  position{line: 1424, col: 1, offset: 53605},
 			expr: &actionExpr{
-				pos: position{line: 1424, col: 15, offset: 53620},
+				pos: position{line: 1424, col: 15, offset: 53619},
 				run: (*parser).callonSimpleWord1,
 				expr: &seqExpr{
-					pos: position{line: 1424, col: 15, offset: 53620},
+					pos: position{line: 1424, col: 15, offset: 53619},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1424, col: 15, offset: 53620},
+							pos:  position{line: 1424, col: 15, offset: 53619},
 							name: "Alphanums",
 						},
 						&andExpr{
-							pos: position{line: 1424, col: 25, offset: 53630},
+							pos: position{line: 1424, col: 25, offset: 53629},
 							expr: &choiceExpr{
-								pos: position{line: 1424, col: 27, offset: 53632},
+								pos: position{line: 1424, col: 27, offset: 53631},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1424, col: 27, offset: 53632},
+										pos:  position{line: 1424, col: 27, offset: 53631},
 										name: "WS",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1424, col: 32, offset: 53637},
+										pos:  position{line: 1424, col: 32, offset: 53636},
 										name: "EOL",
 									},
 								},
@@ -10933,73 +10933,73 @@ var g = &grammar{
 		},
 		{
 			name: "OtherWord",
-			pos:  position{line: 1429, col: 1, offset: 53902},
+			pos:  position{line: 1429, col: 1, offset: 53901},
 			expr: &actionExpr{
-				pos: position{line: 1429, col: 14, offset: 53915},
+				pos: position{line: 1429, col: 14, offset: 53914},
 				run: (*parser).callonOtherWord1,
 				expr: &choiceExpr{
-					pos: position{line: 1429, col: 15, offset: 53916},
+					pos: position{line: 1429, col: 15, offset: 53915},
 					alternatives: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1429, col: 15, offset: 53916},
+							pos:  position{line: 1429, col: 15, offset: 53915},
 							name: "Alphanums",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1429, col: 27, offset: 53928},
+							pos:  position{line: 1429, col: 27, offset: 53927},
 							name: "QuotedTextPrefix",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1429, col: 46, offset: 53947},
+							pos:  position{line: 1429, col: 46, offset: 53946},
 							name: "Parenthesis",
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 1429, col: 60, offset: 53961},
+							pos: position{line: 1429, col: 60, offset: 53960},
 							expr: &actionExpr{
-								pos: position{line: 1429, col: 61, offset: 53962},
+								pos: position{line: 1429, col: 61, offset: 53961},
 								run: (*parser).callonOtherWord7,
 								expr: &seqExpr{
-									pos: position{line: 1429, col: 61, offset: 53962},
+									pos: position{line: 1429, col: 61, offset: 53961},
 									exprs: []interface{}{
 										&seqExpr{
-											pos: position{line: 1429, col: 62, offset: 53963},
+											pos: position{line: 1429, col: 62, offset: 53962},
 											exprs: []interface{}{
 												&notExpr{
-													pos: position{line: 1429, col: 62, offset: 53963},
+													pos: position{line: 1429, col: 62, offset: 53962},
 													expr: &ruleRefExpr{
-														pos:  position{line: 1429, col: 63, offset: 53964},
+														pos:  position{line: 1429, col: 63, offset: 53963},
 														name: "NEWLINE",
 													},
 												},
 												&notExpr{
-													pos: position{line: 1429, col: 71, offset: 53972},
+													pos: position{line: 1429, col: 71, offset: 53971},
 													expr: &ruleRefExpr{
-														pos:  position{line: 1429, col: 72, offset: 53973},
+														pos:  position{line: 1429, col: 72, offset: 53972},
 														name: "WS",
 													},
 												},
 												&notExpr{
-													pos: position{line: 1429, col: 75, offset: 53976},
+													pos: position{line: 1429, col: 75, offset: 53975},
 													expr: &ruleRefExpr{
-														pos:  position{line: 1429, col: 76, offset: 53977},
+														pos:  position{line: 1429, col: 76, offset: 53976},
 														name: "Dot",
 													},
 												},
 												&notExpr{
-													pos: position{line: 1429, col: 80, offset: 53981},
+													pos: position{line: 1429, col: 80, offset: 53980},
 													expr: &ruleRefExpr{
-														pos:  position{line: 1429, col: 81, offset: 53982},
+														pos:  position{line: 1429, col: 81, offset: 53981},
 														name: "QuotedTextPrefix",
 													},
 												},
 												&anyMatcher{
-													line: 1429, col: 98, offset: 53999,
+													line: 1429, col: 98, offset: 53998,
 												},
 											},
 										},
 										&zeroOrOneExpr{
-											pos: position{line: 1429, col: 101, offset: 54002},
+											pos: position{line: 1429, col: 101, offset: 54001},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1429, col: 101, offset: 54002},
+												pos:  position{line: 1429, col: 101, offset: 54001},
 												name: "Dot",
 											},
 										},
@@ -11008,9 +11008,9 @@ var g = &grammar{
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 1431, col: 7, offset: 54111},
+							pos: position{line: 1431, col: 7, offset: 54110},
 							expr: &litMatcher{
-								pos:        position{line: 1431, col: 7, offset: 54111},
+								pos:        position{line: 1431, col: 7, offset: 54110},
 								val:        ".",
 								ignoreCase: false,
 							},
@@ -11021,35 +11021,35 @@ var g = &grammar{
 		},
 		{
 			name: "Spaces",
-			pos:  position{line: 1435, col: 1, offset: 54292},
+			pos:  position{line: 1435, col: 1, offset: 54291},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 1435, col: 11, offset: 54302},
+				pos: position{line: 1435, col: 11, offset: 54301},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1435, col: 11, offset: 54302},
+					pos:  position{line: 1435, col: 11, offset: 54301},
 					name: "WS",
 				},
 			},
 		},
 		{
 			name: "FileLocation",
-			pos:  position{line: 1437, col: 1, offset: 54308},
+			pos:  position{line: 1437, col: 1, offset: 54307},
 			expr: &actionExpr{
-				pos: position{line: 1437, col: 17, offset: 54324},
+				pos: position{line: 1437, col: 17, offset: 54323},
 				run: (*parser).callonFileLocation1,
 				expr: &labeledExpr{
-					pos:   position{line: 1437, col: 17, offset: 54324},
+					pos:   position{line: 1437, col: 17, offset: 54323},
 					label: "elements",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 1437, col: 26, offset: 54333},
+						pos: position{line: 1437, col: 26, offset: 54332},
 						expr: &choiceExpr{
-							pos: position{line: 1437, col: 27, offset: 54334},
+							pos: position{line: 1437, col: 27, offset: 54333},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 1437, col: 27, offset: 54334},
+									pos:  position{line: 1437, col: 27, offset: 54333},
 									name: "FILENAME",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1437, col: 38, offset: 54345},
+									pos:  position{line: 1437, col: 38, offset: 54344},
 									name: "DocumentAttributeSubstitution",
 								},
 							},
@@ -11060,53 +11060,53 @@ var g = &grammar{
 		},
 		{
 			name: "Location",
-			pos:  position{line: 1441, col: 1, offset: 54437},
+			pos:  position{line: 1441, col: 1, offset: 54436},
 			expr: &actionExpr{
-				pos: position{line: 1441, col: 13, offset: 54449},
+				pos: position{line: 1441, col: 13, offset: 54448},
 				run: (*parser).callonLocation1,
 				expr: &labeledExpr{
-					pos:   position{line: 1441, col: 13, offset: 54449},
+					pos:   position{line: 1441, col: 13, offset: 54448},
 					label: "elements",
 					expr: &seqExpr{
-						pos: position{line: 1441, col: 23, offset: 54459},
+						pos: position{line: 1441, col: 23, offset: 54458},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 1441, col: 23, offset: 54459},
+								pos:  position{line: 1441, col: 23, offset: 54458},
 								name: "URL_SCHEME",
 							},
 							&oneOrMoreExpr{
-								pos: position{line: 1441, col: 34, offset: 54470},
+								pos: position{line: 1441, col: 34, offset: 54469},
 								expr: &choiceExpr{
-									pos: position{line: 1441, col: 35, offset: 54471},
+									pos: position{line: 1441, col: 35, offset: 54470},
 									alternatives: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 1441, col: 35, offset: 54471},
+											pos:  position{line: 1441, col: 35, offset: 54470},
 											name: "FILENAME",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1441, col: 46, offset: 54482},
+											pos:  position{line: 1441, col: 46, offset: 54481},
 											name: "DocumentAttributeSubstitution",
 										},
 										&seqExpr{
-											pos: position{line: 1441, col: 78, offset: 54514},
+											pos: position{line: 1441, col: 78, offset: 54513},
 											exprs: []interface{}{
 												&notExpr{
-													pos: position{line: 1441, col: 78, offset: 54514},
+													pos: position{line: 1441, col: 78, offset: 54513},
 													expr: &ruleRefExpr{
-														pos:  position{line: 1441, col: 79, offset: 54515},
+														pos:  position{line: 1441, col: 79, offset: 54514},
 														name: "EOL",
 													},
 												},
 												&notExpr{
-													pos: position{line: 1441, col: 83, offset: 54519},
+													pos: position{line: 1441, col: 83, offset: 54518},
 													expr: &litMatcher{
-														pos:        position{line: 1441, col: 84, offset: 54520},
+														pos:        position{line: 1441, col: 84, offset: 54519},
 														val:        "[",
 														ignoreCase: false,
 													},
 												},
 												&anyMatcher{
-													line: 1441, col: 88, offset: 54524,
+													line: 1441, col: 88, offset: 54523,
 												},
 											},
 										},
@@ -11120,33 +11120,33 @@ var g = &grammar{
 		},
 		{
 			name: "FILENAME",
-			pos:  position{line: 1445, col: 1, offset: 54589},
+			pos:  position{line: 1445, col: 1, offset: 54588},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 1445, col: 13, offset: 54601},
+				pos: position{line: 1445, col: 13, offset: 54600},
 				expr: &choiceExpr{
-					pos: position{line: 1445, col: 14, offset: 54602},
+					pos: position{line: 1445, col: 14, offset: 54601},
 					alternatives: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1445, col: 14, offset: 54602},
+							pos:  position{line: 1445, col: 14, offset: 54601},
 							name: "Alphanums",
 						},
 						&litMatcher{
-							pos:        position{line: 1445, col: 26, offset: 54614},
+							pos:        position{line: 1445, col: 26, offset: 54613},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1445, col: 32, offset: 54620},
+							pos:        position{line: 1445, col: 32, offset: 54619},
 							val:        "_",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1445, col: 38, offset: 54626},
+							pos:        position{line: 1445, col: 38, offset: 54625},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1445, col: 44, offset: 54632},
+							pos:        position{line: 1445, col: 44, offset: 54631},
 							val:        "-",
 							ignoreCase: false,
 						},
@@ -11156,54 +11156,54 @@ var g = &grammar{
 		},
 		{
 			name: "URL",
-			pos:  position{line: 1447, col: 1, offset: 54639},
+			pos:  position{line: 1447, col: 1, offset: 54638},
 			expr: &actionExpr{
-				pos: position{line: 1447, col: 8, offset: 54646},
+				pos: position{line: 1447, col: 8, offset: 54645},
 				run: (*parser).callonURL1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1447, col: 8, offset: 54646},
+					pos: position{line: 1447, col: 8, offset: 54645},
 					expr: &choiceExpr{
-						pos: position{line: 1447, col: 9, offset: 54647},
+						pos: position{line: 1447, col: 9, offset: 54646},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 1447, col: 9, offset: 54647},
+								pos:  position{line: 1447, col: 9, offset: 54646},
 								name: "Alphanums",
 							},
 							&seqExpr{
-								pos: position{line: 1447, col: 22, offset: 54660},
+								pos: position{line: 1447, col: 22, offset: 54659},
 								exprs: []interface{}{
 									&notExpr{
-										pos: position{line: 1447, col: 22, offset: 54660},
+										pos: position{line: 1447, col: 22, offset: 54659},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1447, col: 23, offset: 54661},
+											pos:  position{line: 1447, col: 23, offset: 54660},
 											name: "NEWLINE",
 										},
 									},
 									&notExpr{
-										pos: position{line: 1447, col: 31, offset: 54669},
+										pos: position{line: 1447, col: 31, offset: 54668},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1447, col: 32, offset: 54670},
+											pos:  position{line: 1447, col: 32, offset: 54669},
 											name: "WS",
 										},
 									},
 									&notExpr{
-										pos: position{line: 1447, col: 35, offset: 54673},
+										pos: position{line: 1447, col: 35, offset: 54672},
 										expr: &litMatcher{
-											pos:        position{line: 1447, col: 36, offset: 54674},
+											pos:        position{line: 1447, col: 36, offset: 54673},
 											val:        "[",
 											ignoreCase: false,
 										},
 									},
 									&notExpr{
-										pos: position{line: 1447, col: 40, offset: 54678},
+										pos: position{line: 1447, col: 40, offset: 54677},
 										expr: &litMatcher{
-											pos:        position{line: 1447, col: 41, offset: 54679},
+											pos:        position{line: 1447, col: 41, offset: 54678},
 											val:        "]",
 											ignoreCase: false,
 										},
 									},
 									&anyMatcher{
-										line: 1447, col: 46, offset: 54684,
+										line: 1447, col: 46, offset: 54683,
 									},
 								},
 							},
@@ -11214,32 +11214,32 @@ var g = &grammar{
 		},
 		{
 			name: "URL_SCHEME",
-			pos:  position{line: 1451, col: 1, offset: 54725},
+			pos:  position{line: 1451, col: 1, offset: 54724},
 			expr: &choiceExpr{
-				pos: position{line: 1451, col: 15, offset: 54739},
+				pos: position{line: 1451, col: 15, offset: 54738},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1451, col: 15, offset: 54739},
+						pos:        position{line: 1451, col: 15, offset: 54738},
 						val:        "http://",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1451, col: 27, offset: 54751},
+						pos:        position{line: 1451, col: 27, offset: 54750},
 						val:        "https://",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1451, col: 40, offset: 54764},
+						pos:        position{line: 1451, col: 40, offset: 54763},
 						val:        "ftp://",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1451, col: 51, offset: 54775},
+						pos:        position{line: 1451, col: 51, offset: 54774},
 						val:        "irc://",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1451, col: 62, offset: 54786},
+						pos:        position{line: 1451, col: 62, offset: 54785},
 						val:        "mailto:",
 						ignoreCase: false,
 					},
@@ -11248,78 +11248,78 @@ var g = &grammar{
 		},
 		{
 			name: "ID",
-			pos:  position{line: 1453, col: 1, offset: 54797},
+			pos:  position{line: 1453, col: 1, offset: 54796},
 			expr: &actionExpr{
-				pos: position{line: 1453, col: 7, offset: 54803},
+				pos: position{line: 1453, col: 7, offset: 54802},
 				run: (*parser).callonID1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1453, col: 7, offset: 54803},
+					pos: position{line: 1453, col: 7, offset: 54802},
 					expr: &choiceExpr{
-						pos: position{line: 1453, col: 8, offset: 54804},
+						pos: position{line: 1453, col: 8, offset: 54803},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 1453, col: 8, offset: 54804},
+								pos:  position{line: 1453, col: 8, offset: 54803},
 								name: "Alphanums",
 							},
 							&seqExpr{
-								pos: position{line: 1453, col: 21, offset: 54817},
+								pos: position{line: 1453, col: 21, offset: 54816},
 								exprs: []interface{}{
 									&notExpr{
-										pos: position{line: 1453, col: 21, offset: 54817},
+										pos: position{line: 1453, col: 21, offset: 54816},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1453, col: 22, offset: 54818},
+											pos:  position{line: 1453, col: 22, offset: 54817},
 											name: "NEWLINE",
 										},
 									},
 									&notExpr{
-										pos: position{line: 1453, col: 30, offset: 54826},
+										pos: position{line: 1453, col: 30, offset: 54825},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1453, col: 31, offset: 54827},
+											pos:  position{line: 1453, col: 31, offset: 54826},
 											name: "WS",
 										},
 									},
 									&notExpr{
-										pos: position{line: 1453, col: 34, offset: 54830},
+										pos: position{line: 1453, col: 34, offset: 54829},
 										expr: &litMatcher{
-											pos:        position{line: 1453, col: 35, offset: 54831},
+											pos:        position{line: 1453, col: 35, offset: 54830},
 											val:        "[",
 											ignoreCase: false,
 										},
 									},
 									&notExpr{
-										pos: position{line: 1453, col: 39, offset: 54835},
+										pos: position{line: 1453, col: 39, offset: 54834},
 										expr: &litMatcher{
-											pos:        position{line: 1453, col: 40, offset: 54836},
+											pos:        position{line: 1453, col: 40, offset: 54835},
 											val:        "]",
 											ignoreCase: false,
 										},
 									},
 									&notExpr{
-										pos: position{line: 1453, col: 44, offset: 54840},
+										pos: position{line: 1453, col: 44, offset: 54839},
 										expr: &litMatcher{
-											pos:        position{line: 1453, col: 45, offset: 54841},
+											pos:        position{line: 1453, col: 45, offset: 54840},
 											val:        "<<",
 											ignoreCase: false,
 										},
 									},
 									&notExpr{
-										pos: position{line: 1453, col: 50, offset: 54846},
+										pos: position{line: 1453, col: 50, offset: 54845},
 										expr: &litMatcher{
-											pos:        position{line: 1453, col: 51, offset: 54847},
+											pos:        position{line: 1453, col: 51, offset: 54846},
 											val:        ">>",
 											ignoreCase: false,
 										},
 									},
 									&notExpr{
-										pos: position{line: 1453, col: 56, offset: 54852},
+										pos: position{line: 1453, col: 56, offset: 54851},
 										expr: &litMatcher{
-											pos:        position{line: 1453, col: 57, offset: 54853},
+											pos:        position{line: 1453, col: 57, offset: 54852},
 											val:        ",",
 											ignoreCase: false,
 										},
 									},
 									&anyMatcher{
-										line: 1453, col: 62, offset: 54858,
+										line: 1453, col: 62, offset: 54857,
 									},
 								},
 							},
@@ -11330,12 +11330,12 @@ var g = &grammar{
 		},
 		{
 			name: "DIGIT",
-			pos:  position{line: 1457, col: 1, offset: 54899},
+			pos:  position{line: 1457, col: 1, offset: 54898},
 			expr: &actionExpr{
-				pos: position{line: 1457, col: 10, offset: 54908},
+				pos: position{line: 1457, col: 10, offset: 54907},
 				run: (*parser).callonDIGIT1,
 				expr: &charClassMatcher{
-					pos:        position{line: 1457, col: 10, offset: 54908},
+					pos:        position{line: 1457, col: 10, offset: 54907},
 					val:        "[0-9]",
 					ranges:     []rune{'0', '9'},
 					ignoreCase: false,
@@ -11345,25 +11345,25 @@ var g = &grammar{
 		},
 		{
 			name: "NUMBER",
-			pos:  position{line: 1461, col: 1, offset: 54950},
+			pos:  position{line: 1461, col: 1, offset: 54949},
 			expr: &actionExpr{
-				pos: position{line: 1461, col: 11, offset: 54960},
+				pos: position{line: 1461, col: 11, offset: 54959},
 				run: (*parser).callonNUMBER1,
 				expr: &seqExpr{
-					pos: position{line: 1461, col: 11, offset: 54960},
+					pos: position{line: 1461, col: 11, offset: 54959},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 1461, col: 11, offset: 54960},
+							pos: position{line: 1461, col: 11, offset: 54959},
 							expr: &litMatcher{
-								pos:        position{line: 1461, col: 11, offset: 54960},
+								pos:        position{line: 1461, col: 11, offset: 54959},
 								val:        "-",
 								ignoreCase: false,
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 1461, col: 16, offset: 54965},
+							pos: position{line: 1461, col: 16, offset: 54964},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1461, col: 16, offset: 54965},
+								pos:  position{line: 1461, col: 16, offset: 54964},
 								name: "DIGIT",
 							},
 						},
@@ -11373,20 +11373,20 @@ var g = &grammar{
 		},
 		{
 			name: "WS",
-			pos:  position{line: 1465, col: 1, offset: 55017},
+			pos:  position{line: 1465, col: 1, offset: 55016},
 			expr: &choiceExpr{
-				pos: position{line: 1465, col: 7, offset: 55023},
+				pos: position{line: 1465, col: 7, offset: 55022},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1465, col: 7, offset: 55023},
+						pos:        position{line: 1465, col: 7, offset: 55022},
 						val:        " ",
 						ignoreCase: false,
 					},
 					&actionExpr{
-						pos: position{line: 1465, col: 13, offset: 55029},
+						pos: position{line: 1465, col: 13, offset: 55028},
 						run: (*parser).callonWS3,
 						expr: &litMatcher{
-							pos:        position{line: 1465, col: 13, offset: 55029},
+							pos:        position{line: 1465, col: 13, offset: 55028},
 							val:        "\t",
 							ignoreCase: false,
 						},
@@ -11396,22 +11396,22 @@ var g = &grammar{
 		},
 		{
 			name: "NEWLINE",
-			pos:  position{line: 1469, col: 1, offset: 55070},
+			pos:  position{line: 1469, col: 1, offset: 55069},
 			expr: &choiceExpr{
-				pos: position{line: 1469, col: 12, offset: 55081},
+				pos: position{line: 1469, col: 12, offset: 55080},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1469, col: 12, offset: 55081},
+						pos:        position{line: 1469, col: 12, offset: 55080},
 						val:        "\r\n",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1469, col: 21, offset: 55090},
+						pos:        position{line: 1469, col: 21, offset: 55089},
 						val:        "\r",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1469, col: 28, offset: 55097},
+						pos:        position{line: 1469, col: 28, offset: 55096},
 						val:        "\n",
 						ignoreCase: false,
 					},
@@ -11420,26 +11420,26 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 1471, col: 1, offset: 55103},
+			pos:  position{line: 1471, col: 1, offset: 55102},
 			expr: &notExpr{
-				pos: position{line: 1471, col: 8, offset: 55110},
+				pos: position{line: 1471, col: 8, offset: 55109},
 				expr: &anyMatcher{
-					line: 1471, col: 9, offset: 55111,
+					line: 1471, col: 9, offset: 55110,
 				},
 			},
 		},
 		{
 			name: "EOL",
-			pos:  position{line: 1473, col: 1, offset: 55114},
+			pos:  position{line: 1473, col: 1, offset: 55113},
 			expr: &choiceExpr{
-				pos: position{line: 1473, col: 8, offset: 55121},
+				pos: position{line: 1473, col: 8, offset: 55120},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1473, col: 8, offset: 55121},
+						pos:  position{line: 1473, col: 8, offset: 55120},
 						name: "NEWLINE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1473, col: 18, offset: 55131},
+						pos:  position{line: 1473, col: 18, offset: 55130},
 						name: "EOF",
 					},
 				},
@@ -11447,19 +11447,19 @@ var g = &grammar{
 		},
 		{
 			name: "EOLS",
-			pos:  position{line: 1475, col: 1, offset: 55136},
+			pos:  position{line: 1475, col: 1, offset: 55135},
 			expr: &seqExpr{
-				pos: position{line: 1475, col: 9, offset: 55144},
+				pos: position{line: 1475, col: 9, offset: 55143},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1475, col: 9, offset: 55144},
+						pos: position{line: 1475, col: 9, offset: 55143},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1475, col: 9, offset: 55144},
+							pos:  position{line: 1475, col: 9, offset: 55143},
 							name: "WS",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1475, col: 13, offset: 55148},
+						pos:  position{line: 1475, col: 13, offset: 55147},
 						name: "EOL",
 					},
 				},
@@ -12099,7 +12099,7 @@ func (p *parser) callonFileInclusion4() (interface{}, error) {
 }
 
 func (c *current) onFileInclusion1(incl interface{}) (interface{}, error) {
-	return incl.(*types.FileInclusion), nil
+	return incl.(types.FileInclusion), nil
 }
 
 func (p *parser) callonFileInclusion1() (interface{}, error) {
@@ -14472,7 +14472,7 @@ type position struct {
 }
 
 func (p position) String() string {
-	return fmt.Sprintf("%d:%d [%d]", p.line, p.col, p.offset)
+	return strconv.Itoa(p.line) + ":" + strconv.Itoa(p.col) + " [" + strconv.Itoa(p.offset) + "]"
 }
 
 // savepoint stores all state required to go back to this point in the
@@ -14967,7 +14967,7 @@ func listJoin(list []string, sep string, lastSep string) string {
 	case 1:
 		return list[0]
 	default:
-		return fmt.Sprintf("%s %s %s", strings.Join(list[:len(list)-1], sep), lastSep, list[len(list)-1])
+		return strings.Join(list[:len(list)-1], sep) + " " + lastSep + " " + list[len(list)-1]
 	}
 }
 
@@ -15171,7 +15171,7 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 	if lit.ignoreCase {
 		ignoreCase = "i"
 	}
-	val := fmt.Sprintf("%q%s", lit.val, ignoreCase)
+	val := string(strconv.AppendQuote([]byte{}, lit.val)) + ignoreCase // wrap 'lit.val' with double quotes
 	start := p.pt
 	for _, want := range lit.val {
 		cur := p.pt.rn

--- a/pkg/parser/blank_line_test.go
+++ b/pkg/parser/blank_line_test.go
@@ -10,22 +10,22 @@ var _ = Describe("blank lines - preflight", func() {
 		doc := `first paragraph
  
 second paragraph`
-		expected := &types.PreflightDocument{
+		expected := types.PreflightDocument{
 			Blocks: []interface{}{
-				&types.Paragraph{
+				types.Paragraph{
 					Attributes: types.ElementAttributes{},
 					Lines: []types.InlineElements{
 						{
-							&types.StringElement{Content: "first paragraph"},
+							types.StringElement{Content: "first paragraph"},
 						},
 					},
 				},
-				&types.BlankLine{},
-				&types.Paragraph{
+				types.BlankLine{},
+				types.Paragraph{
 					Attributes: types.ElementAttributes{},
 					Lines: []types.InlineElements{
 						{
-							&types.StringElement{Content: "second paragraph"},
+							types.StringElement{Content: "second paragraph"},
 						},
 					},
 				},
@@ -40,24 +40,24 @@ second paragraph`
 		
 second paragraph
 `
-		expected := &types.PreflightDocument{
+		expected := types.PreflightDocument{
 			Blocks: []interface{}{
-				&types.Paragraph{
+				types.Paragraph{
 					Attributes: types.ElementAttributes{},
 					Lines: []types.InlineElements{
 						{
-							&types.StringElement{Content: "first paragraph"},
+							types.StringElement{Content: "first paragraph"},
 						},
 					},
 				},
-				&types.BlankLine{},
-				&types.BlankLine{},
-				&types.BlankLine{},
-				&types.Paragraph{
+				types.BlankLine{},
+				types.BlankLine{},
+				types.BlankLine{},
+				types.Paragraph{
 					Attributes: types.ElementAttributes{},
 					Lines: []types.InlineElements{
 						{
-							&types.StringElement{Content: "second paragraph"},
+							types.StringElement{Content: "second paragraph"},
 						},
 					},
 				},

--- a/pkg/parser/check_list_test.go
+++ b/pkg/parser/check_list_test.go
@@ -13,30 +13,30 @@ var _ = Describe("checked lists - document", func() {
 - [x] also checked
 - [ ] not checked
 -     normal list item`
-		expected := &types.Document{
+		expected := types.Document{
 			Attributes:         types.DocumentAttributes{},
 			ElementReferences:  types.ElementReferences{},
 			Footnotes:          types.Footnotes{},
 			FootnoteReferences: types.FootnoteReferences{},
 			Elements: []interface{}{
-				&types.UnorderedList{
+				types.UnorderedList{
 					Attributes: types.ElementAttributes{
 						types.AttrTitle: "Checklist",
 					},
-					Items: []*types.UnorderedListItem{
+					Items: []types.UnorderedListItem{
 						{
 							Attributes:  types.ElementAttributes{},
 							Level:       1,
 							BulletStyle: types.Dash,
 							CheckStyle:  types.Checked,
 							Elements: []interface{}{
-								&types.Paragraph{
+								types.Paragraph{
 									Attributes: types.ElementAttributes{
 										types.AttrCheckStyle: types.Checked,
 									},
 									Lines: []types.InlineElements{
 										{
-											&types.StringElement{
+											types.StringElement{
 												Content: "checked",
 											},
 										},
@@ -50,13 +50,13 @@ var _ = Describe("checked lists - document", func() {
 							BulletStyle: types.Dash,
 							CheckStyle:  types.Checked,
 							Elements: []interface{}{
-								&types.Paragraph{
+								types.Paragraph{
 									Attributes: types.ElementAttributes{
 										types.AttrCheckStyle: types.Checked,
 									},
 									Lines: []types.InlineElements{
 										{
-											&types.StringElement{
+											types.StringElement{
 												Content: "also checked",
 											},
 										},
@@ -70,13 +70,13 @@ var _ = Describe("checked lists - document", func() {
 							BulletStyle: types.Dash,
 							CheckStyle:  types.Unchecked,
 							Elements: []interface{}{
-								&types.Paragraph{
+								types.Paragraph{
 									Attributes: types.ElementAttributes{
 										types.AttrCheckStyle: types.Unchecked,
 									},
 									Lines: []types.InlineElements{
 										{
-											&types.StringElement{
+											types.StringElement{
 												Content: "not checked",
 											},
 										},
@@ -90,11 +90,11 @@ var _ = Describe("checked lists - document", func() {
 							BulletStyle: types.Dash,
 							CheckStyle:  types.NoCheck,
 							Elements: []interface{}{
-								&types.Paragraph{
+								types.Paragraph{
 									Attributes: types.ElementAttributes{},
 									Lines: []types.InlineElements{
 										{
-											&types.StringElement{
+											types.StringElement{
 												Content: "normal list item",
 											},
 										},
@@ -116,51 +116,51 @@ var _ = Describe("checked lists - document", func() {
 ** [x] also checked
 ** [ ] not checked
 *     normal list item`
-		expected := &types.Document{
+		expected := types.Document{
 			Attributes:         types.DocumentAttributes{},
 			ElementReferences:  types.ElementReferences{},
 			Footnotes:          types.Footnotes{},
 			FootnoteReferences: types.FootnoteReferences{},
 			Elements: []interface{}{
-				&types.UnorderedList{
+				types.UnorderedList{
 					Attributes: types.ElementAttributes{
 						types.AttrTitle: "Checklist",
 					},
-					Items: []*types.UnorderedListItem{
+					Items: []types.UnorderedListItem{
 						{
 							Attributes:  types.ElementAttributes{},
 							Level:       1,
 							BulletStyle: types.OneAsterisk,
 							CheckStyle:  types.Unchecked,
 							Elements: []interface{}{
-								&types.Paragraph{
+								types.Paragraph{
 									Attributes: types.ElementAttributes{
 										types.AttrCheckStyle: types.Unchecked,
 									},
 									Lines: []types.InlineElements{
 										{
-											&types.StringElement{
+											types.StringElement{
 												Content: "parent not checked",
 											},
 										},
 									},
 								},
-								&types.UnorderedList{
+								types.UnorderedList{
 									Attributes: types.ElementAttributes{},
-									Items: []*types.UnorderedListItem{
+									Items: []types.UnorderedListItem{
 										{
 											Attributes:  types.ElementAttributes{},
 											Level:       2,
 											BulletStyle: types.TwoAsterisks,
 											CheckStyle:  types.Checked,
 											Elements: []interface{}{
-												&types.Paragraph{
+												types.Paragraph{
 													Attributes: types.ElementAttributes{
 														types.AttrCheckStyle: types.Checked,
 													},
 													Lines: []types.InlineElements{
 														{
-															&types.StringElement{
+															types.StringElement{
 																Content: "checked",
 															},
 														},
@@ -174,13 +174,13 @@ var _ = Describe("checked lists - document", func() {
 											BulletStyle: types.TwoAsterisks,
 											CheckStyle:  types.Checked,
 											Elements: []interface{}{
-												&types.Paragraph{
+												types.Paragraph{
 													Attributes: types.ElementAttributes{
 														types.AttrCheckStyle: types.Checked,
 													},
 													Lines: []types.InlineElements{
 														{
-															&types.StringElement{
+															types.StringElement{
 																Content: "also checked",
 															},
 														},
@@ -194,13 +194,13 @@ var _ = Describe("checked lists - document", func() {
 											BulletStyle: types.TwoAsterisks,
 											CheckStyle:  types.Unchecked,
 											Elements: []interface{}{
-												&types.Paragraph{
+												types.Paragraph{
 													Attributes: types.ElementAttributes{
 														types.AttrCheckStyle: types.Unchecked,
 													},
 													Lines: []types.InlineElements{
 														{
-															&types.StringElement{
+															types.StringElement{
 																Content: "not checked",
 															},
 														},
@@ -218,11 +218,11 @@ var _ = Describe("checked lists - document", func() {
 							BulletStyle: types.OneAsterisk,
 							CheckStyle:  types.NoCheck,
 							Elements: []interface{}{
-								&types.Paragraph{
+								types.Paragraph{
 									Attributes: types.ElementAttributes{},
 									Lines: []types.InlineElements{
 										{
-											&types.StringElement{
+											types.StringElement{
 												Content: "normal list item",
 											},
 										},
@@ -243,49 +243,49 @@ var _ = Describe("checked lists - document", func() {
 ** a normal list item
 ** another normal list item
 *     normal list item`
-		expected := &types.Document{
+		expected := types.Document{
 			Attributes:         types.DocumentAttributes{},
 			ElementReferences:  types.ElementReferences{},
 			Footnotes:          types.Footnotes{},
 			FootnoteReferences: types.FootnoteReferences{},
 			Elements: []interface{}{
-				&types.UnorderedList{
+				types.UnorderedList{
 					Attributes: types.ElementAttributes{
 						types.AttrTitle: "Checklist",
 					},
-					Items: []*types.UnorderedListItem{
+					Items: []types.UnorderedListItem{
 						{
 							Attributes:  types.ElementAttributes{},
 							Level:       1,
 							BulletStyle: types.OneAsterisk,
 							CheckStyle:  types.Unchecked,
 							Elements: []interface{}{
-								&types.Paragraph{
+								types.Paragraph{
 									Attributes: types.ElementAttributes{
 										types.AttrCheckStyle: types.Unchecked,
 									},
 									Lines: []types.InlineElements{
 										{
-											&types.StringElement{
+											types.StringElement{
 												Content: "parent not checked",
 											},
 										},
 									},
 								},
-								&types.UnorderedList{
+								types.UnorderedList{
 									Attributes: types.ElementAttributes{},
-									Items: []*types.UnorderedListItem{
+									Items: []types.UnorderedListItem{
 										{
 											Attributes:  types.ElementAttributes{},
 											Level:       2,
 											BulletStyle: types.TwoAsterisks,
 											CheckStyle:  types.NoCheck,
 											Elements: []interface{}{
-												&types.Paragraph{
+												types.Paragraph{
 													Attributes: types.ElementAttributes{},
 													Lines: []types.InlineElements{
 														{
-															&types.StringElement{
+															types.StringElement{
 																Content: "a normal list item",
 															},
 														},
@@ -299,11 +299,11 @@ var _ = Describe("checked lists - document", func() {
 											BulletStyle: types.TwoAsterisks,
 											CheckStyle:  types.NoCheck,
 											Elements: []interface{}{
-												&types.Paragraph{
+												types.Paragraph{
 													Attributes: types.ElementAttributes{},
 													Lines: []types.InlineElements{
 														{
-															&types.StringElement{
+															types.StringElement{
 																Content: "another normal list item",
 															},
 														},
@@ -321,11 +321,11 @@ var _ = Describe("checked lists - document", func() {
 							BulletStyle: types.OneAsterisk,
 							CheckStyle:  types.NoCheck,
 							Elements: []interface{}{
-								&types.Paragraph{
+								types.Paragraph{
 									Attributes: types.ElementAttributes{},
 									Lines: []types.InlineElements{
 										{
-											&types.StringElement{
+											types.StringElement{
 												Content: "normal list item",
 											},
 										},

--- a/pkg/parser/comment_test.go
+++ b/pkg/parser/comment_test.go
@@ -11,7 +11,7 @@ var _ = Describe("comments - preflight", func() {
 
 		It("single line comment alone", func() {
 			doc := `// A single-line comment.`
-			expected := &types.SingleLineComment{
+			expected := types.SingleLineComment{
 				Content: " A single-line comment.",
 			}
 			verifyDocumentBlock(expected, doc)
@@ -19,7 +19,7 @@ var _ = Describe("comments - preflight", func() {
 
 		It("single line comment with prefixing spaces alone", func() {
 			doc := `  // A single-line comment.`
-			expected := &types.SingleLineComment{
+			expected := types.SingleLineComment{
 				Content: " A single-line comment.",
 			}
 			verifyDocumentBlock(expected, doc)
@@ -27,7 +27,7 @@ var _ = Describe("comments - preflight", func() {
 
 		It("single line comment with prefixing tabs alone", func() {
 			doc := "\t\t// A single-line comment."
-			expected := &types.SingleLineComment{
+			expected := types.SingleLineComment{
 				Content: " A single-line comment.",
 			}
 			verifyDocumentBlock(expected, doc)
@@ -35,11 +35,11 @@ var _ = Describe("comments - preflight", func() {
 
 		It("single line comment at end of line", func() {
 			doc := `foo // A single-line comment.`
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{Content: "foo // A single-line comment."},
+						types.StringElement{Content: "foo // A single-line comment."},
 					},
 				},
 			}
@@ -50,17 +50,17 @@ var _ = Describe("comments - preflight", func() {
 			doc := `a first line
 // A single-line comment.
 another line`
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{Content: "a first line"},
+						types.StringElement{Content: "a first line"},
 					},
 					{
-						&types.SingleLineComment{Content: " A single-line comment."},
+						types.SingleLineComment{Content: " A single-line comment."},
 					},
 					{
-						&types.StringElement{Content: "another line"},
+						types.StringElement{Content: "another line"},
 					},
 				},
 			}
@@ -71,17 +71,17 @@ another line`
 			doc := `a first line
 	// A single-line comment.
 another line`
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{Content: "a first line"},
+						types.StringElement{Content: "a first line"},
 					},
 					{
-						&types.SingleLineComment{Content: " A single-line comment."},
+						types.SingleLineComment{Content: " A single-line comment."},
 					},
 					{
-						&types.StringElement{Content: "another line"},
+						types.StringElement{Content: "another line"},
 					},
 				},
 			}
@@ -96,14 +96,14 @@ another line`
 a *comment* block
 with multiple lines
 ////`
-			expected := &types.DelimitedBlock{
+			expected := types.DelimitedBlock{
 				Attributes: types.ElementAttributes{},
 				Kind:       types.Comment,
 				Elements: []interface{}{
-					&types.StringElement{
+					types.StringElement{
 						Content: "a *comment* block",
 					},
-					&types.StringElement{
+					types.StringElement{
 						Content: "with multiple lines",
 					},
 				},
@@ -118,33 +118,33 @@ a *comment* block
 with multiple lines
 ////
 a second paragraph`
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: "a first paragraph"},
+								types.StringElement{Content: "a first paragraph"},
 							},
 						},
 					},
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{},
 						Kind:       types.Comment,
 						Elements: []interface{}{
-							&types.StringElement{
+							types.StringElement{
 								Content: "a *comment* block",
 							},
-							&types.StringElement{
+							types.StringElement{
 								Content: "with multiple lines",
 							},
 						},
 					},
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: "a second paragraph"},
+								types.StringElement{Content: "a second paragraph"},
 							},
 						},
 					},

--- a/pkg/parser/cross_reference_test.go
+++ b/pkg/parser/cross_reference_test.go
@@ -14,34 +14,34 @@ var _ = Describe("cross-references - preflight", func() {
 == a title
 
 with some content linked to <<thetitle>>!`
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.Section{
+					types.Section{
 						Level: 1,
 						Attributes: types.ElementAttributes{
 							types.AttrID:       "thetitle",
 							types.AttrCustomID: true,
 						},
 						Title: types.InlineElements{
-							&types.StringElement{
+							types.StringElement{
 								Content: "a title",
 							},
 						},
 						Elements: []interface{}{},
 					},
-					&types.BlankLine{},
-					&types.Paragraph{
+					types.BlankLine{},
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "with some content linked to ",
 								},
-								&types.CrossReference{
+								types.CrossReference{
 									ID:    "thetitle",
 									Label: "",
 								},
-								&types.StringElement{
+								types.StringElement{
 									Content: "!",
 								},
 							},
@@ -57,34 +57,34 @@ with some content linked to <<thetitle>>!`
 == a title
 
 with some content linked to <<thetitle,a label to the title>>!`
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.Section{
+					types.Section{
 						Level: 1,
 						Attributes: types.ElementAttributes{
 							types.AttrID:       "thetitle",
 							types.AttrCustomID: true,
 						},
 						Title: types.InlineElements{
-							&types.StringElement{
+							types.StringElement{
 								Content: "a title",
 							},
 						},
 						Elements: []interface{}{},
 					},
-					&types.BlankLine{},
-					&types.Paragraph{
+					types.BlankLine{},
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "with some content linked to ",
 								},
-								&types.CrossReference{
+								types.CrossReference{
 									ID:    "thetitle",
 									Label: "a label to the title",
 								},
-								&types.StringElement{
+								types.StringElement{
 									Content: "!",
 								},
 							},
@@ -106,11 +106,11 @@ var _ = Describe("cross-references - document", func() {
 == a title
 
 with some content linked to <<thetitle>>!`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes: types.DocumentAttributes{},
 				ElementReferences: types.ElementReferences{
 					"thetitle": types.InlineElements{
-						&types.StringElement{
+						types.StringElement{
 							Content: "a title",
 						},
 					},
@@ -118,30 +118,30 @@ with some content linked to <<thetitle>>!`
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.Section{
+					types.Section{
 						Level: 1,
 						Attributes: types.ElementAttributes{
 							types.AttrID:       "thetitle",
 							types.AttrCustomID: true,
 						},
 						Title: types.InlineElements{
-							&types.StringElement{
+							types.StringElement{
 								Content: "a title",
 							},
 						},
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "with some content linked to ",
 										},
-										&types.CrossReference{
+										types.CrossReference{
 											ID:    "thetitle",
 											Label: "",
 										},
-										&types.StringElement{
+										types.StringElement{
 											Content: "!",
 										},
 									},
@@ -159,11 +159,11 @@ with some content linked to <<thetitle>>!`
 == a title
 
 with some content linked to <<thetitle,a label to the title>>!`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes: types.DocumentAttributes{},
 				ElementReferences: types.ElementReferences{
 					"thetitle": types.InlineElements{
-						&types.StringElement{
+						types.StringElement{
 							Content: "a title",
 						},
 					},
@@ -171,30 +171,30 @@ with some content linked to <<thetitle,a label to the title>>!`
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.Section{
+					types.Section{
 						Level: 1,
 						Attributes: types.ElementAttributes{
 							types.AttrID:       "thetitle",
 							types.AttrCustomID: true,
 						},
 						Title: types.InlineElements{
-							&types.StringElement{
+							types.StringElement{
 								Content: "a title",
 							},
 						},
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "with some content linked to ",
 										},
-										&types.CrossReference{
+										types.CrossReference{
 											ID:    "thetitle",
 											Label: "a label to the title",
 										},
-										&types.StringElement{
+										types.StringElement{
 											Content: "!",
 										},
 									},

--- a/pkg/parser/delimited_block_test.go
+++ b/pkg/parser/delimited_block_test.go
@@ -12,15 +12,15 @@ var _ = Describe("delimited blocks - preflight", func() {
 		It("fenced block with single line", func() {
 			content := "some fenced code"
 			source := "```\n" + content + "\n```"
-			expected := &types.DelimitedBlock{
+			expected := types.DelimitedBlock{
 				Attributes: types.ElementAttributes{},
 				Kind:       types.Fenced,
 				Elements: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: content,
 								},
 							},
@@ -33,7 +33,7 @@ var _ = Describe("delimited blocks - preflight", func() {
 
 		It("fenced block with no line", func() {
 			source := "```\n```"
-			expected := &types.DelimitedBlock{
+			expected := types.DelimitedBlock{
 				Attributes: types.ElementAttributes{},
 				Kind:       types.Fenced,
 				Elements:   []interface{}{},
@@ -43,31 +43,31 @@ var _ = Describe("delimited blocks - preflight", func() {
 
 		It("fenced block with multiple lines alone", func() {
 			source := "```\nsome fenced code\nwith an empty line\n\nin the middle\n```"
-			expected := &types.DelimitedBlock{
+			expected := types.DelimitedBlock{
 				Attributes: types.ElementAttributes{},
 				Kind:       types.Fenced,
 				Elements: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "some fenced code",
 								},
 							},
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "with an empty line",
 								},
 							},
 						},
 					},
-					&types.BlankLine{},
-					&types.Paragraph{
+					types.BlankLine{},
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "in the middle",
 								},
 							},
@@ -80,33 +80,33 @@ var _ = Describe("delimited blocks - preflight", func() {
 
 		It("fenced block with multiple lines then a paragraph", func() {
 			source := "```\nsome fenced code\nwith an empty line\n\nin the middle\n```\nthen a normal paragraph."
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{},
 						Kind:       types.Fenced,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "some fenced code",
 										},
 									},
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "with an empty line",
 										},
 									},
 								},
 							},
-							&types.BlankLine{},
-							&types.Paragraph{
+							types.BlankLine{},
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "in the middle",
 										},
 									},
@@ -114,11 +114,11 @@ var _ = Describe("delimited blocks - preflight", func() {
 							},
 						},
 					},
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: "then a normal paragraph."},
+								types.StringElement{Content: "then a normal paragraph."},
 							},
 						},
 					},
@@ -130,25 +130,25 @@ var _ = Describe("delimited blocks - preflight", func() {
 		It("fenced block after a paragraph", func() {
 			content := "some fenced code"
 			source := "a paragraph.\n```\n" + content + "\n```\n"
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: "a paragraph."},
+								types.StringElement{Content: "a paragraph."},
 							},
 						},
 					},
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{},
 						Kind:       types.Fenced,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: content,
 										},
 									},
@@ -163,15 +163,15 @@ var _ = Describe("delimited blocks - preflight", func() {
 
 		It("fenced block with unclosed delimiter", func() {
 			source := "```\nEnd of file here"
-			expected := &types.DelimitedBlock{
+			expected := types.DelimitedBlock{
 				Attributes: types.ElementAttributes{},
 				Kind:       types.Fenced,
 				Elements: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "End of file here",
 								},
 							},
@@ -188,33 +188,33 @@ var _ = Describe("delimited blocks - preflight", func() {
 				"and more text on the" + "\n" +
 				"next lines" + "\n" +
 				"```"
-			expected := &types.DelimitedBlock{
+			expected := types.DelimitedBlock{
 				Attributes: types.ElementAttributes{},
 				Kind:       types.Fenced,
 				Elements: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "a ",
 								},
-								&types.InlineLink{
+								types.InlineLink{
 									Attributes: types.ElementAttributes{},
 									Location: types.Location{
-										&types.StringElement{
+										types.StringElement{
 											Content: "http://website.com",
 										},
 									},
 								},
 							},
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "and more text on the",
 								},
 							},
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "next lines",
 								},
 							},
@@ -231,33 +231,33 @@ var _ = Describe("delimited blocks - preflight", func() {
 				"and more text on the" + "\n" +
 				"next lines" + "\n" +
 				"```"
-			expected := &types.DelimitedBlock{
+			expected := types.DelimitedBlock{
 				Attributes: types.ElementAttributes{},
 				Kind:       types.Fenced,
 				Elements: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "a ",
 								},
-								&types.InlineLink{
+								types.InlineLink{
 									Attributes: types.ElementAttributes{},
 									Location: types.Location{
-										&types.StringElement{
+										types.StringElement{
 											Content: "http://website.com",
 										},
 									},
 								},
 							},
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "and more text on the",
 								},
 							},
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "next lines",
 								},
 							},
@@ -275,15 +275,15 @@ var _ = Describe("delimited blocks - preflight", func() {
 			source := `----
 some listing code
 ----`
-			expected := &types.DelimitedBlock{
+			expected := types.DelimitedBlock{
 				Attributes: types.ElementAttributes{},
 				Kind:       types.Listing,
 				Elements: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "some listing code",
 								},
 							},
@@ -297,7 +297,7 @@ some listing code
 		It("listing block with no line", func() {
 			source := `----
 ----`
-			expected := &types.DelimitedBlock{
+			expected := types.DelimitedBlock{
 				Attributes: types.ElementAttributes{},
 				Kind:       types.Listing,
 				Elements:   []interface{}{},
@@ -312,26 +312,26 @@ with an empty line
 
 in the middle
 ----`
-			expected := &types.DelimitedBlock{
+			expected := types.DelimitedBlock{
 				Attributes: types.ElementAttributes{},
 				Kind:       types.Listing,
 				Elements: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "some listing code",
 								},
 							},
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "with an empty line",
 								},
 							},
 							{},
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "in the middle",
 								},
 							},
@@ -348,25 +348,25 @@ in the middle
 * listing 
 * content
 ----`
-			expected := &types.DelimitedBlock{
+			expected := types.DelimitedBlock{
 				Attributes: types.ElementAttributes{},
 				Kind:       types.Listing,
 				Elements: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "* some ",
 								},
 							},
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "* listing ",
 								},
 							},
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "* content",
 								},
 							},
@@ -385,28 +385,28 @@ with an empty line
 in the middle
 ----
 then a normal paragraph.`
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{},
 						Kind:       types.Listing,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "some listing code",
 										},
 									},
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "with an empty line",
 										},
 									},
 									{},
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "in the middle",
 										},
 									},
@@ -414,11 +414,11 @@ then a normal paragraph.`
 							},
 						},
 					},
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: "then a normal paragraph."},
+								types.StringElement{Content: "then a normal paragraph."},
 							},
 						},
 					},
@@ -432,25 +432,25 @@ then a normal paragraph.`
 ----
 some listing code
 ----`
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: "a paragraph."},
+								types.StringElement{Content: "a paragraph."},
 							},
 						},
 					},
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{},
 						Kind:       types.Listing,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "some listing code",
 										},
 									},
@@ -466,15 +466,15 @@ some listing code
 		It("listing block with unclosed delimiter", func() {
 			source := `----
 End of file here.`
-			expected := &types.DelimitedBlock{
+			expected := types.DelimitedBlock{
 				Attributes: types.ElementAttributes{},
 				Kind:       types.Listing,
 				Elements: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "End of file here.",
 								},
 							},
@@ -492,15 +492,15 @@ End of file here.`
 			source := `====
 some listing code
 ====`
-			expected := &types.DelimitedBlock{
+			expected := types.DelimitedBlock{
 				Attributes: types.ElementAttributes{},
 				Kind:       types.Example,
 				Elements: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "some listing code",
 								},
 							},
@@ -515,15 +515,15 @@ some listing code
 			source := `====
 .foo
 ====`
-			expected := &types.DelimitedBlock{
+			expected := types.DelimitedBlock{
 				Attributes: types.ElementAttributes{},
 				Kind:       types.Example,
 				Elements: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: ".foo",
 								},
 							},
@@ -542,31 +542,31 @@ with *bold content*
 
 * and a list item
 ====`
-			expected := &types.DelimitedBlock{
+			expected := types.DelimitedBlock{
 				Attributes: types.ElementAttributes{},
 				Kind:       types.Example,
 				Elements: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: ".foo",
 								},
 							},
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "some listing code",
 								},
 							},
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "with ",
 								},
-								&types.QuotedText{
+								types.QuotedText{
 									Kind: types.Bold,
 									Elements: types.InlineElements{
-										&types.StringElement{
+										types.StringElement{
 											Content: "bold content",
 										},
 									},
@@ -574,18 +574,18 @@ with *bold content*
 							},
 						},
 					},
-					&types.BlankLine{},
-					&types.UnorderedListItem{
+					types.BlankLine{},
+					types.UnorderedListItem{
 						Attributes:  types.ElementAttributes{},
 						Level:       1,
 						BulletStyle: types.OneAsterisk,
 						CheckStyle:  types.NoCheck,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "and a list item",
 										},
 									},
@@ -601,15 +601,15 @@ with *bold content*
 		It("example block with unclosed delimiter", func() {
 			source := `====
 End of file here`
-			expected := &types.DelimitedBlock{
+			expected := types.DelimitedBlock{
 				Attributes: types.ElementAttributes{},
 				Kind:       types.Example,
 				Elements: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "End of file here",
 								},
 							},
@@ -625,17 +625,17 @@ End of file here`
 ====
 foo
 ====`
-			expected := &types.DelimitedBlock{
+			expected := types.DelimitedBlock{
 				Attributes: types.ElementAttributes{
 					types.AttrTitle: "example block title",
 				},
 				Kind: types.Example,
 				Elements: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "foo",
 								},
 							},
@@ -648,7 +648,7 @@ foo
 
 		It("example block starting delimiter only", func() {
 			source := `====`
-			expected := &types.DelimitedBlock{
+			expected := types.DelimitedBlock{
 				Attributes: types.ElementAttributes{},
 				Kind:       types.Example,
 				Elements:   []interface{}{},
@@ -664,17 +664,17 @@ foo
 ====
 foo
 ====`
-			expected := &types.DelimitedBlock{
+			expected := types.DelimitedBlock{
 				Attributes: types.ElementAttributes{
 					types.AttrAdmonitionKind: types.Note,
 				},
 				Kind: types.Example,
 				Elements: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "foo",
 								},
 							},
@@ -694,25 +694,25 @@ multiple
 paragraphs
 ----
 `
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{
 							types.AttrAdmonitionKind: types.Note,
 						},
 						Kind: types.Listing,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "multiple",
 										},
 									},
 									{},
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "paragraphs",
 										},
 									},
@@ -733,7 +733,7 @@ paragraphs
 ____
 some *quote* content
 ____`
-			expected := &types.DelimitedBlock{
+			expected := types.DelimitedBlock{
 				Attributes: types.ElementAttributes{
 					types.AttrKind:        types.Quote,
 					types.AttrQuoteAuthor: "john doe",
@@ -741,22 +741,22 @@ ____`
 				},
 				Kind: types.Quote,
 				Elements: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "some ",
 								},
-								&types.QuotedText{
+								types.QuotedText{
 									Kind: types.Bold,
 									Elements: types.InlineElements{
-										&types.StringElement{
+										types.StringElement{
 											Content: "quote",
 										},
 									},
 								},
-								&types.StringElement{
+								types.StringElement{
 									Content: " content",
 								},
 							},
@@ -775,24 +775,24 @@ ____
 - content 
 ____
 `
-			expected := &types.DelimitedBlock{
+			expected := types.DelimitedBlock{
 				Attributes: types.ElementAttributes{
 					types.AttrKind:        types.Quote,
 					types.AttrQuoteAuthor: "john doe",
 				},
 				Kind: types.Quote,
 				Elements: []interface{}{
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Attributes:  types.ElementAttributes{},
 						Level:       1,
 						BulletStyle: types.Dash,
 						CheckStyle:  types.NoCheck,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "some ",
 										},
 									},
@@ -800,17 +800,17 @@ ____
 							},
 						},
 					},
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Attributes:  types.ElementAttributes{},
 						Level:       1,
 						BulletStyle: types.Dash,
 						CheckStyle:  types.NoCheck,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "quote ",
 										},
 									},
@@ -818,17 +818,17 @@ ____
 							},
 						},
 					},
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Attributes:  types.ElementAttributes{},
 						Level:       1,
 						BulletStyle: types.Dash,
 						CheckStyle:  types.NoCheck,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "content ",
 										},
 									},
@@ -847,18 +847,18 @@ ____
 some quote content 
 ____
 `
-			expected := &types.DelimitedBlock{
+			expected := types.DelimitedBlock{
 				Attributes: types.ElementAttributes{
 					types.AttrKind:       types.Quote,
 					types.AttrQuoteTitle: "quote title",
 				},
 				Kind: types.Quote,
 				Elements: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "some quote content ",
 								},
 							},
@@ -878,23 +878,23 @@ ____
 ----
 * content
 ____`
-			expected := &types.DelimitedBlock{
+			expected := types.DelimitedBlock{
 				Attributes: types.ElementAttributes{
 					types.AttrKind: types.Quote,
 				},
 				Kind: types.Quote,
 				Elements: []interface{}{
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Attributes:  types.ElementAttributes{},
 						Level:       1,
 						BulletStyle: types.OneAsterisk,
 						CheckStyle:  types.NoCheck,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "some",
 										},
 									},
@@ -902,15 +902,15 @@ ____`
 							},
 						},
 					},
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{},
 						Kind:       types.Listing,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "* quote ",
 										},
 									},
@@ -918,17 +918,17 @@ ____`
 							},
 						},
 					},
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Attributes:  types.ElementAttributes{},
 						Level:       1,
 						BulletStyle: types.OneAsterisk,
 						CheckStyle:  types.NoCheck,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "content",
 										},
 									},
@@ -952,23 +952,23 @@ ____
 
 * content
 ____`
-			expected := &types.DelimitedBlock{
+			expected := types.DelimitedBlock{
 				Attributes: types.ElementAttributes{
 					types.AttrKind: types.Quote,
 				},
 				Kind: types.Quote,
 				Elements: []interface{}{
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Attributes:  types.ElementAttributes{},
 						Level:       1,
 						BulletStyle: types.OneAsterisk,
 						CheckStyle:  types.NoCheck,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "some",
 										},
 									},
@@ -976,19 +976,19 @@ ____`
 							},
 						},
 					},
-					&types.BlankLine{},
-					&types.BlankLine{},
-					&types.UnorderedListItem{
+					types.BlankLine{},
+					types.BlankLine{},
+					types.UnorderedListItem{
 						Attributes:  types.ElementAttributes{},
 						Level:       1,
 						BulletStyle: types.OneAsterisk,
 						CheckStyle:  types.NoCheck,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "quote ",
 										},
 									},
@@ -996,19 +996,19 @@ ____`
 							},
 						},
 					},
-					&types.BlankLine{},
-					&types.BlankLine{},
-					&types.UnorderedListItem{
+					types.BlankLine{},
+					types.BlankLine{},
+					types.UnorderedListItem{
 						Attributes:  types.ElementAttributes{},
 						Level:       1,
 						BulletStyle: types.OneAsterisk,
 						CheckStyle:  types.NoCheck,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "content",
 										},
 									},
@@ -1025,7 +1025,7 @@ ____`
 			source := `[quote]
 ____
 ____`
-			expected := &types.DelimitedBlock{
+			expected := types.DelimitedBlock{
 				Attributes: types.ElementAttributes{
 					types.AttrKind: types.Quote,
 				},
@@ -1040,17 +1040,17 @@ ____`
 ____
 foo
 `
-			expected := &types.DelimitedBlock{
+			expected := types.DelimitedBlock{
 				Attributes: types.ElementAttributes{
 					types.AttrKind: types.Quote,
 				},
 				Kind: types.Quote,
 				Elements: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "foo",
 								},
 							},
@@ -1069,7 +1069,7 @@ foo
 ____
 some *verse* content
 ____`
-			expected := &types.DelimitedBlock{
+			expected := types.DelimitedBlock{
 				Attributes: types.ElementAttributes{
 					types.AttrKind:        types.Verse,
 					types.AttrQuoteAuthor: "john doe",
@@ -1077,22 +1077,22 @@ ____`
 				},
 				Kind: types.Verse,
 				Elements: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "some ",
 								},
-								&types.QuotedText{
+								types.QuotedText{
 									Kind: types.Bold,
 									Elements: types.InlineElements{
-										&types.StringElement{
+										types.StringElement{
 											Content: "verse",
 										},
 									},
 								},
-								&types.StringElement{
+								types.StringElement{
 									Content: " content",
 								},
 							},
@@ -1111,28 +1111,28 @@ ____
 - content 
 ____
 `
-			expected := &types.DelimitedBlock{
+			expected := types.DelimitedBlock{
 				Attributes: types.ElementAttributes{
 					types.AttrKind:        types.Verse,
 					types.AttrQuoteAuthor: "john doe",
 				},
 				Kind: types.Verse,
 				Elements: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "- some ",
 								},
 							},
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "- verse ",
 								},
 							},
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "- content ",
 								},
 							},
@@ -1149,18 +1149,18 @@ ____
 some verse content 
 ____
 `
-			expected := &types.DelimitedBlock{
+			expected := types.DelimitedBlock{
 				Attributes: types.ElementAttributes{
 					types.AttrKind:       types.Verse,
 					types.AttrQuoteTitle: "verse title",
 				},
 				Kind: types.Verse,
 				Elements: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "some verse content ",
 								},
 							},
@@ -1180,37 +1180,37 @@ ____
 ----
 * content
 ____`
-			expected := &types.DelimitedBlock{
+			expected := types.DelimitedBlock{
 				Attributes: types.ElementAttributes{
 					types.AttrKind: types.Verse,
 				},
 				Kind: types.Verse,
 				Elements: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "* some",
 								},
 							},
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "----",
 								},
 							},
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "* verse ",
 								},
 							},
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "----",
 								},
 							},
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "* content",
 								},
 							},
@@ -1229,29 +1229,29 @@ ____
 
 	* bar
 ____`
-			expected := &types.DelimitedBlock{
+			expected := types.DelimitedBlock{
 				Attributes: types.ElementAttributes{
 					types.AttrKind: types.Verse,
 				},
 				Kind: types.Verse,
 				Elements: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "* foo",
 								},
 							},
 						},
 					},
-					&types.BlankLine{},
-					&types.BlankLine{},
-					&types.Paragraph{
+					types.BlankLine{},
+					types.BlankLine{},
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "\t* bar",
 								},
 							},
@@ -1266,7 +1266,7 @@ ____`
 			source := `[verse]
 ____
 ____`
-			expected := &types.DelimitedBlock{
+			expected := types.DelimitedBlock{
 				Attributes: types.ElementAttributes{
 					types.AttrKind: types.Verse,
 				},
@@ -1281,17 +1281,17 @@ ____`
 ____
 foo
 `
-			expected := &types.DelimitedBlock{
+			expected := types.DelimitedBlock{
 				Attributes: types.ElementAttributes{
 					types.AttrKind: types.Verse,
 				},
 				Kind: types.Verse,
 				Elements: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "foo",
 								},
 							},
@@ -1314,33 +1314,33 @@ get '/hi' do
   "Hello World!"
 end
 ----`
-			expected := &types.DelimitedBlock{
+			expected := types.DelimitedBlock{
 				Attributes: types.ElementAttributes{
 					types.AttrKind: types.Source,
 				},
 				Kind: types.Source,
 				Elements: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "require 'sinatra'",
 								},
 							},
 							{},
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "get '/hi' do",
 								},
 							},
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "  \"Hello World!\"",
 								},
 							},
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "end",
 								},
 							},
@@ -1361,7 +1361,7 @@ get '/hi' do
   "Hello World!"
 end
 ----`
-			expected := &types.DelimitedBlock{
+			expected := types.DelimitedBlock{
 				Attributes: types.ElementAttributes{
 					types.AttrKind:     types.Source,
 					types.AttrLanguage: "ruby",
@@ -1369,27 +1369,27 @@ end
 				},
 				Kind: types.Source,
 				Elements: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "require 'sinatra'",
 								},
 							},
 							{},
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "get '/hi' do",
 								},
 							},
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "  \"Hello World!\"",
 								},
 							},
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "end",
 								},
 							},
@@ -1411,7 +1411,7 @@ get '/hi' do
   "Hello World!"
 end
 ----`
-			expected := &types.DelimitedBlock{
+			expected := types.DelimitedBlock{
 				Attributes: types.ElementAttributes{
 					types.AttrKind:     types.Source,
 					types.AttrLanguage: "ruby",
@@ -1421,27 +1421,27 @@ end
 				},
 				Kind: types.Source,
 				Elements: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "require 'sinatra'",
 								},
 							},
 							{},
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "get '/hi' do",
 								},
 							},
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "  \"Hello World!\"",
 								},
 							},
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "end",
 								},
 							},
@@ -1459,26 +1459,26 @@ end
 			source := `****
 some *verse* content
 ****`
-			expected := &types.DelimitedBlock{
+			expected := types.DelimitedBlock{
 				Attributes: types.ElementAttributes{},
 				Kind:       types.Sidebar,
 				Elements: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "some ",
 								},
-								&types.QuotedText{
+								types.QuotedText{
 									Kind: types.Bold,
 									Elements: types.InlineElements{
-										&types.StringElement{
+										types.StringElement{
 											Content: "verse",
 										},
 									},
 								},
-								&types.StringElement{
+								types.StringElement{
 									Content: " content",
 								},
 							},
@@ -1498,47 +1498,47 @@ foo
 bar
 ----
 ****`
-			expected := &types.DelimitedBlock{
+			expected := types.DelimitedBlock{
 				Attributes: types.ElementAttributes{
 					types.AttrTitle: "a title",
 				},
 				Kind: types.Sidebar,
 				Elements: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "some ",
 								},
-								&types.QuotedText{
+								types.QuotedText{
 									Kind: types.Bold,
 									Elements: types.InlineElements{
-										&types.StringElement{
+										types.StringElement{
 											Content: "verse",
 										},
 									},
 								},
-								&types.StringElement{
+								types.StringElement{
 									Content: " content",
 								},
 							},
 						},
 					},
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{},
 						Kind:       types.Listing,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "foo",
 										},
 									},
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "bar",
 										},
 									},
@@ -1560,21 +1560,21 @@ var _ = Describe("delimited blocks - document", func() {
 		It("fenced block with single line", func() {
 			content := "some fenced code"
 			source := "```\n" + content + "\n```"
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{},
 						Kind:       types.Fenced,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: content,
 										},
 									},
@@ -1589,13 +1589,13 @@ var _ = Describe("delimited blocks - document", func() {
 
 		It("fenced block with no line", func() {
 			source := "```\n```"
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{},
 						Kind:       types.Fenced,
 						Elements:   []interface{}{},
@@ -1607,37 +1607,37 @@ var _ = Describe("delimited blocks - document", func() {
 
 		It("fenced block with multiple lines alone", func() {
 			source := "```\nsome fenced code\nwith an empty line\n\nin the middle\n```"
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{},
 						Kind:       types.Fenced,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "some fenced code",
 										},
 									},
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "with an empty line",
 										},
 									},
 								},
 							},
-							&types.BlankLine{},
-							&types.Paragraph{
+							types.BlankLine{},
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "in the middle",
 										},
 									},
@@ -1652,37 +1652,37 @@ var _ = Describe("delimited blocks - document", func() {
 
 		It("fenced block with multiple lines then a paragraph", func() {
 			source := "```\nsome fenced code\nwith an empty line\n\nin the middle\n```\nthen a normal paragraph."
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{},
 						Kind:       types.Fenced,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "some fenced code",
 										},
 									},
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "with an empty line",
 										},
 									},
 								},
 							},
-							&types.BlankLine{},
-							&types.Paragraph{
+							types.BlankLine{},
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "in the middle",
 										},
 									},
@@ -1690,11 +1690,11 @@ var _ = Describe("delimited blocks - document", func() {
 							},
 						},
 					},
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: "then a normal paragraph."},
+								types.StringElement{Content: "then a normal paragraph."},
 							},
 						},
 					},
@@ -1706,29 +1706,29 @@ var _ = Describe("delimited blocks - document", func() {
 		It("fenced block after a paragraph", func() {
 			content := "some fenced code"
 			source := "a paragraph.\n```\n" + content + "\n```\n"
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: "a paragraph."},
+								types.StringElement{Content: "a paragraph."},
 							},
 						},
 					},
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{},
 						Kind:       types.Fenced,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: content,
 										},
 									},
@@ -1743,21 +1743,21 @@ var _ = Describe("delimited blocks - document", func() {
 
 		It("fenced block with unclosed delimiter", func() {
 			source := "```\nEnd of file here"
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{},
 						Kind:       types.Fenced,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "End of file here",
 										},
 									},
@@ -1777,39 +1777,39 @@ var _ = Describe("delimited blocks - document", func() {
 				"next lines" + "\n" +
 				"```"
 
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{},
 						Kind:       types.Fenced,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "a ",
 										},
-										&types.InlineLink{
+										types.InlineLink{
 											Attributes: types.ElementAttributes{},
 											Location: types.Location{
-												&types.StringElement{
+												types.StringElement{
 													Content: "http://website.com",
 												},
 											},
 										},
 									},
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "and more text on the",
 										},
 									},
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "next lines",
 										},
 									},
@@ -1829,21 +1829,21 @@ var _ = Describe("delimited blocks - document", func() {
 			source := `----
 some listing code
 ----`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{},
 						Kind:       types.Listing,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "some listing code",
 										},
 									},
@@ -1859,13 +1859,13 @@ some listing code
 		It("listing block with no line", func() {
 			source := `----
 ----`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{},
 						Kind:       types.Listing,
 						Elements:   []interface{}{},
@@ -1882,32 +1882,32 @@ with an empty line
 
 in the middle
 ----`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{},
 						Kind:       types.Listing,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "some listing code",
 										},
 									},
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "with an empty line",
 										},
 									},
 									{},
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "in the middle",
 										},
 									},
@@ -1926,31 +1926,31 @@ in the middle
 * listing 
 * content
 ----`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{},
 						Kind:       types.Listing,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "* some ",
 										},
 									},
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "* listing ",
 										},
 									},
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "* content",
 										},
 									},
@@ -1971,32 +1971,32 @@ with an empty line
 in the middle
 ----
 then a normal paragraph.`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{},
 						Kind:       types.Listing,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "some listing code",
 										},
 									},
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "with an empty line",
 										},
 									},
 									{},
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "in the middle",
 										},
 									},
@@ -2004,11 +2004,11 @@ then a normal paragraph.`
 							},
 						},
 					},
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: "then a normal paragraph."},
+								types.StringElement{Content: "then a normal paragraph."},
 							},
 						},
 					},
@@ -2022,29 +2022,29 @@ then a normal paragraph.`
 ----
 some listing code
 ----`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: "a paragraph."},
+								types.StringElement{Content: "a paragraph."},
 							},
 						},
 					},
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{},
 						Kind:       types.Listing,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "some listing code",
 										},
 									},
@@ -2060,21 +2060,21 @@ some listing code
 		It("listing block with unclosed delimiter", func() {
 			source := `----
 End of file here.`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{},
 						Kind:       types.Listing,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "End of file here.",
 										},
 									},
@@ -2094,21 +2094,21 @@ End of file here.`
 			source := `====
 some listing code
 ====`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{},
 						Kind:       types.Example,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "some listing code",
 										},
 									},
@@ -2125,21 +2125,21 @@ some listing code
 			source := `====
 .foo
 ====`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{},
 						Kind:       types.Example,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: ".foo",
 										},
 									},
@@ -2160,37 +2160,37 @@ with *bold content*
 
 * and a list item
 ====`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{},
 						Kind:       types.Example,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: ".foo",
 										},
 									},
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "some listing code",
 										},
 									},
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "with ",
 										},
-										&types.QuotedText{
+										types.QuotedText{
 											Kind: types.Bold,
 											Elements: types.InlineElements{
-												&types.StringElement{
+												types.StringElement{
 													Content: "bold content",
 												},
 											},
@@ -2198,21 +2198,21 @@ with *bold content*
 									},
 								},
 							},
-							&types.BlankLine{},
-							&types.UnorderedList{
+							types.BlankLine{},
+							types.UnorderedList{
 								Attributes: types.ElementAttributes{},
-								Items: []*types.UnorderedListItem{
+								Items: []types.UnorderedListItem{
 									{
 										Attributes:  types.ElementAttributes{},
 										Level:       1,
 										BulletStyle: types.OneAsterisk,
 										CheckStyle:  types.NoCheck,
 										Elements: []interface{}{
-											&types.Paragraph{
+											types.Paragraph{
 												Attributes: types.ElementAttributes{},
 												Lines: []types.InlineElements{
 													{
-														&types.StringElement{
+														types.StringElement{
 															Content: "and a list item",
 														},
 													},
@@ -2232,21 +2232,21 @@ with *bold content*
 		It("example block with unclosed delimiter", func() {
 			source := `====
 End of file here`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{},
 						Kind:       types.Example,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "End of file here",
 										},
 									},
@@ -2264,23 +2264,23 @@ End of file here`
 ====
 foo
 ====`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{
 							types.AttrTitle: "example block title",
 						},
 						Kind: types.Example,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "foo",
 										},
 									},
@@ -2295,13 +2295,13 @@ foo
 
 		It("example block starting delimiter only", func() {
 			source := `====`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{},
 						Kind:       types.Example,
 						Elements:   []interface{}{},
@@ -2319,23 +2319,23 @@ foo
 ====
 foo
 ====`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{
 							types.AttrAdmonitionKind: types.Note,
 						},
 						Kind: types.Example,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "foo",
 										},
 									},
@@ -2357,29 +2357,29 @@ multiple
 paragraphs
 ----
 `
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{
 							types.AttrAdmonitionKind: types.Note,
 						},
 						Kind: types.Listing,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "multiple",
 										},
 									},
 									{},
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "paragraphs",
 										},
 									},
@@ -2400,13 +2400,13 @@ paragraphs
 ____
 some *quote* content
 ____`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{
 							types.AttrKind:        types.Quote,
 							types.AttrQuoteAuthor: "john doe",
@@ -2414,22 +2414,22 @@ ____`
 						},
 						Kind: types.Quote,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "some ",
 										},
-										&types.QuotedText{
+										types.QuotedText{
 											Kind: types.Bold,
 											Elements: types.InlineElements{
-												&types.StringElement{
+												types.StringElement{
 													Content: "quote",
 												},
 											},
 										},
-										&types.StringElement{
+										types.StringElement{
 											Content: " content",
 										},
 									},
@@ -2450,33 +2450,33 @@ ____
 - content 
 ____
 `
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{
 							types.AttrKind:        types.Quote,
 							types.AttrQuoteAuthor: "john doe",
 						},
 						Kind: types.Quote,
 						Elements: []interface{}{
-							&types.UnorderedList{
+							types.UnorderedList{
 								Attributes: types.ElementAttributes{},
-								Items: []*types.UnorderedListItem{
+								Items: []types.UnorderedListItem{
 									{
 										Attributes:  types.ElementAttributes{},
 										Level:       1,
 										BulletStyle: types.Dash,
 										CheckStyle:  types.NoCheck,
 										Elements: []interface{}{
-											&types.Paragraph{
+											types.Paragraph{
 												Attributes: types.ElementAttributes{},
 												Lines: []types.InlineElements{
 													{
-														&types.StringElement{
+														types.StringElement{
 															Content: "some ",
 														},
 													},
@@ -2490,11 +2490,11 @@ ____
 										BulletStyle: types.Dash,
 										CheckStyle:  types.NoCheck,
 										Elements: []interface{}{
-											&types.Paragraph{
+											types.Paragraph{
 												Attributes: types.ElementAttributes{},
 												Lines: []types.InlineElements{
 													{
-														&types.StringElement{
+														types.StringElement{
 															Content: "quote ",
 														},
 													},
@@ -2508,11 +2508,11 @@ ____
 										BulletStyle: types.Dash,
 										CheckStyle:  types.NoCheck,
 										Elements: []interface{}{
-											&types.Paragraph{
+											types.Paragraph{
 												Attributes: types.ElementAttributes{},
 												Lines: []types.InlineElements{
 													{
-														&types.StringElement{
+														types.StringElement{
 															Content: "content ",
 														},
 													},
@@ -2535,24 +2535,24 @@ ____
 some quote content 
 ____
 `
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{
 							types.AttrKind:       types.Quote,
 							types.AttrQuoteTitle: "quote title",
 						},
 						Kind: types.Quote,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "some quote content ",
 										},
 									},
@@ -2574,32 +2574,32 @@ ____
 ----
 * content
 ____`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{
 							types.AttrKind: types.Quote,
 						},
 						Kind: types.Quote,
 						Elements: []interface{}{
-							&types.UnorderedList{
+							types.UnorderedList{
 								Attributes: types.ElementAttributes{},
-								Items: []*types.UnorderedListItem{
+								Items: []types.UnorderedListItem{
 									{
 										Attributes:  types.ElementAttributes{},
 										Level:       1,
 										BulletStyle: types.OneAsterisk,
 										CheckStyle:  types.NoCheck,
 										Elements: []interface{}{
-											&types.Paragraph{
+											types.Paragraph{
 												Attributes: types.ElementAttributes{},
 												Lines: []types.InlineElements{
 													{
-														&types.StringElement{
+														types.StringElement{
 															Content: "some",
 														},
 													},
@@ -2609,15 +2609,15 @@ ____`
 									},
 								},
 							},
-							&types.DelimitedBlock{
+							types.DelimitedBlock{
 								Attributes: types.ElementAttributes{},
 								Kind:       types.Listing,
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{
+												types.StringElement{
 													Content: "* quote ",
 												},
 											},
@@ -2625,20 +2625,20 @@ ____`
 									},
 								},
 							},
-							&types.UnorderedList{
+							types.UnorderedList{
 								Attributes: types.ElementAttributes{},
-								Items: []*types.UnorderedListItem{
+								Items: []types.UnorderedListItem{
 									{
 										Attributes:  types.ElementAttributes{},
 										Level:       1,
 										BulletStyle: types.OneAsterisk,
 										CheckStyle:  types.NoCheck,
 										Elements: []interface{}{
-											&types.Paragraph{
+											types.Paragraph{
 												Attributes: types.ElementAttributes{},
 												Lines: []types.InlineElements{
 													{
-														&types.StringElement{
+														types.StringElement{
 															Content: "content",
 														},
 													},
@@ -2666,32 +2666,32 @@ ____
 
 * content
 ____`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{
 							types.AttrKind: types.Quote,
 						},
 						Kind: types.Quote,
 						Elements: []interface{}{
-							&types.UnorderedList{
+							types.UnorderedList{
 								Attributes: types.ElementAttributes{},
-								Items: []*types.UnorderedListItem{
+								Items: []types.UnorderedListItem{
 									{
 										Attributes:  types.ElementAttributes{},
 										Level:       1,
 										BulletStyle: types.OneAsterisk,
 										CheckStyle:  types.NoCheck,
 										Elements: []interface{}{
-											&types.Paragraph{
+											types.Paragraph{
 												Attributes: types.ElementAttributes{},
 												Lines: []types.InlineElements{
 													{
-														&types.StringElement{
+														types.StringElement{
 															Content: "some",
 														},
 													},
@@ -2705,11 +2705,11 @@ ____`
 										BulletStyle: types.OneAsterisk,
 										CheckStyle:  types.NoCheck,
 										Elements: []interface{}{
-											&types.Paragraph{
+											types.Paragraph{
 												Attributes: types.ElementAttributes{},
 												Lines: []types.InlineElements{
 													{
-														&types.StringElement{
+														types.StringElement{
 															Content: "quote ",
 														},
 													},
@@ -2723,11 +2723,11 @@ ____`
 										BulletStyle: types.OneAsterisk,
 										CheckStyle:  types.NoCheck,
 										Elements: []interface{}{
-											&types.Paragraph{
+											types.Paragraph{
 												Attributes: types.ElementAttributes{},
 												Lines: []types.InlineElements{
 													{
-														&types.StringElement{
+														types.StringElement{
 															Content: "content",
 														},
 													},
@@ -2748,13 +2748,13 @@ ____`
 			source := `[quote]
 ____
 ____`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{
 							types.AttrKind: types.Quote,
 						},
@@ -2771,23 +2771,23 @@ ____`
 ____
 foo
 `
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{
 							types.AttrKind: types.Quote,
 						},
 						Kind: types.Quote,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "foo",
 										},
 									},
@@ -2808,13 +2808,13 @@ foo
 ____
 some *verse* content
 ____`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{
 							types.AttrKind:        types.Verse,
 							types.AttrQuoteAuthor: "john doe",
@@ -2822,22 +2822,22 @@ ____`
 						},
 						Kind: types.Verse,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "some ",
 										},
-										&types.QuotedText{
+										types.QuotedText{
 											Kind: types.Bold,
 											Elements: types.InlineElements{
-												&types.StringElement{
+												types.StringElement{
 													Content: "verse",
 												},
 											},
 										},
-										&types.StringElement{
+										types.StringElement{
 											Content: " content",
 										},
 									},
@@ -2858,34 +2858,34 @@ ____
 - content 
 ____
 `
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{
 							types.AttrKind:        types.Verse,
 							types.AttrQuoteAuthor: "john doe",
 						},
 						Kind: types.Verse,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "- some ",
 										},
 									},
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "- verse ",
 										},
 									},
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "- content ",
 										},
 									},
@@ -2904,24 +2904,24 @@ ____
 some verse content 
 ____
 `
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{
 							types.AttrKind:       types.Verse,
 							types.AttrQuoteTitle: "verse title",
 						},
 						Kind: types.Verse,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "some verse content ",
 										},
 									},
@@ -2943,43 +2943,43 @@ ____
 ----
 * content
 ____`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{
 							types.AttrKind: types.Verse,
 						},
 						Kind: types.Verse,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "* some",
 										},
 									},
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "----",
 										},
 									},
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "* verse ",
 										},
 									},
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "----",
 										},
 									},
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "* content",
 										},
 									},
@@ -3000,35 +3000,35 @@ ____
 
 	* bar
 ____`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{
 							types.AttrKind: types.Verse,
 						},
 						Kind: types.Verse,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "* foo",
 										},
 									},
 								},
 							},
-							&types.BlankLine{},
-							&types.BlankLine{},
-							&types.Paragraph{
+							types.BlankLine{},
+							types.BlankLine{},
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "\t* bar",
 										},
 									},
@@ -3045,13 +3045,13 @@ ____`
 			source := `[verse]
 ____
 ____`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{
 							types.AttrKind: types.Verse,
 						},
@@ -3068,23 +3068,23 @@ ____`
 ____
 foo
 `
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{
 							types.AttrKind: types.Verse,
 						},
 						Kind: types.Verse,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "foo",
 										},
 									},
@@ -3109,39 +3109,39 @@ get '/hi' do
   "Hello World!"
 end
 ----`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{
 							types.AttrKind: types.Source,
 						},
 						Kind: types.Source,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "require 'sinatra'",
 										},
 									},
 									{},
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "get '/hi' do",
 										},
 									},
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "  \"Hello World!\"",
 										},
 									},
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "end",
 										},
 									},
@@ -3164,13 +3164,13 @@ get '/hi' do
   "Hello World!"
 end
 ----`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{
 							types.AttrKind:     types.Source,
 							types.AttrLanguage: "ruby",
@@ -3178,27 +3178,27 @@ end
 						},
 						Kind: types.Source,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "require 'sinatra'",
 										},
 									},
 									{},
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "get '/hi' do",
 										},
 									},
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "  \"Hello World!\"",
 										},
 									},
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "end",
 										},
 									},
@@ -3222,13 +3222,13 @@ get '/hi' do
   "Hello World!"
 end
 ----`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{
 							types.AttrKind:     types.Source,
 							types.AttrLanguage: "ruby",
@@ -3238,27 +3238,27 @@ end
 						},
 						Kind: types.Source,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "require 'sinatra'",
 										},
 									},
 									{},
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "get '/hi' do",
 										},
 									},
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "  \"Hello World!\"",
 										},
 									},
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "end",
 										},
 									},
@@ -3278,32 +3278,32 @@ end
 			source := `****
 some *verse* content
 ****`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{},
 						Kind:       types.Sidebar,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "some ",
 										},
-										&types.QuotedText{
+										types.QuotedText{
 											Kind: types.Bold,
 											Elements: types.InlineElements{
-												&types.StringElement{
+												types.StringElement{
 													Content: "verse",
 												},
 											},
 										},
-										&types.StringElement{
+										types.StringElement{
 											Content: " content",
 										},
 									},
@@ -3325,53 +3325,53 @@ foo
 bar
 ----
 ****`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{
 							types.AttrTitle: "a title",
 						},
 						Kind: types.Sidebar,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "some ",
 										},
-										&types.QuotedText{
+										types.QuotedText{
 											Kind: types.Bold,
 											Elements: types.InlineElements{
-												&types.StringElement{
+												types.StringElement{
 													Content: "verse",
 												},
 											},
 										},
-										&types.StringElement{
+										types.StringElement{
 											Content: " content",
 										},
 									},
 								},
 							},
-							&types.DelimitedBlock{
+							types.DelimitedBlock{
 								Attributes: types.ElementAttributes{},
 								Kind:       types.Listing,
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{
+												types.StringElement{
 													Content: "foo",
 												},
 											},
 											{
-												&types.StringElement{
+												types.StringElement{
 													Content: "bar",
 												},
 											},

--- a/pkg/parser/document_attributes_test.go
+++ b/pkg/parser/document_attributes_test.go
@@ -15,9 +15,9 @@ var _ = Describe("document attributes", func() {
 This journey begins on a bleary Monday morning.`
 
 			title := types.InlineElements{
-				&types.StringElement{Content: "The Dangerous and Thrilling Documentation Chronicles"},
+				types.StringElement{Content: "The Dangerous and Thrilling Documentation Chronicles"},
 			}
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes: types.DocumentAttributes{},
 				ElementReferences: types.ElementReferences{
 					"the_dangerous_and_thrilling_documentation_chronicles": title,
@@ -25,7 +25,7 @@ This journey begins on a bleary Monday morning.`
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.Section{
+					types.Section{
 						Level: 0,
 						Attributes: types.ElementAttributes{
 							types.AttrID:       "the_dangerous_and_thrilling_documentation_chronicles",
@@ -33,11 +33,11 @@ This journey begins on a bleary Monday morning.`
 						},
 						Title: title,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "This journey begins on a bleary Monday morning."},
+										types.StringElement{Content: "This journey begins on a bleary Monday morning."},
 									},
 								},
 							},
@@ -56,11 +56,11 @@ This journey begins on a bleary Monday morning.`
 					source := `= title
 Kismet  Rainbow Chameleon  <kismet@asciidoctor.org>`
 					title := types.InlineElements{
-						&types.StringElement{
+						types.StringElement{
 							Content: "title",
 						},
 					}
-					expected := &types.Document{
+					expected := types.Document{
 						Attributes: types.DocumentAttributes{},
 						ElementReferences: types.ElementReferences{
 							"title": title,
@@ -68,7 +68,7 @@ Kismet  Rainbow Chameleon  <kismet@asciidoctor.org>`
 						Footnotes:          types.Footnotes{},
 						FootnoteReferences: types.FootnoteReferences{},
 						Elements: []interface{}{
-							&types.Section{
+							types.Section{
 								Level: 0,
 								Attributes: types.ElementAttributes{
 									types.AttrID:       "title",
@@ -92,11 +92,11 @@ Kismet  Rainbow Chameleon  <kismet@asciidoctor.org>`
 					source := `= title
 Lazarus het_Draeke <lazarus@asciidoctor.org>`
 					title := types.InlineElements{
-						&types.StringElement{
+						types.StringElement{
 							Content: "title",
 						},
 					}
-					expected := &types.Document{
+					expected := types.Document{
 						Attributes: types.DocumentAttributes{},
 						ElementReferences: types.ElementReferences{
 							"title": title,
@@ -104,7 +104,7 @@ Lazarus het_Draeke <lazarus@asciidoctor.org>`
 						Footnotes:          types.Footnotes{},
 						FootnoteReferences: types.FootnoteReferences{},
 						Elements: []interface{}{
-							&types.Section{
+							types.Section{
 								Level: 0,
 								Attributes: types.ElementAttributes{
 									types.AttrID:       "title",
@@ -128,11 +128,11 @@ Lazarus het_Draeke <lazarus@asciidoctor.org>`
 					source := `= title
 Kismet Chameleon`
 					title := types.InlineElements{
-						&types.StringElement{
+						types.StringElement{
 							Content: "title",
 						},
 					}
-					expected := &types.Document{
+					expected := types.Document{
 						Attributes: types.DocumentAttributes{},
 						ElementReferences: types.ElementReferences{
 							"title": title,
@@ -140,7 +140,7 @@ Kismet Chameleon`
 						Footnotes:          types.Footnotes{},
 						FootnoteReferences: types.FootnoteReferences{},
 						Elements: []interface{}{
-							&types.Section{
+							types.Section{
 								Level: 0,
 								Attributes: types.ElementAttributes{
 									types.AttrID:       "title",
@@ -164,11 +164,11 @@ Kismet Chameleon`
 					source := `= title
 Chameleon`
 					title := types.InlineElements{
-						&types.StringElement{
+						types.StringElement{
 							Content: "title",
 						},
 					}
-					expected := &types.Document{
+					expected := types.Document{
 						Attributes: types.DocumentAttributes{},
 						ElementReferences: types.ElementReferences{
 							"title": title,
@@ -176,7 +176,7 @@ Chameleon`
 						Footnotes:          types.Footnotes{},
 						FootnoteReferences: types.FootnoteReferences{},
 						Elements: []interface{}{
-							&types.Section{
+							types.Section{
 								Level: 0,
 								Attributes: types.ElementAttributes{
 									types.AttrID:       "title",
@@ -200,11 +200,11 @@ Chameleon`
 					source := `= title
 :author: Kismet Rainbow Chameleon` // `:"email":` is processed as a regular attribute
 					title := types.InlineElements{
-						&types.StringElement{
+						types.StringElement{
 							Content: "title",
 						},
 					}
-					expected := &types.Document{
+					expected := types.Document{
 						Attributes: types.DocumentAttributes{},
 						ElementReferences: types.ElementReferences{
 							"title": title,
@@ -212,7 +212,7 @@ Chameleon`
 						Footnotes:          types.Footnotes{},
 						FootnoteReferences: types.FootnoteReferences{},
 						Elements: []interface{}{
-							&types.Section{
+							types.Section{
 								Level: 0,
 								Attributes: types.ElementAttributes{
 									types.AttrID:       "title",
@@ -239,11 +239,11 @@ Chameleon`
 					source := `= title
 Kismet  Rainbow Chameleon  <kismet@asciidoctor.org>; Lazarus het_Draeke <lazarus@asciidoctor.org>`
 					title := types.InlineElements{
-						&types.StringElement{
+						types.StringElement{
 							Content: "title",
 						},
 					}
-					expected := &types.Document{
+					expected := types.Document{
 						Attributes: types.DocumentAttributes{},
 						ElementReferences: types.ElementReferences{
 							"title": title,
@@ -251,7 +251,7 @@ Kismet  Rainbow Chameleon  <kismet@asciidoctor.org>; Lazarus het_Draeke <lazarus
 						Footnotes:          types.Footnotes{},
 						FootnoteReferences: types.FootnoteReferences{},
 						Elements: []interface{}{
-							&types.Section{
+							types.Section{
 								Level: 0,
 								Attributes: types.ElementAttributes{
 									types.AttrID:       "title",
@@ -284,11 +284,11 @@ Kismet  Rainbow Chameleon  <kismet@asciidoctor.org>; Lazarus het_Draeke <lazarus
 				john doe
 				v1.0, June 19, 2017: First incarnation`
 				title := types.InlineElements{
-					&types.StringElement{
+					types.StringElement{
 						Content: "title",
 					},
 				}
-				expected := &types.Document{
+				expected := types.Document{
 					Attributes: types.DocumentAttributes{},
 					ElementReferences: types.ElementReferences{
 						"title": title,
@@ -296,7 +296,7 @@ Kismet  Rainbow Chameleon  <kismet@asciidoctor.org>; Lazarus het_Draeke <lazarus
 					Footnotes:          types.Footnotes{},
 					FootnoteReferences: types.FootnoteReferences{},
 					Elements: []interface{}{
-						&types.Section{
+						types.Section{
 							Level: 0,
 							Attributes: types.ElementAttributes{
 								types.AttrID:       "title",
@@ -326,11 +326,11 @@ Kismet  Rainbow Chameleon  <kismet@asciidoctor.org>; Lazarus het_Draeke <lazarus
 				john doe
 				v1.0, June 19, 2017`
 				title := types.InlineElements{
-					&types.StringElement{
+					types.StringElement{
 						Content: "title",
 					},
 				}
-				expected := &types.Document{
+				expected := types.Document{
 					Attributes: types.DocumentAttributes{},
 					ElementReferences: types.ElementReferences{
 						"title": title,
@@ -338,7 +338,7 @@ Kismet  Rainbow Chameleon  <kismet@asciidoctor.org>; Lazarus het_Draeke <lazarus
 					Footnotes:          types.Footnotes{},
 					FootnoteReferences: types.FootnoteReferences{},
 					Elements: []interface{}{
-						&types.Section{
+						types.Section{
 							Level: 0,
 							Attributes: types.ElementAttributes{
 								types.AttrID:       "title",
@@ -368,11 +368,11 @@ Kismet  Rainbow Chameleon  <kismet@asciidoctor.org>; Lazarus het_Draeke <lazarus
 				john doe
 				1.0, June 19, 2017:`
 				title := types.InlineElements{
-					&types.StringElement{
+					types.StringElement{
 						Content: "title",
 					},
 				}
-				expected := &types.Document{
+				expected := types.Document{
 					Attributes: types.DocumentAttributes{},
 					ElementReferences: types.ElementReferences{
 						"title": title,
@@ -380,7 +380,7 @@ Kismet  Rainbow Chameleon  <kismet@asciidoctor.org>; Lazarus het_Draeke <lazarus
 					Footnotes:          types.Footnotes{},
 					FootnoteReferences: types.FootnoteReferences{},
 					Elements: []interface{}{
-						&types.Section{
+						types.Section{
 							Level: 0,
 							Attributes: types.ElementAttributes{
 								types.AttrID:       "title",
@@ -409,11 +409,11 @@ Kismet  Rainbow Chameleon  <kismet@asciidoctor.org>; Lazarus het_Draeke <lazarus
 				john doe
 				1.0,`
 				title := types.InlineElements{
-					&types.StringElement{
+					types.StringElement{
 						Content: "title",
 					},
 				}
-				expected := &types.Document{
+				expected := types.Document{
 					Attributes: types.DocumentAttributes{},
 					ElementReferences: types.ElementReferences{
 						"title": title,
@@ -421,7 +421,7 @@ Kismet  Rainbow Chameleon  <kismet@asciidoctor.org>; Lazarus het_Draeke <lazarus
 					Footnotes:          types.Footnotes{},
 					FootnoteReferences: types.FootnoteReferences{},
 					Elements: []interface{}{
-						&types.Section{
+						types.Section{
 							Level: 0,
 							Attributes: types.ElementAttributes{
 								types.AttrID:       "title",
@@ -451,11 +451,11 @@ Kismet  Rainbow Chameleon  <kismet@asciidoctor.org>; Lazarus het_Draeke <lazarus
 				john doe
 				1.0`
 				title := types.InlineElements{
-					&types.StringElement{
+					types.StringElement{
 						Content: "title",
 					},
 				}
-				expected := &types.Document{
+				expected := types.Document{
 					Attributes: types.DocumentAttributes{},
 					ElementReferences: types.ElementReferences{
 						"title": title,
@@ -463,7 +463,7 @@ Kismet  Rainbow Chameleon  <kismet@asciidoctor.org>; Lazarus het_Draeke <lazarus
 					Footnotes:          types.Footnotes{},
 					FootnoteReferences: types.FootnoteReferences{},
 					Elements: []interface{}{
-						&types.Section{
+						types.Section{
 							Level: 0,
 							Attributes: types.ElementAttributes{
 								types.AttrID:       "title",
@@ -493,11 +493,11 @@ Kismet  Rainbow Chameleon  <kismet@asciidoctor.org>; Lazarus het_Draeke <lazarus
 				john doe
 				1.0a`
 				title := types.InlineElements{
-					&types.StringElement{
+					types.StringElement{
 						Content: "title",
 					},
 				}
-				expected := &types.Document{
+				expected := types.Document{
 					Attributes: types.DocumentAttributes{},
 					ElementReferences: types.ElementReferences{
 						"title": title,
@@ -505,7 +505,7 @@ Kismet  Rainbow Chameleon  <kismet@asciidoctor.org>; Lazarus het_Draeke <lazarus
 					Footnotes:          types.Footnotes{},
 					FootnoteReferences: types.FootnoteReferences{},
 					Elements: []interface{}{
-						&types.Section{
+						types.Section{
 							Level: 0,
 							Attributes: types.ElementAttributes{
 								types.AttrID:       "title",
@@ -535,11 +535,11 @@ Kismet  Rainbow Chameleon  <kismet@asciidoctor.org>; Lazarus het_Draeke <lazarus
 				john doe
 				v1.0:`
 				title := types.InlineElements{
-					&types.StringElement{
+					types.StringElement{
 						Content: "title",
 					},
 				}
-				expected := &types.Document{
+				expected := types.Document{
 					Attributes: types.DocumentAttributes{},
 					ElementReferences: types.ElementReferences{
 						"title": title,
@@ -547,7 +547,7 @@ Kismet  Rainbow Chameleon  <kismet@asciidoctor.org>; Lazarus het_Draeke <lazarus
 					Footnotes:          types.Footnotes{},
 					FootnoteReferences: types.FootnoteReferences{},
 					Elements: []interface{}{
-						&types.Section{
+						types.Section{
 							Level: 0,
 							Attributes: types.ElementAttributes{
 								types.AttrID:       "title",
@@ -577,11 +577,11 @@ Kismet  Rainbow Chameleon  <kismet@asciidoctor.org>; Lazarus het_Draeke <lazarus
 				john doe
 				V1.0:`
 				title := types.InlineElements{
-					&types.StringElement{
+					types.StringElement{
 						Content: "title",
 					},
 				}
-				expected := &types.Document{
+				expected := types.Document{
 					Attributes: types.DocumentAttributes{},
 					ElementReferences: types.ElementReferences{
 						"title": title,
@@ -589,7 +589,7 @@ Kismet  Rainbow Chameleon  <kismet@asciidoctor.org>; Lazarus het_Draeke <lazarus
 					Footnotes:          types.Footnotes{},
 					FootnoteReferences: types.FootnoteReferences{},
 					Elements: []interface{}{
-						&types.Section{
+						types.Section{
 							Level: 0,
 							Attributes: types.ElementAttributes{
 								types.AttrID:       "title",
@@ -619,11 +619,11 @@ Kismet  Rainbow Chameleon  <kismet@asciidoctor.org>; Lazarus het_Draeke <lazarus
 				john doe
 				v1.0,`
 				title := types.InlineElements{
-					&types.StringElement{
+					types.StringElement{
 						Content: "title",
 					},
 				}
-				expected := &types.Document{
+				expected := types.Document{
 					Attributes: types.DocumentAttributes{},
 					ElementReferences: types.ElementReferences{
 						"title": title,
@@ -631,7 +631,7 @@ Kismet  Rainbow Chameleon  <kismet@asciidoctor.org>; Lazarus het_Draeke <lazarus
 					Footnotes:          types.Footnotes{},
 					FootnoteReferences: types.FootnoteReferences{},
 					Elements: []interface{}{
-						&types.Section{
+						types.Section{
 							Level: 0,
 							Attributes: types.ElementAttributes{
 								types.AttrID:       "title",
@@ -661,11 +661,11 @@ Kismet  Rainbow Chameleon  <kismet@asciidoctor.org>; Lazarus het_Draeke <lazarus
 				john doe
 				v1.0,:`
 				title := types.InlineElements{
-					&types.StringElement{
+					types.StringElement{
 						Content: "title",
 					},
 				}
-				expected := &types.Document{
+				expected := types.Document{
 					Attributes: types.DocumentAttributes{},
 					ElementReferences: types.ElementReferences{
 						"title": title,
@@ -673,7 +673,7 @@ Kismet  Rainbow Chameleon  <kismet@asciidoctor.org>; Lazarus het_Draeke <lazarus
 					Footnotes:          types.Footnotes{},
 					FootnoteReferences: types.FootnoteReferences{},
 					Elements: []interface{}{
-						&types.Section{
+						types.Section{
 							Level: 0,
 							Attributes: types.ElementAttributes{
 								types.AttrID:       "title",
@@ -703,11 +703,11 @@ Kismet  Rainbow Chameleon  <kismet@asciidoctor.org>; Lazarus het_Draeke <lazarus
 john doe
 v1.0:`
 				title := types.InlineElements{
-					&types.StringElement{
+					types.StringElement{
 						Content: "title",
 					},
 				}
-				expected := &types.Document{
+				expected := types.Document{
 					Attributes: types.DocumentAttributes{},
 					ElementReferences: types.ElementReferences{
 						"title": title,
@@ -715,7 +715,7 @@ v1.0:`
 					Footnotes:          types.Footnotes{},
 					FootnoteReferences: types.FootnoteReferences{},
 					Elements: []interface{}{
-						&types.Section{
+						types.Section{
 							Level: 0,
 							Attributes: types.ElementAttributes{
 								types.AttrID:       "title",
@@ -751,18 +751,18 @@ v1.0:`
 :Author: Xavier
 :0Author: Xavier
 :Auth0r: Xavier`
-				expected := &types.Document{
+				expected := types.Document{
 					Attributes:         types.DocumentAttributes{},
 					ElementReferences:  types.ElementReferences{},
 					Footnotes:          types.Footnotes{},
 					FootnoteReferences: types.FootnoteReferences{},
 					Elements: []interface{}{
-						&types.DocumentAttributeDeclaration{Name: "a"},
-						&types.DocumentAttributeDeclaration{Name: "author", Value: "Xavier"},
-						&types.DocumentAttributeDeclaration{Name: "_author", Value: "Xavier"},
-						&types.DocumentAttributeDeclaration{Name: "Author", Value: "Xavier"},
-						&types.DocumentAttributeDeclaration{Name: "0Author", Value: "Xavier"},
-						&types.DocumentAttributeDeclaration{Name: "Auth0r", Value: "Xavier"},
+						types.DocumentAttributeDeclaration{Name: "a"},
+						types.DocumentAttributeDeclaration{Name: "author", Value: "Xavier"},
+						types.DocumentAttributeDeclaration{Name: "_author", Value: "Xavier"},
+						types.DocumentAttributeDeclaration{Name: "Author", Value: "Xavier"},
+						types.DocumentAttributeDeclaration{Name: "0Author", Value: "Xavier"},
+						types.DocumentAttributeDeclaration{Name: "Auth0r", Value: "Xavier"},
 					},
 				}
 				verifyDocument(expected, source)
@@ -774,21 +774,21 @@ v1.0:`
 :author: Xavier
 :hardbreaks:
 a paragraph`
-				expected := &types.Document{
+				expected := types.Document{
 					Attributes:         types.DocumentAttributes{},
 					ElementReferences:  types.ElementReferences{},
 					Footnotes:          types.Footnotes{},
 					FootnoteReferences: types.FootnoteReferences{},
 					Elements: []interface{}{
-						&types.DocumentAttributeDeclaration{Name: "toc"},
-						&types.DocumentAttributeDeclaration{Name: "date", Value: "2017-01-01"},
-						&types.DocumentAttributeDeclaration{Name: "author", Value: "Xavier"},
-						&types.DocumentAttributeDeclaration{Name: types.DocumentAttrHardBreaks},
-						&types.Paragraph{
+						types.DocumentAttributeDeclaration{Name: "toc"},
+						types.DocumentAttributeDeclaration{Name: "date", Value: "2017-01-01"},
+						types.DocumentAttributeDeclaration{Name: "author", Value: "Xavier"},
+						types.DocumentAttributeDeclaration{Name: types.DocumentAttrHardBreaks},
+						types.Paragraph{
 							Attributes: types.ElementAttributes{},
 							Lines: []types.InlineElements{
 								{
-									&types.StringElement{Content: "a paragraph"},
+									types.StringElement{Content: "a paragraph"},
 								},
 							},
 						},
@@ -803,20 +803,20 @@ a paragraph`
 :author: Xavier
 
 a paragraph`
-				expected := &types.Document{
+				expected := types.Document{
 					Attributes:         types.DocumentAttributes{},
 					ElementReferences:  types.ElementReferences{},
 					Footnotes:          types.Footnotes{},
 					FootnoteReferences: types.FootnoteReferences{},
 					Elements: []interface{}{
-						&types.DocumentAttributeDeclaration{Name: "toc"},
-						&types.DocumentAttributeDeclaration{Name: "date", Value: "2017-01-01"},
-						&types.DocumentAttributeDeclaration{Name: "author", Value: "Xavier"},
-						&types.Paragraph{
+						types.DocumentAttributeDeclaration{Name: "toc"},
+						types.DocumentAttributeDeclaration{Name: "date", Value: "2017-01-01"},
+						types.DocumentAttributeDeclaration{Name: "author", Value: "Xavier"},
+						types.Paragraph{
 							Attributes: types.ElementAttributes{},
 							Lines: []types.InlineElements{
 								{
-									&types.StringElement{Content: "a paragraph"},
+									types.StringElement{Content: "a paragraph"},
 								},
 							},
 						},
@@ -834,21 +834,21 @@ a paragraph`
 :hardbreaks:
 
 a paragraph`
-				expected := &types.Document{
+				expected := types.Document{
 					Attributes:         types.DocumentAttributes{},
 					ElementReferences:  types.ElementReferences{},
 					Footnotes:          types.Footnotes{},
 					FootnoteReferences: types.FootnoteReferences{},
 					Elements: []interface{}{
-						&types.DocumentAttributeDeclaration{Name: "toc"},
-						&types.DocumentAttributeDeclaration{Name: "date", Value: "2017-01-01"},
-						&types.DocumentAttributeDeclaration{Name: "author", Value: "Xavier"},
-						&types.DocumentAttributeDeclaration{Name: "hardbreaks"},
-						&types.Paragraph{
+						types.DocumentAttributeDeclaration{Name: "toc"},
+						types.DocumentAttributeDeclaration{Name: "date", Value: "2017-01-01"},
+						types.DocumentAttributeDeclaration{Name: "author", Value: "Xavier"},
+						types.DocumentAttributeDeclaration{Name: "hardbreaks"},
+						types.Paragraph{
 							Attributes: types.ElementAttributes{},
 							Lines: []types.InlineElements{
 								{
-									&types.StringElement{Content: "a paragraph"},
+									types.StringElement{Content: "a paragraph"},
 								},
 							},
 						},
@@ -863,23 +863,23 @@ a paragraph`
 :toc:
 :date: 2017-01-01
 :author: Xavier`
-				expected := &types.Document{
+				expected := types.Document{
 					Attributes:         types.DocumentAttributes{},
 					ElementReferences:  types.ElementReferences{},
 					Footnotes:          types.Footnotes{},
 					FootnoteReferences: types.FootnoteReferences{},
 					Elements: []interface{}{
-						&types.Paragraph{
+						types.Paragraph{
 							Attributes: types.ElementAttributes{},
 							Lines: []types.InlineElements{
 								{
-									&types.StringElement{Content: "a paragraph"},
+									types.StringElement{Content: "a paragraph"},
 								},
 							},
 						},
-						&types.DocumentAttributeDeclaration{Name: "toc"},
-						&types.DocumentAttributeDeclaration{Name: "date", Value: "2017-01-01"},
-						&types.DocumentAttributeDeclaration{Name: "author", Value: "Xavier"},
+						types.DocumentAttributeDeclaration{Name: "toc"},
+						types.DocumentAttributeDeclaration{Name: "date", Value: "2017-01-01"},
+						types.DocumentAttributeDeclaration{Name: "author", Value: "Xavier"},
 					},
 				}
 				verifyDocument(expected, source)
@@ -892,20 +892,20 @@ a paragraph`
 				source := `:author: Xavier
 			
 a paragraph written by {author}.`
-				expected := &types.Document{
+				expected := types.Document{
 					Attributes:         types.DocumentAttributes{},
 					ElementReferences:  types.ElementReferences{},
 					Footnotes:          types.Footnotes{},
 					FootnoteReferences: types.FootnoteReferences{},
 					Elements: []interface{}{
-						&types.DocumentAttributeDeclaration{Name: "author", Value: "Xavier"},
-						&types.Paragraph{
+						types.DocumentAttributeDeclaration{Name: "author", Value: "Xavier"},
+						types.Paragraph{
 							Attributes: types.ElementAttributes{},
 							Lines: []types.InlineElements{
 								{
-									&types.StringElement{Content: "a paragraph written by "},
-									&types.DocumentAttributeSubstitution{Name: "author"},
-									&types.StringElement{Content: "."},
+									types.StringElement{Content: "a paragraph written by "},
+									types.DocumentAttributeSubstitution{Name: "author"},
+									types.StringElement{Content: "."},
 								},
 							},
 						},
@@ -920,22 +920,22 @@ a paragraph written by {author}.`
 :!author1:
 :author2!:
 a paragraph written by {author}.`
-				expected := &types.Document{
+				expected := types.Document{
 					Attributes:         types.DocumentAttributes{},
 					ElementReferences:  types.ElementReferences{},
 					Footnotes:          types.Footnotes{},
 					FootnoteReferences: types.FootnoteReferences{},
 					Elements: []interface{}{
-						&types.DocumentAttributeDeclaration{Name: "author", Value: "Xavier"},
-						&types.DocumentAttributeReset{Name: "author1"},
-						&types.DocumentAttributeReset{Name: "author2"},
-						&types.Paragraph{
+						types.DocumentAttributeDeclaration{Name: "author", Value: "Xavier"},
+						types.DocumentAttributeReset{Name: "author1"},
+						types.DocumentAttributeReset{Name: "author2"},
+						types.Paragraph{
 							Attributes: types.ElementAttributes{},
 							Lines: []types.InlineElements{
 								{
-									&types.StringElement{Content: "a paragraph written by "},
-									&types.DocumentAttributeSubstitution{Name: "author"},
-									&types.StringElement{Content: "."},
+									types.StringElement{Content: "a paragraph written by "},
+									types.DocumentAttributeSubstitution{Name: "author"},
+									types.StringElement{Content: "."},
 								},
 							},
 						},
@@ -954,9 +954,9 @@ v1.0, June 19, 2017: First incarnation
 
 This journey begins on a bleary Monday morning.`
 			title := types.InlineElements{
-				&types.StringElement{Content: "The Dangerous and Thrilling Documentation Chronicles"},
+				types.StringElement{Content: "The Dangerous and Thrilling Documentation Chronicles"},
 			}
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes: types.DocumentAttributes{},
 				ElementReferences: types.ElementReferences{
 					"the_dangerous_and_thrilling_documentation_chronicles": title,
@@ -964,7 +964,7 @@ This journey begins on a bleary Monday morning.`
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.Section{
+					types.Section{
 						Level: 0,
 						Attributes: types.ElementAttributes{
 							types.AttrID:       "the_dangerous_and_thrilling_documentation_chronicles",
@@ -987,19 +987,19 @@ This journey begins on a bleary Monday morning.`
 						},
 						Title: title,
 						Elements: []interface{}{
-							&types.DocumentAttributeDeclaration{
+							types.DocumentAttributeDeclaration{
 								Name:  "toc",
 								Value: "",
 							},
-							&types.DocumentAttributeDeclaration{
+							types.DocumentAttributeDeclaration{
 								Name:  "keywords",
 								Value: "documentation, team, obstacles, journey, victory",
 							},
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "This journey begins on a bleary Monday morning."},
+										types.StringElement{Content: "This journey begins on a bleary Monday morning."},
 									},
 								},
 							},
@@ -1019,12 +1019,12 @@ This journey begins on a bleary Monday morning.`
 a paragraph with *bold content*`
 
 			title := types.InlineElements{
-				&types.StringElement{Content: "a header"},
+				types.StringElement{Content: "a header"},
 			}
 			section1Title := types.InlineElements{
-				&types.StringElement{Content: "section 1"},
+				types.StringElement{Content: "section 1"},
 			}
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes: types.DocumentAttributes{},
 				ElementReferences: types.ElementReferences{
 					"a_header":  title,
@@ -1033,7 +1033,7 @@ a paragraph with *bold content*`
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.Section{
+					types.Section{
 						Level: 0,
 						Attributes: types.ElementAttributes{
 							types.AttrID:       "a_header",
@@ -1041,7 +1041,7 @@ a paragraph with *bold content*`
 						},
 						Title: title,
 						Elements: []interface{}{
-							&types.Section{
+							types.Section{
 								Level: 1,
 								Title: section1Title,
 								Attributes: types.ElementAttributes{
@@ -1049,15 +1049,15 @@ a paragraph with *bold content*`
 									types.AttrCustomID: false,
 								},
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{Content: "a paragraph with "},
-												&types.QuotedText{
+												types.StringElement{Content: "a paragraph with "},
+												types.QuotedText{
 													Kind: types.Bold,
 													Elements: types.InlineElements{
-														&types.StringElement{Content: "bold content"},
+														types.StringElement{Content: "bold content"},
 													},
 												},
 											},
@@ -1080,26 +1080,26 @@ a paragraph with *bold content*`
 :toc:
 :date: 2017-01-01
 :author: Xavier`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: "a paragraph"},
+								types.StringElement{Content: "a paragraph"},
 							},
 							{
-								&types.StringElement{Content: ":toc:"},
+								types.StringElement{Content: ":toc:"},
 							},
 							{
-								&types.StringElement{Content: ":date: 2017-01-01"},
+								types.StringElement{Content: ":date: 2017-01-01"},
 							},
 							{
-								&types.StringElement{Content: ":author: Xavier"},
+								types.StringElement{Content: ":author: Xavier"},
 							},
 						},
 					},
@@ -1111,20 +1111,20 @@ a paragraph with *bold content*`
 		It("invalid attribute names", func() {
 			source := `:@date: 2017-01-01
 :{author}: Xavier`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: ":@date: 2017-01-01"},
+								types.StringElement{Content: ":@date: 2017-01-01"},
 							},
 							{
-								&types.StringElement{Content: ":{author}: Xavier"},
+								types.StringElement{Content: ":{author}: Xavier"},
 							},
 						},
 					},

--- a/pkg/parser/document_processing.go
+++ b/pkg/parser/document_processing.go
@@ -2,20 +2,21 @@ package parser
 
 import (
 	"io"
+	"reflect"
 	"strconv"
 
-	"github.com/davecgh/go-spew/spew"
-
 	"github.com/bytesparadise/libasciidoc/pkg/types"
+
+	"github.com/davecgh/go-spew/spew"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
 
 // ParseDocument parses the content of the reader identitied by the filename
-func ParseDocument(filename string, r io.Reader, opts ...Option) (*types.Document, error) {
+func ParseDocument(filename string, r io.Reader, opts ...Option) (types.Document, error) {
 	preflightDoc, err := ParsePreflightDocument(filename, r, opts...)
 	if err != nil {
-		return nil, err
+		return types.Document{}, err
 	}
 	if log.IsLevelEnabled(log.DebugLevel) {
 		log.Debug("preflight document")
@@ -24,15 +25,15 @@ func ParseDocument(filename string, r io.Reader, opts ...Option) (*types.Documen
 	// now, merge list items into proper lists
 	blocks, err := rearrangeListItems(preflightDoc.Blocks, false)
 	if err != nil {
-		return nil, err
+		return types.Document{}, err
 	}
 	// now, rearrange elements in a hierarchical manner
 	doc, err := rearrangeSections(blocks)
 	if err != nil {
-		return nil, err
+		return types.Document{}, err
 	}
 	// now, add front-matter attributes
-	if preflightDoc.FrontMatter != nil {
+	if len(preflightDoc.FrontMatter.Content) > 0 {
 		for k, v := range preflightDoc.FrontMatter.Content {
 			doc.Attributes[k] = v
 		}
@@ -42,12 +43,13 @@ func ParseDocument(filename string, r io.Reader, opts ...Option) (*types.Documen
 
 // rearrangeListItems moves the list items into lists, and nested lists if needed
 func rearrangeListItems(blocks []interface{}, withinDelimitedBlock bool) ([]interface{}, error) {
+	// log.Debugf("rearranging list items in %d blocks...", len(blocks))
 	result := make([]interface{}, 0, len(blocks)) // maximum capacity cannot exceed initial input
 	lists := []types.List{}                       // at each level (or depth), we have a list, whatever its type.
 	blankline := false                            // track if the previous block was a blank line
 	for _, block := range blocks {
 		switch block := block.(type) {
-		case *types.DelimitedBlock:
+		case types.DelimitedBlock:
 			// process and replace the elements within this delimited block
 			elements, err := rearrangeListItems(block.Elements, true)
 			if err != nil {
@@ -55,27 +57,40 @@ func rearrangeListItems(blocks []interface{}, withinDelimitedBlock bool) ([]inte
 			}
 			block.Elements = elements
 			if len(lists) > 0 {
-				result = append(result, lists[0]) // just add the top-level list
+				switch list := lists[0].(type) { // just add the top-level list
+				case *types.OrderedList:
+					result = append(result, *list)
+				case *types.UnorderedList:
+					result = append(result, *list)
+				case *types.LabeledList:
+					result = append(result, *list)
+				}
 				// reset the list for further usage while processing the rest of the document
 				lists = []types.List{}
 			}
 			result = append(result, block)
-		case types.ListItem:
+		case types.OrderedListItem, types.UnorderedListItem, types.LabeledListItem:
 			// there's a special case: if the next list item has attributes and was preceeded by a
 			// blank line, then we need to start a new list
-			if blankline && len(block.GetAttributes()) > 0 {
+			if blankline && len(block.(types.DocumentElement).GetAttributes()) > 0 {
 				if len(lists) > 0 {
-					result = append(result, lists[0]) // just add the top-level list
+					for _, list := range pruneLists(lists, 0) {
+						result = append(result, unPtr(list))
+					}
 					// reset the list for further usage while processing the rest of the document
 					lists = []types.List{}
 				}
 			}
-			lists = appendListItem(lists, block)
+			var err error
+			lists, err = appendListItem(lists, block)
+			if err != nil {
+				return nil, errors.Wrapf(err, "unable to rearrange list items in delimited block")
+			}
 			blankline = false
-		case *types.ContinuedListItemElement:
+		case types.ContinuedListItemElement:
 			lists = appendContinuedListItemElement(lists, block)
 			blankline = false
-		case *types.BlankLine:
+		case types.BlankLine:
 			// blank lines are not part of the resulting Document sections (or top-level), but they are part of the delimited blocks
 			// in some cases, they can also be used to split lists apart (when the next item has some attributes,
 			// or if the next block is a comment)
@@ -89,7 +104,10 @@ func rearrangeListItems(blocks []interface{}, withinDelimitedBlock bool) ([]inte
 			// the first thing to do is to process the pending list items,
 			// then only append this block to the result
 			if len(lists) > 0 {
-				result = append(result, lists[0]) // just add the top-level list
+				log.Debugf("appending %d lists before processing element of type %T", len(lists), block)
+				for _, list := range pruneLists(lists, 0) {
+					result = append(result, unPtr(list))
+				}
 				// reset the list for further usage while processing the rest of the document
 				lists = []types.List{}
 			}
@@ -98,55 +116,94 @@ func rearrangeListItems(blocks []interface{}, withinDelimitedBlock bool) ([]inte
 	}
 	// also when all is done, process the remaining pending list items
 	if len(lists) > 0 {
-		result = append(result, lists[0]) // just add the top-level list
+		// if log.IsLevelEnabled(log.DebugLevel) {
+		// 	log.Debugf("processing the remaining %d lists", len(lists))
+		// 	spew.Dump(lists)
+		// }
+		// // add the top-level list *value* (not the pointer)
+		// if reflect.ValueOf(l[0]).Kind() == reflect.Ptr { // TODO: factorize duplicate code
+		// 	tl := reflect.Indirect(reflect.ValueOf(l[0])).Interface()
+		// 	result = append(result, tl) // just add the top-level list
+		// }
+		log.Debugf("processing the remaining %d lists...", len(lists))
+		for _, list := range pruneLists(lists, 0) {
+			result = append(result, unPtr(list))
+			// switch list := list.(type) {
+			// case *types.OrderedList:
+			// 	result = append(result, *list)
+			// case *types.UnorderedList:
+			// 	result = append(result, *list)
+			// case *types.LabeledList:
+			// 	result = append(result, *list)
+			// }
+		}
 	}
+	if log.IsLevelEnabled(log.DebugLevel) {
+		log.Debugf("rearranged list items in %d blocks", len(blocks))
+		spew.Dump(result)
+	}
+
 	return result, nil
 }
 
-func appendListItem(lists []types.List, item types.ListItem) []types.List {
-	switch item := item.(type) {
-	case *types.OrderedListItem:
-		return appendOrderedListItem(lists, item)
-	case *types.UnorderedListItem:
-		return appendUnorderedListItem(lists, item)
-	case *types.LabeledListItem:
-		return appendLabeledListItem(lists, item)
+func unPtr(value interface{}) interface{} {
+	v := reflect.ValueOf(value)
+	k := v.Kind()
+	if k == reflect.Ptr && v.Elem().IsValid() {
+		return v.Elem().Interface()
 	}
-	return lists
+	return value
 }
 
-func appendOrderedListItem(lists []types.List, item *types.OrderedListItem) []types.List {
+func appendListItem(lists []types.List, item interface{}) ([]types.List, error) {
+	switch item := item.(type) {
+	case types.OrderedListItem:
+		return appendOrderedListItem(lists, &item)
+	case types.UnorderedListItem:
+		return appendUnorderedListItem(lists, &item)
+	case types.LabeledListItem:
+		return appendLabeledListItem(lists, item)
+	}
+	return lists, nil
+}
+
+func appendOrderedListItem(lists []types.List, item *types.OrderedListItem) ([]types.List, error) {
 	maxLevel := 0
-	log.Debugf("looking-up list for ordered list item with level=%d and number style=%v", item.Level, item.NumberingStyle)
+	log.Debugf("looking-up list for ordered list having items with level=%d and number style=%v", item.Level, item.NumberingStyle)
 	for i, list := range lists {
 		if list, ok := list.(*types.OrderedList); ok {
 			// assume we can't have empty lists
 			maxLevel++
 			if list.Items[0].NumberingStyle == item.NumberingStyle {
-				log.Debugf("found a matching ordered list")
-				list.AddItem(item)
+				log.Debugf("found a matching ordered list at level %d", list.Items[0].Level)
+				// prune items of "deeper/lower" level
+				lists = pruneLists(lists, i)
 				// apply the same level
 				item.Level = list.Items[0].Level
-				// also, prune the pointers to the remaining sublists
-				return prune(lists, i)
+				list.AddItem(*item)
+				// also, prune the pointers to the remaining sublists (in case there is any...)
+				return lists, nil
 			}
 		}
 	}
+	// force the current item level to (last seen level + 1)
+	item.Level = maxLevel + 1
 	// no match found: create a new list and if needed, adjust the level of the item
 	log.Debugf("adding a new ordered list")
 	list := types.NewOrderedList(item)
 	// also, force the current item level to (last seen level + 1)
 	item.Level = maxLevel + 1
 	// also, attach this list to the one above, if it exists ;)
-	if len(lists) > 0 {
-		parentList := lists[len(lists)-1]
-		parentItem := parentList.LastItem()
-		parentItem.AddElement(list)
-	}
-	return append(lists, list)
+	// if len(lists) > 0 {
+	// 	parentList := &(lists[len(lists)-1])
+	// 	parentItem := (*parentList).LastItem()
+	// 	parentItem.AddElement(list)
+	// 	return append(lists, list), nil
+	// }
+	return append(lists, list), nil
 }
 
-func appendUnorderedListItem(lists []types.List, item *types.UnorderedListItem) []types.List {
+func appendUnorderedListItem(lists []types.List, item *types.UnorderedListItem) ([]types.List, error) {
 	maxLevel := 0
 	log.Debugf("looking-up list for unordered list item with level=%d and bullet style=%v", item.Level, item.BulletStyle)
 	for i, list := range lists {
@@ -154,34 +211,48 @@ func appendUnorderedListItem(lists []types.List, item *types.UnorderedListItem) 
 			// assume we can't have empty lists
 			maxLevel++
 			if list.Items[0].BulletStyle == item.BulletStyle {
-				log.Debugf("found a matching unordered list")
-				list.AddItem(item)
+				log.Debugf("found a matching unordered list at level %d", list.Items[0].Level)
+				// prune items of "deeper/lower" level
+				lists = pruneLists(lists, i)
 				// apply the same level
 				item.Level = list.Items[0].Level
-				return prune(lists, i)
+				list.AddItem(*item)
+				return lists, nil
 			}
 		}
 	}
 	// no match found: create a new list and if needed, adjust the level of the item
 	log.Debugf("adding a new unordered list")
-	list := types.NewUnorderedList(item)
 	// also, force the current item level to (last seen level + 1)
 	item.Level = maxLevel + 1
-	// also, move this first item's attributes to the parent list level
-	// also, attach this list to the one above, if it exists ;)
+	// also, force the bullet-style based on the list on the level above (if it exists)
 	if len(lists) > 0 {
-		parentList := lists[len(lists)-1]
-		parentItem := parentList.LastItem()
-		parentItem.AddElement(list)
+		parentList := &(lists[len(lists)-1])
+		parentItem := (*parentList).LastItem()
 		// also, force the bullet style
 		if parentItem, ok := parentItem.(*types.UnorderedListItem); ok {
 			item.BulletStyle = item.BulletStyle.NextLevel(parentItem.BulletStyle)
 		}
 	}
-	return append(lists, list)
+	list := types.NewUnorderedList(item)
+	// also, attach this list to the one above, if it exists ;)
+	// if len(lists) > 0 {
+	// 	parentList := &(lists[len(lists)-1])
+	// 	parentItem := (*parentList).LastItem()
+	// 	parentItem.AddElement(list)
+	// 	// also, force the bullet style
+	// 	if parentItem, ok := parentItem.(*types.UnorderedListItem); ok {
+	// 		item.BulletStyle = item.BulletStyle.NextLevel(parentItem.BulletStyle)
+	// 	}
+	// 	err := (*parentList).SetLastItem(parentItem)
+	// 	if err != nil {
+	// 		return nil, errors.Wrap(err, "unable to append unordered list item")
+	// 	}
+	// }
+	return append(lists, list), nil
 }
 
-func appendLabeledListItem(lists []types.List, item *types.LabeledListItem) []types.List {
+func appendLabeledListItem(lists []types.List, item types.LabeledListItem) ([]types.List, error) {
 	maxLevel := 0
 	log.Debugf("looking-up list for labeled list item with level=%d and term=%s", item.Level, item.Term)
 	for i, list := range lists {
@@ -192,110 +263,123 @@ func appendLabeledListItem(lists []types.List, item *types.LabeledListItem) []ty
 			log.Debugf("  comparing with list item level %d vs %d", list.Items[0].Level, item.Level)
 			if list.Items[0].Level == item.Level {
 				log.Debugf("found a matching labeled list")
+				lists = pruneLists(lists, i)
 				list.AddItem(item)
 				log.Debugf("labeled list at level %d now has %d items", maxLevel, len(list.Items))
-				return prune(lists, i)
+				return lists, nil
 			}
 		}
 	}
 	// no match found: create a new list and if needed, adjust the level of the item
 	log.Debugf("adding a new labeled list")
-	list := types.NewLabeledList(item)
 	// also, force the current item level to (last seen level + 1)
 	item.Level = maxLevel + 1
-	// also, attach this list to the one above, if it exists ;)
-	if len(lists) > 0 {
-		parentList := lists[len(lists)-1]
-		parentItem := parentList.LastItem()
-		parentItem.AddElement(list)
-	}
-	return append(lists, list)
+	list := types.NewLabeledList(item)
+	// // also, attach this list to the one above, if it exists ;)
+	// if len(lists) > 0 {
+	// 	parentList := &(lists[len(lists)-1])
+	// 	parentItem := (*parentList).LastItem()
+	// 	parentItem.AddElement(list)
+	// 	err := (*parentList).SetLastItem(parentItem)
+	// 	if err != nil {
+	// 		return nil, errors.Wrap(err, "unable to append labeled list item")
+	// 	}
+	// }
+	return append(lists, list), nil
 }
 
-func prune(lists []types.List, level int) []types.List {
-	// also, prune the pointers to the remaining sublists
+func appendContinuedListItemElement(lists []types.List, item types.ContinuedListItemElement) []types.List {
+	lists = pruneLists(lists, len(lists)-1+item.Offset)
+	log.Debugf("appending continued list item element with offset=%d (depth=%d)", item.Offset, len(lists))
+	// lookup the list at which the item should be attached
+	parentList := &(lists[len(lists)-1])
+	parentItem := (*parentList).LastItem()
+	parentItem.AddElement(item.Element)
+	return lists
+}
+
+func pruneLists(lists []types.List, level int) []types.List {
 	if level+1 < len(lists) {
-		log.Debugf("pruning the list path from %d to %d levels", len(lists), level+1)
+		log.Debugf("pruning the list path from %d to %d level(s) deep", len(lists), level+1)
+		// add the last list(s) as children of their parent, in reverse order,
+		// because we copy the value, not the pointers
+		for i := len(lists) - 1; i > level; i-- {
+			log.Debugf("appending list at depth %d to the last item of the parent list...", (i + 1))
+			parentList := &(lists[i-1])
+			parentItem := (*parentList).LastItem()
+			switch childList := lists[i].(type) {
+			case *types.OrderedList:
+				parentItem.AddElement(*childList)
+			case *types.UnorderedList:
+				parentItem.AddElement(*childList)
+			case *types.LabeledList:
+				parentItem.AddElement(*childList)
+			}
+		}
+		// also, prune the pointers to the remaining sublists
 		return lists[0 : level+1]
 	}
 	return lists
 }
 
-func appendContinuedListItemElement(lists []types.List, item *types.ContinuedListItemElement) []types.List {
-	// lookup the list at which the item should be attached
-	parentList := lists[len(lists)-1+item.Offset]
-	parentItem := parentList.LastItem()
-	parentItem.AddElement(item.Element)
-	return lists
-}
-
 // rearrangeSections moves elements into section to obtain a hierarchical document instead of a flat thing
-func rearrangeSections(blocks []interface{}) (*types.Document, error) {
-	elements := make([]interface{}, 0, len(blocks)) // allocate enough room
-	references := types.ElementReferences{}
+func rearrangeSections(blocks []interface{}) (types.Document, error) {
+
+	// use same logic as with list items:
+	// only append a child section to her parent section when
+	// a sibling or higher level section is processed.
+
+	log.Debugf("rearranging sections in %d blocks...", len(blocks))
+	tle := make([]interface{}, 0, len(blocks)) // top-level elements
+	sections := make([]types.Section, 0, 6)    // the path to the current section (eg: []{section-level0, section-level1, etc.})
+	elementRefs := types.ElementReferences{}
 	footnotes := types.Footnotes{}
 	footnoteRefs := types.FootnoteReferences{}
-	sections := make([]*types.Section, 0, 6) // the path to the current section (eg: []{section-level0, section-level1, etc.})
-	var parent *types.Section                // the current "parent" section
+	var previous *types.Section // the current "parent" section
 	for _, element := range blocks {
-		if e, ok := element.(*types.Section); ok {
+		if e, ok := element.(types.Section); ok {
 			// avoid duplicate IDs in sections
-			id := e.Attributes.GetAsString(types.AttrID)
-			for i := 1; ; i++ {
-				var key string
-				if i == 1 {
-					key = id
-				} else {
-					key = id + "_" + strconv.Itoa(i)
-				}
-				if _, found := references[key]; !found {
-					references[key] = e.Title
-					// override the element id
-					e.Attributes[types.AttrID] = key
-					break
-				}
-			}
-			references[e.Attributes.GetAsString(types.AttrID)] = e.Title
-			if parent == nil { // set first parent
+			referenceSection(e, elementRefs)
+			if previous == nil { // set first parent
+				log.Debugf("setting section with title %v as a top-level element", e.Title)
 				sections = append(sections, e)
-				elements = append(elements, e)
-			} else if e.Level == parent.Level { // replace at the deepest level
-				sections[len(sections)-1] = e
-				if len(sections) == 1 { // we have new top-level element
-					elements = append(elements, e)
-				} else {
-					sections[len(sections)-2].Elements = append(sections[len(sections)-2].Elements, e) // attach to parent
-				}
-			} else if e.Level > parent.Level { // add new level
+			} else if e.Level > previous.Level { // add new level
+				log.Debugf("adding section with title %v as the first section at level %d", e.Title, e.Level)
 				sections = append(sections, e)
-				parent.Elements = append(parent.Elements, e)
-			} else { // remove all levels below current section and set this section instead
-				for i := 0; i < len(sections); i++ {
-					if sections[i].Level >= e.Level {
-						sections = sections[0 : i+1]
-						sections[i] = e
-						if i == 0 { // in case we have new top-level element
-							elements = append(elements, element)
-						} else {
-							sections[i-1].Elements = append(sections[i-1].Elements, e)
-						}
-						break
-					}
+			} else { // replace at the deepest level
+				sections = pruneSections(sections, e.Level)
+				if len(sections) > 0 && sections[0].Level == e.Level {
+					log.Debugf("moving section with title %v as a new top-level element", e.Title)
+					tle = append(tle, sections[0])
+					sections = make([]types.Section, 0, 6)
 				}
+				log.Debugf("adding section with title %v as another section at level %d", e.Title, e.Level)
+				sections = append(sections, e)
+				// if len(sections) == 1 { // we have new top-level element
+				// 	log.Debugf("setting section with title %v as secondary top-level", e.Title)
+				// 	tle = append(tle, &e)
+				// } else {
+				// 	log.Debugf("adding section with title %v as child of section at level %d", e.Title, (len(sections) - 2))
+				// 	sections[len(sections)-2].AddElement(e) // attach to parent
+				// }
 			}
-			parent = e // pointer to new current parent
+			previous = &e // pointer to new current parent
 		} else {
-			if parent == nil {
-				elements = append(elements, element)
+			if previous == nil {
+				log.Debugf("adding element of type %T as a top-level element", element)
+				tle = append(tle, element)
 			} else {
-				parent.Elements = append(parent.Elements, element)
+				parentSection := &(sections[len(sections)-1])
+				log.Debugf("adding element of type %T as a child of section with level %d", element, parentSection.Level)
+				(*parentSection).AddElement(element)
 			}
 		}
 		// also collect footnotes
 		if e, ok := element.(types.FootnotesContainer); ok {
+			log.Debugf("collecting footnotes on element of type %T", element)
 			f, fr, err := e.Footnotes()
 			if err != nil {
-				return nil, errors.Wrap(err, "unable to collect footnotes in document")
+				return types.Document{}, errors.Wrap(err, "unable to collect footnotes in document")
 			}
 			footnotes = append(footnotes, f...)
 			for k, v := range fr {
@@ -303,11 +387,54 @@ func rearrangeSections(blocks []interface{}) (*types.Document, error) {
 			}
 		}
 	}
-	return &types.Document{
+	// process the remaining sections
+	sections = pruneSections(sections, 1)
+	if len(sections) > 0 {
+		tle = append(tle, sections[0])
+	}
+
+	return types.Document{
 		Attributes:         types.DocumentAttributes{},
+		Elements:           tle,
+		ElementReferences:  elementRefs,
 		Footnotes:          footnotes,
 		FootnoteReferences: footnoteRefs,
-		ElementReferences:  references,
-		Elements:           elements,
 	}, nil
+}
+
+func referenceSection(e types.Section, elementRefs types.ElementReferences) {
+	id := e.Attributes.GetAsString(types.AttrID)
+	for i := 1; ; i++ {
+		var key string
+		if i == 1 {
+			key = id
+		} else {
+			key = id + "_" + strconv.Itoa(i)
+		}
+		if _, found := elementRefs[key]; !found {
+			elementRefs[key] = e.Title
+			// override the element id
+			e.Attributes[types.AttrID] = key
+			break
+		}
+	}
+	elementRefs[e.Attributes.GetAsString(types.AttrID)] = e.Title
+}
+
+func pruneSections(sections []types.Section, level int) []types.Section {
+	if level > 0 && level < len(sections) {
+		log.Debugf("pruning the section path from %d to %d level(s) deep", len(sections), level)
+		// add the last list(s) as children of their parent, in reverse order,
+		// because we copy the value, not the pointers
+		for i := len(sections) - 1; i > level-1; i-- {
+			parentSection := &(sections[i-1])
+			log.Debugf("appending section at level %d (%v) to the last element of the parent section (%v)", i, sections[i].Title, parentSection.Title)
+			(*parentSection).AddElement(sections[i])
+		}
+		// also, prune the pointers to the remaining sublists
+		sections := sections[0:level]
+		log.Debugf("sections list is has now %d level(s) of depth", len(sections))
+		return sections
+	}
+	return sections
 }

--- a/pkg/parser/element_attributes_test.go
+++ b/pkg/parser/element_attributes_test.go
@@ -13,13 +13,13 @@ var _ = Describe("element attributes - preflight", func() {
 			It("element link alone", func() {
 				source := `[link=http://foo.bar]
 a paragraph`
-				expected := &types.Paragraph{
+				expected := types.Paragraph{
 					Attributes: types.ElementAttributes{
 						"link": "http://foo.bar",
 					},
 					Lines: []types.InlineElements{
 						{
-							&types.StringElement{
+							types.StringElement{
 								Content: "a paragraph",
 							},
 						},
@@ -30,13 +30,13 @@ a paragraph`
 			It("spaces in link", func() {
 				source := `[link= http://foo.bar  ]
 a paragraph`
-				expected := &types.Paragraph{
+				expected := types.Paragraph{
 					Attributes: types.ElementAttributes{
 						"link": "http://foo.bar",
 					},
 					Lines: []types.InlineElements{
 						{
-							&types.StringElement{
+							types.StringElement{
 								Content: "a paragraph",
 							},
 						},
@@ -50,16 +50,16 @@ a paragraph`
 			It("spaces before keyword", func() {
 				source := `[ link=http://foo.bar]
 a paragraph`
-				expected := &types.Paragraph{
+				expected := types.Paragraph{
 					Attributes: types.ElementAttributes{},
 					Lines: []types.InlineElements{
 						{
-							&types.StringElement{
+							types.StringElement{
 								Content: "[ link=http://foo.bar]",
 							},
 						},
 						{
-							&types.StringElement{
+							types.StringElement{
 								Content: "a paragraph",
 							},
 						},
@@ -71,16 +71,16 @@ a paragraph`
 			It("unbalanced brackets", func() {
 				source := `[link=http://foo.bar
 a paragraph`
-				expected := &types.Paragraph{
+				expected := types.Paragraph{
 					Attributes: types.ElementAttributes{},
 					Lines: []types.InlineElements{
 						{
-							&types.StringElement{
+							types.StringElement{
 								Content: "[link=http://foo.bar",
 							},
 						},
 						{
-							&types.StringElement{
+							types.StringElement{
 								Content: "a paragraph",
 							},
 						},
@@ -98,14 +98,14 @@ a paragraph`
 			It("normal syntax", func() {
 				source := `[[img-foobar]]
 a paragraph`
-				expected := &types.Paragraph{
+				expected := types.Paragraph{
 					Attributes: types.ElementAttributes{
 						types.AttrID:       "img-foobar",
 						types.AttrCustomID: true,
 					},
 					Lines: []types.InlineElements{
 						{
-							&types.StringElement{
+							types.StringElement{
 								Content: "a paragraph",
 							},
 						},
@@ -117,14 +117,14 @@ a paragraph`
 			It("short-hand syntax", func() {
 				source := `[#img-foobar]
 a paragraph`
-				expected := &types.Paragraph{
+				expected := types.Paragraph{
 					Attributes: types.ElementAttributes{
 						types.AttrID:       "img-foobar",
 						types.AttrCustomID: true,
 					},
 					Lines: []types.InlineElements{
 						{
-							&types.StringElement{
+							types.StringElement{
 								Content: "a paragraph",
 							},
 						},
@@ -139,16 +139,16 @@ a paragraph`
 			It("extra spaces", func() {
 				source := `[ #img-foobar ]
 a paragraph`
-				expected := &types.Paragraph{
+				expected := types.Paragraph{
 					Attributes: types.ElementAttributes{},
 					Lines: []types.InlineElements{
 						{
-							&types.StringElement{
+							types.StringElement{
 								Content: "[ #img-foobar ]",
 							},
 						},
 						{
-							&types.StringElement{
+							types.StringElement{
 								Content: "a paragraph",
 							},
 						},
@@ -160,16 +160,16 @@ a paragraph`
 			It("unbalanced brackets", func() {
 				source := `[#img-foobar
 a paragraph`
-				expected := &types.Paragraph{
+				expected := types.Paragraph{
 					Attributes: types.ElementAttributes{},
 					Lines: []types.InlineElements{
 						{
-							&types.StringElement{
+							types.StringElement{
 								Content: "[#img-foobar",
 							},
 						},
 						{
-							&types.StringElement{
+							types.StringElement{
 								Content: "a paragraph",
 							},
 						},
@@ -187,13 +187,13 @@ a paragraph`
 			It("valid element title", func() {
 				source := `.a title
 a paragraph`
-				expected := &types.Paragraph{
+				expected := types.Paragraph{
 					Attributes: types.ElementAttributes{
 						types.AttrTitle: "a title",
 					},
 					Lines: []types.InlineElements{
 						{
-							&types.StringElement{
+							types.StringElement{
 								Content: "a paragraph",
 							},
 						},
@@ -208,21 +208,21 @@ a paragraph`
 			It("extra space after dot", func() {
 				source := `. a title
 a list item!`
-				expected := &types.OrderedListItem{
+				expected := types.OrderedListItem{
 					Attributes:     map[string]interface{}{},
 					Level:          1,
 					NumberingStyle: types.Arabic,
 					Elements: []interface{}{
-						&types.Paragraph{
+						types.Paragraph{
 							Attributes: types.ElementAttributes{},
 							Lines: []types.InlineElements{
 								{
-									&types.StringElement{
+									types.StringElement{
 										Content: "a title",
 									},
 								},
 								{
-									&types.StringElement{
+									types.StringElement{
 										Content: "a list item!",
 									},
 								},
@@ -237,16 +237,16 @@ a list item!`
 				source := `!a title
 a paragraph`
 
-				expected := &types.Paragraph{
+				expected := types.Paragraph{
 					Attributes: types.ElementAttributes{},
 					Lines: []types.InlineElements{
 						{
-							&types.StringElement{
+							types.StringElement{
 								Content: "!a title",
 							},
 						},
 						{
-							&types.StringElement{
+							types.StringElement{
 								Content: "a paragraph",
 							},
 						},
@@ -264,13 +264,13 @@ a paragraph`
 			It("shortcut role element", func() {
 				source := `[.a role]
 a paragraph`
-				expected := &types.Paragraph{
+				expected := types.Paragraph{
 					Attributes: types.ElementAttributes{
 						types.AttrRole: "a role",
 					},
 					Lines: []types.InlineElements{
 						{
-							&types.StringElement{
+							types.StringElement{
 								Content: "a paragraph",
 							},
 						},
@@ -282,13 +282,13 @@ a paragraph`
 			It("full role syntax", func() {
 				source := `[role=a role]
 a paragraph`
-				expected := &types.Paragraph{
+				expected := types.Paragraph{
 					Attributes: types.ElementAttributes{
 						types.AttrRole: "a role",
 					},
 					Lines: []types.InlineElements{
 						{
-							&types.StringElement{
+							types.StringElement{
 								Content: "a paragraph",
 							},
 						},

--- a/pkg/parser/file_inclusion_test.go
+++ b/pkg/parser/file_inclusion_test.go
@@ -26,52 +26,52 @@ var _ = Describe("file location", func() {
 			assert.Equal(GinkgoT(), expected, actual)
 		},
 		Entry("'chapter'", "chapter", types.Location{
-			&types.StringElement{
+			types.StringElement{
 				Content: "chapter",
 			},
 		}),
 		Entry("'chapter.adoc'", "chapter.adoc", types.Location{
-			&types.StringElement{
+			types.StringElement{
 				Content: "chapter.adoc",
 			},
 		}),
 		Entry("'chapter-a.adoc'", "chapter-a.adoc", types.Location{
-			&types.StringElement{
+			types.StringElement{
 				Content: "chapter-a.adoc",
 			},
 		}),
 		Entry("'chapter_a.adoc'", "chapter_a.adoc", types.Location{
-			&types.StringElement{
+			types.StringElement{
 				Content: "chapter_a.adoc",
 			},
 		}),
 		Entry("'includes/chapter_a.adoc'", "includes/chapter_a.adoc", types.Location{
-			&types.StringElement{
+			types.StringElement{
 				Content: "includes/chapter_a.adoc",
 			},
 		}),
 		Entry("'chapter-{foo}.adoc'", "chapter-{foo}.adoc", types.Location{
-			&types.StringElement{
+			types.StringElement{
 				Content: "chapter-",
 			},
-			&types.DocumentAttributeSubstitution{
+			types.DocumentAttributeSubstitution{
 				Name: "foo",
 			},
-			&types.StringElement{
+			types.StringElement{
 				Content: ".adoc",
 			},
 		}),
 		Entry("'{includedir}/chapter-{foo}.adoc'", "{includedir}/chapter-{foo}.adoc", types.Location{
-			&types.DocumentAttributeSubstitution{
+			types.DocumentAttributeSubstitution{
 				Name: "includedir",
 			},
-			&types.StringElement{
+			types.StringElement{
 				Content: "/chapter-",
 			},
-			&types.DocumentAttributeSubstitution{
+			types.DocumentAttributeSubstitution{
 				Name: "foo",
 			},
-			&types.StringElement{
+			types.StringElement{
 				Content: ".adoc",
 			},
 		}),
@@ -82,27 +82,27 @@ var _ = Describe("file inclusions - preflight", func() {
 
 	It("should include adoc file without leveloffset", func() {
 		source := "include::includes/chapter-a.adoc[]"
-		expected := &types.PreflightDocument{
+		expected := types.PreflightDocument{
 			Blocks: []interface{}{
-				&types.Section{
+				types.Section{
 					Attributes: types.ElementAttributes{
 						types.AttrID:       "chapter_a",
 						types.AttrCustomID: false,
 					},
 					Level: 0,
 					Title: types.InlineElements{
-						&types.StringElement{
+						types.StringElement{
 							Content: "Chapter A",
 						},
 					},
 					Elements: []interface{}{},
 				},
-				&types.BlankLine{},
-				&types.Paragraph{
+				types.BlankLine{},
+				types.Paragraph{
 					Attributes: types.ElementAttributes{},
 					Lines: []types.InlineElements{
 						{
-							&types.StringElement{
+							types.StringElement{
 								Content: "content",
 							},
 						},
@@ -115,27 +115,27 @@ var _ = Describe("file inclusions - preflight", func() {
 
 	It("should include adoc file with leveloffset", func() {
 		source := "include::includes/chapter-a.adoc[leveloffset=+1]"
-		expected := &types.PreflightDocument{
+		expected := types.PreflightDocument{
 			Blocks: []interface{}{
-				&types.Section{
+				types.Section{
 					Attributes: types.ElementAttributes{
 						types.AttrID:       "chapter_a",
 						types.AttrCustomID: false,
 					},
 					Level: 1,
 					Title: types.InlineElements{
-						&types.StringElement{
+						types.StringElement{
 							Content: "Chapter A",
 						},
 					},
 					Elements: []interface{}{},
 				},
-				&types.BlankLine{},
-				&types.Paragraph{
+				types.BlankLine{},
+				types.Paragraph{
 					Attributes: types.ElementAttributes{},
 					Lines: []types.InlineElements{
 						{
-							&types.StringElement{
+							types.StringElement{
 								Content: "content",
 							},
 						},
@@ -152,28 +152,28 @@ var _ = Describe("file inclusions - preflight", func() {
 			source := "```\n" +
 				"include::includes/chapter-a.adoc[]\n" +
 				"```"
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{},
 						Kind:       types.Fenced,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "= Chapter A",
 										},
 									},
 								},
 							},
-							&types.BlankLine{},
-							&types.Paragraph{
+							types.BlankLine{},
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "content",
 										},
 									},
@@ -190,28 +190,28 @@ var _ = Describe("file inclusions - preflight", func() {
 			source := `----
 include::includes/chapter-a.adoc[]
 ----`
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{},
 						Kind:       types.Listing,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "= Chapter A",
 										},
 									},
 								},
 							},
-							&types.BlankLine{},
-							&types.Paragraph{
+							types.BlankLine{},
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "content",
 										},
 									},
@@ -228,28 +228,28 @@ include::includes/chapter-a.adoc[]
 			source := `====
 include::includes/chapter-a.adoc[]
 ====`
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{},
 						Kind:       types.Example,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "= Chapter A",
 										},
 									},
 								},
 							},
-							&types.BlankLine{},
-							&types.Paragraph{
+							types.BlankLine{},
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "content",
 										},
 									},
@@ -266,28 +266,28 @@ include::includes/chapter-a.adoc[]
 			source := `____
 include::includes/chapter-a.adoc[]
 ____`
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{},
 						Kind:       types.Quote,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "= Chapter A",
 										},
 									},
 								},
 							},
-							&types.BlankLine{},
-							&types.Paragraph{
+							types.BlankLine{},
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "content",
 										},
 									},
@@ -305,30 +305,30 @@ ____`
 ____
 include::includes/chapter-a.adoc[]
 ____`
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{
 							types.AttrKind: types.Verse,
 						},
 						Kind: types.Verse,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "= Chapter A",
 										},
 									},
 								},
 							},
-							&types.BlankLine{},
-							&types.Paragraph{
+							types.BlankLine{},
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "content",
 										},
 									},
@@ -345,28 +345,28 @@ ____`
 			source := `****
 include::includes/chapter-a.adoc[]
 ****`
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{},
 						Kind:       types.Sidebar,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "= Chapter A",
 										},
 									},
 								},
 							},
-							&types.BlankLine{},
-							&types.Paragraph{
+							types.BlankLine{},
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "content",
 										},
 									},
@@ -384,26 +384,26 @@ include::includes/chapter-a.adoc[]
 			source := `++++
 include::includes/chapter-a.adoc[]
 ++++`
-			expected := &types.DelimitedBlock{
+			expected := types.DelimitedBlock{
 				Attributes: types.ElementAttributes{},
 				// Kind:       types.Passthrough,
 				Elements: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "= Chapter A",
 								},
 							},
 						},
 					},
-					&types.BlankLine{},
-					&types.Paragraph{
+					types.BlankLine{},
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "content",
 								},
 							},
@@ -421,16 +421,16 @@ include::includes/chapter-a.adoc[]
 
 			It("file inclusion with single unquoted line", func() {
 				source := `include::includes/chapter-a.adoc[lines=1]`
-				expected := &types.PreflightDocument{
+				expected := types.PreflightDocument{
 					Blocks: []interface{}{
-						&types.Section{
+						types.Section{
 							Attributes: types.ElementAttributes{
 								types.AttrID:       "chapter_a",
 								types.AttrCustomID: false,
 							},
 							Level: 0,
 							Title: types.InlineElements{
-								&types.StringElement{
+								types.StringElement{
 									Content: "Chapter A",
 								},
 							},
@@ -443,22 +443,22 @@ include::includes/chapter-a.adoc[]
 
 			It("file inclusion with multiple unquoted lines", func() {
 				source := `include::includes/chapter-a.adoc[lines=1..2]`
-				expected := &types.PreflightDocument{
+				expected := types.PreflightDocument{
 					Blocks: []interface{}{
-						&types.Section{
+						types.Section{
 							Level: 0,
 							Attributes: types.ElementAttributes{
 								types.AttrID:       "chapter_a",
 								types.AttrCustomID: false,
 							},
 							Title: types.InlineElements{
-								&types.StringElement{
+								types.StringElement{
 									Content: "Chapter A",
 								},
 							},
 							Elements: []interface{}{},
 						},
-						&types.BlankLine{},
+						types.BlankLine{},
 					},
 				}
 				verifyPreflight(expected, source)
@@ -466,9 +466,9 @@ include::includes/chapter-a.adoc[]
 
 			It("file inclusion with multiple unquoted ranges", func() {
 				source := `include::includes/chapter-a.adoc[lines=1;3..4;6..-1]` // paragraph becomes the author since the in-between blank line is stripped out
-				expected := &types.PreflightDocument{
+				expected := types.PreflightDocument{
 					Blocks: []interface{}{
-						&types.Section{
+						types.Section{
 							Level: 0,
 							Attributes: types.ElementAttributes{
 								types.AttrID:       "chapter_a",
@@ -480,7 +480,7 @@ include::includes/chapter-a.adoc[]
 								},
 							},
 							Title: types.InlineElements{
-								&types.StringElement{
+								types.StringElement{
 									Content: "Chapter A",
 								},
 							},
@@ -493,27 +493,27 @@ include::includes/chapter-a.adoc[]
 
 			It("file inclusion with invalid unquoted range - case 1", func() {
 				source := `include::includes/chapter-a.adoc[lines=1;3..4;6..foo]` // not a number
-				expected := &types.PreflightDocument{
+				expected := types.PreflightDocument{
 					Blocks: []interface{}{
-						&types.Section{
+						types.Section{
 							Level: 0,
 							Attributes: types.ElementAttributes{
 								types.AttrID:       "chapter_a",
 								types.AttrCustomID: false,
 							},
 							Title: types.InlineElements{
-								&types.StringElement{
+								types.StringElement{
 									Content: "Chapter A",
 								},
 							},
 							Elements: []interface{}{},
 						},
-						&types.BlankLine{},
-						&types.Paragraph{
+						types.BlankLine{},
+						types.Paragraph{
 							Attributes: types.ElementAttributes{},
 							Lines: []types.InlineElements{
 								{
-									&types.StringElement{
+									types.StringElement{
 										Content: "content",
 									},
 								},
@@ -526,16 +526,16 @@ include::includes/chapter-a.adoc[]
 
 			It("file inclusion with invalid unquoted range - case 2", func() {
 				source := `include::includes/chapter-a.adoc[lines=1,3..4,6..-1]` // using commas instead of semi-colons
-				expected := &types.PreflightDocument{
+				expected := types.PreflightDocument{
 					Blocks: []interface{}{
-						&types.Section{
+						types.Section{
 							Level: 0,
 							Attributes: types.ElementAttributes{
 								types.AttrID:       "chapter_a",
 								types.AttrCustomID: false,
 							},
 							Title: types.InlineElements{
-								&types.StringElement{
+								types.StringElement{
 									Content: "Chapter A",
 								},
 							},
@@ -551,16 +551,16 @@ include::includes/chapter-a.adoc[]
 
 			It("file inclusion with single quoted line", func() {
 				source := `include::includes/chapter-a.adoc[lines="1"]`
-				expected := &types.PreflightDocument{
+				expected := types.PreflightDocument{
 					Blocks: []interface{}{
-						&types.Section{
+						types.Section{
 							Level: 0,
 							Attributes: types.ElementAttributes{
 								types.AttrID:       "chapter_a",
 								types.AttrCustomID: false,
 							},
 							Title: types.InlineElements{
-								&types.StringElement{
+								types.StringElement{
 									Content: "Chapter A",
 								},
 							},
@@ -573,22 +573,22 @@ include::includes/chapter-a.adoc[]
 
 			It("file inclusion with multiple quoted lines", func() {
 				source := `include::includes/chapter-a.adoc[lines="1..2"]`
-				expected := &types.PreflightDocument{
+				expected := types.PreflightDocument{
 					Blocks: []interface{}{
-						&types.Section{
+						types.Section{
 							Level: 0,
 							Attributes: types.ElementAttributes{
 								types.AttrID:       "chapter_a",
 								types.AttrCustomID: false,
 							},
 							Title: types.InlineElements{
-								&types.StringElement{
+								types.StringElement{
 									Content: "Chapter A",
 								},
 							},
 							Elements: []interface{}{},
 						},
-						&types.BlankLine{},
+						types.BlankLine{},
 					},
 				}
 				verifyPreflight(expected, source)
@@ -597,9 +597,9 @@ include::includes/chapter-a.adoc[]
 			It("file inclusion with multiple quoted ranges", func() {
 				// here, the `content` paragraph gets attached to the header and becomes the author
 				source := `include::includes/chapter-a.adoc[lines="1,3..4,6..-1"]`
-				expected := &types.PreflightDocument{
+				expected := types.PreflightDocument{
 					Blocks: []interface{}{
-						&types.Section{
+						types.Section{
 							Level: 0,
 							Attributes: types.ElementAttributes{
 								types.AttrID:       "chapter_a",
@@ -611,7 +611,7 @@ include::includes/chapter-a.adoc[]
 								},
 							},
 							Title: types.InlineElements{
-								&types.StringElement{
+								types.StringElement{
 									Content: "Chapter A",
 								},
 							},
@@ -624,27 +624,27 @@ include::includes/chapter-a.adoc[]
 
 			It("file inclusion with invalid quoted range - case 1", func() {
 				source := `include::includes/chapter-a.adoc[lines="1,3..4,6..foo"]` // not a number
-				expected := &types.PreflightDocument{
+				expected := types.PreflightDocument{
 					Blocks: []interface{}{
-						&types.Section{
+						types.Section{
 							Level: 0,
 							Attributes: types.ElementAttributes{
 								types.AttrID:       "chapter_a",
 								types.AttrCustomID: false,
 							},
 							Title: types.InlineElements{
-								&types.StringElement{
+								types.StringElement{
 									Content: "Chapter A",
 								},
 							},
 							Elements: []interface{}{},
 						},
-						&types.BlankLine{},
-						&types.Paragraph{
+						types.BlankLine{},
+						types.Paragraph{
 							Attributes: types.ElementAttributes{},
 							Lines: []types.InlineElements{
 								{
-									&types.StringElement{
+									types.StringElement{
 										Content: "content",
 									},
 								},
@@ -657,27 +657,27 @@ include::includes/chapter-a.adoc[]
 
 			It("file inclusion with invalid quoted range - case 2", func() {
 				source := `include::includes/chapter-a.adoc[lines="1;3..4;6..10"]` // using semi-colons instead of commas
-				expected := &types.PreflightDocument{
+				expected := types.PreflightDocument{
 					Blocks: []interface{}{
-						&types.Section{
+						types.Section{
 							Level: 0,
 							Attributes: types.ElementAttributes{
 								types.AttrID:       "chapter_a",
 								types.AttrCustomID: false,
 							},
 							Title: types.InlineElements{
-								&types.StringElement{
+								types.StringElement{
 									Content: "Chapter A",
 								},
 							},
 							Elements: []interface{}{},
 						},
-						&types.BlankLine{},
-						&types.Paragraph{
+						types.BlankLine{},
+						types.Paragraph{
 							Attributes: types.ElementAttributes{},
 							Lines: []types.InlineElements{
 								{
-									&types.StringElement{
+									types.StringElement{
 										Content: "content",
 									},
 								},
@@ -694,13 +694,13 @@ include::includes/chapter-a.adoc[]
 
 		It("should replace with string element if directory does not exist in standalone block", func() {
 			source := `include::{unknown}/unknown.adoc[leveloffset=+1]`
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "Unresolved directive in test.adoc - include::{unknown}/unknown.adoc[leveloffset=+1]",
 								},
 							},
@@ -714,13 +714,13 @@ include::includes/chapter-a.adoc[]
 
 		It("should replace with string element if file is missing in standalone block", func() {
 			source := `include::includes/unknown.adoc[leveloffset=+1]`
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "Unresolved directive in test.adoc - include::includes/unknown.adoc[leveloffset=+1]",
 								},
 							},
@@ -736,17 +736,17 @@ include::includes/chapter-a.adoc[]
 			source := `----
 include::includes/unknown.adoc[leveloffset=+1]
 ----`
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{},
 						Kind:       types.Listing,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "Unresolved directive in test.adoc - include::includes/unknown.adoc[leveloffset=+1]",
 										},
 									},
@@ -767,29 +767,29 @@ include::includes/unknown.adoc[leveloffset=+1]
 			source := `:includedir: ./includes
 			
 include::{includedir}/grandchild-include.adoc[]`
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.DocumentAttributeDeclaration{
+					types.DocumentAttributeDeclaration{
 						Name:  "includedir",
 						Value: "./includes",
 					},
-					&types.BlankLine{},
-					&types.Paragraph{
+					types.BlankLine{},
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "first line of grandchild",
 								},
 							},
 						},
 					},
-					&types.BlankLine{},
-					&types.Paragraph{
+					types.BlankLine{},
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "last line of grandchild",
 								},
 							},
@@ -806,33 +806,33 @@ include::{includedir}/grandchild-include.adoc[]`
 ----
 include::{includedir}/grandchild-include.adoc[]
 ----`
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.DocumentAttributeDeclaration{
+					types.DocumentAttributeDeclaration{
 						Name:  "includedir",
 						Value: "./includes",
 					},
-					&types.BlankLine{},
-					&types.DelimitedBlock{
+					types.BlankLine{},
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{},
 						Kind:       types.Listing,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "first line of grandchild",
 										},
 									},
 								},
 							},
-							&types.BlankLine{},
-							&types.Paragraph{
+							types.BlankLine{},
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "last line of grandchild",
 										},
 									},
@@ -853,49 +853,49 @@ include::{includedir}/grandchild-include.adoc[]
 			source := `----
 include::includes/hello_world.go[] 
 ----`
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Kind:       types.Listing,
 						Attributes: types.ElementAttributes{},
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: `package includes`,
 										},
 									},
 								},
 							},
-							&types.BlankLine{},
-							&types.Paragraph{
+							types.BlankLine{},
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: `import "fmt"`,
 										},
 									},
 								},
 							},
-							&types.BlankLine{},
-							&types.Paragraph{
+							types.BlankLine{},
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: `func helloworld() {`,
 										},
 									},
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: `	fmt.Println("hello, world!")`,
 										},
 									},
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: `}`,
 										},
 									},
@@ -914,14 +914,14 @@ var _ = Describe("file inclusions - ignored at preflight", func() {
 
 	It("should include adoc file with leveloffset attribute", func() {
 		source := "include::includes/chapter-a.adoc[leveloffset=+1]"
-		expected := &types.PreflightDocument{
+		expected := types.PreflightDocument{
 			Blocks: []interface{}{
-				&types.FileInclusion{
+				types.FileInclusion{
 					Attributes: types.ElementAttributes{
 						types.AttrLevelOffset: "+1",
 					},
 					Location: types.Location{
-						&types.StringElement{
+						types.StringElement{
 							Content: "includes/chapter-a.adoc",
 						},
 					},
@@ -938,16 +938,16 @@ var _ = Describe("file inclusions - ignored at preflight", func() {
 			source := "```\n" +
 				"include::includes/chapter-a.adoc[]\n" +
 				"```"
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{},
 						Kind:       types.Fenced,
 						Elements: []interface{}{
-							&types.FileInclusion{
+							types.FileInclusion{
 								Attributes: types.ElementAttributes{},
 								Location: types.Location{
-									&types.StringElement{
+									types.StringElement{
 										Content: "includes/chapter-a.adoc",
 									},
 								},
@@ -964,16 +964,16 @@ var _ = Describe("file inclusions - ignored at preflight", func() {
 			source := `----
 include::includes/chapter-a.adoc[]
 ----`
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{},
 						Kind:       types.Listing,
 						Elements: []interface{}{
-							&types.FileInclusion{
+							types.FileInclusion{
 								Attributes: types.ElementAttributes{},
 								Location: types.Location{
-									&types.StringElement{
+									types.StringElement{
 										Content: "includes/chapter-a.adoc",
 									},
 								},
@@ -990,16 +990,16 @@ include::includes/chapter-a.adoc[]
 			source := `====
 include::includes/chapter-a.adoc[]
 ====`
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{},
 						Kind:       types.Example,
 						Elements: []interface{}{
-							&types.FileInclusion{
+							types.FileInclusion{
 								Attributes: types.ElementAttributes{},
 								Location: types.Location{
-									&types.StringElement{
+									types.StringElement{
 										Content: "includes/chapter-a.adoc",
 									},
 								},
@@ -1016,16 +1016,16 @@ include::includes/chapter-a.adoc[]
 			source := `____
 include::includes/chapter-a.adoc[]
 ____`
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{},
 						Kind:       types.Quote,
 						Elements: []interface{}{
-							&types.FileInclusion{
+							types.FileInclusion{
 								Attributes: types.ElementAttributes{},
 								Location: types.Location{
-									&types.StringElement{
+									types.StringElement{
 										Content: "includes/chapter-a.adoc",
 									},
 								},
@@ -1043,18 +1043,18 @@ ____`
 ____
 include::includes/chapter-a.adoc[]
 ____`
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{
 							types.AttrKind: types.Verse,
 						},
 						Kind: types.Verse,
 						Elements: []interface{}{
-							&types.FileInclusion{
+							types.FileInclusion{
 								Attributes: types.ElementAttributes{},
 								Location: types.Location{
-									&types.StringElement{
+									types.StringElement{
 										Content: "includes/chapter-a.adoc",
 									},
 								},
@@ -1071,16 +1071,16 @@ ____`
 			source := `****
 include::includes/chapter-a.adoc[]
 ****`
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{},
 						Kind:       types.Sidebar,
 						Elements: []interface{}{
-							&types.FileInclusion{
+							types.FileInclusion{
 								Attributes: types.ElementAttributes{},
 								Location: types.Location{
-									&types.StringElement{
+									types.StringElement{
 										Content: "includes/chapter-a.adoc",
 									},
 								},
@@ -1098,16 +1098,16 @@ include::includes/chapter-a.adoc[]
 			source := `++++
 include::includes/chapter-a.adoc[]
 ++++`
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{},
 						// Kind:       types.Passthrough,
 						Elements: []interface{}{
-							&types.FileInclusion{
+							types.FileInclusion{
 								Attributes: types.ElementAttributes{},
 								Location: types.Location{
-									&types.StringElement{
+									types.StringElement{
 										Content: "includes/chapter-a.adoc",
 									},
 								},
@@ -1127,16 +1127,16 @@ include::includes/chapter-a.adoc[]
 
 			It("file inclusion with single unquoted line", func() {
 				source := `include::includes/chapter-a.adoc[lines=1]`
-				expected := &types.PreflightDocument{
+				expected := types.PreflightDocument{
 					Blocks: []interface{}{
-						&types.FileInclusion{
+						types.FileInclusion{
 							Attributes: types.ElementAttributes{
 								types.AttrLineRanges: types.LineRanges{
 									{Start: 1, End: 1},
 								},
 							},
 							Location: types.Location{
-								&types.StringElement{
+								types.StringElement{
 									Content: "includes/chapter-a.adoc",
 								},
 							},
@@ -1149,16 +1149,16 @@ include::includes/chapter-a.adoc[]
 
 			It("file inclusion with multiple unquoted lines", func() {
 				source := `include::includes/chapter-a.adoc[lines=1..2]`
-				expected := &types.PreflightDocument{
+				expected := types.PreflightDocument{
 					Blocks: []interface{}{
-						&types.FileInclusion{
+						types.FileInclusion{
 							Attributes: types.ElementAttributes{
 								types.AttrLineRanges: types.LineRanges{
 									{Start: 1, End: 2},
 								},
 							},
 							Location: types.Location{
-								&types.StringElement{
+								types.StringElement{
 									Content: "includes/chapter-a.adoc",
 								},
 							},
@@ -1171,9 +1171,9 @@ include::includes/chapter-a.adoc[]
 
 			It("file inclusion with multiple unquoted ranges", func() {
 				source := `include::includes/chapter-a.adoc[lines=1;3..4;6..-1]`
-				expected := &types.PreflightDocument{
+				expected := types.PreflightDocument{
 					Blocks: []interface{}{
-						&types.FileInclusion{
+						types.FileInclusion{
 							Attributes: types.ElementAttributes{
 								types.AttrLineRanges: types.LineRanges{
 									{Start: 1, End: 1},
@@ -1182,7 +1182,7 @@ include::includes/chapter-a.adoc[]
 								},
 							},
 							Location: types.Location{
-								&types.StringElement{
+								types.StringElement{
 									Content: "includes/chapter-a.adoc",
 								},
 							},
@@ -1195,14 +1195,14 @@ include::includes/chapter-a.adoc[]
 
 			It("file inclusion with invalid unquoted range - case 1", func() {
 				source := `include::includes/chapter-a.adoc[lines=1;3..4;6..foo]` // not a number
-				expected := &types.PreflightDocument{
+				expected := types.PreflightDocument{
 					Blocks: []interface{}{
-						&types.FileInclusion{
+						types.FileInclusion{
 							Attributes: types.ElementAttributes{
 								types.AttrLineRanges: `1;3..4;6..foo`,
 							},
 							Location: types.Location{
-								&types.StringElement{
+								types.StringElement{
 									Content: "includes/chapter-a.adoc",
 								},
 							},
@@ -1215,9 +1215,9 @@ include::includes/chapter-a.adoc[]
 
 			It("file inclusion with invalid unquoted range - case 2", func() {
 				source := `include::includes/chapter-a.adoc[lines=1,3..4,6..-1]` // using commas instead of semi-colons
-				expected := &types.PreflightDocument{
+				expected := types.PreflightDocument{
 					Blocks: []interface{}{
-						&types.FileInclusion{
+						types.FileInclusion{
 							Attributes: types.ElementAttributes{
 								types.AttrLineRanges: types.LineRanges{
 									{Start: 1, End: 1},
@@ -1226,7 +1226,7 @@ include::includes/chapter-a.adoc[]
 								"6..-1": nil,
 							},
 							Location: types.Location{
-								&types.StringElement{
+								types.StringElement{
 									Content: "includes/chapter-a.adoc",
 								},
 							},
@@ -1239,14 +1239,14 @@ include::includes/chapter-a.adoc[]
 
 			It("file inclusion with invalid unquoted range - case 3", func() {
 				source := `include::includes/chapter-a.adoc[lines=foo]` // using commas instead of semi-colons
-				expected := &types.PreflightDocument{
+				expected := types.PreflightDocument{
 					Blocks: []interface{}{
-						&types.FileInclusion{
+						types.FileInclusion{
 							Attributes: types.ElementAttributes{
 								types.AttrLineRanges: "foo",
 							},
 							Location: types.Location{
-								&types.StringElement{
+								types.StringElement{
 									Content: "includes/chapter-a.adoc",
 								},
 							},
@@ -1262,16 +1262,16 @@ include::includes/chapter-a.adoc[]
 
 			It("file inclusion with single quoted line", func() {
 				source := `include::includes/chapter-a.adoc[lines="1"]`
-				expected := &types.PreflightDocument{
+				expected := types.PreflightDocument{
 					Blocks: []interface{}{
-						&types.FileInclusion{
+						types.FileInclusion{
 							Attributes: types.ElementAttributes{
 								types.AttrLineRanges: types.LineRanges{
 									{Start: 1, End: 1},
 								},
 							},
 							Location: types.Location{
-								&types.StringElement{
+								types.StringElement{
 									Content: "includes/chapter-a.adoc",
 								},
 							},
@@ -1284,16 +1284,16 @@ include::includes/chapter-a.adoc[]
 
 			It("file inclusion with multiple quoted lines", func() {
 				source := `include::includes/chapter-a.adoc[lines="1..2"]`
-				expected := &types.PreflightDocument{
+				expected := types.PreflightDocument{
 					Blocks: []interface{}{
-						&types.FileInclusion{
+						types.FileInclusion{
 							Attributes: types.ElementAttributes{
 								types.AttrLineRanges: types.LineRanges{
 									{Start: 1, End: 2},
 								},
 							},
 							Location: types.Location{
-								&types.StringElement{
+								types.StringElement{
 									Content: "includes/chapter-a.adoc",
 								},
 							},
@@ -1306,9 +1306,9 @@ include::includes/chapter-a.adoc[]
 
 			It("file inclusion with multiple quoted ranges", func() {
 				source := `include::includes/chapter-a.adoc[lines="1,3..4,6..-1"]`
-				expected := &types.PreflightDocument{
+				expected := types.PreflightDocument{
 					Blocks: []interface{}{
-						&types.FileInclusion{
+						types.FileInclusion{
 							Attributes: types.ElementAttributes{
 								types.AttrLineRanges: types.LineRanges{
 									{Start: 1, End: 1},
@@ -1317,7 +1317,7 @@ include::includes/chapter-a.adoc[]
 								},
 							},
 							Location: types.Location{
-								&types.StringElement{
+								types.StringElement{
 									Content: "includes/chapter-a.adoc",
 								},
 							},
@@ -1330,16 +1330,16 @@ include::includes/chapter-a.adoc[]
 
 			It("file inclusion with invalid quoted range - case 1", func() {
 				source := `include::includes/chapter-a.adoc[lines="1,3..4,6..foo"]` // not a number
-				expected := &types.PreflightDocument{
+				expected := types.PreflightDocument{
 					Blocks: []interface{}{
-						&types.FileInclusion{
+						types.FileInclusion{
 							Attributes: types.ElementAttributes{
 								types.AttrLineRanges: `"1`, // viewed as a string
 								"3..4":               nil,
 								"6..foo":             nil,
 							},
 							Location: types.Location{
-								&types.StringElement{
+								types.StringElement{
 									Content: "includes/chapter-a.adoc",
 								},
 							},
@@ -1352,14 +1352,14 @@ include::includes/chapter-a.adoc[]
 
 			It("file inclusion with invalid quoted range - case 2", func() {
 				source := `include::includes/chapter-a.adoc[lines="1;3..4;6..10"]` // using semi-colons instead of commas
-				expected := &types.PreflightDocument{
+				expected := types.PreflightDocument{
 					Blocks: []interface{}{
-						&types.FileInclusion{
+						types.FileInclusion{
 							Attributes: types.ElementAttributes{
 								types.AttrLineRanges: `"1;3..4;6..10"`,
 							},
 							Location: types.Location{
-								&types.StringElement{
+								types.StringElement{
 									Content: "includes/chapter-a.adoc",
 								},
 							},

--- a/pkg/parser/footnote_test.go
+++ b/pkg/parser/footnote_test.go
@@ -21,21 +21,21 @@ var _ = Describe("footnotes - preflight", func() {
 			footnote1 := types.Footnote{
 				ID: 0,
 				Elements: types.InlineElements{
-					&types.StringElement{
+					types.StringElement{
 						Content: footnoteContent,
 					},
 				},
 			}
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "foo ",
 								},
-								&footnote1,
+								footnote1,
 							},
 						},
 					},
@@ -49,46 +49,46 @@ var _ = Describe("footnotes - preflight", func() {
 			footnote1 := types.Footnote{
 				ID: 0,
 				Elements: types.InlineElements{
-					&types.StringElement{
+					types.StringElement{
 						Content: "some ",
 					},
-					&types.QuotedText{
+					types.QuotedText{
 						Kind: types.Bold,
 						Elements: types.InlineElements{
-							&types.StringElement{
+							types.StringElement{
 								Content: "rich",
 							},
 						},
 					},
-					&types.StringElement{
+					types.StringElement{
 						Content: " ",
 					},
-					&types.InlineLink{
+					types.InlineLink{
 						Attributes: types.ElementAttributes{
 							types.AttrInlineLinkText: types.InlineElements{
-								&types.StringElement{
+								types.StringElement{
 									Content: "content",
 								},
 							},
 						},
 						Location: types.Location{
-							&types.StringElement{
+							types.StringElement{
 								Content: "https://foo.com",
 							},
 						},
 					},
 				},
 			}
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "foo ",
 								},
-								&footnote1,
+								footnote1,
 							},
 						},
 					},
@@ -99,19 +99,19 @@ var _ = Describe("footnotes - preflight", func() {
 
 		It("footnote in a paragraph", func() {
 			source := `This is another paragraph.footnote:[I am footnote text and will be displayed at the bottom of the article.]`
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "This is another paragraph.",
 								},
-								&types.Footnote{
+								types.Footnote{
 									ID: 0,
 									Elements: types.InlineElements{
-										&types.StringElement{
+										types.StringElement{
 											Content: "I am footnote text and will be displayed at the bottom of the article.",
 										},
 									},
@@ -136,7 +136,7 @@ var _ = Describe("footnotes - preflight", func() {
 				ID:  0,
 				Ref: footnoteRef,
 				Elements: types.InlineElements{
-					&types.StringElement{
+					types.StringElement{
 						Content: footnoteContent,
 					},
 				},
@@ -146,21 +146,21 @@ var _ = Describe("footnotes - preflight", func() {
 				Ref:      footnoteRef,
 				Elements: types.InlineElements{},
 			}
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "foo ",
 								},
-								&footnote1,
-								&types.StringElement{
+								footnote1,
+								types.StringElement{
 									Content: " and ",
 								},
-								&footnote2,
-								&types.StringElement{
+								footnote2,
+								types.StringElement{
 									Content: " again",
 								},
 							},
@@ -180,7 +180,7 @@ var _ = Describe("footnotes - preflight", func() {
 				ID:  0,
 				Ref: footnoteRef1,
 				Elements: types.InlineElements{
-					&types.StringElement{
+					types.StringElement{
 						Content: footnoteContent,
 					},
 				},
@@ -190,21 +190,21 @@ var _ = Describe("footnotes - preflight", func() {
 				Ref:      footnoteRef2,
 				Elements: types.InlineElements{},
 			}
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "foo ",
 								},
-								&footnote1,
-								&types.StringElement{
+								footnote1,
+								types.StringElement{
 									Content: " and ",
 								},
-								&footnote2,
-								&types.StringElement{
+								footnote2,
+								types.StringElement{
 									Content: " again",
 								},
 							},
@@ -229,7 +229,7 @@ a paragraph with another footnote:[baz]`
 		footnote1 := types.Footnote{
 			ID: 0,
 			Elements: types.InlineElements{
-				&types.StringElement{
+				types.StringElement{
 					Content: "foo",
 				},
 			},
@@ -237,7 +237,7 @@ a paragraph with another footnote:[baz]`
 		footnote2 := types.Footnote{
 			ID: 1,
 			Elements: types.InlineElements{
-				&types.StringElement{
+				types.StringElement{
 					Content: "bar",
 				},
 			},
@@ -245,25 +245,25 @@ a paragraph with another footnote:[baz]`
 		footnote3 := types.Footnote{
 			ID: 2,
 			Elements: types.InlineElements{
-				&types.StringElement{
+				types.StringElement{
 					Content: "baz",
 				},
 			},
 		}
 		docTitle := types.InlineElements{
-			&types.StringElement{
+			types.StringElement{
 				Content: "title",
 			},
 		}
 		section1Title := types.InlineElements{
-			&types.StringElement{
+			types.StringElement{
 				Content: "section 1 ",
 			},
-			&footnote2,
+			footnote2,
 		}
-		expected := &types.PreflightDocument{
+		expected := types.PreflightDocument{
 			Blocks: []interface{}{
-				&types.Section{
+				types.Section{
 					Level: 0,
 					Title: docTitle,
 					Attributes: types.ElementAttributes{
@@ -273,24 +273,24 @@ a paragraph with another footnote:[baz]`
 
 					Elements: []interface{}{},
 				},
-				&types.DocumentAttributeDeclaration{
+				types.DocumentAttributeDeclaration{
 					Name:  "idprefix",
 					Value: "id_",
 				},
-				&types.BlankLine{},
-				&types.Paragraph{
+				types.BlankLine{},
+				types.Paragraph{
 					Attributes: types.ElementAttributes{},
 					Lines: []types.InlineElements{
 						{
-							&types.StringElement{
+							types.StringElement{
 								Content: "a premable with a ",
 							},
-							&footnote1,
+							footnote1,
 						},
 					},
 				},
-				&types.BlankLine{},
-				&types.Section{
+				types.BlankLine{},
+				types.Section{
 					Attributes: types.ElementAttributes{
 						types.AttrID:       "section_1",
 						types.AttrCustomID: false,
@@ -299,15 +299,15 @@ a paragraph with another footnote:[baz]`
 					Title:    section1Title,
 					Elements: []interface{}{},
 				},
-				&types.BlankLine{},
-				&types.Paragraph{
+				types.BlankLine{},
+				types.Paragraph{
 					Attributes: types.ElementAttributes{},
 					Lines: []types.InlineElements{
 						{
-							&types.StringElement{
+							types.StringElement{
 								Content: "a paragraph with another ",
 							},
-							&footnote3,
+							footnote3,
 						},
 					},
 				},
@@ -331,27 +331,27 @@ var _ = Describe("footnotes - document", func() {
 			footnote1 := types.Footnote{
 				ID: 0,
 				Elements: types.InlineElements{
-					&types.StringElement{
+					types.StringElement{
 						Content: footnoteContent,
 					},
 				},
 			}
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:        types.DocumentAttributes{},
 				ElementReferences: types.ElementReferences{},
-				Footnotes: []*types.Footnote{
-					&footnote1,
+				Footnotes: []types.Footnote{
+					footnote1,
 				},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "foo ",
 								},
-								&footnote1,
+								footnote1,
 							},
 						},
 					},
@@ -365,52 +365,52 @@ var _ = Describe("footnotes - document", func() {
 			footnote1 := types.Footnote{
 				ID: 0,
 				Elements: types.InlineElements{
-					&types.StringElement{
+					types.StringElement{
 						Content: "some ",
 					},
-					&types.QuotedText{
+					types.QuotedText{
 						Kind: types.Bold,
 						Elements: types.InlineElements{
-							&types.StringElement{
+							types.StringElement{
 								Content: "rich",
 							},
 						},
 					},
-					&types.StringElement{
+					types.StringElement{
 						Content: " ",
 					},
-					&types.InlineLink{
+					types.InlineLink{
 						Attributes: types.ElementAttributes{
 							types.AttrInlineLinkText: types.InlineElements{
-								&types.StringElement{
+								types.StringElement{
 									Content: "content",
 								},
 							},
 						},
 						Location: types.Location{
-							&types.StringElement{
+							types.StringElement{
 								Content: "https://foo.com",
 							},
 						},
 					},
 				},
 			}
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:        types.DocumentAttributes{},
 				ElementReferences: types.ElementReferences{},
-				Footnotes: []*types.Footnote{
-					&footnote1,
+				Footnotes: []types.Footnote{
+					footnote1,
 				},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "foo ",
 								},
-								&footnote1,
+								footnote1,
 							},
 						},
 					},
@@ -424,27 +424,27 @@ var _ = Describe("footnotes - document", func() {
 			footnote1 := types.Footnote{
 				ID: 0,
 				Elements: types.InlineElements{
-					&types.StringElement{
+					types.StringElement{
 						Content: "I am footnote text and will be displayed at the bottom of the article.",
 					},
 				},
 			}
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:        types.DocumentAttributes{},
 				ElementReferences: types.ElementReferences{},
-				Footnotes: []*types.Footnote{
-					&footnote1,
+				Footnotes: []types.Footnote{
+					footnote1,
 				},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "This is another paragraph.",
 								},
-								&footnote1,
+								footnote1,
 							},
 						},
 					},
@@ -465,7 +465,7 @@ var _ = Describe("footnotes - document", func() {
 				ID:  0,
 				Ref: footnoteRef,
 				Elements: types.InlineElements{
-					&types.StringElement{
+					types.StringElement{
 						Content: footnoteContent,
 					},
 				},
@@ -475,29 +475,29 @@ var _ = Describe("footnotes - document", func() {
 				Ref:      footnoteRef,
 				Elements: types.InlineElements{},
 			}
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:        types.DocumentAttributes{},
 				ElementReferences: types.ElementReferences{},
 				Footnotes: types.Footnotes{
-					&footnote1,
+					footnote1,
 				},
 				FootnoteReferences: types.FootnoteReferences{
-					"ref": &footnote1,
+					"ref": footnote1,
 				},
 				Elements: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "foo ",
 								},
-								&footnote1,
-								&types.StringElement{
+								footnote1,
+								types.StringElement{
 									Content: " and ",
 								},
-								&footnote2,
-								&types.StringElement{
+								footnote2,
+								types.StringElement{
 									Content: " again",
 								},
 							},
@@ -517,7 +517,7 @@ var _ = Describe("footnotes - document", func() {
 				ID:  0,
 				Ref: footnoteRef1,
 				Elements: types.InlineElements{
-					&types.StringElement{
+					types.StringElement{
 						Content: footnoteContent,
 					},
 				},
@@ -527,29 +527,29 @@ var _ = Describe("footnotes - document", func() {
 				Ref:      footnoteRef2,
 				Elements: types.InlineElements{},
 			}
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:        types.DocumentAttributes{},
 				ElementReferences: types.ElementReferences{},
 				Footnotes: types.Footnotes{
-					&footnote1,
+					footnote1,
 				},
 				FootnoteReferences: types.FootnoteReferences{
-					"ref": &footnote1,
+					"ref": footnote1,
 				},
 				Elements: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "foo ",
 								},
-								&footnote1,
-								&types.StringElement{
+								footnote1,
+								types.StringElement{
 									Content: " and ",
 								},
-								&footnote2,
-								&types.StringElement{
+								footnote2,
+								types.StringElement{
 									Content: " again",
 								},
 							},
@@ -574,7 +574,7 @@ a paragraph with another footnote:[baz]`
 		footnote1 := types.Footnote{
 			ID: 0,
 			Elements: types.InlineElements{
-				&types.StringElement{
+				types.StringElement{
 					Content: "foo",
 				},
 			},
@@ -582,7 +582,7 @@ a paragraph with another footnote:[baz]`
 		footnote2 := types.Footnote{
 			ID: 1,
 			Elements: types.InlineElements{
-				&types.StringElement{
+				types.StringElement{
 					Content: "bar",
 				},
 			},
@@ -590,36 +590,36 @@ a paragraph with another footnote:[baz]`
 		footnote3 := types.Footnote{
 			ID: 2,
 			Elements: types.InlineElements{
-				&types.StringElement{
+				types.StringElement{
 					Content: "baz",
 				},
 			},
 		}
 		docTitle := types.InlineElements{
-			&types.StringElement{
+			types.StringElement{
 				Content: "title",
 			},
 		}
 		section1Title := types.InlineElements{
-			&types.StringElement{
+			types.StringElement{
 				Content: "section 1 ",
 			},
-			&footnote2,
+			footnote2,
 		}
-		expected := &types.Document{
+		expected := types.Document{
 			Attributes: types.DocumentAttributes{},
 			ElementReferences: types.ElementReferences{
 				"title":     docTitle,
 				"section_1": section1Title,
 			},
 			Footnotes: types.Footnotes{
-				&footnote1,
-				&footnote2,
-				&footnote3,
+				footnote1,
+				footnote2,
+				footnote3,
 			},
 			FootnoteReferences: types.FootnoteReferences{},
 			Elements: []interface{}{
-				&types.Section{
+				types.Section{
 					Level: 0,
 					Title: docTitle,
 					Attributes: types.ElementAttributes{
@@ -627,22 +627,22 @@ a paragraph with another footnote:[baz]`
 						types.AttrCustomID: false,
 					},
 					Elements: []interface{}{
-						&types.DocumentAttributeDeclaration{
+						types.DocumentAttributeDeclaration{
 							Name:  "idprefix",
 							Value: "id_",
 						},
-						&types.Paragraph{
+						types.Paragraph{
 							Attributes: types.ElementAttributes{},
 							Lines: []types.InlineElements{
 								{
-									&types.StringElement{
+									types.StringElement{
 										Content: "a premable with a ",
 									},
-									&footnote1,
+									footnote1,
 								},
 							},
 						},
-						&types.Section{
+						types.Section{
 							Attributes: types.ElementAttributes{
 								types.AttrID:       "section_1",
 								types.AttrCustomID: false,
@@ -650,14 +650,14 @@ a paragraph with another footnote:[baz]`
 							Level: 1,
 							Title: section1Title,
 							Elements: []interface{}{
-								&types.Paragraph{
+								types.Paragraph{
 									Attributes: types.ElementAttributes{},
 									Lines: []types.InlineElements{
 										{
-											&types.StringElement{
+											types.StringElement{
 												Content: "a paragraph with another ",
 											},
-											&footnote3,
+											footnote3,
 										},
 									},
 								},

--- a/pkg/parser/frontmatter_test.go
+++ b/pkg/parser/frontmatter_test.go
@@ -16,20 +16,20 @@ author: Xavier
 ---
 
 first paragraph`
-			expected := &types.PreflightDocument{
-				FrontMatter: &types.FrontMatter{
+			expected := types.PreflightDocument{
+				FrontMatter: types.FrontMatter{
 					Content: map[string]interface{}{
 						"title":  "a title",
 						"author": "Xavier",
 					},
 				},
 				Blocks: []interface{}{
-					&types.BlankLine{},
-					&types.Paragraph{
+					types.BlankLine{},
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: "first paragraph"},
+								types.StringElement{Content: "first paragraph"},
 							},
 						},
 					},
@@ -43,17 +43,17 @@ first paragraph`
 ---
 
 first paragraph`
-			expected := &types.PreflightDocument{
-				FrontMatter: &types.FrontMatter{
+			expected := types.PreflightDocument{
+				FrontMatter: types.FrontMatter{
 					Content: map[string]interface{}{},
 				},
 				Blocks: []interface{}{
-					&types.BlankLine{},
-					&types.Paragraph{
+					types.BlankLine{},
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: "first paragraph"},
+								types.StringElement{Content: "first paragraph"},
 							},
 						},
 					},
@@ -76,7 +76,7 @@ author: Xavier
 ---
 
 first paragraph`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes: types.DocumentAttributes{
 					"title":  "a title", // TODO: convert `title` attribute from front-matter into `doctitle` here ?
 					"author": "Xavier",
@@ -85,11 +85,11 @@ first paragraph`
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: "first paragraph"},
+								types.StringElement{Content: "first paragraph"},
 							},
 						},
 					},
@@ -103,17 +103,17 @@ first paragraph`
 ---
 
 first paragraph`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: "first paragraph"},
+								types.StringElement{Content: "first paragraph"},
 							},
 						},
 					},

--- a/pkg/parser/image_test.go
+++ b/pkg/parser/image_test.go
@@ -13,7 +13,7 @@ var _ = Describe("images", func() {
 
 			It("block image with empty alt", func() {
 				source := "image::images/foo.png[]"
-				expected := &types.ImageBlock{
+				expected := types.ImageBlock{
 					Attributes: types.ElementAttributes{
 						types.AttrImageAlt: "foo",
 					},
@@ -24,7 +24,7 @@ var _ = Describe("images", func() {
 
 			It("block image with empty alt and trailing spaces", func() {
 				source := "image::images/foo.png[]  \t\t  "
-				expected := &types.ImageBlock{
+				expected := types.ImageBlock{
 					Attributes: types.ElementAttributes{
 						types.AttrImageAlt: "foo",
 					},
@@ -37,7 +37,7 @@ var _ = Describe("images", func() {
 				// line return here is not considered as a blank line
 				source := `image::images/foo.png[]
 `
-				expected := &types.ImageBlock{
+				expected := types.ImageBlock{
 					Attributes: types.ElementAttributes{
 						types.AttrImageAlt: "foo",
 					},
@@ -50,7 +50,7 @@ var _ = Describe("images", func() {
 				// here, there's a real blank line with some spaces
 				source := `image::images/foo.png[]
   `
-				expected := &types.ImageBlock{
+				expected := types.ImageBlock{
 					Attributes: types.ElementAttributes{
 						types.AttrImageAlt: "foo",
 					},
@@ -62,7 +62,7 @@ var _ = Describe("images", func() {
 			It("block image with 2 blank lines with spaces and tabs", func() {
 				source := `image::images/foo.png[]
 			`
-				expected := &types.ImageBlock{
+				expected := types.ImageBlock{
 					Attributes: types.ElementAttributes{
 						types.AttrImageAlt: "foo",
 					},
@@ -73,7 +73,7 @@ var _ = Describe("images", func() {
 
 			It("block image with alt", func() {
 				source := `image::images/foo.png[the foo.png image]`
-				expected := &types.ImageBlock{
+				expected := types.ImageBlock{
 					Attributes: types.ElementAttributes{
 						types.AttrImageAlt: "the foo.png image",
 					},
@@ -87,7 +87,7 @@ var _ = Describe("images", func() {
 .A title to foobar
 [link=http://foo.bar]
 image::images/foo.png[the foo.png image, 600, 400]`
-				expected := &types.ImageBlock{
+				expected := types.ImageBlock{
 					Attributes: types.ElementAttributes{
 						types.AttrID:          "img-foobar",
 						types.AttrCustomID:    true,
@@ -105,15 +105,15 @@ image::images/foo.png[the foo.png image, 600, 400]`
 			It("2 block images", func() {
 				source := `image::app.png[]
 image::appa.png[]`
-				expected := &types.PreflightDocument{
+				expected := types.PreflightDocument{
 					Blocks: []interface{}{
-						&types.ImageBlock{
+						types.ImageBlock{
 							Attributes: types.ElementAttributes{
 								types.AttrImageAlt: "app",
 							},
 							Path: "app.png",
 						},
-						&types.ImageBlock{
+						types.ImageBlock{
 							Attributes: types.ElementAttributes{
 								types.AttrImageAlt: "appa",
 							},
@@ -131,14 +131,14 @@ image::appa.png[]`
 
 				It("block image appending inline content", func() {
 					source := "a paragraph\nimage::images/foo.png[]"
-					expected := &types.Paragraph{
+					expected := types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: "a paragraph"},
+								types.StringElement{Content: "a paragraph"},
 							},
 							{
-								&types.StringElement{Content: "image::images/foo.png[]"},
+								types.StringElement{Content: "image::images/foo.png[]"},
 							},
 						},
 					}
@@ -150,13 +150,13 @@ image::appa.png[]`
 
 				It("paragraph with block image with alt and dimensions", func() {
 					source := "a foo image::foo.png[foo image, 600, 400] bar"
-					expected := &types.PreflightDocument{
+					expected := types.PreflightDocument{
 						Blocks: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "a foo image::foo.png[foo image, 600, 400] bar"},
+										types.StringElement{Content: "a foo image::foo.png[foo image, 600, 400] bar"},
 									},
 								},
 							},
@@ -174,11 +174,11 @@ image::appa.png[]`
 
 			It("inline image with empty alt only", func() {
 				source := "image:images/foo.png[]"
-				expected := &types.Paragraph{
+				expected := types.Paragraph{
 					Attributes: types.ElementAttributes{},
 					Lines: []types.InlineElements{
 						{
-							&types.InlineImage{
+							types.InlineImage{
 								Attributes: types.ElementAttributes{
 									types.AttrImageAlt: "foo",
 								},
@@ -192,17 +192,17 @@ image::appa.png[]`
 
 			It("inline image with empty alt and trailing spaces", func() {
 				source := "image:images/foo.png[]  \t\t  "
-				expected := &types.Paragraph{
+				expected := types.Paragraph{
 					Attributes: types.ElementAttributes{},
 					Lines: []types.InlineElements{
 						{
-							&types.InlineImage{
+							types.InlineImage{
 								Attributes: types.ElementAttributes{
 									types.AttrImageAlt: "foo",
 								},
 								Path: "images/foo.png",
 							},
-							&types.StringElement{
+							types.StringElement{
 								Content: "  \t\t  ",
 							},
 						},
@@ -213,20 +213,20 @@ image::appa.png[]`
 
 			It("inline image surrounded with test", func() {
 				source := "a foo image:images/foo.png[] bar..."
-				expected := &types.Paragraph{
+				expected := types.Paragraph{
 					Attributes: types.ElementAttributes{},
 					Lines: []types.InlineElements{
 						{
-							&types.StringElement{
+							types.StringElement{
 								Content: "a foo ",
 							},
-							&types.InlineImage{
+							types.InlineImage{
 								Attributes: types.ElementAttributes{
 									types.AttrImageAlt: "foo",
 								},
 								Path: "images/foo.png",
 							},
-							&types.StringElement{
+							types.StringElement{
 								Content: " bar...",
 							},
 						},
@@ -237,11 +237,11 @@ image::appa.png[]`
 
 			It("inline image with alt alone", func() {
 				source := "image:images/foo.png[the foo.png image]"
-				expected := &types.Paragraph{
+				expected := types.Paragraph{
 					Attributes: types.ElementAttributes{},
 					Lines: []types.InlineElements{
 						{
-							&types.InlineImage{
+							types.InlineImage{
 								Attributes: types.ElementAttributes{
 									types.AttrImageAlt: "the foo.png image",
 								},
@@ -255,11 +255,11 @@ image::appa.png[]`
 
 			It("inline image with alt and width", func() {
 				source := "image:images/foo.png[the foo.png image, 600]"
-				expected := &types.Paragraph{
+				expected := types.Paragraph{
 					Attributes: types.ElementAttributes{},
 					Lines: []types.InlineElements{
 						{
-							&types.InlineImage{
+							types.InlineImage{
 								Attributes: types.ElementAttributes{
 									types.AttrImageAlt:   "the foo.png image",
 									types.AttrImageWidth: "600",
@@ -274,11 +274,11 @@ image::appa.png[]`
 
 			It("inline image with alt, width and height", func() {
 				source := "image:images/foo.png[the foo.png image, 600, 400]"
-				expected := &types.Paragraph{
+				expected := types.Paragraph{
 					Attributes: types.ElementAttributes{},
 					Lines: []types.InlineElements{
 						{
-							&types.InlineImage{
+							types.InlineImage{
 								Attributes: types.ElementAttributes{
 									types.AttrImageAlt:    "the foo.png image",
 									types.AttrImageWidth:  "600",
@@ -294,11 +294,11 @@ image::appa.png[]`
 
 			It("inline image with alt, but empty width and height", func() {
 				source := "image:images/foo.png[the foo.png image, , ]"
-				expected := &types.Paragraph{
+				expected := types.Paragraph{
 					Attributes: types.ElementAttributes{},
 					Lines: []types.InlineElements{
 						{
-							&types.InlineImage{
+							types.InlineImage{
 								Attributes: types.ElementAttributes{
 									types.AttrImageAlt: "the foo.png image",
 								},
@@ -312,11 +312,11 @@ image::appa.png[]`
 
 			It("inline image with single other attribute only", func() {
 				source := "image:images/foo.png[id=myid]"
-				expected := &types.Paragraph{
+				expected := types.Paragraph{
 					Attributes: types.ElementAttributes{},
 					Lines: []types.InlineElements{
 						{
-							&types.InlineImage{
+							types.InlineImage{
 								Attributes: types.ElementAttributes{
 									types.AttrImageAlt: "foo", // based on filename
 									types.AttrID:       "myid",
@@ -332,11 +332,11 @@ image::appa.png[]`
 
 			It("inline image with multiple other attributes only", func() {
 				source := "image:images/foo.png[id=myid, title= mytitle, role = myrole ]"
-				expected := &types.Paragraph{
+				expected := types.Paragraph{
 					Attributes: types.ElementAttributes{},
 					Lines: []types.InlineElements{
 						{
-							&types.InlineImage{
+							types.InlineImage{
 								Attributes: types.ElementAttributes{
 									types.AttrImageAlt: "foo", // based on filename
 									types.AttrID:       "myid",
@@ -354,11 +354,11 @@ image::appa.png[]`
 
 			It("inline image with alt, width, height and other attributes", func() {
 				source := "image:images/foo.png[ foo, 600, 400, id=myid, title=mytitle, role=myrole ]"
-				expected := &types.Paragraph{
+				expected := types.Paragraph{
 					Attributes: types.ElementAttributes{},
 					Lines: []types.InlineElements{
 						{
-							&types.InlineImage{
+							types.InlineImage{
 								Attributes: types.ElementAttributes{
 									types.AttrImageAlt:    "foo",
 									types.AttrImageWidth:  "600",
@@ -378,14 +378,14 @@ image::appa.png[]`
 
 			It("inline image in a paragraph with space after colon", func() {
 				source := "this is an image: image:images/foo.png[]"
-				expected := &types.Paragraph{
+				expected := types.Paragraph{
 					Attributes: types.ElementAttributes{},
 					Lines: []types.InlineElements{
 						{
-							&types.StringElement{
+							types.StringElement{
 								Content: "this is an image: ",
 							},
-							&types.InlineImage{
+							types.InlineImage{
 								Attributes: types.ElementAttributes{
 									types.AttrImageAlt: "foo",
 								},
@@ -399,14 +399,14 @@ image::appa.png[]`
 
 			It("inline image in a paragraph without space keyword", func() {
 				source := "this is an inline.image:images/foo.png[]"
-				expected := &types.Paragraph{
+				expected := types.Paragraph{
 					Attributes: types.ElementAttributes{},
 					Lines: []types.InlineElements{
 						{
-							&types.StringElement{
+							types.StringElement{
 								Content: "this is an inline.",
 							},
-							&types.InlineImage{
+							types.InlineImage{
 								Attributes: types.ElementAttributes{
 									types.AttrImageAlt: "foo",
 								},
@@ -422,14 +422,14 @@ image::appa.png[]`
 		Context("errors", func() {
 			It("inline image appending inline content", func() {
 				source := "a paragraph\nimage::images/foo.png[]"
-				expected := &types.Paragraph{
+				expected := types.Paragraph{
 					Attributes: types.ElementAttributes{},
 					Lines: []types.InlineElements{
 						{
-							&types.StringElement{Content: "a paragraph"},
+							types.StringElement{Content: "a paragraph"},
 						},
 						{
-							&types.StringElement{Content: "image::images/foo.png[]"},
+							types.StringElement{Content: "image::images/foo.png[]"},
 						},
 					},
 				}

--- a/pkg/parser/inline_elements_test.go
+++ b/pkg/parser/inline_elements_test.go
@@ -9,14 +9,14 @@ var _ = Describe("inline elements", func() {
 
 	It("bold text without parenthesis", func() {
 		source := "*some bold content*"
-		expected := &types.Paragraph{
+		expected := types.Paragraph{
 			Attributes: types.ElementAttributes{},
 			Lines: []types.InlineElements{
 				{
-					&types.QuotedText{
+					types.QuotedText{
 						Kind: types.Bold,
 						Elements: types.InlineElements{
-							&types.StringElement{Content: "some bold content"},
+							types.StringElement{Content: "some bold content"},
 						},
 					},
 				},
@@ -27,18 +27,18 @@ var _ = Describe("inline elements", func() {
 
 	It("bold text within parenthesis", func() {
 		source := "(*some bold content*)"
-		expected := &types.Paragraph{
+		expected := types.Paragraph{
 			Attributes: types.ElementAttributes{},
 			Lines: []types.InlineElements{
 				{
-					&types.StringElement{Content: "("},
-					&types.QuotedText{
+					types.StringElement{Content: "("},
+					types.QuotedText{
 						Kind: types.Bold,
 						Elements: types.InlineElements{
-							&types.StringElement{Content: "some bold content"},
+							types.StringElement{Content: "some bold content"},
 						},
 					},
-					&types.StringElement{Content: ")"},
+					types.StringElement{Content: ")"},
 				},
 			},
 		}
@@ -47,11 +47,11 @@ var _ = Describe("inline elements", func() {
 
 	It("bold text within words", func() {
 		source := "some*bold*content"
-		expected := &types.Paragraph{
+		expected := types.Paragraph{
 			Attributes: types.ElementAttributes{},
 			Lines: []types.InlineElements{
 				{
-					&types.StringElement{Content: "some*bold*content"},
+					types.StringElement{Content: "some*bold*content"},
 				},
 			},
 		}
@@ -60,11 +60,11 @@ var _ = Describe("inline elements", func() {
 
 	It("invalid bold portion of text", func() {
 		source := "*foo*bar"
-		expected := &types.Paragraph{
+		expected := types.Paragraph{
 			Attributes: types.ElementAttributes{},
 			Lines: []types.InlineElements{
 				{
-					&types.StringElement{Content: "*foo*bar"},
+					types.StringElement{Content: "*foo*bar"},
 				},
 			},
 		}
@@ -73,17 +73,17 @@ var _ = Describe("inline elements", func() {
 
 	It("valid bold portion of text", func() {
 		source := "**foo**bar"
-		expected := &types.Paragraph{
+		expected := types.Paragraph{
 			Attributes: types.ElementAttributes{},
 			Lines: []types.InlineElements{
 				{
-					&types.QuotedText{
+					types.QuotedText{
 						Kind: types.Bold,
 						Elements: types.InlineElements{
-							&types.StringElement{Content: "foo"},
+							types.StringElement{Content: "foo"},
 						},
 					},
-					&types.StringElement{Content: "bar"},
+					types.StringElement{Content: "bar"},
 				},
 			},
 		}
@@ -92,11 +92,11 @@ var _ = Describe("inline elements", func() {
 
 	It("latin characters", func() {
 		source := "à bientôt"
-		expected := &types.Paragraph{
+		expected := types.Paragraph{
 			Attributes: types.ElementAttributes{},
 			Lines: []types.InlineElements{
 				{
-					&types.StringElement{Content: "à bientôt"},
+					types.StringElement{Content: "à bientôt"},
 				},
 			},
 		}

--- a/pkg/parser/labeled_list_test.go
+++ b/pkg/parser/labeled_list_test.go
@@ -11,21 +11,21 @@ var _ = Describe("labeled lists - preflight", func() {
 		source := `Item1::
 Item 1 description
 on 2 lines`
-		expected := &types.PreflightDocument{
+		expected := types.PreflightDocument{
 			Blocks: []interface{}{
-				&types.LabeledListItem{
+				types.LabeledListItem{
 					Attributes: types.ElementAttributes{},
 					Level:      1,
 					Term:       "Item1",
 					Elements: []interface{}{
-						&types.Paragraph{
+						types.Paragraph{
 							Attributes: types.ElementAttributes{},
 							Lines: []types.InlineElements{
 								{
-									&types.StringElement{Content: "Item 1 description"},
+									types.StringElement{Content: "Item 1 description"},
 								},
 								{
-									&types.StringElement{Content: "on 2 lines"},
+									types.StringElement{Content: "on 2 lines"},
 								},
 							},
 						},
@@ -38,9 +38,9 @@ on 2 lines`
 
 	It("labeled list with a single term and no description", func() {
 		source := `Item1::`
-		expected := &types.PreflightDocument{
+		expected := types.PreflightDocument{
 			Blocks: []interface{}{
-				&types.LabeledListItem{
+				types.LabeledListItem{
 					Attributes: types.ElementAttributes{},
 					Term:       "Item1",
 					Level:      1,
@@ -54,20 +54,20 @@ on 2 lines`
 	It("labeled list with a horizontal layout attribute", func() {
 		source := `[horizontal]
 Item1:: foo`
-		expected := &types.PreflightDocument{
+		expected := types.PreflightDocument{
 			Blocks: []interface{}{
-				&types.LabeledListItem{
+				types.LabeledListItem{
 					Attributes: types.ElementAttributes{
 						"layout": "horizontal",
 					},
 					Level: 1,
 					Term:  "Item1",
 					Elements: []interface{}{
-						&types.Paragraph{
+						types.Paragraph{
 							Attributes: types.ElementAttributes{},
 							Lines: []types.InlineElements{
 								{
-									&types.StringElement{Content: "foo"},
+									types.StringElement{Content: "foo"},
 								},
 							},
 						},
@@ -81,9 +81,9 @@ Item1:: foo`
 	It("labeled list with a single term and a blank line", func() {
 		source := `Item1::
 			`
-		expected := &types.PreflightDocument{
+		expected := types.PreflightDocument{
 			Blocks: []interface{}{
-				&types.LabeledListItem{
+				types.LabeledListItem{
 					Attributes: types.ElementAttributes{},
 					Level:      1,
 					Term:       "Item1",
@@ -101,48 +101,48 @@ Item 2::
 Item 2 description
 Item 3:: 
 Item 3 description`
-		expected := &types.PreflightDocument{
+		expected := types.PreflightDocument{
 			Blocks: []interface{}{
-				&types.LabeledListItem{
+				types.LabeledListItem{
 					Attributes: types.ElementAttributes{},
 					Level:      1,
 					Term:       "Item 1",
 					Elements: []interface{}{
-						&types.Paragraph{
+						types.Paragraph{
 							Attributes: types.ElementAttributes{},
 							Lines: []types.InlineElements{
 								{
-									&types.StringElement{Content: "Item 1 description"},
+									types.StringElement{Content: "Item 1 description"},
 								},
 							},
 						},
 					},
 				},
-				&types.LabeledListItem{
+				types.LabeledListItem{
 					Attributes: types.ElementAttributes{},
 					Level:      1,
 					Term:       "Item 2",
 					Elements: []interface{}{
-						&types.Paragraph{
+						types.Paragraph{
 							Attributes: types.ElementAttributes{},
 							Lines: []types.InlineElements{
 								{
-									&types.StringElement{Content: "Item 2 description"},
+									types.StringElement{Content: "Item 2 description"},
 								},
 							},
 						},
 					},
 				},
-				&types.LabeledListItem{
+				types.LabeledListItem{
 					Attributes: types.ElementAttributes{},
 					Level:      1,
 					Term:       "Item 3",
 					Elements: []interface{}{
-						&types.Paragraph{
+						types.Paragraph{
 							Attributes: types.ElementAttributes{},
 							Lines: []types.InlineElements{
 								{
-									&types.StringElement{Content: "Item 3 description"},
+									types.StringElement{Content: "Item 3 description"},
 								},
 							},
 						},
@@ -160,48 +160,48 @@ Item 2:::
 Item 2 description
 Item 3::::
 Item 3 description`
-		expected := &types.PreflightDocument{
+		expected := types.PreflightDocument{
 			Blocks: []interface{}{
-				&types.LabeledListItem{
+				types.LabeledListItem{
 					Attributes: types.ElementAttributes{},
 					Level:      1,
 					Term:       "Item 1",
 					Elements: []interface{}{
-						&types.Paragraph{
+						types.Paragraph{
 							Attributes: types.ElementAttributes{},
 							Lines: []types.InlineElements{
 								{
-									&types.StringElement{Content: "Item 1 description"},
+									types.StringElement{Content: "Item 1 description"},
 								},
 							},
 						},
 					},
 				},
-				&types.LabeledListItem{
+				types.LabeledListItem{
 					Attributes: types.ElementAttributes{},
 					Level:      2,
 					Term:       "Item 2",
 					Elements: []interface{}{
-						&types.Paragraph{
+						types.Paragraph{
 							Attributes: types.ElementAttributes{},
 							Lines: []types.InlineElements{
 								{
-									&types.StringElement{Content: "Item 2 description"},
+									types.StringElement{Content: "Item 2 description"},
 								},
 							},
 						},
 					},
 				},
-				&types.LabeledListItem{
+				types.LabeledListItem{
 					Attributes: types.ElementAttributes{},
 					Level:      3,
 					Term:       "Item 3",
 					Elements: []interface{}{
-						&types.Paragraph{
+						types.Paragraph{
 							Attributes: types.ElementAttributes{},
 							Lines: []types.InlineElements{
 								{
-									&types.StringElement{Content: "Item 3 description"},
+									types.StringElement{Content: "Item 3 description"},
 								},
 							},
 						},
@@ -217,56 +217,56 @@ Item 3 description`
 * foo
 * bar
 Item with description:: something simple`
-		expected := &types.PreflightDocument{
+		expected := types.PreflightDocument{
 			Blocks: []interface{}{
-				&types.LabeledListItem{
+				types.LabeledListItem{
 					Attributes: types.ElementAttributes{},
 					Level:      1,
 					Term:       "Empty item",
 					Elements:   []interface{}{},
 				},
-				&types.UnorderedListItem{
+				types.UnorderedListItem{
 					Attributes:  types.ElementAttributes{},
 					Level:       1,
 					BulletStyle: types.OneAsterisk,
 					CheckStyle:  types.NoCheck,
 					Elements: []interface{}{
-						&types.Paragraph{
+						types.Paragraph{
 							Attributes: types.ElementAttributes{},
 							Lines: []types.InlineElements{
 								{
-									&types.StringElement{Content: "foo"},
+									types.StringElement{Content: "foo"},
 								},
 							},
 						},
 					},
 				},
-				&types.UnorderedListItem{
+				types.UnorderedListItem{
 					Attributes:  types.ElementAttributes{},
 					Level:       1,
 					BulletStyle: types.OneAsterisk,
 					CheckStyle:  types.NoCheck,
 					Elements: []interface{}{
-						&types.Paragraph{
+						types.Paragraph{
 							Attributes: types.ElementAttributes{},
 							Lines: []types.InlineElements{
 								{
-									&types.StringElement{Content: "bar"},
+									types.StringElement{Content: "bar"},
 								},
 							},
 						},
 					},
 				},
-				&types.LabeledListItem{
+				types.LabeledListItem{
 					Attributes: types.ElementAttributes{},
 					Level:      1,
 					Term:       "Item with description",
 					Elements: []interface{}{
-						&types.Paragraph{
+						types.Paragraph{
 							Attributes: types.ElementAttributes{},
 							Lines: []types.InlineElements{
 								{
-									&types.StringElement{Content: "something simple"},
+									types.StringElement{Content: "something simple"},
 								},
 							},
 						},
@@ -284,32 +284,32 @@ foo
 bar
 
 a normal paragraph.`
-		expected := &types.PreflightDocument{
+		expected := types.PreflightDocument{
 			Blocks: []interface{}{
-				&types.LabeledListItem{
+				types.LabeledListItem{
 					Attributes: types.ElementAttributes{},
 					Level:      1,
 					Term:       "Item 1",
 					Elements: []interface{}{
-						&types.Paragraph{
+						types.Paragraph{
 							Attributes: types.ElementAttributes{},
 							Lines: []types.InlineElements{
 								{
-									&types.StringElement{Content: "foo"},
+									types.StringElement{Content: "foo"},
 								},
 								{
-									&types.StringElement{Content: "bar"},
+									types.StringElement{Content: "bar"},
 								},
 							},
 						},
 					},
 				},
-				&types.BlankLine{},
-				&types.Paragraph{
+				types.BlankLine{},
+				types.Paragraph{
 					Attributes: types.ElementAttributes{},
 					Lines: []types.InlineElements{
 						{
-							&types.StringElement{Content: "a normal paragraph."},
+							types.StringElement{Content: "a normal paragraph."},
 						},
 					},
 				},
@@ -329,26 +329,26 @@ Item 2:: something simple
 ----
 another fenced block
 ----`
-		expected := &types.PreflightDocument{
+		expected := types.PreflightDocument{
 			Blocks: []interface{}{
-				&types.LabeledListItem{
+				types.LabeledListItem{
 					Attributes: types.ElementAttributes{},
 					Level:      1,
 					Term:       "Item 1",
 					Elements:   []interface{}{},
 				},
 				// the `+` continuation produces the element below
-				&types.ContinuedListItemElement{
+				types.ContinuedListItemElement{
 					Offset: 0,
-					Element: &types.DelimitedBlock{
+					Element: types.DelimitedBlock{
 						Attributes: types.ElementAttributes{},
 						Kind:       types.Listing,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "a fenced block",
 										},
 									},
@@ -357,33 +357,33 @@ another fenced block
 						},
 					},
 				},
-				&types.LabeledListItem{
+				types.LabeledListItem{
 					Attributes: types.ElementAttributes{},
 					Level:      1,
 					Term:       "Item 2",
 					Elements: []interface{}{
-						&types.Paragraph{
+						types.Paragraph{
 							Attributes: types.ElementAttributes{},
 							Lines: []types.InlineElements{
 								{
-									&types.StringElement{Content: "something simple"},
+									types.StringElement{Content: "something simple"},
 								},
 							},
 						},
 					},
 				},
 				// the `+` continuation produces the second element below
-				&types.ContinuedListItemElement{
+				types.ContinuedListItemElement{
 					Offset: 0,
-					Element: &types.DelimitedBlock{
+					Element: types.DelimitedBlock{
 						Attributes: types.ElementAttributes{},
 						Kind:       types.Listing,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "another fenced block",
 										},
 									},
@@ -406,23 +406,23 @@ Item 2:: something simple
 ----
 another fenced block
 ----`
-		expected := &types.PreflightDocument{
+		expected := types.PreflightDocument{
 			Blocks: []interface{}{
-				&types.LabeledListItem{
+				types.LabeledListItem{
 					Attributes: types.ElementAttributes{},
 					Level:      1,
 					Term:       "Item 1",
 					Elements:   []interface{}{},
 				},
-				&types.DelimitedBlock{
+				types.DelimitedBlock{
 					Attributes: types.ElementAttributes{},
 					Kind:       types.Listing,
 					Elements: []interface{}{
-						&types.Paragraph{
+						types.Paragraph{
 							Attributes: types.ElementAttributes{},
 							Lines: []types.InlineElements{
 								{
-									&types.StringElement{
+									types.StringElement{
 										Content: "a fenced block",
 									},
 								},
@@ -430,30 +430,30 @@ another fenced block
 						},
 					},
 				},
-				&types.LabeledListItem{
+				types.LabeledListItem{
 					Attributes: types.ElementAttributes{},
 					Level:      1,
 					Term:       "Item 2",
 					Elements: []interface{}{
-						&types.Paragraph{
+						types.Paragraph{
 							Attributes: types.ElementAttributes{},
 							Lines: []types.InlineElements{
 								{
-									&types.StringElement{Content: "something simple"},
+									types.StringElement{Content: "something simple"},
 								},
 							},
 						},
 					},
 				},
-				&types.DelimitedBlock{
+				types.DelimitedBlock{
 					Attributes: types.ElementAttributes{},
 					Kind:       types.Listing,
 					Elements: []interface{}{
-						&types.Paragraph{
+						types.Paragraph{
 							Attributes: types.ElementAttributes{},
 							Lines: []types.InlineElements{
 								{
-									&types.StringElement{
+									types.StringElement{
 										Content: "another fenced block",
 									},
 								},
@@ -469,25 +469,25 @@ another fenced block
 	It("labeled list with nested unordered list - case 2", func() {
 		source := `Labeled item::
 - unordered item`
-		expected := &types.PreflightDocument{
+		expected := types.PreflightDocument{
 			Blocks: []interface{}{
-				&types.LabeledListItem{
+				types.LabeledListItem{
 					Attributes: types.ElementAttributes{},
 					Level:      1,
 					Term:       "Labeled item",
 					Elements:   []interface{}{},
 				},
-				&types.UnorderedListItem{
+				types.UnorderedListItem{
 					Attributes:  types.ElementAttributes{},
 					Level:       1,
 					BulletStyle: types.Dash,
 					CheckStyle:  types.NoCheck,
 					Elements: []interface{}{
-						&types.Paragraph{
+						types.Paragraph{
 							Attributes: types.ElementAttributes{},
 							Lines: []types.InlineElements{
 								{
-									&types.StringElement{Content: "unordered item"},
+									types.StringElement{Content: "unordered item"},
 								},
 							},
 						},
@@ -502,20 +502,20 @@ another fenced block
 		source := `.Labeled, single-line
 first term:: definition of the first term
 second term:: definition of the second term`
-		expected := &types.PreflightDocument{
+		expected := types.PreflightDocument{
 			Blocks: []interface{}{
-				&types.LabeledListItem{
+				types.LabeledListItem{
 					Attributes: types.ElementAttributes{
 						types.AttrTitle: "Labeled, single-line",
 					},
 					Level: 1,
 					Term:  "first term",
 					Elements: []interface{}{
-						&types.Paragraph{
+						types.Paragraph{
 							Attributes: types.ElementAttributes{},
 							Lines: []types.InlineElements{
 								{
-									&types.StringElement{
+									types.StringElement{
 										Content: "definition of the first term",
 									},
 								},
@@ -523,16 +523,16 @@ second term:: definition of the second term`
 						},
 					},
 				},
-				&types.LabeledListItem{
+				types.LabeledListItem{
 					Attributes: types.ElementAttributes{},
 					Level:      1,
 					Term:       "second term",
 					Elements: []interface{}{
-						&types.Paragraph{
+						types.Paragraph{
 							Attributes: types.ElementAttributes{},
 							Lines: []types.InlineElements{
 								{
-									&types.StringElement{
+									types.StringElement{
 										Content: "definition of the second term",
 									},
 								},
@@ -551,20 +551,20 @@ level 1:: description 1
 level 2::: description 2
 level 3:::: description 3
 level 1:: description 1`
-		expected := &types.PreflightDocument{
+		expected := types.PreflightDocument{
 			Blocks: []interface{}{
-				&types.LabeledListItem{
+				types.LabeledListItem{
 					Attributes: types.ElementAttributes{
 						types.AttrTitle: "Labeled, max nesting",
 					},
 					Level: 1,
 					Term:  "level 1",
 					Elements: []interface{}{
-						&types.Paragraph{
+						types.Paragraph{
 							Attributes: types.ElementAttributes{},
 							Lines: []types.InlineElements{
 								{
-									&types.StringElement{
+									types.StringElement{
 										Content: "description 1",
 									},
 								},
@@ -572,16 +572,16 @@ level 1:: description 1`
 						},
 					},
 				},
-				&types.LabeledListItem{
+				types.LabeledListItem{
 					Level:      2,
 					Term:       "level 2",
 					Attributes: types.ElementAttributes{},
 					Elements: []interface{}{
-						&types.Paragraph{
+						types.Paragraph{
 							Attributes: types.ElementAttributes{},
 							Lines: []types.InlineElements{
 								{
-									&types.StringElement{
+									types.StringElement{
 										Content: "description 2",
 									},
 								},
@@ -589,16 +589,16 @@ level 1:: description 1`
 						},
 					},
 				},
-				&types.LabeledListItem{
+				types.LabeledListItem{
 					Level:      3,
 					Term:       "level 3",
 					Attributes: types.ElementAttributes{},
 					Elements: []interface{}{
-						&types.Paragraph{
+						types.Paragraph{
 							Attributes: types.ElementAttributes{},
 							Lines: []types.InlineElements{
 								{
-									&types.StringElement{
+									types.StringElement{
 										Content: "description 3",
 									},
 								},
@@ -606,16 +606,16 @@ level 1:: description 1`
 						},
 					},
 				},
-				&types.LabeledListItem{
+				types.LabeledListItem{
 					Level:      1,
 					Term:       "level 1",
 					Attributes: types.ElementAttributes{},
 					Elements: []interface{}{
-						&types.Paragraph{
+						types.Paragraph{
 							Attributes: types.ElementAttributes{},
 							Lines: []types.InlineElements{
 								{
-									&types.StringElement{
+									types.StringElement{
 										Content: "description 1",
 									},
 								},
@@ -634,20 +634,20 @@ level 1:: description 1
 level 2::: description 2
 level 3:::: description 3
 level 2::: description 2`
-		expected := &types.PreflightDocument{
+		expected := types.PreflightDocument{
 			Blocks: []interface{}{
-				&types.LabeledListItem{
+				types.LabeledListItem{
 					Attributes: types.ElementAttributes{
 						types.AttrTitle: "Labeled, max nesting",
 					},
 					Level: 1,
 					Term:  "level 1",
 					Elements: []interface{}{
-						&types.Paragraph{
+						types.Paragraph{
 							Attributes: types.ElementAttributes{},
 							Lines: []types.InlineElements{
 								{
-									&types.StringElement{
+									types.StringElement{
 										Content: "description 1",
 									},
 								},
@@ -655,16 +655,16 @@ level 2::: description 2`
 						},
 					},
 				},
-				&types.LabeledListItem{
+				types.LabeledListItem{
 					Level:      2,
 					Term:       "level 2",
 					Attributes: types.ElementAttributes{},
 					Elements: []interface{}{
-						&types.Paragraph{
+						types.Paragraph{
 							Attributes: types.ElementAttributes{},
 							Lines: []types.InlineElements{
 								{
-									&types.StringElement{
+									types.StringElement{
 										Content: "description 2",
 									},
 								},
@@ -672,16 +672,16 @@ level 2::: description 2`
 						},
 					},
 				},
-				&types.LabeledListItem{
+				types.LabeledListItem{
 					Level:      3,
 					Term:       "level 3",
 					Attributes: types.ElementAttributes{},
 					Elements: []interface{}{
-						&types.Paragraph{
+						types.Paragraph{
 							Attributes: types.ElementAttributes{},
 							Lines: []types.InlineElements{
 								{
-									&types.StringElement{
+									types.StringElement{
 										Content: "description 3",
 									},
 								},
@@ -689,16 +689,16 @@ level 2::: description 2`
 						},
 					},
 				},
-				&types.LabeledListItem{
+				types.LabeledListItem{
 					Level:      2,
 					Term:       "level 2",
 					Attributes: types.ElementAttributes{},
 					Elements: []interface{}{
-						&types.Paragraph{
+						types.Paragraph{
 							Attributes: types.ElementAttributes{},
 							Lines: []types.InlineElements{
 								{
-									&types.StringElement{
+									types.StringElement{
 										Content: "description 2",
 									},
 								},
@@ -718,28 +718,28 @@ var _ = Describe("labeled lists - document", func() {
 		source := `Item1::
 Item 1 description
 on 2 lines`
-		expected := &types.Document{
+		expected := types.Document{
 			Attributes:         types.DocumentAttributes{},
 			ElementReferences:  types.ElementReferences{},
 			Footnotes:          types.Footnotes{},
 			FootnoteReferences: types.FootnoteReferences{},
 			Elements: []interface{}{
-				&types.LabeledList{
+				types.LabeledList{
 					Attributes: types.ElementAttributes{},
-					Items: []*types.LabeledListItem{
+					Items: []types.LabeledListItem{
 						{
 							Attributes: types.ElementAttributes{},
 							Level:      1,
 							Term:       "Item1",
 							Elements: []interface{}{
-								&types.Paragraph{
+								types.Paragraph{
 									Attributes: types.ElementAttributes{},
 									Lines: []types.InlineElements{
 										{
-											&types.StringElement{Content: "Item 1 description"},
+											types.StringElement{Content: "Item 1 description"},
 										},
 										{
-											&types.StringElement{Content: "on 2 lines"},
+											types.StringElement{Content: "on 2 lines"},
 										},
 									},
 								},
@@ -754,15 +754,15 @@ on 2 lines`
 
 	It("labeled list with a single term and no description", func() {
 		source := `Item1::`
-		expected := &types.Document{
+		expected := types.Document{
 			Attributes:         types.DocumentAttributes{},
 			ElementReferences:  types.ElementReferences{},
 			Footnotes:          types.Footnotes{},
 			FootnoteReferences: types.FootnoteReferences{},
 			Elements: []interface{}{
-				&types.LabeledList{
+				types.LabeledList{
 					Attributes: types.ElementAttributes{},
-					Items: []*types.LabeledListItem{
+					Items: []types.LabeledListItem{
 						{
 							Attributes: types.ElementAttributes{},
 							Term:       "Item1",
@@ -779,27 +779,27 @@ on 2 lines`
 	It("labeled list with a horizontal layout attribute", func() {
 		source := `[horizontal]
 Item1:: foo`
-		expected := &types.Document{
+		expected := types.Document{
 			Attributes:         types.DocumentAttributes{},
 			ElementReferences:  types.ElementReferences{},
 			Footnotes:          types.Footnotes{},
 			FootnoteReferences: types.FootnoteReferences{},
 			Elements: []interface{}{
-				&types.LabeledList{
+				types.LabeledList{
 					Attributes: types.ElementAttributes{
 						"layout": "horizontal",
 					},
-					Items: []*types.LabeledListItem{
+					Items: []types.LabeledListItem{
 						{
 							Attributes: types.ElementAttributes{},
 							Level:      1,
 							Term:       "Item1",
 							Elements: []interface{}{
-								&types.Paragraph{
+								types.Paragraph{
 									Attributes: types.ElementAttributes{},
 									Lines: []types.InlineElements{
 										{
-											&types.StringElement{Content: "foo"},
+											types.StringElement{Content: "foo"},
 										},
 									},
 								},
@@ -815,15 +815,15 @@ Item1:: foo`
 	It("labeled list with a single term and a blank line", func() {
 		source := `Item1::
 			`
-		expected := &types.Document{
+		expected := types.Document{
 			Attributes:         types.DocumentAttributes{},
 			ElementReferences:  types.ElementReferences{},
 			Footnotes:          types.Footnotes{},
 			FootnoteReferences: types.FootnoteReferences{},
 			Elements: []interface{}{
-				&types.LabeledList{
+				types.LabeledList{
 					Attributes: types.ElementAttributes{},
-					Items: []*types.LabeledListItem{
+					Items: []types.LabeledListItem{
 						{
 							Attributes: types.ElementAttributes{},
 							Level:      1,
@@ -844,25 +844,25 @@ Item 2::
 Item 2 description
 Item 3:: 
 Item 3 description`
-		expected := &types.Document{
+		expected := types.Document{
 			Attributes:         types.DocumentAttributes{},
 			ElementReferences:  types.ElementReferences{},
 			Footnotes:          types.Footnotes{},
 			FootnoteReferences: types.FootnoteReferences{},
 			Elements: []interface{}{
-				&types.LabeledList{
+				types.LabeledList{
 					Attributes: types.ElementAttributes{},
-					Items: []*types.LabeledListItem{
+					Items: []types.LabeledListItem{
 						{
 							Attributes: types.ElementAttributes{},
 							Level:      1,
 							Term:       "Item 1",
 							Elements: []interface{}{
-								&types.Paragraph{
+								types.Paragraph{
 									Attributes: types.ElementAttributes{},
 									Lines: []types.InlineElements{
 										{
-											&types.StringElement{Content: "Item 1 description"},
+											types.StringElement{Content: "Item 1 description"},
 										},
 									},
 								},
@@ -873,11 +873,11 @@ Item 3 description`
 							Level:      1,
 							Term:       "Item 2",
 							Elements: []interface{}{
-								&types.Paragraph{
+								types.Paragraph{
 									Attributes: types.ElementAttributes{},
 									Lines: []types.InlineElements{
 										{
-											&types.StringElement{Content: "Item 2 description"},
+											types.StringElement{Content: "Item 2 description"},
 										},
 									},
 								},
@@ -888,11 +888,11 @@ Item 3 description`
 							Level:      1,
 							Term:       "Item 3",
 							Elements: []interface{}{
-								&types.Paragraph{
+								types.Paragraph{
 									Attributes: types.ElementAttributes{},
 									Lines: []types.InlineElements{
 										{
-											&types.StringElement{Content: "Item 3 description"},
+											types.StringElement{Content: "Item 3 description"},
 										},
 									},
 								},
@@ -912,57 +912,57 @@ Item 2:::
 Item 2 description
 Item 3::::
 Item 3 description`
-		expected := &types.Document{
+		expected := types.Document{
 			Attributes:         types.DocumentAttributes{},
 			ElementReferences:  types.ElementReferences{},
 			Footnotes:          types.Footnotes{},
 			FootnoteReferences: types.FootnoteReferences{},
 			Elements: []interface{}{
-				&types.LabeledList{
+				types.LabeledList{
 					Attributes: types.ElementAttributes{},
-					Items: []*types.LabeledListItem{
+					Items: []types.LabeledListItem{
 						{
 							Attributes: types.ElementAttributes{},
 							Level:      1,
 							Term:       "Item 1",
 							Elements: []interface{}{
-								&types.Paragraph{
+								types.Paragraph{
 									Attributes: types.ElementAttributes{},
 									Lines: []types.InlineElements{
 										{
-											&types.StringElement{Content: "Item 1 description"},
+											types.StringElement{Content: "Item 1 description"},
 										},
 									},
 								},
-								&types.LabeledList{
+								types.LabeledList{
 									Attributes: types.ElementAttributes{},
-									Items: []*types.LabeledListItem{
+									Items: []types.LabeledListItem{
 										{
 											Attributes: types.ElementAttributes{},
 											Level:      2,
 											Term:       "Item 2",
 											Elements: []interface{}{
-												&types.Paragraph{
+												types.Paragraph{
 													Attributes: types.ElementAttributes{},
 													Lines: []types.InlineElements{
 														{
-															&types.StringElement{Content: "Item 2 description"},
+															types.StringElement{Content: "Item 2 description"},
 														},
 													},
 												},
-												&types.LabeledList{
+												types.LabeledList{
 													Attributes: types.ElementAttributes{},
-													Items: []*types.LabeledListItem{
+													Items: []types.LabeledListItem{
 														{
 															Attributes: types.ElementAttributes{},
 															Level:      3,
 															Term:       "Item 3",
 															Elements: []interface{}{
-																&types.Paragraph{
+																types.Paragraph{
 																	Attributes: types.ElementAttributes{},
 																	Lines: []types.InlineElements{
 																		{
-																			&types.StringElement{Content: "Item 3 description"},
+																			types.StringElement{Content: "Item 3 description"},
 																		},
 																	},
 																},
@@ -988,34 +988,34 @@ Item 3 description`
 * foo
 * bar
 Item with description:: something simple`
-		expected := &types.Document{
+		expected := types.Document{
 			Attributes:         types.DocumentAttributes{},
 			ElementReferences:  types.ElementReferences{},
 			Footnotes:          types.Footnotes{},
 			FootnoteReferences: types.FootnoteReferences{},
 			Elements: []interface{}{
-				&types.LabeledList{
+				types.LabeledList{
 					Attributes: types.ElementAttributes{},
-					Items: []*types.LabeledListItem{
+					Items: []types.LabeledListItem{
 						{
 							Attributes: types.ElementAttributes{},
 							Level:      1,
 							Term:       "Empty item",
 							Elements: []interface{}{
-								&types.UnorderedList{
+								types.UnorderedList{
 									Attributes: types.ElementAttributes{},
-									Items: []*types.UnorderedListItem{
+									Items: []types.UnorderedListItem{
 										{
 											Attributes:  types.ElementAttributes{},
 											Level:       1,
 											BulletStyle: types.OneAsterisk,
 											CheckStyle:  types.NoCheck,
 											Elements: []interface{}{
-												&types.Paragraph{
+												types.Paragraph{
 													Attributes: types.ElementAttributes{},
 													Lines: []types.InlineElements{
 														{
-															&types.StringElement{Content: "foo"},
+															types.StringElement{Content: "foo"},
 														},
 													},
 												},
@@ -1027,11 +1027,11 @@ Item with description:: something simple`
 											BulletStyle: types.OneAsterisk,
 											CheckStyle:  types.NoCheck,
 											Elements: []interface{}{
-												&types.Paragraph{
+												types.Paragraph{
 													Attributes: types.ElementAttributes{},
 													Lines: []types.InlineElements{
 														{
-															&types.StringElement{Content: "bar"},
+															types.StringElement{Content: "bar"},
 														},
 													},
 												},
@@ -1046,11 +1046,11 @@ Item with description:: something simple`
 							Level:      1,
 							Term:       "Item with description",
 							Elements: []interface{}{
-								&types.Paragraph{
+								types.Paragraph{
 									Attributes: types.ElementAttributes{},
 									Lines: []types.InlineElements{
 										{
-											&types.StringElement{Content: "something simple"},
+											types.StringElement{Content: "something simple"},
 										},
 									},
 								},
@@ -1070,28 +1070,28 @@ foo
 bar
 
 a normal paragraph.`
-		expected := &types.Document{
+		expected := types.Document{
 			Attributes:         types.DocumentAttributes{},
 			ElementReferences:  types.ElementReferences{},
 			Footnotes:          types.Footnotes{},
 			FootnoteReferences: types.FootnoteReferences{},
 			Elements: []interface{}{
-				&types.LabeledList{
+				types.LabeledList{
 					Attributes: types.ElementAttributes{},
-					Items: []*types.LabeledListItem{
+					Items: []types.LabeledListItem{
 						{
 							Attributes: types.ElementAttributes{},
 							Level:      1,
 							Term:       "Item 1",
 							Elements: []interface{}{
-								&types.Paragraph{
+								types.Paragraph{
 									Attributes: types.ElementAttributes{},
 									Lines: []types.InlineElements{
 										{
-											&types.StringElement{Content: "foo"},
+											types.StringElement{Content: "foo"},
 										},
 										{
-											&types.StringElement{Content: "bar"},
+											types.StringElement{Content: "bar"},
 										},
 									},
 								},
@@ -1099,11 +1099,11 @@ a normal paragraph.`
 						},
 					},
 				},
-				&types.Paragraph{
+				types.Paragraph{
 					Attributes: types.ElementAttributes{},
 					Lines: []types.InlineElements{
 						{
-							&types.StringElement{Content: "a normal paragraph."},
+							types.StringElement{Content: "a normal paragraph."},
 						},
 					},
 				},
@@ -1123,29 +1123,29 @@ Item 2:: something simple
 ----
 another fenced block
 ----`
-		expected := &types.Document{
+		expected := types.Document{
 			Attributes:         types.DocumentAttributes{},
 			ElementReferences:  types.ElementReferences{},
 			Footnotes:          types.Footnotes{},
 			FootnoteReferences: types.FootnoteReferences{},
 			Elements: []interface{}{
-				&types.LabeledList{
+				types.LabeledList{
 					Attributes: types.ElementAttributes{},
-					Items: []*types.LabeledListItem{
+					Items: []types.LabeledListItem{
 						{
 							Attributes: types.ElementAttributes{},
 							Level:      1,
 							Term:       "Item 1",
 							Elements: []interface{}{
-								&types.DelimitedBlock{
+								types.DelimitedBlock{
 									Attributes: types.ElementAttributes{},
 									Kind:       types.Listing,
 									Elements: []interface{}{
-										&types.Paragraph{
+										types.Paragraph{
 											Attributes: types.ElementAttributes{},
 											Lines: []types.InlineElements{
 												{
-													&types.StringElement{
+													types.StringElement{
 														Content: "a fenced block",
 													},
 												},
@@ -1160,23 +1160,23 @@ another fenced block
 							Level:      1,
 							Term:       "Item 2",
 							Elements: []interface{}{
-								&types.Paragraph{
+								types.Paragraph{
 									Attributes: types.ElementAttributes{},
 									Lines: []types.InlineElements{
 										{
-											&types.StringElement{Content: "something simple"},
+											types.StringElement{Content: "something simple"},
 										},
 									},
 								},
-								&types.DelimitedBlock{
+								types.DelimitedBlock{
 									Attributes: types.ElementAttributes{},
 									Kind:       types.Listing,
 									Elements: []interface{}{
-										&types.Paragraph{
+										types.Paragraph{
 											Attributes: types.ElementAttributes{},
 											Lines: []types.InlineElements{
 												{
-													&types.StringElement{
+													types.StringElement{
 														Content: "another fenced block",
 													},
 												},
@@ -1203,15 +1203,15 @@ Item 2:: something simple
 ----
 another fenced block
 ----`
-		expected := &types.Document{
+		expected := types.Document{
 			Attributes:         types.DocumentAttributes{},
 			ElementReferences:  types.ElementReferences{},
 			Footnotes:          types.Footnotes{},
 			FootnoteReferences: types.FootnoteReferences{},
 			Elements: []interface{}{
-				&types.LabeledList{
+				types.LabeledList{
 					Attributes: types.ElementAttributes{},
-					Items: []*types.LabeledListItem{
+					Items: []types.LabeledListItem{
 						{
 							Attributes: types.ElementAttributes{},
 							Level:      1,
@@ -1220,15 +1220,15 @@ another fenced block
 						},
 					},
 				},
-				&types.DelimitedBlock{
+				types.DelimitedBlock{
 					Attributes: types.ElementAttributes{},
 					Kind:       types.Listing,
 					Elements: []interface{}{
-						&types.Paragraph{
+						types.Paragraph{
 							Attributes: types.ElementAttributes{},
 							Lines: []types.InlineElements{
 								{
-									&types.StringElement{
+									types.StringElement{
 										Content: "a fenced block",
 									},
 								},
@@ -1236,19 +1236,19 @@ another fenced block
 						},
 					},
 				},
-				&types.LabeledList{
+				types.LabeledList{
 					Attributes: types.ElementAttributes{},
-					Items: []*types.LabeledListItem{
+					Items: []types.LabeledListItem{
 						{
 							Attributes: types.ElementAttributes{},
 							Level:      1,
 							Term:       "Item 2",
 							Elements: []interface{}{
-								&types.Paragraph{
+								types.Paragraph{
 									Attributes: types.ElementAttributes{},
 									Lines: []types.InlineElements{
 										{
-											&types.StringElement{Content: "something simple"},
+											types.StringElement{Content: "something simple"},
 										},
 									},
 								},
@@ -1256,15 +1256,15 @@ another fenced block
 						},
 					},
 				},
-				&types.DelimitedBlock{
+				types.DelimitedBlock{
 					Attributes: types.ElementAttributes{},
 					Kind:       types.Listing,
 					Elements: []interface{}{
-						&types.Paragraph{
+						types.Paragraph{
 							Attributes: types.ElementAttributes{},
 							Lines: []types.InlineElements{
 								{
-									&types.StringElement{
+									types.StringElement{
 										Content: "another fenced block",
 									},
 								},
@@ -1280,34 +1280,34 @@ another fenced block
 	It("labeled list with nested unordered list - case 2", func() {
 		source := `Labeled item::
 - unordered item`
-		expected := &types.Document{
+		expected := types.Document{
 			Attributes:         types.DocumentAttributes{},
 			ElementReferences:  types.ElementReferences{},
 			Footnotes:          types.Footnotes{},
 			FootnoteReferences: types.FootnoteReferences{},
 			Elements: []interface{}{
-				&types.LabeledList{
+				types.LabeledList{
 					Attributes: types.ElementAttributes{},
-					Items: []*types.LabeledListItem{
+					Items: []types.LabeledListItem{
 						{
 							Attributes: types.ElementAttributes{},
 							Level:      1,
 							Term:       "Labeled item",
 							Elements: []interface{}{
-								&types.UnorderedList{
+								types.UnorderedList{
 									Attributes: types.ElementAttributes{},
-									Items: []*types.UnorderedListItem{
+									Items: []types.UnorderedListItem{
 										{
 											Attributes:  types.ElementAttributes{},
 											Level:       1,
 											BulletStyle: types.Dash,
 											CheckStyle:  types.NoCheck,
 											Elements: []interface{}{
-												&types.Paragraph{
+												types.Paragraph{
 													Attributes: types.ElementAttributes{},
 													Lines: []types.InlineElements{
 														{
-															&types.StringElement{Content: "unordered item"},
+															types.StringElement{Content: "unordered item"},
 														},
 													},
 												},
@@ -1328,27 +1328,27 @@ another fenced block
 		source := `.Labeled, single-line
 first term:: definition of the first term
 second term:: definition of the second term`
-		expected := &types.Document{
+		expected := types.Document{
 			Attributes:         types.DocumentAttributes{},
 			ElementReferences:  types.ElementReferences{},
 			Footnotes:          types.Footnotes{},
 			FootnoteReferences: types.FootnoteReferences{},
 			Elements: []interface{}{
-				&types.LabeledList{
+				types.LabeledList{
 					Attributes: types.ElementAttributes{
 						types.AttrTitle: "Labeled, single-line",
 					},
-					Items: []*types.LabeledListItem{
+					Items: []types.LabeledListItem{
 						{
 							Attributes: types.ElementAttributes{},
 							Level:      1,
 							Term:       "first term",
 							Elements: []interface{}{
-								&types.Paragraph{
+								types.Paragraph{
 									Attributes: types.ElementAttributes{},
 									Lines: []types.InlineElements{
 										{
-											&types.StringElement{
+											types.StringElement{
 												Content: "definition of the first term",
 											},
 										},
@@ -1361,11 +1361,11 @@ second term:: definition of the second term`
 							Level:      1,
 							Term:       "second term",
 							Elements: []interface{}{
-								&types.Paragraph{
+								types.Paragraph{
 									Attributes: types.ElementAttributes{},
 									Lines: []types.InlineElements{
 										{
-											&types.StringElement{
+											types.StringElement{
 												Content: "definition of the second term",
 											},
 										},
@@ -1386,63 +1386,63 @@ level 1:: description 1
 level 2::: description 2
 level 3:::: description 3
 level 1:: description 1`
-		expected := &types.Document{
+		expected := types.Document{
 			Attributes:         types.DocumentAttributes{},
 			ElementReferences:  types.ElementReferences{},
 			Footnotes:          types.Footnotes{},
 			FootnoteReferences: types.FootnoteReferences{},
 			Elements: []interface{}{
-				&types.LabeledList{
+				types.LabeledList{
 					Attributes: types.ElementAttributes{
 						types.AttrTitle: "Labeled, max nesting",
 					},
-					Items: []*types.LabeledListItem{
+					Items: []types.LabeledListItem{
 						{
 							Level:      1,
 							Term:       "level 1",
 							Attributes: types.ElementAttributes{},
 							Elements: []interface{}{
-								&types.Paragraph{
+								types.Paragraph{
 									Attributes: types.ElementAttributes{},
 									Lines: []types.InlineElements{
 										{
-											&types.StringElement{
+											types.StringElement{
 												Content: "description 1",
 											},
 										},
 									},
 								},
-								&types.LabeledList{
+								types.LabeledList{
 									Attributes: types.ElementAttributes{},
-									Items: []*types.LabeledListItem{
+									Items: []types.LabeledListItem{
 										{
 											Level:      2,
 											Term:       "level 2",
 											Attributes: types.ElementAttributes{},
 											Elements: []interface{}{
-												&types.Paragraph{
+												types.Paragraph{
 													Attributes: types.ElementAttributes{},
 													Lines: []types.InlineElements{
 														{
-															&types.StringElement{
+															types.StringElement{
 																Content: "description 2",
 															},
 														},
 													},
 												},
-												&types.LabeledList{
+												types.LabeledList{
 													Attributes: types.ElementAttributes{},
-													Items: []*types.LabeledListItem{
+													Items: []types.LabeledListItem{
 														{
 															Level:      3,
 															Term:       "level 3",
 															Attributes: types.ElementAttributes{},
 															Elements: []interface{}{
-																&types.Paragraph{
+																types.Paragraph{
 																	Attributes: types.ElementAttributes{},
 																	Lines: []types.InlineElements{
 																		{
-																			&types.StringElement{
+																			types.StringElement{
 																				Content: "description 3",
 																			},
 																		},
@@ -1463,11 +1463,11 @@ level 1:: description 1`
 							Term:       "level 1",
 							Attributes: types.ElementAttributes{},
 							Elements: []interface{}{
-								&types.Paragraph{
+								types.Paragraph{
 									Attributes: types.ElementAttributes{},
 									Lines: []types.InlineElements{
 										{
-											&types.StringElement{
+											types.StringElement{
 												Content: "description 1",
 											},
 										},
@@ -1488,63 +1488,63 @@ level 1:: description 1
 level 2::: description 2
 level 3:::: description 3
 level 2::: description 2`
-		expected := &types.Document{
+		expected := types.Document{
 			Attributes:         types.DocumentAttributes{},
 			ElementReferences:  types.ElementReferences{},
 			Footnotes:          types.Footnotes{},
 			FootnoteReferences: types.FootnoteReferences{},
 			Elements: []interface{}{
-				&types.LabeledList{
+				types.LabeledList{
 					Attributes: types.ElementAttributes{
 						types.AttrTitle: "Labeled, max nesting",
 					},
-					Items: []*types.LabeledListItem{
+					Items: []types.LabeledListItem{
 						{
 							Level:      1,
 							Term:       "level 1",
 							Attributes: types.ElementAttributes{},
 							Elements: []interface{}{
-								&types.Paragraph{
+								types.Paragraph{
 									Attributes: types.ElementAttributes{},
 									Lines: []types.InlineElements{
 										{
-											&types.StringElement{
+											types.StringElement{
 												Content: "description 1",
 											},
 										},
 									},
 								},
-								&types.LabeledList{
+								types.LabeledList{
 									Attributes: types.ElementAttributes{},
-									Items: []*types.LabeledListItem{
+									Items: []types.LabeledListItem{
 										{
 											Level:      2,
 											Term:       "level 2",
 											Attributes: types.ElementAttributes{},
 											Elements: []interface{}{
-												&types.Paragraph{
+												types.Paragraph{
 													Attributes: types.ElementAttributes{},
 													Lines: []types.InlineElements{
 														{
-															&types.StringElement{
+															types.StringElement{
 																Content: "description 2",
 															},
 														},
 													},
 												},
-												&types.LabeledList{
+												types.LabeledList{
 													Attributes: types.ElementAttributes{},
-													Items: []*types.LabeledListItem{
+													Items: []types.LabeledListItem{
 														{
 															Level:      3,
 															Term:       "level 3",
 															Attributes: types.ElementAttributes{},
 															Elements: []interface{}{
-																&types.Paragraph{
+																types.Paragraph{
 																	Attributes: types.ElementAttributes{},
 																	Lines: []types.InlineElements{
 																		{
-																			&types.StringElement{
+																			types.StringElement{
 																				Content: "description 3",
 																			},
 																		},
@@ -1561,11 +1561,11 @@ level 2::: description 2`
 											Term:       "level 2",
 											Attributes: types.ElementAttributes{},
 											Elements: []interface{}{
-												&types.Paragraph{
+												types.Paragraph{
 													Attributes: types.ElementAttributes{},
 													Lines: []types.InlineElements{
 														{
-															&types.StringElement{
+															types.StringElement{
 																Content: "description 2",
 															},
 														},

--- a/pkg/parser/link_test.go
+++ b/pkg/parser/link_test.go
@@ -11,14 +11,14 @@ var _ = Describe("links - preflight", func() {
 
 		It("external link without text", func() {
 			source := "a link to https://foo.bar"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{Content: "a link to "},
-						&types.InlineLink{
+						types.StringElement{Content: "a link to "},
+						types.InlineLink{
 							Location: types.Location{
-								&types.StringElement{
+								types.StringElement{
 									Content: "https://foo.bar",
 								},
 							},
@@ -32,14 +32,14 @@ var _ = Describe("links - preflight", func() {
 
 		It("external link with empty text", func() {
 			source := "a link to https://foo.bar[]"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{Content: "a link to "},
-						&types.InlineLink{
+						types.StringElement{Content: "a link to "},
+						types.InlineLink{
 							Location: types.Location{
-								&types.StringElement{
+								types.StringElement{
 									Content: "https://foo.bar",
 								},
 							},
@@ -53,26 +53,26 @@ var _ = Describe("links - preflight", func() {
 
 		It("external link with text only", func() {
 			source := "a link to mailto:foo@bar[the foo@bar email]."
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{Content: "a link to "},
-						&types.InlineLink{
+						types.StringElement{Content: "a link to "},
+						types.InlineLink{
 							Location: types.Location{
-								&types.StringElement{
+								types.StringElement{
 									Content: "mailto:foo@bar",
 								},
 							},
 							Attributes: types.ElementAttributes{
 								types.AttrInlineLinkText: types.InlineElements{
-									&types.StringElement{
+									types.StringElement{
 										Content: "the foo@bar email",
 									},
 								},
 							},
 						},
-						&types.StringElement{Content: "."},
+						types.StringElement{Content: "."},
 					},
 				},
 			}
@@ -81,20 +81,20 @@ var _ = Describe("links - preflight", func() {
 
 		It("external link with text and extra attributes", func() {
 			source := "a link to mailto:foo@bar[the foo@bar email, foo=bar]"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{Content: "a link to "},
-						&types.InlineLink{
+						types.StringElement{Content: "a link to "},
+						types.InlineLink{
 							Location: types.Location{
-								&types.StringElement{
+								types.StringElement{
 									Content: "mailto:foo@bar",
 								},
 							},
 							Attributes: types.ElementAttributes{
 								types.AttrInlineLinkText: types.InlineElements{
-									&types.StringElement{
+									types.StringElement{
 										Content: "the foo@bar email",
 									},
 								},
@@ -112,29 +112,29 @@ var _ = Describe("links - preflight", func() {
 and more text on the
 next lines`
 
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{
+						types.StringElement{
 							Content: "a ",
 						},
-						&types.InlineLink{
+						types.InlineLink{
 							Attributes: types.ElementAttributes{},
 							Location: types.Location{
-								&types.StringElement{
+								types.StringElement{
 									Content: "http://website.com",
 								},
 							},
 						},
 					},
 					{
-						&types.StringElement{
+						types.StringElement{
 							Content: "and more text on the",
 						},
 					},
 					{
-						&types.StringElement{
+						types.StringElement{
 							Content: "next lines",
 						},
 					},
@@ -148,29 +148,29 @@ next lines`
 and more text on the
 next lines`
 
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{
+						types.StringElement{
 							Content: "a ",
 						},
-						&types.InlineLink{
+						types.InlineLink{
 							Attributes: types.ElementAttributes{},
 							Location: types.Location{
-								&types.StringElement{
+								types.StringElement{
 									Content: "http://website.com",
 								},
 							},
 						},
 					},
 					{
-						&types.StringElement{
+						types.StringElement{
 							Content: "and more text on the",
 						},
 					},
 					{
-						&types.StringElement{
+						types.StringElement{
 							Content: "next lines",
 						},
 					},
@@ -185,14 +185,14 @@ next lines`
 
 		It("relative link to doc without text", func() {
 			source := "a link to link:foo.adoc[]"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{Content: "a link to "},
-						&types.InlineLink{
+						types.StringElement{Content: "a link to "},
+						types.InlineLink{
 							Location: types.Location{
-								&types.StringElement{
+								types.StringElement{
 									Content: "foo.adoc",
 								},
 							},
@@ -206,20 +206,20 @@ next lines`
 
 		It("relative link to doc with text", func() {
 			source := "a link to link:foo.adoc[foo doc]"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{Content: "a link to "},
-						&types.InlineLink{
+						types.StringElement{Content: "a link to "},
+						types.InlineLink{
 							Location: types.Location{
-								&types.StringElement{
+								types.StringElement{
 									Content: "foo.adoc",
 								},
 							},
 							Attributes: types.ElementAttributes{
 								types.AttrInlineLinkText: types.InlineElements{
-									&types.StringElement{
+									types.StringElement{
 										Content: "foo doc",
 									},
 								},
@@ -233,20 +233,20 @@ next lines`
 
 		It("relative link to external URL with text only", func() {
 			source := "a link to link:https://foo.bar[foo doc]"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{Content: "a link to "},
-						&types.InlineLink{
+						types.StringElement{Content: "a link to "},
+						types.InlineLink{
 							Location: types.Location{
-								&types.StringElement{
+								types.StringElement{
 									Content: "https://foo.bar",
 								},
 							},
 							Attributes: types.ElementAttributes{
 								types.AttrInlineLinkText: types.InlineElements{
-									&types.StringElement{
+									types.StringElement{
 										Content: "foo doc",
 									},
 								},
@@ -260,20 +260,20 @@ next lines`
 
 		It("relative link to external URL with text and extra attributes", func() {
 			source := "a link to link:https://foo.bar[foo doc, foo=bar]"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{Content: "a link to "},
-						&types.InlineLink{
+						types.StringElement{Content: "a link to "},
+						types.InlineLink{
 							Location: types.Location{
-								&types.StringElement{
+								types.StringElement{
 									Content: "https://foo.bar",
 								},
 							},
 							Attributes: types.ElementAttributes{
 								types.AttrInlineLinkText: types.InlineElements{
-									&types.StringElement{
+									types.StringElement{
 										Content: "foo doc",
 									},
 								},
@@ -288,14 +288,14 @@ next lines`
 
 		It("relative link to external URL with extra attributes only", func() {
 			source := "a link to link:https://foo.bar[foo=bar]"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{Content: "a link to "},
-						&types.InlineLink{
+						types.StringElement{Content: "a link to "},
+						types.InlineLink{
 							Location: types.Location{
-								&types.StringElement{
+								types.StringElement{
 									Content: "https://foo.bar",
 								},
 							},
@@ -311,11 +311,11 @@ next lines`
 
 		It("invalid relative link to doc", func() {
 			source := "a link to link:foo.adoc"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{
+						types.StringElement{
 							Content: "a link to link:foo.adoc",
 						},
 					},
@@ -326,47 +326,47 @@ next lines`
 
 		It("relative link with quoted text", func() {
 			source := "link:/[a _a_ b *b* c `c`]"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.InlineLink{
+						types.InlineLink{
 							Location: types.Location{
-								&types.StringElement{
+								types.StringElement{
 									Content: "/",
 								},
 							},
 							Attributes: types.ElementAttributes{
 								types.AttrInlineLinkText: types.InlineElements{
-									&types.StringElement{
+									types.StringElement{
 										Content: "a ",
 									},
-									&types.QuotedText{
+									types.QuotedText{
 										Kind: types.Italic,
 										Elements: types.InlineElements{
-											&types.StringElement{
+											types.StringElement{
 												Content: "a",
 											},
 										},
 									},
-									&types.StringElement{
+									types.StringElement{
 										Content: " b ",
 									},
-									&types.QuotedText{
+									types.QuotedText{
 										Kind: types.Bold,
 										Elements: types.InlineElements{
-											&types.StringElement{
+											types.StringElement{
 												Content: "b",
 											},
 										},
 									},
-									&types.StringElement{
+									types.StringElement{
 										Content: " c ",
 									},
-									&types.QuotedText{
+									types.QuotedText{
 										Kind: types.Monospace,
 										Elements: types.InlineElements{
-											&types.StringElement{
+											types.StringElement{
 												Content: "c",
 											},
 										},

--- a/pkg/parser/literal_block_test.go
+++ b/pkg/parser/literal_block_test.go
@@ -11,7 +11,7 @@ var _ = Describe("literal blocks - preflight", func() {
 
 		It("literal block from 1-line paragraph with single space", func() {
 			source := ` some literal content`
-			expected := &types.LiteralBlock{
+			expected := types.LiteralBlock{
 				Attributes: types.ElementAttributes{
 					types.AttrKind:             types.Literal,
 					types.AttrLiteralBlockType: types.LiteralBlockWithSpacesOnFirstLine,
@@ -27,7 +27,7 @@ var _ = Describe("literal blocks - preflight", func() {
 			source := ` some literal content
 on 3
 lines.`
-			expected := &types.LiteralBlock{
+			expected := types.LiteralBlock{
 				Attributes: types.ElementAttributes{
 					types.AttrKind:             types.Literal,
 					types.AttrLiteralBlockType: types.LiteralBlockWithSpacesOnFirstLine,
@@ -47,9 +47,9 @@ lines.`
   some literal content
 
 a normal paragraph.`
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.LiteralBlock{
+					types.LiteralBlock{
 						Attributes: types.ElementAttributes{
 							types.AttrKind:             types.Literal,
 							types.AttrLiteralBlockType: types.LiteralBlockWithSpacesOnFirstLine,
@@ -61,12 +61,12 @@ a normal paragraph.`
 							"  some literal content",
 						},
 					},
-					&types.BlankLine{},
-					&types.Paragraph{
+					types.BlankLine{},
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: "a normal paragraph."},
+								types.StringElement{Content: "a normal paragraph."},
 							},
 						},
 					},
@@ -84,7 +84,7 @@ a normal paragraph.`
 
 some content
 ....`
-			expected := &types.LiteralBlock{
+			expected := types.LiteralBlock{
 				Attributes: types.ElementAttributes{
 					types.AttrKind:             types.Literal,
 					types.AttrLiteralBlockType: types.LiteralBlockWithDelimiter,
@@ -104,9 +104,9 @@ some content
 some literal content
 ....
 a normal paragraph.`
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.LiteralBlock{
+					types.LiteralBlock{
 						Attributes: types.ElementAttributes{
 							types.AttrKind:             types.Literal,
 							types.AttrLiteralBlockType: types.LiteralBlockWithDelimiter,
@@ -118,11 +118,11 @@ a normal paragraph.`
 							"some literal content",
 						},
 					},
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: "a normal paragraph."},
+								types.StringElement{Content: "a normal paragraph."},
 							},
 						},
 					},
@@ -139,9 +139,9 @@ a normal paragraph.`
 some literal content
 
 a normal paragraph.`
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.LiteralBlock{
+					types.LiteralBlock{
 						Attributes: types.ElementAttributes{
 							types.AttrKind:             types.Literal,
 							types.AttrLiteralBlockType: types.LiteralBlockWithAttribute,
@@ -150,12 +150,12 @@ a normal paragraph.`
 							"some literal content",
 						},
 					},
-					&types.BlankLine{},
-					&types.Paragraph{
+					types.BlankLine{},
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: "a normal paragraph."},
+								types.StringElement{Content: "a normal paragraph."},
 							},
 						},
 					},
@@ -172,9 +172,9 @@ some literal content
 on two lines.
 
 a normal paragraph.`
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.LiteralBlock{
+					types.LiteralBlock{
 						Attributes: types.ElementAttributes{
 							types.AttrKind:             types.Literal,
 							types.AttrID:               "ID",
@@ -187,12 +187,12 @@ a normal paragraph.`
 							"on two lines.",
 						},
 					},
-					&types.BlankLine{},
-					&types.Paragraph{
+					types.BlankLine{},
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: "a normal paragraph."},
+								types.StringElement{Content: "a normal paragraph."},
 							},
 						},
 					},

--- a/pkg/parser/mixed_lists_test.go
+++ b/pkg/parser/mixed_lists_test.go
@@ -16,42 +16,42 @@ var _ = Describe("mixed lists - document", func() {
 . Item 2
 * Item C
 * Item D`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.OrderedList{
+					types.OrderedList{
 						Attributes: types.ElementAttributes{},
-						Items: []*types.OrderedListItem{
+						Items: []types.OrderedListItem{
 							{
 								Level:          1,
 								NumberingStyle: types.Arabic,
 								Attributes:     map[string]interface{}{},
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{Content: "Item 1"},
+												types.StringElement{Content: "Item 1"},
 											},
 										},
 									},
-									&types.UnorderedList{
+									types.UnorderedList{
 										Attributes: types.ElementAttributes{},
-										Items: []*types.UnorderedListItem{
+										Items: []types.UnorderedListItem{
 											{
 												Attributes:  types.ElementAttributes{},
 												Level:       1,
 												BulletStyle: types.OneAsterisk,
 												CheckStyle:  types.NoCheck,
 												Elements: []interface{}{
-													&types.Paragraph{
+													types.Paragraph{
 														Attributes: types.ElementAttributes{},
 														Lines: []types.InlineElements{
 															{
-																&types.StringElement{Content: "Item A"},
+																types.StringElement{Content: "Item A"},
 															},
 														},
 													},
@@ -63,11 +63,11 @@ var _ = Describe("mixed lists - document", func() {
 												BulletStyle: types.OneAsterisk,
 												CheckStyle:  types.NoCheck,
 												Elements: []interface{}{
-													&types.Paragraph{
+													types.Paragraph{
 														Attributes: types.ElementAttributes{},
 														Lines: []types.InlineElements{
 															{
-																&types.StringElement{Content: "Item B"},
+																types.StringElement{Content: "Item B"},
 															},
 														},
 													},
@@ -82,28 +82,28 @@ var _ = Describe("mixed lists - document", func() {
 								Level:          1,
 								NumberingStyle: types.Arabic,
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{Content: "Item 2"},
+												types.StringElement{Content: "Item 2"},
 											},
 										},
 									},
-									&types.UnorderedList{
+									types.UnorderedList{
 										Attributes: types.ElementAttributes{},
-										Items: []*types.UnorderedListItem{
+										Items: []types.UnorderedListItem{
 											{
 												Attributes:  types.ElementAttributes{},
 												Level:       1,
 												BulletStyle: types.OneAsterisk,
 												CheckStyle:  types.NoCheck,
 												Elements: []interface{}{
-													&types.Paragraph{
+													types.Paragraph{
 														Attributes: types.ElementAttributes{},
 														Lines: []types.InlineElements{
 															{
-																&types.StringElement{Content: "Item C"},
+																types.StringElement{Content: "Item C"},
 															},
 														},
 													},
@@ -115,11 +115,11 @@ var _ = Describe("mixed lists - document", func() {
 												BulletStyle: types.OneAsterisk,
 												CheckStyle:  types.NoCheck,
 												Elements: []interface{}{
-													&types.Paragraph{
+													types.Paragraph{
 														Attributes: types.ElementAttributes{},
 														Lines: []types.InlineElements{
 															{
-																&types.StringElement{Content: "Item D"},
+																types.StringElement{Content: "Item D"},
 															},
 														},
 													},
@@ -152,58 +152,58 @@ var _ = Describe("mixed lists - document", func() {
 	4. ordered 1.4
 	- unordered 2
 	* unordered 2.1`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.UnorderedList{
+					types.UnorderedList{
 						Attributes: types.ElementAttributes{},
-						Items: []*types.UnorderedListItem{
+						Items: []types.UnorderedListItem{
 							{
 								Attributes:  types.ElementAttributes{},
 								Level:       1,
 								BulletStyle: types.Dash,
 								CheckStyle:  types.NoCheck,
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{Content: "unordered 1"},
+												types.StringElement{Content: "unordered 1"},
 											},
 										},
 									},
-									&types.OrderedList{
+									types.OrderedList{
 										Attributes: types.ElementAttributes{},
-										Items: []*types.OrderedListItem{
+										Items: []types.OrderedListItem{
 											{
 												Attributes:     types.ElementAttributes{},
 												Level:          1,
 												NumberingStyle: types.Arabic,
 												Elements: []interface{}{
-													&types.Paragraph{
+													types.Paragraph{
 														Attributes: types.ElementAttributes{},
 														Lines: []types.InlineElements{
 															{
-																&types.StringElement{Content: "ordered 1.1"},
+																types.StringElement{Content: "ordered 1.1"},
 															},
 														},
 													},
-													&types.OrderedList{
+													types.OrderedList{
 														Attributes: types.ElementAttributes{},
-														Items: []*types.OrderedListItem{
+														Items: []types.OrderedListItem{
 															{
 																Attributes:     types.ElementAttributes{},
 																Level:          2,
 																NumberingStyle: types.LowerAlpha,
 																Elements: []interface{}{
-																	&types.Paragraph{
+																	types.Paragraph{
 																		Attributes: types.ElementAttributes{},
 																		Lines: []types.InlineElements{
 																			{
-																				&types.StringElement{Content: "ordered 1.1.a"},
+																				types.StringElement{Content: "ordered 1.1.a"},
 																			},
 																		},
 																	},
@@ -214,11 +214,11 @@ var _ = Describe("mixed lists - document", func() {
 																Level:          2,
 																NumberingStyle: types.LowerAlpha,
 																Elements: []interface{}{
-																	&types.Paragraph{
+																	types.Paragraph{
 																		Attributes: types.ElementAttributes{},
 																		Lines: []types.InlineElements{
 																			{
-																				&types.StringElement{Content: "ordered 1.1.b"},
+																				types.StringElement{Content: "ordered 1.1.b"},
 																			},
 																		},
 																	},
@@ -229,11 +229,11 @@ var _ = Describe("mixed lists - document", func() {
 																Level:          2,
 																NumberingStyle: types.LowerAlpha,
 																Elements: []interface{}{
-																	&types.Paragraph{
+																	types.Paragraph{
 																		Attributes: types.ElementAttributes{},
 																		Lines: []types.InlineElements{
 																			{
-																				&types.StringElement{Content: "ordered 1.1.c"},
+																				types.StringElement{Content: "ordered 1.1.c"},
 																			},
 																		},
 																	},
@@ -248,27 +248,27 @@ var _ = Describe("mixed lists - document", func() {
 												Level:          1,
 												NumberingStyle: types.Arabic,
 												Elements: []interface{}{
-													&types.Paragraph{
+													types.Paragraph{
 														Attributes: types.ElementAttributes{},
 														Lines: []types.InlineElements{
 															{
-																&types.StringElement{Content: "ordered 1.2"},
+																types.StringElement{Content: "ordered 1.2"},
 															},
 														},
 													},
-													&types.OrderedList{
+													types.OrderedList{
 														Attributes: types.ElementAttributes{},
-														Items: []*types.OrderedListItem{
+														Items: []types.OrderedListItem{
 															{
 																Attributes:     types.ElementAttributes{},
 																Level:          2,
 																NumberingStyle: types.LowerRoman,
 																Elements: []interface{}{
-																	&types.Paragraph{
+																	types.Paragraph{
 																		Attributes: types.ElementAttributes{},
 																		Lines: []types.InlineElements{
 																			{
-																				&types.StringElement{Content: "ordered 1.2.i"},
+																				types.StringElement{Content: "ordered 1.2.i"},
 																			},
 																		},
 																	},
@@ -279,11 +279,11 @@ var _ = Describe("mixed lists - document", func() {
 																Level:          2,
 																NumberingStyle: types.LowerRoman,
 																Elements: []interface{}{
-																	&types.Paragraph{
+																	types.Paragraph{
 																		Attributes: types.ElementAttributes{},
 																		Lines: []types.InlineElements{
 																			{
-																				&types.StringElement{Content: "ordered 1.2.ii"},
+																				types.StringElement{Content: "ordered 1.2.ii"},
 																			},
 																		},
 																	},
@@ -298,11 +298,11 @@ var _ = Describe("mixed lists - document", func() {
 												Level:          1,
 												NumberingStyle: types.Arabic,
 												Elements: []interface{}{
-													&types.Paragraph{
+													types.Paragraph{
 														Attributes: types.ElementAttributes{},
 														Lines: []types.InlineElements{
 															{
-																&types.StringElement{Content: "ordered 1.3"},
+																types.StringElement{Content: "ordered 1.3"},
 															},
 														},
 													},
@@ -313,11 +313,11 @@ var _ = Describe("mixed lists - document", func() {
 												Level:          1,
 												NumberingStyle: types.Arabic,
 												Elements: []interface{}{
-													&types.Paragraph{
+													types.Paragraph{
 														Attributes: types.ElementAttributes{},
 														Lines: []types.InlineElements{
 															{
-																&types.StringElement{Content: "ordered 1.4"},
+																types.StringElement{Content: "ordered 1.4"},
 															},
 														},
 													},
@@ -333,28 +333,28 @@ var _ = Describe("mixed lists - document", func() {
 								BulletStyle: types.Dash,
 								CheckStyle:  types.NoCheck,
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{Content: "unordered 2"},
+												types.StringElement{Content: "unordered 2"},
 											},
 										},
 									},
-									&types.UnorderedList{
+									types.UnorderedList{
 										Attributes: types.ElementAttributes{},
-										Items: []*types.UnorderedListItem{
+										Items: []types.UnorderedListItem{
 											{
 												Attributes:  types.ElementAttributes{},
 												Level:       2,
 												BulletStyle: types.OneAsterisk,
 												CheckStyle:  types.NoCheck,
 												Elements: []interface{}{
-													&types.Paragraph{
+													types.Paragraph{
 														Attributes: types.ElementAttributes{},
 														Lines: []types.InlineElements{
 															{
-																&types.StringElement{Content: "unordered 2.1"},
+																types.StringElement{Content: "unordered 2.1"},
 															},
 														},
 													},
@@ -396,58 +396,58 @@ ii) ordered 1.2.ii
 .. ordered 3.2.I
 .. ordered 3.2.II
 . ordered 3.3`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.UnorderedList{
+					types.UnorderedList{
 						Attributes: types.ElementAttributes{},
-						Items: []*types.UnorderedListItem{
+						Items: []types.UnorderedListItem{
 							{
 								Attributes:  types.ElementAttributes{},
 								Level:       1,
 								BulletStyle: types.Dash,
 								CheckStyle:  types.NoCheck,
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{Content: "unordered 1"},
+												types.StringElement{Content: "unordered 1"},
 											},
 										},
 									},
-									&types.OrderedList{
+									types.OrderedList{
 										Attributes: types.ElementAttributes{},
-										Items: []*types.OrderedListItem{
+										Items: []types.OrderedListItem{
 											{
 												Attributes:     types.ElementAttributes{},
 												Level:          1,
 												NumberingStyle: types.Arabic,
 												Elements: []interface{}{
-													&types.Paragraph{
+													types.Paragraph{
 														Attributes: types.ElementAttributes{},
 														Lines: []types.InlineElements{
 															{
-																&types.StringElement{Content: "ordered 1.1"},
+																types.StringElement{Content: "ordered 1.1"},
 															},
 														},
 													},
-													&types.OrderedList{
+													types.OrderedList{
 														Attributes: types.ElementAttributes{},
-														Items: []*types.OrderedListItem{
+														Items: []types.OrderedListItem{
 															{
 																Attributes:     types.ElementAttributes{},
 																Level:          2,
 																NumberingStyle: types.LowerAlpha,
 																Elements: []interface{}{
-																	&types.Paragraph{
+																	types.Paragraph{
 																		Attributes: types.ElementAttributes{},
 																		Lines: []types.InlineElements{
 																			{
-																				&types.StringElement{Content: "ordered 1.1.a"},
+																				types.StringElement{Content: "ordered 1.1.a"},
 																			},
 																		},
 																	},
@@ -458,11 +458,11 @@ ii) ordered 1.2.ii
 																Level:          2,
 																NumberingStyle: types.LowerAlpha,
 																Elements: []interface{}{
-																	&types.Paragraph{
+																	types.Paragraph{
 																		Attributes: types.ElementAttributes{},
 																		Lines: []types.InlineElements{
 																			{
-																				&types.StringElement{Content: "ordered 1.1.b"},
+																				types.StringElement{Content: "ordered 1.1.b"},
 																			},
 																		},
 																	},
@@ -473,11 +473,11 @@ ii) ordered 1.2.ii
 																Level:          2,
 																NumberingStyle: types.LowerAlpha,
 																Elements: []interface{}{
-																	&types.Paragraph{
+																	types.Paragraph{
 																		Attributes: types.ElementAttributes{},
 																		Lines: []types.InlineElements{
 																			{
-																				&types.StringElement{Content: "ordered 1.1.c"},
+																				types.StringElement{Content: "ordered 1.1.c"},
 																			},
 																		},
 																	},
@@ -492,27 +492,27 @@ ii) ordered 1.2.ii
 												Level:          1,
 												NumberingStyle: types.Arabic,
 												Elements: []interface{}{
-													&types.Paragraph{
+													types.Paragraph{
 														Attributes: types.ElementAttributes{},
 														Lines: []types.InlineElements{
 															{
-																&types.StringElement{Content: "ordered 1.2"},
+																types.StringElement{Content: "ordered 1.2"},
 															},
 														},
 													},
-													&types.OrderedList{
+													types.OrderedList{
 														Attributes: types.ElementAttributes{},
-														Items: []*types.OrderedListItem{
+														Items: []types.OrderedListItem{
 															{
 																Attributes:     types.ElementAttributes{},
 																Level:          2,
 																NumberingStyle: types.LowerRoman,
 																Elements: []interface{}{
-																	&types.Paragraph{
+																	types.Paragraph{
 																		Attributes: types.ElementAttributes{},
 																		Lines: []types.InlineElements{
 																			{
-																				&types.StringElement{Content: "ordered 1.2.i"},
+																				types.StringElement{Content: "ordered 1.2.i"},
 																			},
 																		},
 																	},
@@ -523,11 +523,11 @@ ii) ordered 1.2.ii
 																Level:          2,
 																NumberingStyle: types.LowerRoman,
 																Elements: []interface{}{
-																	&types.Paragraph{
+																	types.Paragraph{
 																		Attributes: types.ElementAttributes{},
 																		Lines: []types.InlineElements{
 																			{
-																				&types.StringElement{Content: "ordered 1.2.ii"},
+																				types.StringElement{Content: "ordered 1.2.ii"},
 																			},
 																		},
 																	},
@@ -542,11 +542,11 @@ ii) ordered 1.2.ii
 												Level:          1,
 												NumberingStyle: types.Arabic,
 												Elements: []interface{}{
-													&types.Paragraph{
+													types.Paragraph{
 														Attributes: types.ElementAttributes{},
 														Lines: []types.InlineElements{
 															{
-																&types.StringElement{Content: "ordered 1.3"},
+																types.StringElement{Content: "ordered 1.3"},
 															},
 														},
 													},
@@ -557,11 +557,11 @@ ii) ordered 1.2.ii
 												Level:          1,
 												NumberingStyle: types.Arabic,
 												Elements: []interface{}{
-													&types.Paragraph{
+													types.Paragraph{
 														Attributes: types.ElementAttributes{},
 														Lines: []types.InlineElements{
 															{
-																&types.StringElement{Content: "ordered 1.4"},
+																types.StringElement{Content: "ordered 1.4"},
 															},
 														},
 													},
@@ -577,51 +577,51 @@ ii) ordered 1.2.ii
 								BulletStyle: types.Dash,
 								CheckStyle:  types.NoCheck,
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{Content: "unordered 2"},
+												types.StringElement{Content: "unordered 2"},
 											},
 										},
 									},
-									&types.UnorderedList{
+									types.UnorderedList{
 										Attributes: types.ElementAttributes{},
-										Items: []*types.UnorderedListItem{
+										Items: []types.UnorderedListItem{
 											{
 												Attributes:  types.ElementAttributes{},
 												Level:       2,
 												BulletStyle: types.OneAsterisk,
 												CheckStyle:  types.NoCheck,
 												Elements: []interface{}{
-													&types.Paragraph{
+													types.Paragraph{
 														Attributes: types.ElementAttributes{},
 														Lines: []types.InlineElements{
 															{
-																&types.StringElement{Content: "unordered 2.1"},
+																types.StringElement{Content: "unordered 2.1"},
 															},
 														},
 													},
-													&types.UnorderedList{
+													types.UnorderedList{
 														Attributes: types.ElementAttributes{},
-														Items: []*types.UnorderedListItem{
+														Items: []types.UnorderedListItem{
 															{
 																Attributes:  types.ElementAttributes{},
 																Level:       3,
 																BulletStyle: types.TwoAsterisks,
 																CheckStyle:  types.NoCheck,
 																Elements: []interface{}{
-																	&types.Paragraph{
+																	types.Paragraph{
 																		Attributes: types.ElementAttributes{},
 																		Lines: []types.InlineElements{
 																			{
-																				&types.StringElement{Content: "unordered 2.1.1"},
+																				types.StringElement{Content: "unordered 2.1.1"},
 																			},
 																			{
-																				&types.StringElement{Content: "\twith some"},
+																				types.StringElement{Content: "\twith some"},
 																			},
 																			{
-																				&types.StringElement{Content: "\textra lines."},
+																				types.StringElement{Content: "\textra lines."},
 																			},
 																		},
 																	},
@@ -633,11 +633,11 @@ ii) ordered 1.2.ii
 																BulletStyle: types.TwoAsterisks,
 																CheckStyle:  types.NoCheck,
 																Elements: []interface{}{
-																	&types.Paragraph{
+																	types.Paragraph{
 																		Attributes: types.ElementAttributes{},
 																		Lines: []types.InlineElements{
 																			{
-																				&types.StringElement{Content: "unordered 2.1.2"},
+																				types.StringElement{Content: "unordered 2.1.2"},
 																			},
 																		},
 																	},
@@ -653,11 +653,11 @@ ii) ordered 1.2.ii
 												BulletStyle: types.OneAsterisk,
 												CheckStyle:  types.NoCheck,
 												Elements: []interface{}{
-													&types.Paragraph{
+													types.Paragraph{
 														Attributes: types.ElementAttributes{},
 														Lines: []types.InlineElements{
 															{
-																&types.StringElement{Content: "unordered 2.2"},
+																types.StringElement{Content: "unordered 2.2"},
 															},
 														},
 													},
@@ -673,27 +673,27 @@ ii) ordered 1.2.ii
 								BulletStyle: types.Dash,
 								CheckStyle:  types.NoCheck,
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{Content: "unordered 3"},
+												types.StringElement{Content: "unordered 3"},
 											},
 										},
 									},
-									&types.OrderedList{
+									types.OrderedList{
 										Attributes: types.ElementAttributes{},
-										Items: []*types.OrderedListItem{
+										Items: []types.OrderedListItem{
 											{
 												Attributes:     types.ElementAttributes{},
 												Level:          1,
 												NumberingStyle: types.Arabic,
 												Elements: []interface{}{
-													&types.Paragraph{
+													types.Paragraph{
 														Attributes: types.ElementAttributes{},
 														Lines: []types.InlineElements{
 															{
-																&types.StringElement{Content: "ordered 3.1"},
+																types.StringElement{Content: "ordered 3.1"},
 															},
 														},
 													},
@@ -704,29 +704,29 @@ ii) ordered 1.2.ii
 												Level:          1,
 												NumberingStyle: types.Arabic,
 												Elements: []interface{}{
-													&types.Paragraph{
+													types.Paragraph{
 														Attributes: types.ElementAttributes{},
 														Lines: []types.InlineElements{
 															{
-																&types.StringElement{Content: "ordered 3.2"},
+																types.StringElement{Content: "ordered 3.2"},
 															},
 														},
 													},
-													&types.OrderedList{
+													types.OrderedList{
 														Attributes: types.ElementAttributes{
 															types.AttrNumberingStyle: "upperroman",
 														},
-														Items: []*types.OrderedListItem{
+														Items: []types.OrderedListItem{
 															{
 																Attributes:     types.ElementAttributes{},
 																Level:          2,
 																NumberingStyle: types.LowerAlpha,
 																Elements: []interface{}{
-																	&types.Paragraph{
+																	types.Paragraph{
 																		Attributes: types.ElementAttributes{},
 																		Lines: []types.InlineElements{
 																			{
-																				&types.StringElement{Content: "ordered 3.2.I"},
+																				types.StringElement{Content: "ordered 3.2.I"},
 																			},
 																		},
 																	},
@@ -737,11 +737,11 @@ ii) ordered 1.2.ii
 																Level:          2,
 																NumberingStyle: types.LowerAlpha,
 																Elements: []interface{}{
-																	&types.Paragraph{
+																	types.Paragraph{
 																		Attributes: types.ElementAttributes{},
 																		Lines: []types.InlineElements{
 																			{
-																				&types.StringElement{Content: "ordered 3.2.II"},
+																				types.StringElement{Content: "ordered 3.2.II"},
 																			},
 																		},
 																	},
@@ -756,11 +756,11 @@ ii) ordered 1.2.ii
 												Level:          1,
 												NumberingStyle: types.Arabic,
 												Elements: []interface{}{
-													&types.Paragraph{
+													types.Paragraph{
 														Attributes: types.ElementAttributes{},
 														Lines: []types.InlineElements{
 															{
-																&types.StringElement{Content: "ordered 3.3"},
+																types.StringElement{Content: "ordered 3.3"},
 															},
 														},
 													},
@@ -782,54 +782,54 @@ ii) ordered 1.2.ii
 Operating Systems::
   . Fedora
     * Desktop`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.LabeledList{
+					types.LabeledList{
 						Attributes: types.ElementAttributes{
 							types.AttrTitle: "Mixed",
 						},
-						Items: []*types.LabeledListItem{
+						Items: []types.LabeledListItem{
 							{
 								Attributes: types.ElementAttributes{},
 								Level:      1,
 								Term:       "Operating Systems",
 								Elements: []interface{}{
-									&types.OrderedList{
+									types.OrderedList{
 										Attributes: types.ElementAttributes{},
-										Items: []*types.OrderedListItem{
+										Items: []types.OrderedListItem{
 											{
 												Attributes:     types.ElementAttributes{},
 												Level:          1,
 												NumberingStyle: types.Arabic,
 												Elements: []interface{}{
-													&types.Paragraph{
+													types.Paragraph{
 														Attributes: types.ElementAttributes{},
 														Lines: []types.InlineElements{
 															{
-																&types.StringElement{
+																types.StringElement{
 																	Content: "Fedora",
 																},
 															},
 														},
 													},
-													&types.UnorderedList{
+													types.UnorderedList{
 														Attributes: types.ElementAttributes{},
-														Items: []*types.UnorderedListItem{
+														Items: []types.UnorderedListItem{
 															{
 																Attributes:  types.ElementAttributes{},
 																Level:       1,
 																BulletStyle: types.OneAsterisk,
 																CheckStyle:  types.NoCheck,
 																Elements: []interface{}{
-																	&types.Paragraph{
+																	types.Paragraph{
 																		Attributes: types.ElementAttributes{},
 																		Lines: []types.InlineElements{
 																			{
-																				&types.StringElement{
+																				types.StringElement{
 																					Content: "Desktop",
 																				},
 																			},
@@ -852,7 +852,7 @@ Operating Systems::
 			verifyDocument(expected, source)
 		})
 
-		It("complex case 5 - mixed lists", func() {
+		It("complex case 5 - mixed lists and a paragraph", func() {
 			source := `.Mixed
 Operating Systems::
   Linux:::
@@ -871,64 +871,66 @@ Cloud Providers::
     . CloudBees
   IaaS:::
     . Amazon EC2
-    . Rackspace
+	. Rackspace
+	
+a paragraph
 `
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.LabeledList{
+					types.LabeledList{
 						Attributes: types.ElementAttributes{
 							types.AttrTitle: "Mixed",
 						},
-						Items: []*types.LabeledListItem{
+						Items: []types.LabeledListItem{
 							{
 								Attributes: types.ElementAttributes{},
 								Level:      1,
 								Term:       "Operating Systems",
 								Elements: []interface{}{
-									&types.LabeledList{
+									types.LabeledList{
 										Attributes: types.ElementAttributes{},
-										Items: []*types.LabeledListItem{
+										Items: []types.LabeledListItem{
 											{
 												Attributes: types.ElementAttributes{},
 												Level:      2,
 												Term:       "Linux",
 												Elements: []interface{}{
-													&types.OrderedList{
+													types.OrderedList{
 														Attributes: types.ElementAttributes{},
-														Items: []*types.OrderedListItem{
+														Items: []types.OrderedListItem{
 															{
 																Attributes:     types.ElementAttributes{},
 																Level:          1,
 																NumberingStyle: types.Arabic,
 																Elements: []interface{}{
-																	&types.Paragraph{
+																	types.Paragraph{
 																		Attributes: types.ElementAttributes{},
 																		Lines: []types.InlineElements{
 																			{
-																				&types.StringElement{
+																				types.StringElement{
 																					Content: "Fedora",
 																				},
 																			},
 																		},
 																	},
-																	&types.UnorderedList{
+																	types.UnorderedList{
 																		Attributes: types.ElementAttributes{},
-																		Items: []*types.UnorderedListItem{
+																		Items: []types.UnorderedListItem{
 																			{
 																				Attributes:  types.ElementAttributes{},
 																				Level:       1,
 																				BulletStyle: types.OneAsterisk,
 																				CheckStyle:  types.NoCheck,
 																				Elements: []interface{}{
-																					&types.Paragraph{
+																					types.Paragraph{
 																						Attributes: types.ElementAttributes{},
 																						Lines: []types.InlineElements{
 																							{
-																								&types.StringElement{
+																								types.StringElement{
 																									Content: "Desktop",
 																								},
 																							},
@@ -945,30 +947,30 @@ Cloud Providers::
 																Level:          1,
 																NumberingStyle: types.Arabic,
 																Elements: []interface{}{
-																	&types.Paragraph{
+																	types.Paragraph{
 																		Attributes: types.ElementAttributes{},
 																		Lines: []types.InlineElements{
 																			{
-																				&types.StringElement{
+																				types.StringElement{
 																					Content: "Ubuntu",
 																				},
 																			},
 																		},
 																	},
-																	&types.UnorderedList{
+																	types.UnorderedList{
 																		Attributes: types.ElementAttributes{},
-																		Items: []*types.UnorderedListItem{
+																		Items: []types.UnorderedListItem{
 																			{
 																				Attributes:  types.ElementAttributes{},
 																				Level:       1,
 																				BulletStyle: types.OneAsterisk,
 																				CheckStyle:  types.NoCheck,
 																				Elements: []interface{}{
-																					&types.Paragraph{
+																					types.Paragraph{
 																						Attributes: types.ElementAttributes{},
 																						Lines: []types.InlineElements{
 																							{
-																								&types.StringElement{
+																								types.StringElement{
 																									Content: "Desktop",
 																								},
 																							},
@@ -982,11 +984,11 @@ Cloud Providers::
 																				BulletStyle: types.OneAsterisk,
 																				CheckStyle:  types.NoCheck,
 																				Elements: []interface{}{
-																					&types.Paragraph{
+																					types.Paragraph{
 																						Attributes: types.ElementAttributes{},
 																						Lines: []types.InlineElements{
 																							{
-																								&types.StringElement{
+																								types.StringElement{
 																									Content: "Server",
 																								},
 																							},
@@ -1007,19 +1009,19 @@ Cloud Providers::
 												Level:      2,
 												Term:       "BSD",
 												Elements: []interface{}{
-													&types.OrderedList{
+													types.OrderedList{
 														Attributes: types.ElementAttributes{},
-														Items: []*types.OrderedListItem{
+														Items: []types.OrderedListItem{
 															{
 																Attributes:     types.ElementAttributes{},
 																Level:          1,
 																NumberingStyle: types.Arabic,
 																Elements: []interface{}{
-																	&types.Paragraph{
+																	types.Paragraph{
 																		Attributes: types.ElementAttributes{},
 																		Lines: []types.InlineElements{
 																			{
-																				&types.StringElement{
+																				types.StringElement{
 																					Content: "FreeBSD",
 																				},
 																			},
@@ -1032,11 +1034,11 @@ Cloud Providers::
 																Level:          1,
 																NumberingStyle: types.Arabic,
 																Elements: []interface{}{
-																	&types.Paragraph{
+																	types.Paragraph{
 																		Attributes: types.ElementAttributes{},
 																		Lines: []types.InlineElements{
 																			{
-																				&types.StringElement{
+																				types.StringElement{
 																					Content: "NetBSD",
 																				},
 																			},
@@ -1057,27 +1059,27 @@ Cloud Providers::
 								Level:      1,
 								Term:       "Cloud Providers",
 								Elements: []interface{}{
-									&types.LabeledList{
+									types.LabeledList{
 										Attributes: types.ElementAttributes{},
-										Items: []*types.LabeledListItem{
+										Items: []types.LabeledListItem{
 											{
 												Attributes: types.ElementAttributes{},
 												Level:      2,
 												Term:       "PaaS",
 												Elements: []interface{}{
-													&types.OrderedList{
+													types.OrderedList{
 														Attributes: types.ElementAttributes{},
-														Items: []*types.OrderedListItem{
+														Items: []types.OrderedListItem{
 															{
 																Attributes:     types.ElementAttributes{},
 																Level:          1,
 																NumberingStyle: types.Arabic,
 																Elements: []interface{}{
-																	&types.Paragraph{
+																	types.Paragraph{
 																		Attributes: types.ElementAttributes{},
 																		Lines: []types.InlineElements{
 																			{
-																				&types.StringElement{
+																				types.StringElement{
 																					Content: "OpenShift",
 																				},
 																			},
@@ -1090,11 +1092,11 @@ Cloud Providers::
 																Level:          1,
 																NumberingStyle: types.Arabic,
 																Elements: []interface{}{
-																	&types.Paragraph{
+																	types.Paragraph{
 																		Attributes: types.ElementAttributes{},
 																		Lines: []types.InlineElements{
 																			{
-																				&types.StringElement{
+																				types.StringElement{
 																					Content: "CloudBees",
 																				},
 																			},
@@ -1111,19 +1113,19 @@ Cloud Providers::
 												Level:      2,
 												Term:       "IaaS",
 												Elements: []interface{}{
-													&types.OrderedList{
+													types.OrderedList{
 														Attributes: types.ElementAttributes{},
-														Items: []*types.OrderedListItem{
+														Items: []types.OrderedListItem{
 															{
 																Attributes:     types.ElementAttributes{},
 																Level:          1,
 																NumberingStyle: types.Arabic,
 																Elements: []interface{}{
-																	&types.Paragraph{
+																	types.Paragraph{
 																		Attributes: types.ElementAttributes{},
 																		Lines: []types.InlineElements{
 																			{
-																				&types.StringElement{
+																				types.StringElement{
 																					Content: "Amazon EC2",
 																				},
 																			},
@@ -1136,11 +1138,11 @@ Cloud Providers::
 																Level:          1,
 																NumberingStyle: types.Arabic,
 																Elements: []interface{}{
-																	&types.Paragraph{
+																	types.Paragraph{
 																		Attributes: types.ElementAttributes{},
 																		Lines: []types.InlineElements{
 																			{
-																				&types.StringElement{
+																				types.StringElement{
 																					Content: "Rackspace",
 																				},
 																			},
@@ -1158,6 +1160,17 @@ Cloud Providers::
 							},
 						},
 					},
+					// types.BlankLine{},
+					types.Paragraph{
+						Attributes: types.ElementAttributes{},
+						Lines: []types.InlineElements{
+							{
+								types.StringElement{
+									Content: "a paragraph",
+								},
+							},
+						},
+					},
 				},
 			}
 			verifyDocument(expected, source)
@@ -1171,46 +1184,46 @@ Cloud Providers::
 	. Five
 	.. a
 	. Six`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{ // a single ordered list
-					&types.OrderedList{
+					types.OrderedList{
 						Attributes: types.ElementAttributes{
 							types.AttrNumberingStyle: "lowerroman",
 							types.AttrStart:          "5",
 						},
-						Items: []*types.OrderedListItem{
+						Items: []types.OrderedListItem{
 							{
 								Attributes:     types.ElementAttributes{},
 								Level:          1,
 								NumberingStyle: types.Arabic, // will be overridden during rendering
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{
+												types.StringElement{
 													Content: "Five",
 												},
 											},
 										},
 									},
-									&types.OrderedList{
+									types.OrderedList{
 										Attributes: types.ElementAttributes{},
-										Items: []*types.OrderedListItem{
+										Items: []types.OrderedListItem{
 											{
 												Attributes:     types.ElementAttributes{},
 												Level:          2,
 												NumberingStyle: types.LowerAlpha,
 												Elements: []interface{}{
-													&types.Paragraph{
+													types.Paragraph{
 														Attributes: types.ElementAttributes{},
 														Lines: []types.InlineElements{
 															{
-																&types.StringElement{
+																types.StringElement{
 																	Content: "a",
 																},
 															},
@@ -1227,11 +1240,11 @@ Cloud Providers::
 								Level:          1,
 								NumberingStyle: types.Arabic, // will be overridden during rendering
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{
+												types.StringElement{
 													Content: "Six",
 												},
 											},
@@ -1254,48 +1267,48 @@ Cloud Providers::
 .. a
 .. b
 . Six`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{ // a single ordered list
-					&types.OrderedList{
+					types.OrderedList{
 						Attributes: types.ElementAttributes{
 							types.AttrNumberingStyle: "lowerroman",
 							types.AttrStart:          "5",
 						},
-						Items: []*types.OrderedListItem{
+						Items: []types.OrderedListItem{
 							{
 								Attributes:     types.ElementAttributes{},
 								Level:          1,
 								NumberingStyle: types.Arabic, // will be overridden during rendering
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{
+												types.StringElement{
 													Content: "Five",
 												},
 											},
 										},
 									},
-									&types.OrderedList{
+									types.OrderedList{
 										Attributes: types.ElementAttributes{
 											types.AttrNumberingStyle: "upperalpha",
 										},
-										Items: []*types.OrderedListItem{
+										Items: []types.OrderedListItem{
 											{
 												Attributes:     types.ElementAttributes{},
 												Level:          2,
 												NumberingStyle: types.LowerAlpha, // will be overridden during rendering
 												Elements: []interface{}{
-													&types.Paragraph{
+													types.Paragraph{
 														Attributes: types.ElementAttributes{},
 														Lines: []types.InlineElements{
 															{
-																&types.StringElement{
+																types.StringElement{
 																	Content: "a",
 																},
 															},
@@ -1308,11 +1321,11 @@ Cloud Providers::
 												Level:          2,
 												NumberingStyle: types.LowerAlpha, // will be overridden during rendering
 												Elements: []interface{}{
-													&types.Paragraph{
+													types.Paragraph{
 														Attributes: types.ElementAttributes{},
 														Lines: []types.InlineElements{
 															{
-																&types.StringElement{
+																types.StringElement{
 																	Content: "b",
 																},
 															},
@@ -1329,11 +1342,11 @@ Cloud Providers::
 								Level:          1,
 								NumberingStyle: types.Arabic, // will be overridden during rendering
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{
+												types.StringElement{
 													Content: "Six",
 												},
 											},
@@ -1355,28 +1368,28 @@ Cloud Providers::
 [upperalpha]
 .. a
 . Six`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{ // a single ordered list
-					&types.OrderedList{
+					types.OrderedList{
 						Attributes: types.ElementAttributes{
 							types.AttrNumberingStyle: "lowerroman",
 							types.AttrStart:          "5",
 						},
-						Items: []*types.OrderedListItem{
+						Items: []types.OrderedListItem{
 							{
 								Attributes:     types.ElementAttributes{},
 								Level:          1,
 								NumberingStyle: types.Arabic,
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{
+												types.StringElement{
 													Content: "Five",
 												},
 											},
@@ -1386,39 +1399,39 @@ Cloud Providers::
 							},
 						},
 					},
-					&types.OrderedList{
+					types.OrderedList{
 						Attributes: types.ElementAttributes{
 							types.AttrNumberingStyle: "upperalpha",
 						},
-						Items: []*types.OrderedListItem{
+						Items: []types.OrderedListItem{
 							{
 								Attributes:     types.ElementAttributes{},
 								Level:          1,
 								NumberingStyle: types.LowerAlpha,
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{
+												types.StringElement{
 													Content: "a",
 												},
 											},
 										},
 									},
-									&types.OrderedList{
+									types.OrderedList{
 										Attributes: types.ElementAttributes{},
-										Items: []*types.OrderedListItem{
+										Items: []types.OrderedListItem{
 											{
 												Attributes:     types.ElementAttributes{},
 												Level:          2,
 												NumberingStyle: types.Arabic,
 												Elements: []interface{}{
-													&types.Paragraph{
+													types.Paragraph{
 														Attributes: types.ElementAttributes{},
 														Lines: []types.InlineElements{
 															{
-																&types.StringElement{
+																types.StringElement{
 																	Content: "Six",
 																},
 															},
@@ -1446,30 +1459,30 @@ Cloud Providers::
 .Ordered, basic
 . Step 1
 . Step 2`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.UnorderedList{
+					types.UnorderedList{
 						Attributes: types.ElementAttributes{
 							types.AttrTitle: "Checklist",
 						},
-						Items: []*types.UnorderedListItem{
+						Items: []types.UnorderedListItem{
 							{
 								Attributes:  types.ElementAttributes{},
 								Level:       1,
 								BulletStyle: types.Dash,
 								CheckStyle:  types.Checked,
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{
 											types.AttrCheckStyle: types.Checked,
 										},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{
+												types.StringElement{
 													Content: "checked",
 												},
 											},
@@ -1483,11 +1496,11 @@ Cloud Providers::
 								BulletStyle: types.Dash,
 								CheckStyle:  types.NoCheck,
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{
+												types.StringElement{
 													Content: "normal list item",
 												},
 											},
@@ -1497,21 +1510,21 @@ Cloud Providers::
 							},
 						},
 					},
-					&types.OrderedList{
+					types.OrderedList{
 						Attributes: types.ElementAttributes{
 							types.AttrTitle: "Ordered, basic",
 						},
-						Items: []*types.OrderedListItem{
+						Items: []types.OrderedListItem{
 							{
 								Attributes:     types.ElementAttributes{},
 								Level:          1,
 								NumberingStyle: types.Arabic,
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{
+												types.StringElement{
 													Content: "Step 1",
 												},
 											},
@@ -1524,11 +1537,11 @@ Cloud Providers::
 								Level:          1,
 								NumberingStyle: types.Arabic,
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{
+												types.StringElement{
 													Content: "Step 2",
 												},
 											},
@@ -1547,31 +1560,31 @@ Cloud Providers::
 			source := `. a
 	// -
 	. b`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.OrderedList{
+					types.OrderedList{
 						Attributes: types.ElementAttributes{},
-						Items: []*types.OrderedListItem{
+						Items: []types.OrderedListItem{
 							{
 								Attributes:     types.ElementAttributes{},
 								Level:          1,
 								NumberingStyle: types.Arabic,
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{
+												types.StringElement{
 													Content: "a",
 												},
 											},
 										},
 									},
-									&types.SingleLineComment{
+									types.SingleLineComment{
 										Content: " -",
 									},
 								},
@@ -1581,11 +1594,11 @@ Cloud Providers::
 								Level:          1,
 								NumberingStyle: types.Arabic,
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{
+												types.StringElement{
 													Content: "b",
 												},
 											},
@@ -1606,37 +1619,37 @@ Cloud Providers::
 	// -
 	// -
 	. b`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.OrderedList{
+					types.OrderedList{
 						Attributes: types.ElementAttributes{},
-						Items: []*types.OrderedListItem{
+						Items: []types.OrderedListItem{
 							{
 								Attributes:     types.ElementAttributes{},
 								Level:          1,
 								NumberingStyle: types.Arabic,
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{
+												types.StringElement{
 													Content: "a",
 												},
 											},
 										},
 									},
-									&types.SingleLineComment{
+									types.SingleLineComment{
 										Content: " -",
 									},
-									&types.SingleLineComment{
+									types.SingleLineComment{
 										Content: " -",
 									},
-									&types.SingleLineComment{
+									types.SingleLineComment{
 										Content: " -",
 									},
 								},
@@ -1646,11 +1659,11 @@ Cloud Providers::
 								Level:          1,
 								NumberingStyle: types.Arabic,
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{
+												types.StringElement{
 													Content: "b",
 												},
 											},
@@ -1670,25 +1683,25 @@ Cloud Providers::
 	
 	// -
 	. b`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.OrderedList{
+					types.OrderedList{
 						Attributes: types.ElementAttributes{},
-						Items: []*types.OrderedListItem{
+						Items: []types.OrderedListItem{
 							{
 								Attributes:     types.ElementAttributes{},
 								Level:          1,
 								NumberingStyle: types.Arabic,
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{
+												types.StringElement{
 													Content: "a",
 												},
 											},
@@ -1698,22 +1711,22 @@ Cloud Providers::
 							},
 						},
 					},
-					&types.SingleLineComment{
+					types.SingleLineComment{
 						Content: " -",
 					},
-					&types.OrderedList{
+					types.OrderedList{
 						Attributes: types.ElementAttributes{},
-						Items: []*types.OrderedListItem{
+						Items: []types.OrderedListItem{
 							{
 								Attributes:     types.ElementAttributes{},
 								Level:          1,
 								NumberingStyle: types.Arabic,
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{
+												types.StringElement{
 													Content: "b",
 												},
 											},
@@ -1735,25 +1748,25 @@ Cloud Providers::
 // -
 // -
 . b`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.OrderedList{
+					types.OrderedList{
 						Attributes: types.ElementAttributes{},
-						Items: []*types.OrderedListItem{
+						Items: []types.OrderedListItem{
 							{
 								Attributes:     types.ElementAttributes{},
 								Level:          1,
 								NumberingStyle: types.Arabic,
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{
+												types.StringElement{
 													Content: "a",
 												},
 											},
@@ -1763,28 +1776,28 @@ Cloud Providers::
 							},
 						},
 					},
-					&types.SingleLineComment{
+					types.SingleLineComment{
 						Content: " -",
 					},
-					&types.SingleLineComment{
+					types.SingleLineComment{
 						Content: " -",
 					},
-					&types.SingleLineComment{
+					types.SingleLineComment{
 						Content: " -",
 					},
-					&types.OrderedList{
+					types.OrderedList{
 						Attributes: types.ElementAttributes{},
-						Items: []*types.OrderedListItem{
+						Items: []types.OrderedListItem{
 							{
 								Attributes:     types.ElementAttributes{},
 								Level:          1,
 								NumberingStyle: types.Arabic,
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{
+												types.StringElement{
 													Content: "b",
 												},
 											},

--- a/pkg/parser/ordered_list_test.go
+++ b/pkg/parser/ordered_list_test.go
@@ -11,11 +11,11 @@ var _ = Describe("ordered lists - preflight", func() {
 
 		// same single item in the list for each test in this context
 		elements := []interface{}{
-			&types.Paragraph{
+			types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{Content: "item"},
+						types.StringElement{Content: "item"},
 					},
 				},
 			},
@@ -23,9 +23,9 @@ var _ = Describe("ordered lists - preflight", func() {
 
 		It("ordered list item with implicit numbering style", func() {
 			source := `.. item`
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.OrderedListItem{
+					types.OrderedListItem{
 						Level:          2,
 						NumberingStyle: types.LowerAlpha,
 						Attributes:     map[string]interface{}{},
@@ -38,9 +38,9 @@ var _ = Describe("ordered lists - preflight", func() {
 
 		It("ordered list item with arabic numbering style", func() {
 			source := `1. item`
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.OrderedListItem{
+					types.OrderedListItem{
 						Level:          1,
 						NumberingStyle: types.Arabic,
 						Attributes:     map[string]interface{}{},
@@ -53,9 +53,9 @@ var _ = Describe("ordered lists - preflight", func() {
 
 		It("ordered list item with lower alpha numbering style", func() {
 			source := `b. item`
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.OrderedListItem{
+					types.OrderedListItem{
 						Level:          1,
 						NumberingStyle: types.LowerAlpha,
 						Attributes:     map[string]interface{}{},
@@ -68,9 +68,9 @@ var _ = Describe("ordered lists - preflight", func() {
 
 		It("ordered list item with upper alpha numbering style", func() {
 			source := `B. item`
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.OrderedListItem{
+					types.OrderedListItem{
 						Level:          1,
 						NumberingStyle: types.UpperAlpha,
 						Attributes:     map[string]interface{}{},
@@ -83,9 +83,9 @@ var _ = Describe("ordered lists - preflight", func() {
 
 		It("ordered list item with lower roman numbering style", func() {
 			source := `i) item`
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.OrderedListItem{
+					types.OrderedListItem{
 						Level:          1,
 						NumberingStyle: types.LowerRoman,
 						Attributes:     map[string]interface{}{},
@@ -98,9 +98,9 @@ var _ = Describe("ordered lists - preflight", func() {
 
 		It("ordered list item with upper roman numbering style", func() {
 			source := `I) item`
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.OrderedListItem{
+					types.OrderedListItem{
 						Level:          1,
 						NumberingStyle: types.UpperRoman,
 						Attributes:     map[string]interface{}{},
@@ -115,9 +115,9 @@ var _ = Describe("ordered lists - preflight", func() {
 			source := `[lowerroman]
 . item
 . item`
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.OrderedListItem{
+					types.OrderedListItem{
 						Attributes: types.ElementAttributes{
 							"lowerroman": nil,
 						},
@@ -125,7 +125,7 @@ var _ = Describe("ordered lists - preflight", func() {
 						NumberingStyle: types.Arabic,
 						Elements:       elements,
 					},
-					&types.OrderedListItem{
+					types.OrderedListItem{
 						Attributes:     types.ElementAttributes{},
 						Level:          1,
 						NumberingStyle: types.Arabic,
@@ -139,9 +139,9 @@ var _ = Describe("ordered lists - preflight", func() {
 		It("ordered list item with explicit start only", func() {
 			source := `[start=5]
 . item`
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.OrderedListItem{
+					types.OrderedListItem{
 						Level:          1,
 						NumberingStyle: types.Arabic,
 						Attributes: types.ElementAttributes{
@@ -157,9 +157,9 @@ var _ = Describe("ordered lists - preflight", func() {
 		It("ordered list item with explicit quoted numbering and start", func() {
 			source := `["lowerroman", start="5"]
 . item`
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.OrderedListItem{
+					types.OrderedListItem{
 						Level:          1,
 						NumberingStyle: types.Arabic,
 						Attributes: types.ElementAttributes{
@@ -181,20 +181,20 @@ var _ = Describe("ordered lists - preflight", func() {
 .... level 4
 ..... level 5
 . level 1`
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.OrderedListItem{
+					types.OrderedListItem{
 						Level:          1,
 						NumberingStyle: types.Arabic,
 						Attributes: types.ElementAttributes{
 							types.AttrTitle: "Ordered, max nesting",
 						},
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "level 1",
 										},
 									},
@@ -202,16 +202,16 @@ var _ = Describe("ordered lists - preflight", func() {
 							},
 						},
 					},
-					&types.OrderedListItem{
+					types.OrderedListItem{
 						Level:          2,
 						NumberingStyle: types.LowerAlpha,
 						Attributes:     types.ElementAttributes{},
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "level 2",
 										},
 									},
@@ -219,16 +219,16 @@ var _ = Describe("ordered lists - preflight", func() {
 							},
 						},
 					},
-					&types.OrderedListItem{
+					types.OrderedListItem{
 						Level:          3,
 						NumberingStyle: types.LowerRoman,
 						Attributes:     types.ElementAttributes{},
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "level 3",
 										},
 									},
@@ -236,16 +236,16 @@ var _ = Describe("ordered lists - preflight", func() {
 							},
 						},
 					},
-					&types.OrderedListItem{
+					types.OrderedListItem{
 						Level:          4,
 						NumberingStyle: types.UpperAlpha,
 						Attributes:     types.ElementAttributes{},
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "level 4",
 										},
 									},
@@ -253,16 +253,16 @@ var _ = Describe("ordered lists - preflight", func() {
 							},
 						},
 					},
-					&types.OrderedListItem{
+					types.OrderedListItem{
 						Level:          5,
 						NumberingStyle: types.UpperRoman,
 						Attributes:     types.ElementAttributes{},
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "level 5",
 										},
 									},
@@ -270,16 +270,16 @@ var _ = Describe("ordered lists - preflight", func() {
 							},
 						},
 					},
-					&types.OrderedListItem{
+					types.OrderedListItem{
 						Level:          1,
 						NumberingStyle: types.Arabic,
 						Attributes:     types.ElementAttributes{},
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "level 1",
 										},
 									},
@@ -299,21 +299,21 @@ var _ = Describe("ordered lists - preflight", func() {
 ... level 3
 .... level 4
 ..... level 5
-.. level 2`
-			expected := &types.PreflightDocument{
+.. level 2b`
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.OrderedListItem{
+					types.OrderedListItem{
 						Level:          1,
 						NumberingStyle: types.Arabic,
 						Attributes: types.ElementAttributes{
 							types.AttrTitle: "Ordered, max nesting",
 						},
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "level 1",
 										},
 									},
@@ -321,16 +321,16 @@ var _ = Describe("ordered lists - preflight", func() {
 							},
 						},
 					},
-					&types.OrderedListItem{
+					types.OrderedListItem{
 						Level:          2,
 						NumberingStyle: types.LowerAlpha,
 						Attributes:     types.ElementAttributes{},
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "level 2",
 										},
 									},
@@ -338,16 +338,16 @@ var _ = Describe("ordered lists - preflight", func() {
 							},
 						},
 					},
-					&types.OrderedListItem{
+					types.OrderedListItem{
 						Level:          3,
 						NumberingStyle: types.LowerRoman,
 						Attributes:     types.ElementAttributes{},
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "level 3",
 										},
 									},
@@ -355,16 +355,16 @@ var _ = Describe("ordered lists - preflight", func() {
 							},
 						},
 					},
-					&types.OrderedListItem{
+					types.OrderedListItem{
 						Level:          4,
 						NumberingStyle: types.UpperAlpha,
 						Attributes:     types.ElementAttributes{},
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "level 4",
 										},
 									},
@@ -372,16 +372,16 @@ var _ = Describe("ordered lists - preflight", func() {
 							},
 						},
 					},
-					&types.OrderedListItem{
+					types.OrderedListItem{
 						Level:          5,
 						NumberingStyle: types.UpperRoman,
 						Attributes:     types.ElementAttributes{},
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "level 5",
 										},
 									},
@@ -389,17 +389,17 @@ var _ = Describe("ordered lists - preflight", func() {
 							},
 						},
 					},
-					&types.OrderedListItem{
+					types.OrderedListItem{
 						Level:          2,
 						NumberingStyle: types.LowerAlpha,
 						Attributes:     types.ElementAttributes{},
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
-											Content: "level 2",
+										types.StringElement{
+											Content: "level 2b",
 										},
 									},
 								},
@@ -418,33 +418,33 @@ var _ = Describe("ordered lists - preflight", func() {
 			source := `. a
 . b`
 
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.OrderedListItem{
+					types.OrderedListItem{
 						Level:          1,
 						NumberingStyle: types.Arabic,
 						Attributes:     map[string]interface{}{},
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "a"},
+										types.StringElement{Content: "a"},
 									},
 								},
 							},
 						},
 					},
-					&types.OrderedListItem{
+					types.OrderedListItem{
 						Level:          1,
 						NumberingStyle: types.Arabic,
 						Attributes:     map[string]interface{}{},
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "b"},
+										types.StringElement{Content: "b"},
 									},
 								},
 							},
@@ -459,33 +459,33 @@ var _ = Describe("ordered lists - preflight", func() {
 			source := `. item 1
 . item 2`
 
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.OrderedListItem{
+					types.OrderedListItem{
 						Level:          1,
 						NumberingStyle: types.Arabic,
 						Attributes:     map[string]interface{}{},
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "item 1"},
+										types.StringElement{Content: "item 1"},
 									},
 								},
 							},
 						},
 					},
-					&types.OrderedListItem{
+					types.OrderedListItem{
 						Level:          1,
 						NumberingStyle: types.Arabic,
 						Attributes:     map[string]interface{}{},
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "item 2"},
+										types.StringElement{Content: "item 2"},
 									},
 								},
 							},
@@ -507,110 +507,110 @@ var _ = Describe("ordered lists - preflight", func() {
 			. item 2
 			.. item 2.1`
 
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.OrderedListItem{
+					types.OrderedListItem{
 						Level:          1,
 						NumberingStyle: types.Arabic,
 						Attributes:     map[string]interface{}{},
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "item 1"},
+										types.StringElement{Content: "item 1"},
 									},
 								},
 							},
 						},
 					},
-					&types.OrderedListItem{
+					types.OrderedListItem{
 						Level:          2,
 						NumberingStyle: types.LowerAlpha,
 						Attributes:     map[string]interface{}{},
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "item 1.1"},
+										types.StringElement{Content: "item 1.1"},
 									},
 								},
 							},
 						},
 					},
-					&types.OrderedListItem{
+					types.OrderedListItem{
 						Level:          3,
 						NumberingStyle: types.LowerRoman,
 						Attributes: types.ElementAttributes{
 							"upperroman": nil,
 						},
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "item 1.1.1"},
+										types.StringElement{Content: "item 1.1.1"},
 									},
 								},
 							},
 						},
 					},
-					&types.OrderedListItem{
+					types.OrderedListItem{
 						Level:          3,
 						NumberingStyle: types.LowerRoman,
 						Attributes:     map[string]interface{}{},
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "item 1.1.2"},
+										types.StringElement{Content: "item 1.1.2"},
 									},
 								},
 							},
 						},
 					},
-					&types.OrderedListItem{
+					types.OrderedListItem{
 						Level:          2,
 						NumberingStyle: types.LowerAlpha,
 						Attributes:     map[string]interface{}{},
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "item 1.2"},
+										types.StringElement{Content: "item 1.2"},
 									},
 								},
 							},
 						},
 					},
-					&types.OrderedListItem{
+					types.OrderedListItem{
 						Level:          1,
 						NumberingStyle: types.Arabic,
 						Attributes:     map[string]interface{}{},
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "item 2"},
+										types.StringElement{Content: "item 2"},
 									},
 								},
 							},
 						},
 					},
-					&types.OrderedListItem{
+					types.OrderedListItem{
 						Level:          2,
 						NumberingStyle: types.LowerAlpha,
 						Attributes:     map[string]interface{}{},
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "item 2.1"},
+										types.StringElement{Content: "item 2.1"},
 									},
 								},
 							},
@@ -636,91 +636,91 @@ var _ = Describe("ordered lists - preflight", func() {
 
 
 `
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.OrderedListItem{
+					types.OrderedListItem{
 						Level:          1,
 						NumberingStyle: types.Arabic,
 						Attributes:     map[string]interface{}{},
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "level 1"},
+										types.StringElement{Content: "level 1"},
 									},
 								},
 							},
 						},
 					},
-					&types.BlankLine{},
-					&types.OrderedListItem{
+					types.BlankLine{},
+					types.OrderedListItem{
 						Level:          2,
 						NumberingStyle: types.LowerAlpha,
 						Attributes:     map[string]interface{}{},
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "level 2"},
+										types.StringElement{Content: "level 2"},
 									},
 								},
 							},
 						},
 					},
-					&types.BlankLine{},
-					&types.BlankLine{},
-					&types.OrderedListItem{
+					types.BlankLine{},
+					types.BlankLine{},
+					types.OrderedListItem{
 						Level:          3,
 						NumberingStyle: types.LowerRoman,
 						Attributes:     map[string]interface{}{},
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "level 3"},
+										types.StringElement{Content: "level 3"},
 									},
 								},
 							},
 						},
 					},
-					&types.BlankLine{},
-					&types.BlankLine{},
-					&types.BlankLine{},
-					&types.OrderedListItem{
+					types.BlankLine{},
+					types.BlankLine{},
+					types.BlankLine{},
+					types.OrderedListItem{
 						Level:          4,
 						NumberingStyle: types.UpperAlpha,
 						Attributes:     map[string]interface{}{},
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "level 4"},
+										types.StringElement{Content: "level 4"},
 									},
 								},
 							},
 						},
 					},
-					&types.OrderedListItem{
+					types.OrderedListItem{
 						Level:          5,
 						NumberingStyle: types.UpperRoman,
 						Attributes:     map[string]interface{}{},
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "level 5."},
+										types.StringElement{Content: "level 5."},
 									},
 								},
 							},
 						},
 					},
-					&types.BlankLine{},
-					&types.BlankLine{},
+					types.BlankLine{},
+					types.BlankLine{},
 				},
 			}
 			verifyPreflight(expected, source)
@@ -732,33 +732,33 @@ var _ = Describe("ordered lists - preflight", func() {
 		It("ordered list with simple numbered items", func() {
 			source := `1. a
 2. b`
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.OrderedListItem{
+					types.OrderedListItem{
 						Level:          1,
 						NumberingStyle: types.Arabic,
 						Attributes:     map[string]interface{}{},
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "a"},
+										types.StringElement{Content: "a"},
 									},
 								},
 							},
 						},
 					},
-					&types.OrderedListItem{
+					types.OrderedListItem{
 						Level:          1,
 						NumberingStyle: types.Arabic,
 						Attributes:     map[string]interface{}{},
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "b"},
+										types.StringElement{Content: "b"},
 									},
 								},
 							},
@@ -774,63 +774,63 @@ var _ = Describe("ordered lists - preflight", func() {
 a. item 1.a
 2. item 2
 b. item 2.a`
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.OrderedListItem{
+					types.OrderedListItem{
 						Level:          1,
 						NumberingStyle: types.Arabic,
 						Attributes:     map[string]interface{}{},
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "item 1"},
+										types.StringElement{Content: "item 1"},
 									},
 								},
 							},
 						},
 					},
-					&types.OrderedListItem{
+					types.OrderedListItem{
 						Level:          1,
 						NumberingStyle: types.LowerAlpha,
 						Attributes:     map[string]interface{}{},
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "item 1.a"},
+										types.StringElement{Content: "item 1.a"},
 									},
 								},
 							},
 						},
 					},
-					&types.OrderedListItem{
+					types.OrderedListItem{
 						Level:          1,
 						NumberingStyle: types.Arabic,
 						Attributes:     map[string]interface{}{},
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "item 2"},
+										types.StringElement{Content: "item 2"},
 									},
 								},
 							},
 						},
 					},
-					&types.OrderedListItem{
+					types.OrderedListItem{
 						Level:          1,
 						NumberingStyle: types.LowerAlpha,
 						Attributes:     map[string]interface{}{},
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "item 2.a"},
+										types.StringElement{Content: "item 2.a"},
 									},
 								},
 							},
@@ -856,34 +856,34 @@ another delimited block
 ----
 . bar
 `
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.OrderedListItem{
+					types.OrderedListItem{
 						Attributes:     types.ElementAttributes{},
 						Level:          1,
 						NumberingStyle: types.Arabic,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "foo"},
+										types.StringElement{Content: "foo"},
 									},
 								},
 							},
 						},
 					},
-					&types.ContinuedListItemElement{
+					types.ContinuedListItemElement{
 						Offset: 0,
-						Element: &types.DelimitedBlock{
+						Element: types.DelimitedBlock{
 							Attributes: types.ElementAttributes{},
 							Kind:       types.Listing,
 							Elements: []interface{}{
-								&types.Paragraph{
+								types.Paragraph{
 									Attributes: types.ElementAttributes{},
 									Lines: []types.InlineElements{
 										{
-											&types.StringElement{
+											types.StringElement{
 												Content: "a delimited block",
 											},
 										},
@@ -892,17 +892,17 @@ another delimited block
 							},
 						},
 					},
-					&types.ContinuedListItemElement{
+					types.ContinuedListItemElement{
 						Offset: 0,
-						Element: &types.DelimitedBlock{
+						Element: types.DelimitedBlock{
 							Attributes: types.ElementAttributes{},
 							Kind:       types.Listing,
 							Elements: []interface{}{
-								&types.Paragraph{
+								types.Paragraph{
 									Attributes: types.ElementAttributes{},
 									Lines: []types.InlineElements{
 										{
-											&types.StringElement{
+											types.StringElement{
 												Content: "another delimited block",
 											},
 										},
@@ -911,16 +911,16 @@ another delimited block
 							},
 						},
 					},
-					&types.OrderedListItem{
+					types.OrderedListItem{
 						Attributes:     types.ElementAttributes{},
 						Level:          1,
 						NumberingStyle: types.Arabic,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "bar"},
+										types.StringElement{Content: "bar"},
 									},
 								},
 							},
@@ -939,26 +939,26 @@ var _ = Describe("ordered lists - document", func() {
 
 		// same single item in the list for each test in this context
 		elements := []interface{}{
-			&types.Paragraph{
+			types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{Content: "item"},
+						types.StringElement{Content: "item"},
 					},
 				},
 			},
 		}
 		It("ordered list item with implicit numbering style", func() {
 			source := `.. item`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.OrderedList{
+					types.OrderedList{
 						Attributes: types.ElementAttributes{},
-						Items: []*types.OrderedListItem{
+						Items: []types.OrderedListItem{
 							{
 								Level:          1,
 								NumberingStyle: types.LowerAlpha,
@@ -974,15 +974,15 @@ var _ = Describe("ordered lists - document", func() {
 
 		It("ordered list item with arabic numbering style", func() {
 			source := `1. item`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.OrderedList{
+					types.OrderedList{
 						Attributes: types.ElementAttributes{},
-						Items: []*types.OrderedListItem{
+						Items: []types.OrderedListItem{
 							{
 								Level:          1,
 								NumberingStyle: types.Arabic,
@@ -998,15 +998,15 @@ var _ = Describe("ordered lists - document", func() {
 
 		It("ordered list item with lower alpha numbering style", func() {
 			source := `b. item`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.OrderedList{
+					types.OrderedList{
 						Attributes: types.ElementAttributes{},
-						Items: []*types.OrderedListItem{
+						Items: []types.OrderedListItem{
 							{
 								Level:          1,
 								NumberingStyle: types.LowerAlpha,
@@ -1022,15 +1022,15 @@ var _ = Describe("ordered lists - document", func() {
 
 		It("ordered list item with upper alpha numbering style", func() {
 			source := `B. item`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.OrderedList{
+					types.OrderedList{
 						Attributes: types.ElementAttributes{},
-						Items: []*types.OrderedListItem{
+						Items: []types.OrderedListItem{
 							{
 
 								Level:          1,
@@ -1047,15 +1047,15 @@ var _ = Describe("ordered lists - document", func() {
 
 		It("ordered list item with lower roman numbering style", func() {
 			source := `i) item`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.OrderedList{
+					types.OrderedList{
 						Attributes: types.ElementAttributes{},
-						Items: []*types.OrderedListItem{
+						Items: []types.OrderedListItem{
 							{
 								Level:          1,
 								NumberingStyle: types.LowerRoman,
@@ -1071,15 +1071,15 @@ var _ = Describe("ordered lists - document", func() {
 
 		It("ordered list item with upper roman numbering style", func() {
 			source := `I) item`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.OrderedList{
+					types.OrderedList{
 						Attributes: types.ElementAttributes{},
-						Items: []*types.OrderedListItem{
+						Items: []types.OrderedListItem{
 							{
 
 								Level:          1,
@@ -1098,17 +1098,17 @@ var _ = Describe("ordered lists - document", func() {
 			source := `[lowerroman]
 . item
 . item`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.OrderedList{
+					types.OrderedList{
 						Attributes: types.ElementAttributes{
 							types.AttrNumberingStyle: "lowerroman", // will be used during rendering
 						},
-						Items: []*types.OrderedListItem{
+						Items: []types.OrderedListItem{
 							{
 								Attributes:     types.ElementAttributes{},
 								Level:          1,
@@ -1131,17 +1131,17 @@ var _ = Describe("ordered lists - document", func() {
 		It("ordered list item with explicit start only", func() {
 			source := `[start=5]
 . item`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.OrderedList{
+					types.OrderedList{
 						Attributes: types.ElementAttributes{
 							"start": "5",
 						},
-						Items: []*types.OrderedListItem{
+						Items: []types.OrderedListItem{
 							{
 								Level:          1,
 								NumberingStyle: types.Arabic,
@@ -1158,18 +1158,18 @@ var _ = Describe("ordered lists - document", func() {
 		It("ordered list item with explicit quoted numbering and start", func() {
 			source := `["lowerroman", start="5"]
 . item`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.OrderedList{
+					types.OrderedList{
 						Attributes: types.ElementAttributes{
 							types.AttrNumberingStyle: "lowerroman", // will be used during rendering
 							"start":                  "5",
 						},
-						Items: []*types.OrderedListItem{
+						Items: []types.OrderedListItem{
 							{
 								Level:          1,
 								NumberingStyle: types.Arabic, // will be overridden during rendering
@@ -1191,99 +1191,99 @@ var _ = Describe("ordered lists - document", func() {
 .... level 4
 ..... level 5
 . level 1`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.OrderedList{
+					types.OrderedList{
 						Attributes: types.ElementAttributes{
 							types.AttrTitle: "Ordered, max nesting",
 						},
-						Items: []*types.OrderedListItem{
+						Items: []types.OrderedListItem{
 							{
 								Level:          1,
 								NumberingStyle: types.Arabic,
 								Attributes:     types.ElementAttributes{},
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{
+												types.StringElement{
 													Content: "level 1",
 												},
 											},
 										},
 									},
-									&types.OrderedList{
+									types.OrderedList{
 										Attributes: types.ElementAttributes{},
-										Items: []*types.OrderedListItem{
+										Items: []types.OrderedListItem{
 											{
 												Level:          2,
 												NumberingStyle: types.LowerAlpha,
 												Attributes:     types.ElementAttributes{},
 												Elements: []interface{}{
-													&types.Paragraph{
+													types.Paragraph{
 														Attributes: types.ElementAttributes{},
 														Lines: []types.InlineElements{
 															{
-																&types.StringElement{
+																types.StringElement{
 																	Content: "level 2",
 																},
 															},
 														},
 													},
-													&types.OrderedList{
+													types.OrderedList{
 														Attributes: types.ElementAttributes{},
-														Items: []*types.OrderedListItem{
+														Items: []types.OrderedListItem{
 															{
 																Level:          3,
 																NumberingStyle: types.LowerRoman,
 																Attributes:     types.ElementAttributes{},
 																Elements: []interface{}{
-																	&types.Paragraph{
+																	types.Paragraph{
 																		Attributes: types.ElementAttributes{},
 																		Lines: []types.InlineElements{
 																			{
-																				&types.StringElement{
+																				types.StringElement{
 																					Content: "level 3",
 																				},
 																			},
 																		},
 																	},
-																	&types.OrderedList{
+																	types.OrderedList{
 																		Attributes: types.ElementAttributes{},
-																		Items: []*types.OrderedListItem{
+																		Items: []types.OrderedListItem{
 																			{
 																				Level:          4,
 																				NumberingStyle: types.UpperAlpha,
 																				Attributes:     types.ElementAttributes{},
 																				Elements: []interface{}{
-																					&types.Paragraph{
+																					types.Paragraph{
 																						Attributes: types.ElementAttributes{},
 																						Lines: []types.InlineElements{
 																							{
-																								&types.StringElement{
+																								types.StringElement{
 																									Content: "level 4",
 																								},
 																							},
 																						},
 																					},
-																					&types.OrderedList{
+																					types.OrderedList{
 																						Attributes: types.ElementAttributes{},
-																						Items: []*types.OrderedListItem{
+																						Items: []types.OrderedListItem{
 																							{
 																								Level:          5,
 																								NumberingStyle: types.UpperRoman,
 																								Attributes:     types.ElementAttributes{},
 																								Elements: []interface{}{
-																									&types.Paragraph{
+																									types.Paragraph{
 																										Attributes: types.ElementAttributes{},
 																										Lines: []types.InlineElements{
 																											{
-																												&types.StringElement{
+																												types.StringElement{
 																													Content: "level 5",
 																												},
 																											},
@@ -1312,11 +1312,11 @@ var _ = Describe("ordered lists - document", func() {
 								NumberingStyle: types.Arabic,
 								Attributes:     types.ElementAttributes{},
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{
+												types.StringElement{
 													Content: "level 1",
 												},
 											},
@@ -1338,100 +1338,100 @@ var _ = Describe("ordered lists - document", func() {
 ... level 3
 .... level 4
 ..... level 5
-.. level 2`
-			expected := &types.Document{
+.. level 2b`
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.OrderedList{
+					types.OrderedList{
 						Attributes: types.ElementAttributes{
 							types.AttrTitle: "Ordered, max nesting",
 						},
-						Items: []*types.OrderedListItem{
+						Items: []types.OrderedListItem{
 							{
 								Level:          1,
 								NumberingStyle: types.Arabic,
 								Attributes:     types.ElementAttributes{},
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{
+												types.StringElement{
 													Content: "level 1",
 												},
 											},
 										},
 									},
-									&types.OrderedList{
+									types.OrderedList{
 										Attributes: types.ElementAttributes{},
-										Items: []*types.OrderedListItem{
+										Items: []types.OrderedListItem{
 											{
 												Level:          2,
 												NumberingStyle: types.LowerAlpha,
 												Attributes:     types.ElementAttributes{},
 												Elements: []interface{}{
-													&types.Paragraph{
+													types.Paragraph{
 														Attributes: types.ElementAttributes{},
 														Lines: []types.InlineElements{
 															{
-																&types.StringElement{
+																types.StringElement{
 																	Content: "level 2",
 																},
 															},
 														},
 													},
-													&types.OrderedList{
+													types.OrderedList{
 														Attributes: types.ElementAttributes{},
-														Items: []*types.OrderedListItem{
+														Items: []types.OrderedListItem{
 															{
 																Level:          3,
 																NumberingStyle: types.LowerRoman,
 																Attributes:     types.ElementAttributes{},
 																Elements: []interface{}{
-																	&types.Paragraph{
+																	types.Paragraph{
 																		Attributes: types.ElementAttributes{},
 																		Lines: []types.InlineElements{
 																			{
-																				&types.StringElement{
+																				types.StringElement{
 																					Content: "level 3",
 																				},
 																			},
 																		},
 																	},
-																	&types.OrderedList{
+																	types.OrderedList{
 																		Attributes: types.ElementAttributes{},
-																		Items: []*types.OrderedListItem{
+																		Items: []types.OrderedListItem{
 																			{
 																				Level:          4,
 																				NumberingStyle: types.UpperAlpha,
 																				Attributes:     types.ElementAttributes{},
 																				Elements: []interface{}{
-																					&types.Paragraph{
+																					types.Paragraph{
 																						Attributes: types.ElementAttributes{},
 																						Lines: []types.InlineElements{
 																							{
-																								&types.StringElement{
+																								types.StringElement{
 																									Content: "level 4",
 																								},
 																							},
 																						},
 																					},
-																					&types.OrderedList{
+																					types.OrderedList{
 																						Attributes: types.ElementAttributes{},
-																						Items: []*types.OrderedListItem{
+																						Items: []types.OrderedListItem{
 																							{
 																								Level:          5,
 																								NumberingStyle: types.UpperRoman,
 																								Attributes:     types.ElementAttributes{},
 																								Elements: []interface{}{
-																									&types.Paragraph{
+																									types.Paragraph{
 																										Attributes: types.ElementAttributes{},
 																										Lines: []types.InlineElements{
 																											{
-																												&types.StringElement{
+																												types.StringElement{
 																													Content: "level 5",
 																												},
 																											},
@@ -1456,12 +1456,12 @@ var _ = Describe("ordered lists - document", func() {
 												NumberingStyle: types.LowerAlpha,
 												Attributes:     types.ElementAttributes{},
 												Elements: []interface{}{
-													&types.Paragraph{
+													types.Paragraph{
 														Attributes: types.ElementAttributes{},
 														Lines: []types.InlineElements{
 															{
-																&types.StringElement{
-																	Content: "level 2",
+																types.StringElement{
+																	Content: "level 2b",
 																},
 															},
 														},
@@ -1486,25 +1486,25 @@ var _ = Describe("ordered lists - document", func() {
 			source := `. a
 . b`
 
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.OrderedList{
+					types.OrderedList{
 						Attributes: types.ElementAttributes{},
-						Items: []*types.OrderedListItem{
+						Items: []types.OrderedListItem{
 							{
 								Level:          1,
 								NumberingStyle: types.Arabic,
 								Attributes:     map[string]interface{}{},
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{Content: "a"},
+												types.StringElement{Content: "a"},
 											},
 										},
 									},
@@ -1515,11 +1515,11 @@ var _ = Describe("ordered lists - document", func() {
 								NumberingStyle: types.Arabic,
 								Attributes:     map[string]interface{}{},
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{Content: "b"},
+												types.StringElement{Content: "b"},
 											},
 										},
 									},
@@ -1536,25 +1536,25 @@ var _ = Describe("ordered lists - document", func() {
 			source := `. item 1
 . item 2`
 
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.OrderedList{
+					types.OrderedList{
 						Attributes: types.ElementAttributes{},
-						Items: []*types.OrderedListItem{
+						Items: []types.OrderedListItem{
 							{
 								Level:          1,
 								NumberingStyle: types.Arabic,
 								Attributes:     map[string]interface{}{},
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{Content: "item 1"},
+												types.StringElement{Content: "item 1"},
 											},
 										},
 									},
@@ -1565,11 +1565,11 @@ var _ = Describe("ordered lists - document", func() {
 								NumberingStyle: types.Arabic,
 								Attributes:     map[string]interface{}{},
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{Content: "item 2"},
+												types.StringElement{Content: "item 2"},
 											},
 										},
 									},
@@ -1593,59 +1593,59 @@ var _ = Describe("ordered lists - document", func() {
 			. item 2
 			.. item 2.1`
 
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.OrderedList{
+					types.OrderedList{
 						Attributes: types.ElementAttributes{},
-						Items: []*types.OrderedListItem{
+						Items: []types.OrderedListItem{
 							{
 								Level:          1,
 								NumberingStyle: types.Arabic,
 								Attributes:     map[string]interface{}{},
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{Content: "item 1"},
+												types.StringElement{Content: "item 1"},
 											},
 										},
 									},
-									&types.OrderedList{
+									types.OrderedList{
 										Attributes: types.ElementAttributes{},
-										Items: []*types.OrderedListItem{
+										Items: []types.OrderedListItem{
 											{
 												Level:          2,
 												NumberingStyle: types.LowerAlpha,
 												Attributes:     map[string]interface{}{},
 												Elements: []interface{}{
-													&types.Paragraph{
+													types.Paragraph{
 														Attributes: types.ElementAttributes{},
 														Lines: []types.InlineElements{
 															{
-																&types.StringElement{Content: "item 1.1"},
+																types.StringElement{Content: "item 1.1"},
 															},
 														},
 													},
-													&types.OrderedList{
+													types.OrderedList{
 														Attributes: types.ElementAttributes{
 															types.AttrNumberingStyle: "upperroman",
 														},
-														Items: []*types.OrderedListItem{
+														Items: []types.OrderedListItem{
 															{
 																Level:          3,
 																NumberingStyle: types.LowerRoman, // will be overridden during rendering
 																Attributes:     types.ElementAttributes{},
 																Elements: []interface{}{
-																	&types.Paragraph{
+																	types.Paragraph{
 																		Attributes: types.ElementAttributes{},
 																		Lines: []types.InlineElements{
 																			{
-																				&types.StringElement{Content: "item 1.1.1"},
+																				types.StringElement{Content: "item 1.1.1"},
 																			},
 																		},
 																	},
@@ -1656,11 +1656,11 @@ var _ = Describe("ordered lists - document", func() {
 																NumberingStyle: types.LowerRoman, // will be overridden during rendering
 																Attributes:     map[string]interface{}{},
 																Elements: []interface{}{
-																	&types.Paragraph{
+																	types.Paragraph{
 																		Attributes: types.ElementAttributes{},
 																		Lines: []types.InlineElements{
 																			{
-																				&types.StringElement{Content: "item 1.1.2"},
+																				types.StringElement{Content: "item 1.1.2"},
 																			},
 																		},
 																	},
@@ -1675,11 +1675,11 @@ var _ = Describe("ordered lists - document", func() {
 												NumberingStyle: types.LowerAlpha,
 												Attributes:     map[string]interface{}{},
 												Elements: []interface{}{
-													&types.Paragraph{
+													types.Paragraph{
 														Attributes: types.ElementAttributes{},
 														Lines: []types.InlineElements{
 															{
-																&types.StringElement{Content: "item 1.2"},
+																types.StringElement{Content: "item 1.2"},
 															},
 														},
 													},
@@ -1694,27 +1694,27 @@ var _ = Describe("ordered lists - document", func() {
 								NumberingStyle: types.Arabic,
 								Attributes:     map[string]interface{}{},
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{Content: "item 2"},
+												types.StringElement{Content: "item 2"},
 											},
 										},
 									},
-									&types.OrderedList{
+									types.OrderedList{
 										Attributes: types.ElementAttributes{},
-										Items: []*types.OrderedListItem{
+										Items: []types.OrderedListItem{
 											{
 												Level:          2,
 												NumberingStyle: types.LowerAlpha,
 												Attributes:     map[string]interface{}{},
 												Elements: []interface{}{
-													&types.Paragraph{
+													types.Paragraph{
 														Attributes: types.ElementAttributes{},
 														Lines: []types.InlineElements{
 															{
-																&types.StringElement{Content: "item 2.1"},
+																types.StringElement{Content: "item 2.1"},
 															},
 														},
 													},
@@ -1746,89 +1746,89 @@ var _ = Describe("ordered lists - document", func() {
 
 
 `
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.OrderedList{
+					types.OrderedList{
 						Attributes: types.ElementAttributes{},
-						Items: []*types.OrderedListItem{
+						Items: []types.OrderedListItem{
 							{
 								Level:          1,
 								NumberingStyle: types.Arabic,
 								Attributes:     map[string]interface{}{},
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{Content: "level 1"},
+												types.StringElement{Content: "level 1"},
 											},
 										},
 									},
-									&types.OrderedList{
+									types.OrderedList{
 										Attributes: types.ElementAttributes{},
-										Items: []*types.OrderedListItem{
+										Items: []types.OrderedListItem{
 											{
 												Level:          2,
 												NumberingStyle: types.LowerAlpha,
 												Attributes:     map[string]interface{}{},
 												Elements: []interface{}{
-													&types.Paragraph{
+													types.Paragraph{
 														Attributes: types.ElementAttributes{},
 														Lines: []types.InlineElements{
 															{
-																&types.StringElement{Content: "level 2"},
+																types.StringElement{Content: "level 2"},
 															},
 														},
 													},
-													&types.OrderedList{
+													types.OrderedList{
 														Attributes: types.ElementAttributes{},
-														Items: []*types.OrderedListItem{
+														Items: []types.OrderedListItem{
 															{
 																Level:          3,
 																NumberingStyle: types.LowerRoman,
 																Attributes:     map[string]interface{}{},
 																Elements: []interface{}{
-																	&types.Paragraph{
+																	types.Paragraph{
 																		Attributes: types.ElementAttributes{},
 																		Lines: []types.InlineElements{
 																			{
-																				&types.StringElement{Content: "level 3"},
+																				types.StringElement{Content: "level 3"},
 																			},
 																		},
 																	},
-																	&types.OrderedList{
+																	types.OrderedList{
 																		Attributes: types.ElementAttributes{},
-																		Items: []*types.OrderedListItem{
+																		Items: []types.OrderedListItem{
 																			{
 																				Level:          4,
 																				NumberingStyle: types.UpperAlpha,
 																				Attributes:     map[string]interface{}{},
 																				Elements: []interface{}{
-																					&types.Paragraph{
+																					types.Paragraph{
 																						Attributes: types.ElementAttributes{},
 																						Lines: []types.InlineElements{
 																							{
-																								&types.StringElement{Content: "level 4"},
+																								types.StringElement{Content: "level 4"},
 																							},
 																						},
 																					},
-																					&types.OrderedList{
+																					types.OrderedList{
 																						Attributes: types.ElementAttributes{},
-																						Items: []*types.OrderedListItem{
+																						Items: []types.OrderedListItem{
 																							{
 																								Level:          5,
 																								NumberingStyle: types.UpperRoman,
 																								Attributes:     map[string]interface{}{},
 																								Elements: []interface{}{
-																									&types.Paragraph{
+																									types.Paragraph{
 																										Attributes: types.ElementAttributes{},
 																										Lines: []types.InlineElements{
 																											{
-																												&types.StringElement{Content: "level 5."},
+																												types.StringElement{Content: "level 5."},
 																											},
 																										},
 																									},
@@ -1863,25 +1863,25 @@ var _ = Describe("ordered lists - document", func() {
 		It("ordered list with simple numbered items", func() {
 			source := `1. a
 2. b`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.OrderedList{
+					types.OrderedList{
 						Attributes: types.ElementAttributes{},
-						Items: []*types.OrderedListItem{
+						Items: []types.OrderedListItem{
 							{
 								Level:          1,
 								NumberingStyle: types.Arabic,
 								Attributes:     map[string]interface{}{},
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{Content: "a"},
+												types.StringElement{Content: "a"},
 											},
 										},
 									},
@@ -1892,11 +1892,11 @@ var _ = Describe("ordered lists - document", func() {
 								NumberingStyle: types.Arabic,
 								Attributes:     map[string]interface{}{},
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{Content: "b"},
+												types.StringElement{Content: "b"},
 											},
 										},
 									},
@@ -1914,41 +1914,41 @@ var _ = Describe("ordered lists - document", func() {
 a. item 1.a
 2. item 2
 b. item 2.a`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.OrderedList{
+					types.OrderedList{
 						Attributes: types.ElementAttributes{},
-						Items: []*types.OrderedListItem{
+						Items: []types.OrderedListItem{
 							{
 								Level:          1,
 								NumberingStyle: types.Arabic,
 								Attributes:     map[string]interface{}{},
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{Content: "item 1"},
+												types.StringElement{Content: "item 1"},
 											},
 										},
 									},
-									&types.OrderedList{
+									types.OrderedList{
 										Attributes: types.ElementAttributes{},
-										Items: []*types.OrderedListItem{
+										Items: []types.OrderedListItem{
 											{
 												Level:          2,
 												NumberingStyle: types.LowerAlpha,
 												Attributes:     map[string]interface{}{},
 												Elements: []interface{}{
-													&types.Paragraph{
+													types.Paragraph{
 														Attributes: types.ElementAttributes{},
 														Lines: []types.InlineElements{
 															{
-																&types.StringElement{Content: "item 1.a"},
+																types.StringElement{Content: "item 1.a"},
 															},
 														},
 													},
@@ -1963,27 +1963,27 @@ b. item 2.a`
 								NumberingStyle: types.Arabic,
 								Attributes:     map[string]interface{}{},
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{Content: "item 2"},
+												types.StringElement{Content: "item 2"},
 											},
 										},
 									},
-									&types.OrderedList{
+									types.OrderedList{
 										Attributes: types.ElementAttributes{},
-										Items: []*types.OrderedListItem{
+										Items: []types.OrderedListItem{
 											{
 												Level:          2,
 												NumberingStyle: types.LowerAlpha,
 												Attributes:     map[string]interface{}{},
 												Elements: []interface{}{
-													&types.Paragraph{
+													types.Paragraph{
 														Attributes: types.ElementAttributes{},
 														Lines: []types.InlineElements{
 															{
-																&types.StringElement{Content: "item 2.a"},
+																types.StringElement{Content: "item 2.a"},
 															},
 														},
 													},
@@ -2015,37 +2015,37 @@ another delimited block
 ----
 . bar
 `
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.OrderedList{
+					types.OrderedList{
 						Attributes: types.ElementAttributes{},
-						Items: []*types.OrderedListItem{
+						Items: []types.OrderedListItem{
 							{
 								Attributes:     types.ElementAttributes{},
 								Level:          1,
 								NumberingStyle: types.Arabic,
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{Content: "foo"},
+												types.StringElement{Content: "foo"},
 											},
 										},
 									},
-									&types.DelimitedBlock{
+									types.DelimitedBlock{
 										Attributes: types.ElementAttributes{},
 										Kind:       types.Listing,
 										Elements: []interface{}{
-											&types.Paragraph{
+											types.Paragraph{
 												Attributes: types.ElementAttributes{},
 												Lines: []types.InlineElements{
 													{
-														&types.StringElement{
+														types.StringElement{
 															Content: "a delimited block",
 														},
 													},
@@ -2053,15 +2053,15 @@ another delimited block
 											},
 										},
 									},
-									&types.DelimitedBlock{
+									types.DelimitedBlock{
 										Attributes: types.ElementAttributes{},
 										Kind:       types.Listing,
 										Elements: []interface{}{
-											&types.Paragraph{
+											types.Paragraph{
 												Attributes: types.ElementAttributes{},
 												Lines: []types.InlineElements{
 													{
-														&types.StringElement{
+														types.StringElement{
 															Content: "another delimited block",
 														},
 													},
@@ -2076,11 +2076,11 @@ another delimited block
 								Level:          1,
 								NumberingStyle: types.Arabic,
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{Content: "bar"},
+												types.StringElement{Content: "bar"},
 											},
 										},
 									},

--- a/pkg/parser/paragraph_test.go
+++ b/pkg/parser/paragraph_test.go
@@ -11,11 +11,11 @@ var _ = Describe("paragraphs - preflight", func() {
 
 		It("paragraph with 1 word", func() {
 			source := "hello"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{Content: "hello"},
+						types.StringElement{Content: "hello"},
 					},
 				},
 			}
@@ -24,11 +24,11 @@ var _ = Describe("paragraphs - preflight", func() {
 
 		It("paragraph with few words and ending with spaces", func() {
 			source := "a paragraph with some content  "
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{Content: "a paragraph with some content  "},
+						types.StringElement{Content: "a paragraph with some content  "},
 					},
 				},
 			}
@@ -37,18 +37,18 @@ var _ = Describe("paragraphs - preflight", func() {
 
 		It("paragraph with bold content and spaces", func() {
 			source := "a paragraph with *some bold content*  "
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{Content: "a paragraph with "},
-						&types.QuotedText{
+						types.StringElement{Content: "a paragraph with "},
+						types.QuotedText{
 							Kind: types.Bold,
 							Elements: types.InlineElements{
-								&types.StringElement{Content: "some bold content"},
+								types.StringElement{Content: "some bold content"},
 							},
 						},
-						&types.StringElement{Content: "  "},
+						types.StringElement{Content: "  "},
 					},
 				},
 			}
@@ -57,15 +57,15 @@ var _ = Describe("paragraphs - preflight", func() {
 
 		It("paragraph with non-alphnum character before bold text", func() {
 			source := "+*some bold content*"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{Content: "+"},
-						&types.QuotedText{
+						types.StringElement{Content: "+"},
+						types.QuotedText{
 							Kind: types.Bold,
 							Elements: types.InlineElements{
-								&types.StringElement{Content: "some bold content"},
+								types.StringElement{Content: "some bold content"},
 							},
 						},
 					},
@@ -78,7 +78,7 @@ var _ = Describe("paragraphs - preflight", func() {
 			source := `[#foo]
 .a title
 a paragraph`
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{
 					types.AttrID:       "foo",
 					types.AttrCustomID: true,
@@ -86,7 +86,7 @@ a paragraph`
 				},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{Content: "a paragraph"},
+						types.StringElement{Content: "a paragraph"},
 					},
 				},
 			}
@@ -95,11 +95,11 @@ a paragraph`
 
 		It("paragraph with words and dots on same line", func() {
 			source := `foo. bar.`
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{Content: "foo. bar."},
+						types.StringElement{Content: "foo. bar."},
 					},
 				},
 			}
@@ -109,14 +109,14 @@ a paragraph`
 		It("paragraph with words and dots on two lines", func() {
 			source := `foo. 
 bar.`
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{Content: "foo. "},
+						types.StringElement{Content: "foo. "},
 					},
 					{
-						&types.StringElement{Content: "bar."},
+						types.StringElement{Content: "bar."},
 					},
 				},
 			}
@@ -130,18 +130,18 @@ bar.`
 			source := `foo +
 bar
 baz`
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{Content: "foo"},
-						&types.LineBreak{},
+						types.StringElement{Content: "foo"},
+						types.LineBreak{},
 					},
 					{
-						&types.StringElement{Content: "bar"},
+						types.StringElement{Content: "bar"},
 					},
 					{
-						&types.StringElement{Content: "baz"},
+						types.StringElement{Content: "baz"},
 					},
 				},
 			}
@@ -153,19 +153,19 @@ baz`
 foo
 bar
 baz`
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{
 					types.AttrHardBreaks: nil,
 				},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{Content: "foo"},
+						types.StringElement{Content: "foo"},
 					},
 					{
-						&types.StringElement{Content: "bar"},
+						types.StringElement{Content: "bar"},
 					},
 					{
-						&types.StringElement{Content: "baz"},
+						types.StringElement{Content: "baz"},
 					},
 				},
 			}
@@ -178,13 +178,13 @@ baz`
 
 		It("note admonition paragraph", func() {
 			source := `NOTE: this is a note.`
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{
 					types.AttrAdmonitionKind: types.Note,
 				},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{
+						types.StringElement{
 							Content: "this is a note.",
 						},
 					},
@@ -196,18 +196,18 @@ baz`
 		It("warning admonition paragraph", func() {
 			source := `WARNING: this is a multiline
 warning!`
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{
 					types.AttrAdmonitionKind: types.Warning,
 				},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{
+						types.StringElement{
 							Content: "this is a multiline",
 						},
 					},
 					{
-						&types.StringElement{
+						types.StringElement{
 							Content: "warning!",
 						},
 					},
@@ -220,7 +220,7 @@ warning!`
 			source := `[[foo]]
 .bar
 NOTE: this is a note.`
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{
 					types.AttrAdmonitionKind: types.Note,
 					types.AttrID:             "foo",
@@ -229,7 +229,7 @@ NOTE: this is a note.`
 				},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{
+						types.StringElement{
 							Content: "this is a note.",
 						},
 					},
@@ -241,13 +241,13 @@ NOTE: this is a note.`
 		It("caution admonition paragraph with single line", func() {
 			source := `[CAUTION]
 this is a caution!`
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{
 					types.AttrAdmonitionKind: types.Caution,
 				},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{
+						types.StringElement{
 							Content: "this is a caution!",
 						},
 					},
@@ -262,7 +262,7 @@ this is a caution!`
 .bar
 this is a 
 *caution*!`
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{
 					types.AttrAdmonitionKind: types.Caution,
 					types.AttrID:             "foo",
@@ -271,20 +271,20 @@ this is a
 				},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{
+						types.StringElement{
 							Content: "this is a ",
 						},
 					},
 					{
-						&types.QuotedText{
+						types.QuotedText{
 							Kind: types.Bold,
 							Elements: types.InlineElements{
-								&types.StringElement{
+								types.StringElement{
 									Content: "caution",
 								},
 							},
 						},
-						&types.StringElement{
+						types.StringElement{
 							Content: "!",
 						},
 					},
@@ -299,28 +299,28 @@ No space after the [NOTE]!
 
 [CAUTION]
 And no space after [CAUTION] either.`
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{
 							types.AttrAdmonitionKind: types.Note,
 						},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "No space after the [NOTE]!",
 								},
 							},
 						},
 					},
-					&types.BlankLine{},
-					&types.Paragraph{
+					types.BlankLine{},
+					types.Paragraph{
 						Attributes: types.ElementAttributes{
 							types.AttrAdmonitionKind: types.Caution,
 						},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "And no space after [CAUTION] either.",
 								},
 							},
@@ -337,7 +337,7 @@ And no space after [CAUTION] either.`
 		It("paragraph as a verse with author and title", func() {
 			source := `[verse, john doe, verse title]
 I am a verse paragraph.`
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{
 					types.AttrKind:        types.Verse,
 					types.AttrQuoteAuthor: "john doe",
@@ -345,7 +345,7 @@ I am a verse paragraph.`
 				},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{
+						types.StringElement{
 							Content: "I am a verse paragraph.",
 						},
 					},
@@ -359,7 +359,7 @@ I am a verse paragraph.`
 [verse, john doe, verse title]
 .universe
 I am a verse paragraph.`
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{
 					types.AttrKind:        types.Verse,
 					types.AttrQuoteAuthor: "john doe",
@@ -370,7 +370,7 @@ I am a verse paragraph.`
 				},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{
+						types.StringElement{
 							Content: "I am a verse paragraph.",
 						},
 					},
@@ -382,14 +382,14 @@ I am a verse paragraph.`
 		It("paragraph as a verse with empty title", func() {
 			source := `[verse, john doe, ]
 I am a verse paragraph.`
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{
 					types.AttrKind:        types.Verse,
 					types.AttrQuoteAuthor: "john doe",
 				},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{
+						types.StringElement{
 							Content: "I am a verse paragraph.",
 						},
 					},
@@ -401,14 +401,14 @@ I am a verse paragraph.`
 		It("paragraph as a verse without title", func() {
 			source := `[verse, john doe ]
 I am a verse paragraph.`
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{
 					types.AttrKind:        types.Verse,
 					types.AttrQuoteAuthor: "john doe",
 				},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{
+						types.StringElement{
 							Content: "I am a verse paragraph.",
 						},
 					},
@@ -420,13 +420,13 @@ I am a verse paragraph.`
 		It("paragraph as a verse with empty author", func() {
 			source := `[verse,  ]
 I am a verse paragraph.`
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{
 					types.AttrKind: types.Verse,
 				},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{
+						types.StringElement{
 							Content: "I am a verse paragraph.",
 						},
 					},
@@ -438,13 +438,13 @@ I am a verse paragraph.`
 		It("paragraph as a verse without author", func() {
 			source := `[verse]
 I am a verse paragraph.`
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{
 					types.AttrKind: types.Verse,
 				},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{
+						types.StringElement{
 							Content: "I am a verse paragraph.",
 						},
 					},
@@ -456,7 +456,7 @@ I am a verse paragraph.`
 		It("image block as a verse", func() {
 			source := `[verse, john doe, verse title]
 image::foo.png[]`
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{
 					types.AttrKind:        types.Verse,
 					types.AttrQuoteAuthor: "john doe",
@@ -464,7 +464,7 @@ image::foo.png[]`
 				},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{
+						types.StringElement{
 							Content: "image::foo.png[]",
 						},
 					},
@@ -479,7 +479,7 @@ image::foo.png[]`
 		It("paragraph as a quote with author and title", func() {
 			source := `[quote, john doe, quote title]
 I am a quote paragraph.`
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{
 					types.AttrKind:        types.Quote,
 					types.AttrQuoteAuthor: "john doe",
@@ -487,7 +487,7 @@ I am a quote paragraph.`
 				},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{
+						types.StringElement{
 							Content: "I am a quote paragraph.",
 						},
 					},
@@ -501,7 +501,7 @@ I am a quote paragraph.`
 [quote, john doe, quote title]
 .universe
 I am a quote paragraph.`
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{
 					types.AttrKind:        types.Quote,
 					types.AttrQuoteAuthor: "john doe",
@@ -512,7 +512,7 @@ I am a quote paragraph.`
 				},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{
+						types.StringElement{
 							Content: "I am a quote paragraph.",
 						},
 					},
@@ -524,14 +524,14 @@ I am a quote paragraph.`
 		It("paragraph as a quote with empty title", func() {
 			source := `[quote, john doe, ]
 I am a quote paragraph.`
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{
 					types.AttrKind:        types.Quote,
 					types.AttrQuoteAuthor: "john doe",
 				},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{
+						types.StringElement{
 							Content: "I am a quote paragraph.",
 						},
 					},
@@ -543,14 +543,14 @@ I am a quote paragraph.`
 		It("paragraph as a quote without title", func() {
 			source := `[quote, john doe ]
 I am a quote paragraph.`
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{
 					types.AttrKind:        types.Quote,
 					types.AttrQuoteAuthor: "john doe",
 				},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{
+						types.StringElement{
 							Content: "I am a quote paragraph.",
 						},
 					},
@@ -562,13 +562,13 @@ I am a quote paragraph.`
 		It("paragraph as a quote with empty author", func() {
 			source := `[quote,  ]
 I am a quote paragraph.`
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{
 					types.AttrKind: types.Quote,
 				},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{
+						types.StringElement{
 							Content: "I am a quote paragraph.",
 						},
 					},
@@ -580,13 +580,13 @@ I am a quote paragraph.`
 		It("paragraph as a quote without author", func() {
 			source := `[quote]
 I am a quote paragraph.`
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{
 					types.AttrKind: types.Quote,
 				},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{
+						types.StringElement{
 							Content: "I am a quote paragraph.",
 						},
 					},
@@ -598,7 +598,7 @@ I am a quote paragraph.`
 		It("inline image within a quote", func() {
 			source := `[quote, john doe, quote title]
 a foo image:foo.png[]`
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{
 					types.AttrKind:        types.Quote,
 					types.AttrQuoteAuthor: "john doe",
@@ -606,10 +606,10 @@ a foo image:foo.png[]`
 				},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{
+						types.StringElement{
 							Content: "a foo ",
 						},
-						&types.InlineImage{
+						types.InlineImage{
 							Attributes: types.ElementAttributes{
 								types.AttrImageAlt: "foo",
 							},
@@ -624,7 +624,7 @@ a foo image:foo.png[]`
 		It("image block is NOT a quote", func() {
 			source := `[quote, john doe, quote title]
 image::foo.png[]`
-			expected := &types.ImageBlock{
+			expected := types.ImageBlock{
 				Attributes: types.ElementAttributes{
 					types.AttrImageAlt: "foo",
 					// quote attributes

--- a/pkg/parser/passthrough_test.go
+++ b/pkg/parser/passthrough_test.go
@@ -11,14 +11,14 @@ var _ = Describe("passthroughs - preflight", func() {
 
 		It("tripleplus passthrough with words", func() {
 			source := `+++hello, world+++`
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.Passthrough{
+						types.Passthrough{
 							Kind: types.TriplePlusPassthrough,
 							Elements: types.InlineElements{
-								&types.StringElement{
+								types.StringElement{
 									Content: "hello, world",
 								},
 							},
@@ -31,11 +31,11 @@ var _ = Describe("passthroughs - preflight", func() {
 
 		It("tripleplus empty passthrough ", func() {
 			source := `++++++`
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.Passthrough{
+						types.Passthrough{
 							Kind:     types.TriplePlusPassthrough,
 							Elements: types.InlineElements{},
 						},
@@ -47,14 +47,14 @@ var _ = Describe("passthroughs - preflight", func() {
 
 		It("tripleplus passthrough with spaces", func() {
 			source := `+++ *hello*, world +++`
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.Passthrough{
+						types.Passthrough{
 							Kind: types.TriplePlusPassthrough,
 							Elements: types.InlineElements{
-								&types.StringElement{
+								types.StringElement{
 									Content: " *hello*, world ",
 								},
 							},
@@ -67,14 +67,14 @@ var _ = Describe("passthroughs - preflight", func() {
 
 		It("tripleplus passthrough with only spaces", func() {
 			source := `+++ +++`
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.Passthrough{
+						types.Passthrough{
 							Kind: types.TriplePlusPassthrough,
 							Elements: types.InlineElements{
-								&types.StringElement{
+								types.StringElement{
 									Content: " ",
 								},
 							},
@@ -87,14 +87,14 @@ var _ = Describe("passthroughs - preflight", func() {
 
 		It("tripleplus passthrough with line breaks", func() {
 			source := "+++\nhello,\nworld\n+++"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.Passthrough{
+						types.Passthrough{
 							Kind: types.TriplePlusPassthrough,
 							Elements: types.InlineElements{
-								&types.StringElement{
+								types.StringElement{
 									Content: "\nhello,\nworld\n",
 								},
 							},
@@ -107,20 +107,20 @@ var _ = Describe("passthroughs - preflight", func() {
 
 		It("tripleplus passthrough in paragraph", func() {
 			source := `The text +++<u>underline & me</u>+++ is underlined.`
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{Content: "The text "},
-						&types.Passthrough{
+						types.StringElement{Content: "The text "},
+						types.Passthrough{
 							Kind: types.TriplePlusPassthrough,
 							Elements: types.InlineElements{
-								&types.StringElement{
+								types.StringElement{
 									Content: "<u>underline & me</u>",
 								},
 							},
 						},
-						&types.StringElement{Content: " is underlined."},
+						types.StringElement{Content: " is underlined."},
 					},
 				},
 			}
@@ -129,14 +129,14 @@ var _ = Describe("passthroughs - preflight", func() {
 
 		It("tripleplus passthrough with embedded image", func() {
 			source := `+++image:foo.png[]+++`
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.Passthrough{
+						types.Passthrough{
 							Kind: types.TriplePlusPassthrough,
 							Elements: types.InlineElements{
-								&types.StringElement{
+								types.StringElement{
 									Content: "image:foo.png[]",
 								},
 							},
@@ -153,14 +153,14 @@ var _ = Describe("passthroughs - preflight", func() {
 
 		It("singleplus passthrough with words", func() {
 			source := `+hello, world+`
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.Passthrough{
+						types.Passthrough{
 							Kind: types.SinglePlusPassthrough,
 							Elements: types.InlineElements{
-								&types.StringElement{
+								types.StringElement{
 									Content: "hello, world",
 								},
 							},
@@ -173,11 +173,11 @@ var _ = Describe("passthroughs - preflight", func() {
 
 		It("singleplus empty passthrough", func() {
 			source := `++`
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{
+						types.StringElement{
 							Content: "++",
 						},
 					},
@@ -188,14 +188,14 @@ var _ = Describe("passthroughs - preflight", func() {
 
 		It("singleplus passthrough with embedded image", func() {
 			source := `+image:foo.png[]+`
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.Passthrough{
+						types.Passthrough{
 							Kind: types.SinglePlusPassthrough,
 							Elements: types.InlineElements{
-								&types.StringElement{
+								types.StringElement{
 									Content: "image:foo.png[]",
 								},
 							},
@@ -208,25 +208,25 @@ var _ = Describe("passthroughs - preflight", func() {
 
 		It("invalid singleplus passthrough with spaces - case 1", func() {
 			source := `+*hello*, world +` // invalid: space before last `+`
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{
+						types.StringElement{
 							Content: "+",
 						},
-						&types.QuotedText{
+						types.QuotedText{
 							Kind: types.Bold,
 							Elements: types.InlineElements{
-								&types.StringElement{
+								types.StringElement{
 									Content: "hello",
 								},
 							},
 						},
-						&types.StringElement{
+						types.StringElement{
 							Content: ", world",
 						},
-						&types.LineBreak{},
+						types.LineBreak{},
 					},
 				},
 			}
@@ -235,22 +235,22 @@ var _ = Describe("passthroughs - preflight", func() {
 
 		It("invalid singleplus passthrough with spaces - case 2", func() {
 			source := `+ *hello*, world+` // invalid: space after first `+`
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{
+						types.StringElement{
 							Content: "+ ",
 						},
-						&types.QuotedText{
+						types.QuotedText{
 							Kind: types.Bold,
 							Elements: types.InlineElements{
-								&types.StringElement{
+								types.StringElement{
 									Content: "hello",
 								},
 							},
 						},
-						&types.StringElement{
+						types.StringElement{
 							Content: ", world+",
 						},
 					},
@@ -261,25 +261,25 @@ var _ = Describe("passthroughs - preflight", func() {
 
 		It("invalid singleplus passthrough with spaces - case 3", func() {
 			source := `+ *hello*, world +` // invalid: spaces within
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{
+						types.StringElement{
 							Content: "+ ",
 						},
-						&types.QuotedText{
+						types.QuotedText{
 							Kind: types.Bold,
 							Elements: types.InlineElements{
-								&types.StringElement{
+								types.StringElement{
 									Content: "hello",
 								},
 							},
 						},
-						&types.StringElement{
+						types.StringElement{
 							Content: ", world",
 						},
-						&types.LineBreak{},
+						types.LineBreak{},
 					},
 				},
 			}
@@ -288,16 +288,16 @@ var _ = Describe("passthroughs - preflight", func() {
 
 		It("invalid singleplus passthrough with line break", func() {
 			source := "+hello,\nworld+"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{
+						types.StringElement{
 							Content: "+hello,",
 						},
 					},
 					{
-						&types.StringElement{
+						types.StringElement{
 							Content: "world+",
 						},
 					},
@@ -314,14 +314,14 @@ var _ = Describe("passthroughs - preflight", func() {
 
 			It("passthrough macro with single word", func() {
 				source := `pass:[hello]`
-				expected := &types.Paragraph{
+				expected := types.Paragraph{
 					Attributes: types.ElementAttributes{},
 					Lines: []types.InlineElements{
 						{
-							&types.Passthrough{
+							types.Passthrough{
 								Kind: types.PassthroughMacro,
 								Elements: types.InlineElements{
-									&types.StringElement{
+									types.StringElement{
 										Content: "hello",
 									},
 								},
@@ -334,14 +334,14 @@ var _ = Describe("passthroughs - preflight", func() {
 
 			It("passthrough macro with words", func() {
 				source := `pass:[hello, world]`
-				expected := &types.Paragraph{
+				expected := types.Paragraph{
 					Attributes: types.ElementAttributes{},
 					Lines: []types.InlineElements{
 						{
-							&types.Passthrough{
+							types.Passthrough{
 								Kind: types.PassthroughMacro,
 								Elements: types.InlineElements{
-									&types.StringElement{
+									types.StringElement{
 										Content: "hello, world",
 									},
 								},
@@ -354,11 +354,11 @@ var _ = Describe("passthroughs - preflight", func() {
 
 			It("empty passthrough macro", func() {
 				source := `pass:[]`
-				expected := &types.Paragraph{
+				expected := types.Paragraph{
 					Attributes: types.ElementAttributes{},
 					Lines: []types.InlineElements{
 						{
-							&types.Passthrough{
+							types.Passthrough{
 								Kind:     types.PassthroughMacro,
 								Elements: types.InlineElements{},
 							},
@@ -370,14 +370,14 @@ var _ = Describe("passthroughs - preflight", func() {
 
 			It("passthrough macro with spaces", func() {
 				source := `pass:[ *hello*, world ]`
-				expected := &types.Paragraph{
+				expected := types.Paragraph{
 					Attributes: types.ElementAttributes{},
 					Lines: []types.InlineElements{
 						{
-							&types.Passthrough{
+							types.Passthrough{
 								Kind: types.PassthroughMacro,
 								Elements: types.InlineElements{
-									&types.StringElement{
+									types.StringElement{
 										Content: " *hello*, world ",
 									},
 								},
@@ -390,14 +390,14 @@ var _ = Describe("passthroughs - preflight", func() {
 
 			It("passthrough macro with line break", func() {
 				source := "pass:[hello,\nworld]"
-				expected := &types.Paragraph{
+				expected := types.Paragraph{
 					Attributes: types.ElementAttributes{},
 					Lines: []types.InlineElements{
 						{
-							&types.Passthrough{
+							types.Passthrough{
 								Kind: types.PassthroughMacro,
 								Elements: types.InlineElements{
-									&types.StringElement{
+									types.StringElement{
 										Content: "hello,\nworld",
 									},
 								},
@@ -413,17 +413,17 @@ var _ = Describe("passthroughs - preflight", func() {
 
 			It("passthrough macro with single quoted word", func() {
 				source := `pass:q[*hello*]`
-				expected := &types.Paragraph{
+				expected := types.Paragraph{
 					Attributes: types.ElementAttributes{},
 					Lines: []types.InlineElements{
 						{
-							&types.Passthrough{
+							types.Passthrough{
 								Kind: types.PassthroughMacro,
 								Elements: types.InlineElements{
-									&types.QuotedText{
+									types.QuotedText{
 										Kind: types.Bold,
 										Elements: types.InlineElements{
-											&types.StringElement{
+											types.StringElement{
 												Content: "hello",
 											},
 										},
@@ -438,25 +438,25 @@ var _ = Describe("passthroughs - preflight", func() {
 
 			It("passthrough macro with quoted word in sentence", func() {
 				source := `pass:q[ a *hello*, world ]`
-				expected := &types.Paragraph{
+				expected := types.Paragraph{
 					Attributes: types.ElementAttributes{},
 					Lines: []types.InlineElements{
 						{
-							&types.Passthrough{
+							types.Passthrough{
 								Kind: types.PassthroughMacro,
 								Elements: types.InlineElements{
-									&types.StringElement{
+									types.StringElement{
 										Content: " a ",
 									},
-									&types.QuotedText{
+									types.QuotedText{
 										Kind: types.Bold,
 										Elements: types.InlineElements{
-											&types.StringElement{
+											types.StringElement{
 												Content: "hello",
 											},
 										},
 									},
-									&types.StringElement{
+									types.StringElement{
 										Content: ", world ",
 									},
 								},

--- a/pkg/parser/q_a_list_test.go
+++ b/pkg/parser/q_a_list_test.go
@@ -14,28 +14,28 @@ What is libsciidoc?::
 	An implementation of the AsciiDoc processor in Golang.
 What is the answer to the Ultimate Question?:: 42`
 
-		expected := &types.Document{
+		expected := types.Document{
 			Attributes:         types.DocumentAttributes{},
 			ElementReferences:  types.ElementReferences{},
 			Footnotes:          types.Footnotes{},
 			FootnoteReferences: types.FootnoteReferences{},
 			Elements: []interface{}{
-				&types.LabeledList{
+				types.LabeledList{
 					Attributes: types.ElementAttributes{
 						types.AttrTitle: "Q&A",
 						types.AttrQandA: nil,
 					},
-					Items: []*types.LabeledListItem{
+					Items: []types.LabeledListItem{
 						{
 							Attributes: types.ElementAttributes{},
 							Level:      1,
 							Term:       "What is libsciidoc?",
 							Elements: []interface{}{
-								&types.Paragraph{
+								types.Paragraph{
 									Attributes: types.ElementAttributes{},
 									Lines: []types.InlineElements{
 										{
-											&types.StringElement{
+											types.StringElement{
 												Content: "An implementation of the AsciiDoc processor in Golang.",
 											},
 										},
@@ -48,11 +48,11 @@ What is the answer to the Ultimate Question?:: 42`
 							Level:      1,
 							Term:       "What is the answer to the Ultimate Question?",
 							Elements: []interface{}{
-								&types.Paragraph{
+								types.Paragraph{
 									Attributes: types.ElementAttributes{},
 									Lines: []types.InlineElements{
 										{
-											&types.StringElement{
+											types.StringElement{
 												Content: "42",
 											},
 										},

--- a/pkg/parser/quoted_text_test.go
+++ b/pkg/parser/quoted_text_test.go
@@ -11,16 +11,16 @@ var _ = Describe("quoted texts - preflight", func() {
 
 		It("bold text with 1 word", func() {
 			source := "*hello*"
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.QuotedText{
+								types.QuotedText{
 									Kind: types.Bold,
 									Elements: types.InlineElements{
-										&types.StringElement{Content: "hello"},
+										types.StringElement{Content: "hello"},
 									},
 								},
 							},
@@ -33,16 +33,16 @@ var _ = Describe("quoted texts - preflight", func() {
 
 		It("bold text with 2 words", func() {
 			source := "*bold    content*"
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.QuotedText{
+								types.QuotedText{
 									Kind: types.Bold,
 									Elements: types.InlineElements{
-										&types.StringElement{Content: "bold    content"},
+										types.StringElement{Content: "bold    content"},
 									},
 								},
 							},
@@ -55,16 +55,16 @@ var _ = Describe("quoted texts - preflight", func() {
 
 		It("bold text with 3 words", func() {
 			source := "*some bold content*"
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.QuotedText{
+								types.QuotedText{
 									Kind: types.Bold,
 									Elements: types.InlineElements{
-										&types.StringElement{Content: "some bold content"},
+										types.StringElement{Content: "some bold content"},
 									},
 								},
 							},
@@ -77,16 +77,16 @@ var _ = Describe("quoted texts - preflight", func() {
 
 		It("italic text with 3 words in single quote", func() {
 			source := "_some italic content_"
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.QuotedText{
+								types.QuotedText{
 									Kind: types.Italic,
 									Elements: types.InlineElements{
-										&types.StringElement{Content: "some italic content"},
+										types.StringElement{Content: "some italic content"},
 									},
 								},
 							},
@@ -99,16 +99,16 @@ var _ = Describe("quoted texts - preflight", func() {
 
 		It("monospace text with 3 words", func() {
 			source := "`some monospace content`"
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.QuotedText{
+								types.QuotedText{
 									Kind: types.Monospace,
 									Elements: types.InlineElements{
-										&types.StringElement{Content: "some monospace content"},
+										types.StringElement{Content: "some monospace content"},
 									},
 								},
 							},
@@ -121,11 +121,11 @@ var _ = Describe("quoted texts - preflight", func() {
 
 		It("invalid subscript text with 3 words", func() {
 			source := "~some subscript content~"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{Content: "~some subscript content~"},
+						types.StringElement{Content: "~some subscript content~"},
 					},
 				},
 			}
@@ -134,11 +134,11 @@ var _ = Describe("quoted texts - preflight", func() {
 
 		It("invalid superscript text with 3 words", func() {
 			source := "^some superscript content^"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{Content: "^some superscript content^"},
+						types.StringElement{Content: "^some superscript content^"},
 					},
 				},
 			}
@@ -147,23 +147,23 @@ var _ = Describe("quoted texts - preflight", func() {
 
 		It("bold text within italic text", func() {
 			source := "_some *bold* content_"
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.QuotedText{
+								types.QuotedText{
 									Kind: types.Italic,
 									Elements: types.InlineElements{
-										&types.StringElement{Content: "some "},
-										&types.QuotedText{
+										types.StringElement{Content: "some "},
+										types.QuotedText{
 											Kind: types.Bold,
 											Elements: types.InlineElements{
-												&types.StringElement{Content: "bold"},
+												types.StringElement{Content: "bold"},
 											},
 										},
-										&types.StringElement{Content: " content"},
+										types.StringElement{Content: " content"},
 									},
 								},
 							},
@@ -176,24 +176,24 @@ var _ = Describe("quoted texts - preflight", func() {
 
 		It("monospace text within bold text within italic quote", func() {
 			source := "*some _italic and `monospaced content`_*"
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.QuotedText{
+								types.QuotedText{
 									Kind: types.Bold,
 									Elements: types.InlineElements{
-										&types.StringElement{Content: "some "},
-										&types.QuotedText{
+										types.StringElement{Content: "some "},
+										types.QuotedText{
 											Kind: types.Italic,
 											Elements: types.InlineElements{
-												&types.StringElement{Content: "italic and "},
-												&types.QuotedText{
+												types.StringElement{Content: "italic and "},
+												types.QuotedText{
 													Kind: types.Monospace,
 													Elements: types.InlineElements{
-														&types.StringElement{Content: "monospaced content"},
+														types.StringElement{Content: "monospaced content"},
 													},
 												},
 											},
@@ -210,17 +210,17 @@ var _ = Describe("quoted texts - preflight", func() {
 
 		It("italic text within italic text", func() {
 			source := "_some _very italic_ content_"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.QuotedText{
+						types.QuotedText{
 							Kind: types.Italic,
 							Elements: types.InlineElements{
-								&types.StringElement{Content: "some _very italic"},
+								types.StringElement{Content: "some _very italic"},
 							},
 						},
-						&types.StringElement{Content: " content_"},
+						types.StringElement{Content: " content_"},
 					},
 				},
 			}
@@ -229,18 +229,18 @@ var _ = Describe("quoted texts - preflight", func() {
 
 		It("subscript text attached", func() {
 			source := "O~2~ is a molecule"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{Content: "O"},
-						&types.QuotedText{
+						types.StringElement{Content: "O"},
+						types.QuotedText{
 							Kind: types.Subscript,
 							Elements: types.InlineElements{
-								&types.StringElement{Content: "2"},
+								types.StringElement{Content: "2"},
 							},
 						},
-						&types.StringElement{Content: " is a molecule"},
+						types.StringElement{Content: " is a molecule"},
 					},
 				},
 			}
@@ -249,18 +249,18 @@ var _ = Describe("quoted texts - preflight", func() {
 
 		It("superscript text attached", func() {
 			source := "M^me^ White"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{Content: "M"},
-						&types.QuotedText{
+						types.StringElement{Content: "M"},
+						types.QuotedText{
 							Kind: types.Superscript,
 							Elements: types.InlineElements{
-								&types.StringElement{Content: "me"},
+								types.StringElement{Content: "me"},
 							},
 						},
-						&types.StringElement{Content: " White"},
+						types.StringElement{Content: " White"},
 					},
 				},
 			}
@@ -269,11 +269,11 @@ var _ = Describe("quoted texts - preflight", func() {
 
 		It("invalid subscript text with 3 words", func() {
 			source := "~some subscript content~"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{Content: "~some subscript content~"},
+						types.StringElement{Content: "~some subscript content~"},
 					},
 				},
 			}
@@ -286,16 +286,16 @@ var _ = Describe("quoted texts - preflight", func() {
 
 		It("bold text of 1 word in double quote", func() {
 			source := "**hello**"
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.QuotedText{
+								types.QuotedText{
 									Kind: types.Bold,
 									Elements: types.InlineElements{
-										&types.StringElement{Content: "hello"},
+										types.StringElement{Content: "hello"},
 									},
 								},
 							},
@@ -308,16 +308,16 @@ var _ = Describe("quoted texts - preflight", func() {
 
 		It("italic text with 3 words in double quote", func() {
 			source := "__some italic content__"
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.QuotedText{
+								types.QuotedText{
 									Kind: types.Italic,
 									Elements: types.InlineElements{
-										&types.StringElement{Content: "some italic content"},
+										types.StringElement{Content: "some italic content"},
 									},
 								},
 							},
@@ -330,16 +330,16 @@ var _ = Describe("quoted texts - preflight", func() {
 
 		It("monospace text with 3 words in double quote", func() {
 			source := "``some monospace content``"
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.QuotedText{
+								types.QuotedText{
 									Kind: types.Monospace,
 									Elements: types.InlineElements{
-										&types.StringElement{Content: "some monospace content"},
+										types.StringElement{Content: "some monospace content"},
 									},
 								},
 							},
@@ -352,23 +352,23 @@ var _ = Describe("quoted texts - preflight", func() {
 
 		It("superscript text within italic text", func() {
 			source := "__some ^superscript^ content__"
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.QuotedText{
+								types.QuotedText{
 									Kind: types.Italic,
 									Elements: types.InlineElements{
-										&types.StringElement{Content: "some "},
-										&types.QuotedText{
+										types.StringElement{Content: "some "},
+										types.QuotedText{
 											Kind: types.Superscript,
 											Elements: types.InlineElements{
-												&types.StringElement{Content: "superscript"},
+												types.StringElement{Content: "superscript"},
 											},
 										},
-										&types.StringElement{Content: " content"},
+										types.StringElement{Content: " content"},
 									},
 								},
 							},
@@ -381,24 +381,24 @@ var _ = Describe("quoted texts - preflight", func() {
 
 		It("superscript text within italic text within bold quote", func() {
 			source := "**some _italic and ^superscriptcontent^_**"
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.QuotedText{
+								types.QuotedText{
 									Kind: types.Bold,
 									Elements: types.InlineElements{
-										&types.StringElement{Content: "some "},
-										&types.QuotedText{
+										types.StringElement{Content: "some "},
+										types.QuotedText{
 											Kind: types.Italic,
 											Elements: types.InlineElements{
-												&types.StringElement{Content: "italic and "},
-												&types.QuotedText{
+												types.StringElement{Content: "italic and "},
+												types.QuotedText{
 													Kind: types.Superscript,
 													Elements: types.InlineElements{
-														&types.StringElement{Content: "superscriptcontent"},
+														types.StringElement{Content: "superscriptcontent"},
 													},
 												},
 											},
@@ -418,15 +418,15 @@ var _ = Describe("quoted texts - preflight", func() {
 
 		It("inline content with bold text", func() {
 			source := "a paragraph with *some bold content*"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{Content: "a paragraph with "},
-						&types.QuotedText{
+						types.StringElement{Content: "a paragraph with "},
+						types.QuotedText{
 							Kind: types.Bold,
 							Elements: types.InlineElements{
-								&types.StringElement{Content: "some bold content"},
+								types.StringElement{Content: "some bold content"},
 							},
 						},
 					},
@@ -437,11 +437,11 @@ var _ = Describe("quoted texts - preflight", func() {
 
 		It("inline content with invalid bold text - use case 1", func() {
 			source := "a paragraph with *some bold content"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{Content: "a paragraph with *some bold content"},
+						types.StringElement{Content: "a paragraph with *some bold content"},
 					},
 				},
 			}
@@ -450,11 +450,11 @@ var _ = Describe("quoted texts - preflight", func() {
 
 		It("inline content with invalid bold text - use case 2", func() {
 			source := "a paragraph with *some bold content *"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{Content: "a paragraph with *some bold content *"},
+						types.StringElement{Content: "a paragraph with *some bold content *"},
 					},
 				},
 			}
@@ -463,11 +463,11 @@ var _ = Describe("quoted texts - preflight", func() {
 
 		It("inline content with invalid bold text - use case 3", func() {
 			source := "a paragraph with * some bold content*"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{Content: "a paragraph with * some bold content*"},
+						types.StringElement{Content: "a paragraph with * some bold content*"},
 					},
 				},
 			}
@@ -476,19 +476,19 @@ var _ = Describe("quoted texts - preflight", func() {
 
 		It("invalid italic text within bold text", func() {
 			source := "some *bold and _italic content _ together*."
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
 
-						&types.StringElement{Content: "some "},
-						&types.QuotedText{
+						types.StringElement{Content: "some "},
+						types.QuotedText{
 							Kind: types.Bold,
 							Elements: types.InlineElements{
-								&types.StringElement{Content: "bold and _italic content _ together"},
+								types.StringElement{Content: "bold and _italic content _ together"},
 							},
 						},
-						&types.StringElement{Content: "."},
+						types.StringElement{Content: "."},
 					},
 				},
 			}
@@ -497,18 +497,18 @@ var _ = Describe("quoted texts - preflight", func() {
 
 		It("italic text within invalid bold text", func() {
 			source := "some *bold and _italic content_ together *."
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{Content: "some *bold and "},
-						&types.QuotedText{
+						types.StringElement{Content: "some *bold and "},
+						types.QuotedText{
 							Kind: types.Italic,
 							Elements: types.InlineElements{
-								&types.StringElement{Content: "italic content"},
+								types.StringElement{Content: "italic content"},
 							},
 						},
-						&types.StringElement{Content: " together *."},
+						types.StringElement{Content: " together *."},
 					},
 				},
 			}
@@ -517,11 +517,11 @@ var _ = Describe("quoted texts - preflight", func() {
 
 		It("inline content with invalid subscript text - use case 1", func() {
 			source := "a paragraph with ~some subscript content"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{Content: "a paragraph with ~some subscript content"},
+						types.StringElement{Content: "a paragraph with ~some subscript content"},
 					},
 				},
 			}
@@ -530,11 +530,11 @@ var _ = Describe("quoted texts - preflight", func() {
 
 		It("inline content with invalid subscript text - use case 2", func() {
 			source := "a paragraph with ~some subscript content ~"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{Content: "a paragraph with ~some subscript content ~"},
+						types.StringElement{Content: "a paragraph with ~some subscript content ~"},
 					},
 				},
 			}
@@ -543,11 +543,11 @@ var _ = Describe("quoted texts - preflight", func() {
 
 		It("inline content with invalid subscript text - use case 3", func() {
 			source := "a paragraph with ~ some subscript content~"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{Content: "a paragraph with ~ some subscript content~"},
+						types.StringElement{Content: "a paragraph with ~ some subscript content~"},
 					},
 				},
 			}
@@ -556,12 +556,12 @@ var _ = Describe("quoted texts - preflight", func() {
 
 		It("inline content with invalid superscript text - use case 1", func() {
 			source := "a paragraph with ^some superscript content"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
 
-						&types.StringElement{Content: "a paragraph with ^some superscript content"},
+						types.StringElement{Content: "a paragraph with ^some superscript content"},
 					},
 				},
 			}
@@ -570,12 +570,12 @@ var _ = Describe("quoted texts - preflight", func() {
 
 		It("inline content with invalid superscript text - use case 2", func() {
 			source := "a paragraph with ^some superscript content ^"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
 
-						&types.StringElement{Content: "a paragraph with ^some superscript content ^"},
+						types.StringElement{Content: "a paragraph with ^some superscript content ^"},
 					},
 				},
 			}
@@ -584,12 +584,12 @@ var _ = Describe("quoted texts - preflight", func() {
 
 		It("inline content with invalid superscript text - use case 3", func() {
 			source := "a paragraph with ^ some superscript content^"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
 
-						&types.StringElement{Content: "a paragraph with ^ some superscript content^"},
+						types.StringElement{Content: "a paragraph with ^ some superscript content^"},
 					},
 				},
 			}
@@ -601,25 +601,25 @@ var _ = Describe("quoted texts - preflight", func() {
 
 		It("italic text within bold text", func() {
 			source := "some *bold and _italic content_ together*."
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{Content: "some "},
-						&types.QuotedText{
+						types.StringElement{Content: "some "},
+						types.QuotedText{
 							Kind: types.Bold,
 							Elements: types.InlineElements{
-								&types.StringElement{Content: "bold and "},
-								&types.QuotedText{
+								types.StringElement{Content: "bold and "},
+								types.QuotedText{
 									Kind: types.Italic,
 									Elements: types.InlineElements{
-										&types.StringElement{Content: "italic content"},
+										types.StringElement{Content: "italic content"},
 									},
 								},
-								&types.StringElement{Content: " together"},
+								types.StringElement{Content: " together"},
 							},
 						},
-						&types.StringElement{Content: "."},
+						types.StringElement{Content: "."},
 					},
 				},
 			}
@@ -629,17 +629,17 @@ var _ = Describe("quoted texts - preflight", func() {
 		It("single-quote bold within single-quote bold text", func() {
 			// here we don't allow for bold text within bold text, to comply with the existing implementations (asciidoc and asciidoctor)
 			source := "*some *nested bold* content*"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.QuotedText{
+						types.QuotedText{
 							Kind: types.Bold,
 							Elements: types.InlineElements{
-								&types.StringElement{Content: "some *nested bold"},
+								types.StringElement{Content: "some *nested bold"},
 							},
 						},
-						&types.StringElement{Content: " content*"},
+						types.StringElement{Content: " content*"},
 					},
 				},
 			}
@@ -649,21 +649,21 @@ var _ = Describe("quoted texts - preflight", func() {
 		It("double-quote bold within double-quote bold text", func() {
 			// here we don't allow for bold text within bold text, to comply with the existing implementations (asciidoc and asciidoctor)
 			source := "**some **nested bold** content**"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.QuotedText{
+						types.QuotedText{
 							Kind: types.Bold,
 							Elements: types.InlineElements{
-								&types.StringElement{Content: "some "},
+								types.StringElement{Content: "some "},
 							},
 						},
-						&types.StringElement{Content: "nested bold"},
-						&types.QuotedText{
+						types.StringElement{Content: "nested bold"},
+						types.QuotedText{
 							Kind: types.Bold,
 							Elements: types.InlineElements{
-								&types.StringElement{Content: " content"},
+								types.StringElement{Content: " content"},
 							},
 						},
 					},
@@ -675,21 +675,21 @@ var _ = Describe("quoted texts - preflight", func() {
 		It("single-quote bold within double-quote bold text", func() {
 			// here we don't allow for bold text within bold text, to comply with the existing implementations (asciidoc and asciidoctor)
 			source := "**some *nested bold* content**"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.QuotedText{
+						types.QuotedText{
 							Kind: types.Bold,
 							Elements: types.InlineElements{
-								&types.StringElement{Content: "some "},
-								&types.QuotedText{
+								types.StringElement{Content: "some "},
+								types.QuotedText{
 									Kind: types.Bold,
 									Elements: types.InlineElements{
-										&types.StringElement{Content: "nested bold"},
+										types.StringElement{Content: "nested bold"},
 									},
 								},
-								&types.StringElement{Content: " content"},
+								types.StringElement{Content: " content"},
 							},
 						},
 					},
@@ -701,21 +701,21 @@ var _ = Describe("quoted texts - preflight", func() {
 		It("double-quote bold within single-quote bold text", func() {
 			// here we don't allow for bold text within bold text, to comply with the existing implementations (asciidoc and asciidoctor)
 			source := "*some **nested bold** content*"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.QuotedText{
+						types.QuotedText{
 							Kind: types.Bold,
 							Elements: types.InlineElements{
-								&types.StringElement{Content: "some "},
-								&types.QuotedText{
+								types.StringElement{Content: "some "},
+								types.QuotedText{
 									Kind: types.Bold,
 									Elements: types.InlineElements{
-										&types.StringElement{Content: "nested bold"},
+										types.StringElement{Content: "nested bold"},
 									},
 								},
-								&types.StringElement{Content: " content"},
+								types.StringElement{Content: " content"},
 							},
 						},
 					},
@@ -727,17 +727,17 @@ var _ = Describe("quoted texts - preflight", func() {
 		It("single-quote italic within single-quote italic text", func() {
 			// here we don't allow for italic text within italic text, to comply with the existing implementations (asciidoc and asciidoctor)
 			source := "_some _nested italic_ content_"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.QuotedText{
+						types.QuotedText{
 							Kind: types.Italic,
 							Elements: types.InlineElements{
-								&types.StringElement{Content: "some _nested italic"},
+								types.StringElement{Content: "some _nested italic"},
 							},
 						},
-						&types.StringElement{Content: " content_"},
+						types.StringElement{Content: " content_"},
 					},
 				},
 			}
@@ -747,21 +747,21 @@ var _ = Describe("quoted texts - preflight", func() {
 		It("double-quote italic within double-quote italic text", func() {
 			// here we don't allow for italic text within italic text, to comply with the existing implementations (asciidoc and asciidoctor)
 			source := "__some __nested italic__ content__"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.QuotedText{
+						types.QuotedText{
 							Kind: types.Italic,
 							Elements: types.InlineElements{
-								&types.StringElement{Content: "some "},
+								types.StringElement{Content: "some "},
 							},
 						},
-						&types.StringElement{Content: "nested italic"},
-						&types.QuotedText{
+						types.StringElement{Content: "nested italic"},
+						types.QuotedText{
 							Kind: types.Italic,
 							Elements: types.InlineElements{
-								&types.StringElement{Content: " content"},
+								types.StringElement{Content: " content"},
 							},
 						},
 					},
@@ -773,21 +773,21 @@ var _ = Describe("quoted texts - preflight", func() {
 		It("single-quote italic within double-quote italic text", func() {
 			// here we allow for italic text within italic text, to comply with the existing implementations (asciidoc and asciidoctor)
 			source := "_some __nested italic__ content_"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.QuotedText{
+						types.QuotedText{
 							Kind: types.Italic,
 							Elements: types.InlineElements{
-								&types.StringElement{Content: "some "},
-								&types.QuotedText{
+								types.StringElement{Content: "some "},
+								types.QuotedText{
 									Kind: types.Italic,
 									Elements: types.InlineElements{
-										&types.StringElement{Content: "nested italic"},
+										types.StringElement{Content: "nested italic"},
 									},
 								},
-								&types.StringElement{Content: " content"},
+								types.StringElement{Content: " content"},
 							},
 						},
 					},
@@ -799,21 +799,21 @@ var _ = Describe("quoted texts - preflight", func() {
 		It("double-quote italic within single-quote italic text", func() {
 			// here we allow for italic text within italic text, to comply with the existing implementations (asciidoc and asciidoctor)
 			source := "_some __nested italic__ content_"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.QuotedText{
+						types.QuotedText{
 							Kind: types.Italic,
 							Elements: types.InlineElements{
-								&types.StringElement{Content: "some "},
-								&types.QuotedText{
+								types.StringElement{Content: "some "},
+								types.QuotedText{
 									Kind: types.Italic,
 									Elements: types.InlineElements{
-										&types.StringElement{Content: "nested italic"},
+										types.StringElement{Content: "nested italic"},
 									},
 								},
-								&types.StringElement{Content: " content"},
+								types.StringElement{Content: " content"},
 							},
 						},
 					},
@@ -825,17 +825,17 @@ var _ = Describe("quoted texts - preflight", func() {
 		It("single-quote monospace within single-quote monospace text", func() {
 			// here we don't allow for monospace text within monospace text, to comply with the existing implementations (asciidoc and asciidoctor)
 			source := "`some `nested monospace` content`"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.QuotedText{
+						types.QuotedText{
 							Kind: types.Monospace,
 							Elements: types.InlineElements{
-								&types.StringElement{Content: "some `nested monospace"},
+								types.StringElement{Content: "some `nested monospace"},
 							},
 						},
-						&types.StringElement{Content: " content`"},
+						types.StringElement{Content: " content`"},
 					},
 				},
 			}
@@ -845,21 +845,21 @@ var _ = Describe("quoted texts - preflight", func() {
 		It("double-quote monospace within double-quote monospace text", func() {
 			// here we don't allow for monospace text within monospace text, to comply with the existing implementations (asciidoc and asciidoctor)
 			source := "``some ``nested monospace`` content``"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.QuotedText{
+						types.QuotedText{
 							Kind: types.Monospace,
 							Elements: types.InlineElements{
-								&types.StringElement{Content: "some "},
+								types.StringElement{Content: "some "},
 							},
 						},
-						&types.StringElement{Content: "nested monospace"},
-						&types.QuotedText{
+						types.StringElement{Content: "nested monospace"},
+						types.QuotedText{
 							Kind: types.Monospace,
 							Elements: types.InlineElements{
-								&types.StringElement{Content: " content"},
+								types.StringElement{Content: " content"},
 							},
 						},
 					},
@@ -871,21 +871,21 @@ var _ = Describe("quoted texts - preflight", func() {
 		It("single-quote monospace within double-quote monospace text", func() {
 			// here we allow for monospace text within monospace text, to comply with the existing implementations (asciidoc and asciidoctor)
 			source := "`some ``nested monospace`` content`"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.QuotedText{
+						types.QuotedText{
 							Kind: types.Monospace,
 							Elements: types.InlineElements{
-								&types.StringElement{Content: "some "},
-								&types.QuotedText{
+								types.StringElement{Content: "some "},
+								types.QuotedText{
 									Kind: types.Monospace,
 									Elements: types.InlineElements{
-										&types.StringElement{Content: "nested monospace"},
+										types.StringElement{Content: "nested monospace"},
 									},
 								},
-								&types.StringElement{Content: " content"},
+								types.StringElement{Content: " content"},
 							},
 						},
 					},
@@ -897,21 +897,21 @@ var _ = Describe("quoted texts - preflight", func() {
 		It("double-quote monospace within single-quote monospace text", func() {
 			// here we allow for monospace text within monospace text, to comply with the existing implementations (asciidoc and asciidoctor)
 			source := "`some ``nested monospace`` content`"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.QuotedText{
+						types.QuotedText{
 							Kind: types.Monospace,
 							Elements: types.InlineElements{
-								&types.StringElement{Content: "some "},
-								&types.QuotedText{
+								types.StringElement{Content: "some "},
+								types.QuotedText{
 									Kind: types.Monospace,
 									Elements: types.InlineElements{
-										&types.StringElement{Content: "nested monospace"},
+										types.StringElement{Content: "nested monospace"},
 									},
 								},
-								&types.StringElement{Content: " content"},
+								types.StringElement{Content: " content"},
 							},
 						},
 					},
@@ -922,14 +922,14 @@ var _ = Describe("quoted texts - preflight", func() {
 
 		It("unbalanced bold in monospace - case 1", func() {
 			source := "`*a`"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.QuotedText{
+						types.QuotedText{
 							Kind: types.Monospace,
 							Elements: types.InlineElements{
-								&types.StringElement{Content: "*a"},
+								types.StringElement{Content: "*a"},
 							},
 						},
 					},
@@ -940,14 +940,14 @@ var _ = Describe("quoted texts - preflight", func() {
 
 		It("unbalanced bold in monospace - case 2", func() {
 			source := "`a*b`"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.QuotedText{
+						types.QuotedText{
 							Kind: types.Monospace,
 							Elements: types.InlineElements{
-								&types.StringElement{Content: "a*b"},
+								types.StringElement{Content: "a*b"},
 							},
 						},
 					},
@@ -958,17 +958,17 @@ var _ = Describe("quoted texts - preflight", func() {
 
 		It("italic in monospace", func() {
 			source := "`_a_`"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.QuotedText{
+						types.QuotedText{
 							Kind: types.Monospace,
 							Elements: types.InlineElements{
-								&types.QuotedText{
+								types.QuotedText{
 									Kind: types.Italic,
 									Elements: types.InlineElements{
-										&types.StringElement{Content: "a"},
+										types.StringElement{Content: "a"},
 									},
 								},
 							},
@@ -981,14 +981,14 @@ var _ = Describe("quoted texts - preflight", func() {
 
 		It("unbalanced italic in monospace", func() {
 			source := "`a_b`"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.QuotedText{
+						types.QuotedText{
 							Kind: types.Monospace,
 							Elements: types.InlineElements{
-								&types.StringElement{Content: "a_b"},
+								types.StringElement{Content: "a_b"},
 							},
 						},
 					},
@@ -999,14 +999,14 @@ var _ = Describe("quoted texts - preflight", func() {
 
 		It("unparsed bold in monospace", func() {
 			source := "`a*b*`"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.QuotedText{
+						types.QuotedText{
 							Kind: types.Monospace,
 							Elements: types.InlineElements{
-								&types.StringElement{Content: "a*b*"},
+								types.StringElement{Content: "a*b*"},
 							},
 						},
 					},
@@ -1017,18 +1017,18 @@ var _ = Describe("quoted texts - preflight", func() {
 
 		It("parsed subscript in monospace", func() {
 			source := "`a~b~`"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.QuotedText{
+						types.QuotedText{
 							Kind: types.Monospace,
 							Elements: types.InlineElements{
-								&types.StringElement{Content: "a"},
-								&types.QuotedText{
+								types.StringElement{Content: "a"},
+								types.QuotedText{
 									Kind: types.Subscript,
 									Elements: types.InlineElements{
-										&types.StringElement{Content: "b"},
+										types.StringElement{Content: "b"},
 									},
 								},
 							},
@@ -1041,14 +1041,14 @@ var _ = Describe("quoted texts - preflight", func() {
 
 		It("multiline in single quoted monospace - case 1", func() {
 			source := "`a\nb`"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.QuotedText{
+						types.QuotedText{
 							Kind: types.Monospace,
 							Elements: types.InlineElements{
-								&types.StringElement{Content: "a\nb"},
+								types.StringElement{Content: "a\nb"},
 							},
 						},
 					},
@@ -1059,14 +1059,14 @@ var _ = Describe("quoted texts - preflight", func() {
 
 		It("multiline in double quoted monospace - case 1", func() {
 			source := "`a\nb`"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.QuotedText{
+						types.QuotedText{
 							Kind: types.Monospace,
 							Elements: types.InlineElements{
-								&types.StringElement{Content: "a\nb"},
+								types.StringElement{Content: "a\nb"},
 							},
 						},
 					},
@@ -1077,18 +1077,18 @@ var _ = Describe("quoted texts - preflight", func() {
 
 		It("multiline in single quoted  monospace - case 2", func() {
 			source := "`a\n*b*`"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.QuotedText{
+						types.QuotedText{
 							Kind: types.Monospace,
 							Elements: types.InlineElements{
-								&types.StringElement{Content: "a\n"},
-								&types.QuotedText{
+								types.StringElement{Content: "a\n"},
+								types.QuotedText{
 									Kind: types.Bold,
 									Elements: types.InlineElements{
-										&types.StringElement{Content: "b"},
+										types.StringElement{Content: "b"},
 									},
 								},
 							},
@@ -1101,18 +1101,18 @@ var _ = Describe("quoted texts - preflight", func() {
 
 		It("multiline in double quoted  monospace - case 2", func() {
 			source := "`a\n*b*`"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.QuotedText{
+						types.QuotedText{
 							Kind: types.Monospace,
 							Elements: types.InlineElements{
-								&types.StringElement{Content: "a\n"},
-								&types.QuotedText{
+								types.StringElement{Content: "a\n"},
+								types.QuotedText{
 									Kind: types.Bold,
 									Elements: types.InlineElements{
-										&types.StringElement{Content: "b"},
+										types.StringElement{Content: "b"},
 									},
 								},
 							},
@@ -1125,24 +1125,24 @@ var _ = Describe("quoted texts - preflight", func() {
 
 		It("link in bold", func() {
 			source := "*a link:/[b]*"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.QuotedText{
+						types.QuotedText{
 							Kind: types.Bold,
 							Elements: types.InlineElements{
-								&types.StringElement{Content: "a "},
-								&types.InlineLink{
+								types.StringElement{Content: "a "},
+								types.InlineLink{
 									Attributes: types.ElementAttributes{
 										types.AttrInlineLinkText: types.InlineElements{
-											&types.StringElement{
+											types.StringElement{
 												Content: "b",
 											},
 										},
 									},
 									Location: types.Location{
-										&types.StringElement{
+										types.StringElement{
 											Content: "/",
 										},
 									},
@@ -1157,15 +1157,15 @@ var _ = Describe("quoted texts - preflight", func() {
 
 		It("image in bold", func() {
 			source := "*a image:foo.png[]*"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.QuotedText{
+						types.QuotedText{
 							Kind: types.Bold,
 							Elements: types.InlineElements{
-								&types.StringElement{Content: "a "},
-								&types.InlineImage{
+								types.StringElement{Content: "a "},
+								types.InlineImage{
 									Attributes: types.ElementAttributes{
 										types.AttrImageAlt: "foo",
 									},
@@ -1181,18 +1181,18 @@ var _ = Describe("quoted texts - preflight", func() {
 
 		It("singleplus passthrough in bold", func() {
 			source := "*a +image:foo.png[]+*"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.QuotedText{
+						types.QuotedText{
 							Kind: types.Bold,
 							Elements: types.InlineElements{
-								&types.StringElement{Content: "a "},
-								&types.Passthrough{
+								types.StringElement{Content: "a "},
+								types.Passthrough{
 									Kind: types.SinglePlusPassthrough,
 									Elements: types.InlineElements{
-										&types.StringElement{Content: "image:foo.png[]"},
+										types.StringElement{Content: "image:foo.png[]"},
 									},
 								},
 							},
@@ -1205,18 +1205,18 @@ var _ = Describe("quoted texts - preflight", func() {
 
 		It("tripleplus passthrough in bold", func() {
 			source := "*a +++image:foo.png[]+++*"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.QuotedText{
+						types.QuotedText{
 							Kind: types.Bold,
 							Elements: types.InlineElements{
-								&types.StringElement{Content: "a "},
-								&types.Passthrough{
+								types.StringElement{Content: "a "},
+								types.Passthrough{
 									Kind: types.TriplePlusPassthrough,
 									Elements: types.InlineElements{
-										&types.StringElement{Content: "image:foo.png[]"},
+										types.StringElement{Content: "image:foo.png[]"},
 									},
 								},
 							},
@@ -1229,24 +1229,24 @@ var _ = Describe("quoted texts - preflight", func() {
 
 		It("link in italic", func() {
 			source := "_a link:/[b]_"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.QuotedText{
+						types.QuotedText{
 							Kind: types.Italic,
 							Elements: types.InlineElements{
-								&types.StringElement{Content: "a "},
-								&types.InlineLink{
+								types.StringElement{Content: "a "},
+								types.InlineLink{
 									Attributes: types.ElementAttributes{
 										types.AttrInlineLinkText: types.InlineElements{
-											&types.StringElement{
+											types.StringElement{
 												Content: "b",
 											},
 										},
 									},
 									Location: types.Location{
-										&types.StringElement{
+										types.StringElement{
 											Content: "/",
 										},
 									},
@@ -1261,15 +1261,15 @@ var _ = Describe("quoted texts - preflight", func() {
 
 		It("image in italic", func() {
 			source := "_a image:foo.png[]_"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.QuotedText{
+						types.QuotedText{
 							Kind: types.Italic,
 							Elements: types.InlineElements{
-								&types.StringElement{Content: "a "},
-								&types.InlineImage{
+								types.StringElement{Content: "a "},
+								types.InlineImage{
 									Attributes: types.ElementAttributes{
 										types.AttrImageAlt: "foo",
 									},
@@ -1285,18 +1285,18 @@ var _ = Describe("quoted texts - preflight", func() {
 
 		It("singleplus passthrough in italic", func() {
 			source := "_a +image:foo.png[]+_"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.QuotedText{
+						types.QuotedText{
 							Kind: types.Italic,
 							Elements: types.InlineElements{
-								&types.StringElement{Content: "a "},
-								&types.Passthrough{
+								types.StringElement{Content: "a "},
+								types.Passthrough{
 									Kind: types.SinglePlusPassthrough,
 									Elements: types.InlineElements{
-										&types.StringElement{Content: "image:foo.png[]"},
+										types.StringElement{Content: "image:foo.png[]"},
 									},
 								},
 							},
@@ -1309,18 +1309,18 @@ var _ = Describe("quoted texts - preflight", func() {
 
 		It("tripleplus passthrough in italic", func() {
 			source := "_a +++image:foo.png[]+++_"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.QuotedText{
+						types.QuotedText{
 							Kind: types.Italic,
 							Elements: types.InlineElements{
-								&types.StringElement{Content: "a "},
-								&types.Passthrough{
+								types.StringElement{Content: "a "},
+								types.Passthrough{
 									Kind: types.TriplePlusPassthrough,
 									Elements: types.InlineElements{
-										&types.StringElement{Content: "image:foo.png[]"},
+										types.StringElement{Content: "image:foo.png[]"},
 									},
 								},
 							},
@@ -1333,24 +1333,24 @@ var _ = Describe("quoted texts - preflight", func() {
 
 		It("link in monospace", func() {
 			source := "`a link:/[b]`"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.QuotedText{
+						types.QuotedText{
 							Kind: types.Monospace,
 							Elements: types.InlineElements{
-								&types.StringElement{Content: "a "},
-								&types.InlineLink{
+								types.StringElement{Content: "a "},
+								types.InlineLink{
 									Attributes: types.ElementAttributes{
 										types.AttrInlineLinkText: types.InlineElements{
-											&types.StringElement{
+											types.StringElement{
 												Content: "b",
 											},
 										},
 									},
 									Location: types.Location{
-										&types.StringElement{
+										types.StringElement{
 											Content: "/",
 										},
 									},
@@ -1365,15 +1365,15 @@ var _ = Describe("quoted texts - preflight", func() {
 
 		It("image in monospace", func() {
 			source := "`a image:foo.png[]`"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.QuotedText{
+						types.QuotedText{
 							Kind: types.Monospace,
 							Elements: types.InlineElements{
-								&types.StringElement{Content: "a "},
-								&types.InlineImage{
+								types.StringElement{Content: "a "},
+								types.InlineImage{
 									Attributes: types.ElementAttributes{
 										types.AttrImageAlt: "foo",
 									},
@@ -1389,19 +1389,19 @@ var _ = Describe("quoted texts - preflight", func() {
 
 		It("singleplus passthrough in monospace", func() {
 			source := "`a +image:foo.png[]+`"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
 
-						&types.QuotedText{
+						types.QuotedText{
 							Kind: types.Monospace,
 							Elements: types.InlineElements{
-								&types.StringElement{Content: "a "},
-								&types.Passthrough{
+								types.StringElement{Content: "a "},
+								types.Passthrough{
 									Kind: types.SinglePlusPassthrough,
 									Elements: types.InlineElements{
-										&types.StringElement{Content: "image:foo.png[]"},
+										types.StringElement{Content: "image:foo.png[]"},
 									},
 								},
 							},
@@ -1414,19 +1414,19 @@ var _ = Describe("quoted texts - preflight", func() {
 
 		It("tripleplus passthrough in monospace", func() {
 			source := "`a +++image:foo.png[]+++`"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
 
-						&types.QuotedText{
+						types.QuotedText{
 							Kind: types.Monospace,
 							Elements: types.InlineElements{
-								&types.StringElement{Content: "a "},
-								&types.Passthrough{
+								types.StringElement{Content: "a "},
+								types.Passthrough{
 									Kind: types.TriplePlusPassthrough,
 									Elements: types.InlineElements{
-										&types.StringElement{Content: "image:foo.png[]"},
+										types.StringElement{Content: "image:foo.png[]"},
 									},
 								},
 							},
@@ -1445,15 +1445,15 @@ var _ = Describe("quoted texts - preflight", func() {
 
 			It("unbalanced bold text - extra on left", func() {
 				source := "**some bold content*"
-				expected := &types.Paragraph{
+				expected := types.Paragraph{
 					Attributes: types.ElementAttributes{},
 					Lines: []types.InlineElements{
 						{
 
-							&types.QuotedText{
+							types.QuotedText{
 								Kind: types.Bold,
 								Elements: types.InlineElements{
-									&types.StringElement{Content: "*some bold content"},
+									types.StringElement{Content: "*some bold content"},
 								},
 							},
 						},
@@ -1464,18 +1464,18 @@ var _ = Describe("quoted texts - preflight", func() {
 
 			It("unbalanced bold text - extra on right", func() {
 				source := "*some bold content**"
-				expected := &types.Paragraph{
+				expected := types.Paragraph{
 					Attributes: types.ElementAttributes{},
 					Lines: []types.InlineElements{
 						{
 
-							&types.QuotedText{
+							types.QuotedText{
 								Kind: types.Bold,
 								Elements: types.InlineElements{
-									&types.StringElement{Content: "some bold content"},
+									types.StringElement{Content: "some bold content"},
 								},
 							},
-							&types.StringElement{Content: "*"},
+							types.StringElement{Content: "*"},
 						},
 					},
 				}
@@ -1487,15 +1487,15 @@ var _ = Describe("quoted texts - preflight", func() {
 
 			It("unbalanced italic text - extra on left", func() {
 				source := "__some italic content_"
-				expected := &types.Paragraph{
+				expected := types.Paragraph{
 					Attributes: types.ElementAttributes{},
 					Lines: []types.InlineElements{
 						{
 
-							&types.QuotedText{
+							types.QuotedText{
 								Kind: types.Italic,
 								Elements: types.InlineElements{
-									&types.StringElement{Content: "_some italic content"},
+									types.StringElement{Content: "_some italic content"},
 								},
 							},
 						},
@@ -1506,17 +1506,17 @@ var _ = Describe("quoted texts - preflight", func() {
 
 			It("unbalanced italic text - extra on right", func() {
 				source := "_some italic content__"
-				expected := &types.Paragraph{
+				expected := types.Paragraph{
 					Attributes: types.ElementAttributes{},
 					Lines: []types.InlineElements{
 						{
-							&types.QuotedText{
+							types.QuotedText{
 								Kind: types.Italic,
 								Elements: types.InlineElements{
-									&types.StringElement{Content: "some italic content"},
+									types.StringElement{Content: "some italic content"},
 								},
 							},
-							&types.StringElement{Content: "_"},
+							types.StringElement{Content: "_"},
 						},
 					},
 				}
@@ -1528,15 +1528,15 @@ var _ = Describe("quoted texts - preflight", func() {
 
 			It("unbalanced monospace text - extra on left", func() {
 				source := "``some monospace content`"
-				expected := &types.Paragraph{
+				expected := types.Paragraph{
 					Attributes: types.ElementAttributes{},
 					Lines: []types.InlineElements{
 						{
 
-							&types.QuotedText{
+							types.QuotedText{
 								Kind: types.Monospace,
 								Elements: types.InlineElements{
-									&types.StringElement{Content: "`some monospace content"},
+									types.StringElement{Content: "`some monospace content"},
 								},
 							},
 						},
@@ -1547,17 +1547,17 @@ var _ = Describe("quoted texts - preflight", func() {
 
 			It("unbalanced monospace text - extra on right", func() {
 				source := "`some monospace content``"
-				expected := &types.Paragraph{
+				expected := types.Paragraph{
 					Attributes: types.ElementAttributes{},
 					Lines: []types.InlineElements{
 						{
-							&types.QuotedText{
+							types.QuotedText{
 								Kind: types.Monospace,
 								Elements: types.InlineElements{
-									&types.StringElement{Content: "some monospace content"},
+									types.StringElement{Content: "some monospace content"},
 								},
 							},
-							&types.StringElement{Content: "`"},
+							types.StringElement{Content: "`"},
 						},
 					},
 				}
@@ -1567,11 +1567,11 @@ var _ = Describe("quoted texts - preflight", func() {
 
 		It("inline content with unbalanced bold text", func() {
 			source := "a paragraph with *some bold content"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{Content: "a paragraph with *some bold content"},
+						types.StringElement{Content: "a paragraph with *some bold content"},
 					},
 				},
 			}
@@ -1588,11 +1588,11 @@ var _ = Describe("quoted texts - preflight", func() {
 
 				It("escaped bold text with single backslash", func() {
 					source := `\*bold content*`
-					expected := &types.Paragraph{
+					expected := types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: "*bold content*"},
+								types.StringElement{Content: "*bold content*"},
 							},
 						},
 					}
@@ -1601,11 +1601,11 @@ var _ = Describe("quoted texts - preflight", func() {
 
 				It("escaped bold text with multiple backslashes", func() {
 					source := `\\*bold content*`
-					expected := &types.Paragraph{
+					expected := types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: `\*bold content*`},
+								types.StringElement{Content: `\*bold content*`},
 							},
 						},
 					}
@@ -1614,11 +1614,11 @@ var _ = Describe("quoted texts - preflight", func() {
 
 				It("escaped bold text with double quote", func() {
 					source := `\\**bold content**`
-					expected := &types.Paragraph{
+					expected := types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: `**bold content**`},
+								types.StringElement{Content: `**bold content**`},
 							},
 						},
 					}
@@ -1627,11 +1627,11 @@ var _ = Describe("quoted texts - preflight", func() {
 
 				It("escaped bold text with double quote and more backslashes", func() {
 					source := `\\\**bold content**`
-					expected := &types.Paragraph{
+					expected := types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: `\**bold content**`},
+								types.StringElement{Content: `\**bold content**`},
 							},
 						},
 					}
@@ -1640,11 +1640,11 @@ var _ = Describe("quoted texts - preflight", func() {
 
 				It("escaped bold text with unbalanced double quote", func() {
 					source := `\**bold content*`
-					expected := &types.Paragraph{
+					expected := types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: `**bold content*`},
+								types.StringElement{Content: `**bold content*`},
 							},
 						},
 					}
@@ -1653,11 +1653,11 @@ var _ = Describe("quoted texts - preflight", func() {
 
 				It("escaped bold text with unbalanced double quote and more backslashes", func() {
 					source := `\\\**bold content*`
-					expected := &types.Paragraph{
+					expected := types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: `\\**bold content*`},
+								types.StringElement{Content: `\\**bold content*`},
 							},
 						},
 					}
@@ -1669,18 +1669,18 @@ var _ = Describe("quoted texts - preflight", func() {
 
 				It("escaped bold text with nested italic text", func() {
 					source := `\*_italic content_*`
-					expected := &types.Paragraph{
+					expected := types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: "*"},
-								&types.QuotedText{
+								types.StringElement{Content: "*"},
+								types.QuotedText{
 									Kind: types.Italic,
 									Elements: types.InlineElements{
-										&types.StringElement{Content: "italic content"},
+										types.StringElement{Content: "italic content"},
 									},
 								},
-								&types.StringElement{Content: "*"},
+								types.StringElement{Content: "*"},
 							},
 						},
 					}
@@ -1689,18 +1689,18 @@ var _ = Describe("quoted texts - preflight", func() {
 
 				It("escaped bold text with unbalanced double quote and nested italic test", func() {
 					source := `\**_italic content_*`
-					expected := &types.Paragraph{
+					expected := types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: "**"},
-								&types.QuotedText{
+								types.StringElement{Content: "**"},
+								types.QuotedText{
 									Kind: types.Italic,
 									Elements: types.InlineElements{
-										&types.StringElement{Content: "italic content"},
+										types.StringElement{Content: "italic content"},
 									},
 								},
-								&types.StringElement{Content: "*"},
+								types.StringElement{Content: "*"},
 							},
 						},
 					}
@@ -1709,18 +1709,18 @@ var _ = Describe("quoted texts - preflight", func() {
 
 				It("escaped bold text with nested italic", func() {
 					source := `\*bold _and italic_ content*`
-					expected := &types.Paragraph{
+					expected := types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: "*bold "},
-								&types.QuotedText{
+								types.StringElement{Content: "*bold "},
+								types.QuotedText{
 									Kind: types.Italic,
 									Elements: types.InlineElements{
-										&types.StringElement{Content: "and italic"},
+										types.StringElement{Content: "and italic"},
 									},
 								},
-								&types.StringElement{Content: " content*"},
+								types.StringElement{Content: " content*"},
 							},
 						},
 					}
@@ -1736,11 +1736,11 @@ var _ = Describe("quoted texts - preflight", func() {
 
 				It("escaped italic text with single quote", func() {
 					source := `\_italic content_`
-					expected := &types.Paragraph{
+					expected := types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: "_italic content_"},
+								types.StringElement{Content: "_italic content_"},
 							},
 						},
 					}
@@ -1749,11 +1749,11 @@ var _ = Describe("quoted texts - preflight", func() {
 
 				It("escaped italic text with single quote and more backslashes", func() {
 					source := `\\_italic content_`
-					expected := &types.Paragraph{
+					expected := types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: `\_italic content_`},
+								types.StringElement{Content: `\_italic content_`},
 							},
 						},
 					}
@@ -1762,11 +1762,11 @@ var _ = Describe("quoted texts - preflight", func() {
 
 				It("escaped italic text with double quote with 2 backslashes", func() {
 					source := `\\__italic content__`
-					expected := &types.Paragraph{
+					expected := types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: `__italic content__`},
+								types.StringElement{Content: `__italic content__`},
 							},
 						},
 					}
@@ -1775,11 +1775,11 @@ var _ = Describe("quoted texts - preflight", func() {
 
 				It("escaped italic text with double quote with 3 backslashes", func() {
 					source := `\\\__italic content__`
-					expected := &types.Paragraph{
+					expected := types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: `\__italic content__`},
+								types.StringElement{Content: `\__italic content__`},
 							},
 						},
 					}
@@ -1788,11 +1788,11 @@ var _ = Describe("quoted texts - preflight", func() {
 
 				It("escaped italic text with unbalanced double quote", func() {
 					source := `\__italic content_`
-					expected := &types.Paragraph{
+					expected := types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: `__italic content_`},
+								types.StringElement{Content: `__italic content_`},
 							},
 						},
 					}
@@ -1801,11 +1801,11 @@ var _ = Describe("quoted texts - preflight", func() {
 
 				It("escaped italic text with unbalanced double quote and more backslashes", func() {
 					source := `\\\__italic content_`
-					expected := &types.Paragraph{
+					expected := types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: `\\__italic content_`}, // only 1 backslash remove
+								types.StringElement{Content: `\\__italic content_`}, // only 1 backslash remove
 							},
 						},
 					}
@@ -1817,18 +1817,18 @@ var _ = Describe("quoted texts - preflight", func() {
 
 				It("escaped italic text with nested monospace text", func() {
 					source := `\` + "_`monospace content`_" // gives: \_`monospace content`_
-					expected := &types.Paragraph{
+					expected := types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: "_"},
-								&types.QuotedText{
+								types.StringElement{Content: "_"},
+								types.QuotedText{
 									Kind: types.Monospace,
 									Elements: types.InlineElements{
-										&types.StringElement{Content: "monospace content"},
+										types.StringElement{Content: "monospace content"},
 									},
 								},
-								&types.StringElement{Content: "_"},
+								types.StringElement{Content: "_"},
 							},
 						},
 					}
@@ -1837,18 +1837,18 @@ var _ = Describe("quoted texts - preflight", func() {
 
 				It("escaped italic text with unbalanced double quote and nested bold test", func() {
 					source := `\__*bold content*_`
-					expected := &types.Paragraph{
+					expected := types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: "__"},
-								&types.QuotedText{
+								types.StringElement{Content: "__"},
+								types.QuotedText{
 									Kind: types.Bold,
 									Elements: types.InlineElements{
-										&types.StringElement{Content: "bold content"},
+										types.StringElement{Content: "bold content"},
 									},
 								},
-								&types.StringElement{Content: "_"},
+								types.StringElement{Content: "_"},
 							},
 						},
 					}
@@ -1857,18 +1857,18 @@ var _ = Describe("quoted texts - preflight", func() {
 
 				It("escaped italic text with nested bold text", func() {
 					source := `\_italic *and bold* content_`
-					expected := &types.Paragraph{
+					expected := types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: "_italic "},
-								&types.QuotedText{
+								types.StringElement{Content: "_italic "},
+								types.QuotedText{
 									Kind: types.Bold,
 									Elements: types.InlineElements{
-										&types.StringElement{Content: "and bold"},
+										types.StringElement{Content: "and bold"},
 									},
 								},
-								&types.StringElement{Content: " content_"},
+								types.StringElement{Content: " content_"},
 							},
 						},
 					}
@@ -1883,11 +1883,11 @@ var _ = Describe("quoted texts - preflight", func() {
 
 				It("escaped monospace text with single quote", func() {
 					source := `\` + "`monospace content`"
-					expected := &types.Paragraph{
+					expected := types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: "`monospace content`"}, // backslash removed
+								types.StringElement{Content: "`monospace content`"}, // backslash removed
 							},
 						},
 					}
@@ -1896,11 +1896,11 @@ var _ = Describe("quoted texts - preflight", func() {
 
 				It("escaped monospace text with single quote and more backslashes", func() {
 					source := `\\` + "`monospace content`"
-					expected := &types.Paragraph{
+					expected := types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: `\` + "`monospace content`"}, // only 1 backslash removed
+								types.StringElement{Content: `\` + "`monospace content`"}, // only 1 backslash removed
 							},
 						},
 					}
@@ -1909,11 +1909,11 @@ var _ = Describe("quoted texts - preflight", func() {
 
 				It("escaped monospace text with double quote", func() {
 					source := `\\` + "`monospace content``"
-					expected := &types.Paragraph{
+					expected := types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: `\` + "`monospace content``"}, // 2 back slashes "consumed"
+								types.StringElement{Content: `\` + "`monospace content``"}, // 2 back slashes "consumed"
 							},
 						},
 					}
@@ -1922,11 +1922,11 @@ var _ = Describe("quoted texts - preflight", func() {
 
 				It("escaped monospace text with double quote and more backslashes", func() {
 					source := `\\\` + "``monospace content``" // 3 backslashes
-					expected := &types.Paragraph{
+					expected := types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: `\` + "``monospace content``"}, // 2 back slashes "consumed"
+								types.StringElement{Content: `\` + "``monospace content``"}, // 2 back slashes "consumed"
 							},
 						},
 					}
@@ -1935,11 +1935,11 @@ var _ = Describe("quoted texts - preflight", func() {
 
 				It("escaped monospace text with unbalanced double quote", func() {
 					source := `\` + "``monospace content`"
-					expected := &types.Paragraph{
+					expected := types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: "``monospace content`"},
+								types.StringElement{Content: "``monospace content`"},
 							},
 						},
 					}
@@ -1948,11 +1948,11 @@ var _ = Describe("quoted texts - preflight", func() {
 
 				It("escaped monospace text with unbalanced double quote and more backslashes", func() {
 					source := `\\\` + "``monospace content`" // 3 backslashes
-					expected := &types.Paragraph{
+					expected := types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: `\\` + "``monospace content`"}, // 2 backslashes removed
+								types.StringElement{Content: `\\` + "``monospace content`"}, // 2 backslashes removed
 							},
 						},
 					}
@@ -1964,18 +1964,18 @@ var _ = Describe("quoted texts - preflight", func() {
 
 				It("escaped monospace text with nested bold text", func() {
 					source := `\` + "`*bold content*`" // gives: \`*bold content*`
-					expected := &types.Paragraph{
+					expected := types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: "`"},
-								&types.QuotedText{
+								types.StringElement{Content: "`"},
+								types.QuotedText{
 									Kind: types.Bold,
 									Elements: types.InlineElements{
-										&types.StringElement{Content: "bold content"},
+										types.StringElement{Content: "bold content"},
 									},
 								},
-								&types.StringElement{Content: "`"},
+								types.StringElement{Content: "`"},
 							},
 						},
 					}
@@ -1984,18 +1984,18 @@ var _ = Describe("quoted texts - preflight", func() {
 
 				It("escaped monospace text with unbalanced double backquote and nested bold test", func() {
 					source := `\` + "``*bold content*`"
-					expected := &types.Paragraph{
+					expected := types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: "``"},
-								&types.QuotedText{
+								types.StringElement{Content: "``"},
+								types.QuotedText{
 									Kind: types.Bold,
 									Elements: types.InlineElements{
-										&types.StringElement{Content: "bold content"},
+										types.StringElement{Content: "bold content"},
 									},
 								},
-								&types.StringElement{Content: "`"},
+								types.StringElement{Content: "`"},
 							},
 						},
 					}
@@ -2004,18 +2004,18 @@ var _ = Describe("quoted texts - preflight", func() {
 
 				It("escaped monospace text with nested bold text", func() {
 					source := `\` + "`monospace *and bold* content`"
-					expected := &types.Paragraph{
+					expected := types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: "`monospace "},
-								&types.QuotedText{
+								types.StringElement{Content: "`monospace "},
+								types.QuotedText{
 									Kind: types.Bold,
 									Elements: types.InlineElements{
-										&types.StringElement{Content: "and bold"},
+										types.StringElement{Content: "and bold"},
 									},
 								},
-								&types.StringElement{Content: " content`"},
+								types.StringElement{Content: " content`"},
 							},
 						},
 					}
@@ -2030,11 +2030,11 @@ var _ = Describe("quoted texts - preflight", func() {
 
 				It("escaped subscript text with single quote", func() {
 					source := `\~subscriptcontent~`
-					expected := &types.Paragraph{
+					expected := types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: "~subscriptcontent~"},
+								types.StringElement{Content: "~subscriptcontent~"},
 							},
 						},
 					}
@@ -2043,11 +2043,11 @@ var _ = Describe("quoted texts - preflight", func() {
 
 				It("escaped subscript text with single quote and more backslashes", func() {
 					source := `\\~subscriptcontent~`
-					expected := &types.Paragraph{
+					expected := types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: `\~subscriptcontent~`}, // only 1 backslash removed
+								types.StringElement{Content: `\~subscriptcontent~`}, // only 1 backslash removed
 							},
 						},
 					}
@@ -2060,18 +2060,18 @@ var _ = Describe("quoted texts - preflight", func() {
 
 				It("escaped subscript text with nested bold text", func() {
 					source := `\~*boldcontent*~`
-					expected := &types.Paragraph{
+					expected := types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: "~"},
-								&types.QuotedText{
+								types.StringElement{Content: "~"},
+								types.QuotedText{
 									Kind: types.Bold,
 									Elements: types.InlineElements{
-										&types.StringElement{Content: "boldcontent"},
+										types.StringElement{Content: "boldcontent"},
 									},
 								},
-								&types.StringElement{Content: "~"},
+								types.StringElement{Content: "~"},
 							},
 						},
 					}
@@ -2080,18 +2080,18 @@ var _ = Describe("quoted texts - preflight", func() {
 
 				It("escaped subscript text with nested bold text", func() {
 					source := `\~subscript *and bold* content~`
-					expected := &types.Paragraph{
+					expected := types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: `\~subscript `},
-								&types.QuotedText{
+								types.StringElement{Content: `\~subscript `},
+								types.QuotedText{
 									Kind: types.Bold,
 									Elements: types.InlineElements{
-										&types.StringElement{Content: "and bold"},
+										types.StringElement{Content: "and bold"},
 									},
 								},
-								&types.StringElement{Content: " content~"},
+								types.StringElement{Content: " content~"},
 							},
 						},
 					}
@@ -2106,11 +2106,11 @@ var _ = Describe("quoted texts - preflight", func() {
 
 				It("escaped superscript text with single quote", func() {
 					source := `\^superscriptcontent^`
-					expected := &types.Paragraph{
+					expected := types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: "^superscriptcontent^"},
+								types.StringElement{Content: "^superscriptcontent^"},
 							},
 						},
 					}
@@ -2119,11 +2119,11 @@ var _ = Describe("quoted texts - preflight", func() {
 
 				It("escaped superscript text with single quote and more backslashes", func() {
 					source := `\\^superscriptcontent^`
-					expected := &types.Paragraph{
+					expected := types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: `\^superscriptcontent^`}, // only 1 backslash removed
+								types.StringElement{Content: `\^superscriptcontent^`}, // only 1 backslash removed
 							},
 						},
 					}
@@ -2136,18 +2136,18 @@ var _ = Describe("quoted texts - preflight", func() {
 
 				It("escaped superscript text with nested bold text - case 1", func() {
 					source := `\^*bold content*^` // valid escaped superscript since it has no space within
-					expected := &types.Paragraph{
+					expected := types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: `^`},
-								&types.QuotedText{
+								types.StringElement{Content: `^`},
+								types.QuotedText{
 									Kind: types.Bold,
 									Elements: types.InlineElements{
-										&types.StringElement{Content: "bold content"},
+										types.StringElement{Content: "bold content"},
 									},
 								},
-								&types.StringElement{Content: "^"},
+								types.StringElement{Content: "^"},
 							},
 						},
 					}
@@ -2156,18 +2156,18 @@ var _ = Describe("quoted texts - preflight", func() {
 
 				It("escaped superscript text with unbalanced double backquote and nested bold test", func() {
 					source := `\^*bold content*^`
-					expected := &types.Paragraph{
+					expected := types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: "^"},
-								&types.QuotedText{
+								types.StringElement{Content: "^"},
+								types.QuotedText{
 									Kind: types.Bold,
 									Elements: types.InlineElements{
-										&types.StringElement{Content: "bold content"},
+										types.StringElement{Content: "bold content"},
 									},
 								},
-								&types.StringElement{Content: "^"},
+								types.StringElement{Content: "^"},
 							},
 						},
 					}
@@ -2176,18 +2176,18 @@ var _ = Describe("quoted texts - preflight", func() {
 
 				It("escaped superscript text with nested bold text - case 2", func() {
 					source := `\^superscript *and bold* content^` // invalid superscript text since it has spaces within
-					expected := &types.Paragraph{
+					expected := types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: `\^superscript `},
-								&types.QuotedText{
+								types.StringElement{Content: `\^superscript `},
+								types.QuotedText{
 									Kind: types.Bold,
 									Elements: types.InlineElements{
-										&types.StringElement{Content: "and bold"},
+										types.StringElement{Content: "and bold"},
 									},
 								},
-								&types.StringElement{Content: " content^"},
+								types.StringElement{Content: " content^"},
 							},
 						},
 					}

--- a/pkg/parser/section_test.go
+++ b/pkg/parser/section_test.go
@@ -12,11 +12,11 @@ var _ = Describe("sections - preflight", func() {
 		It("header only", func() {
 			source := "= a header"
 			doctitle := types.InlineElements{
-				&types.StringElement{Content: "a header"},
+				types.StringElement{Content: "a header"},
 			}
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.Section{
+					types.Section{
 						Attributes: types.ElementAttributes{
 							types.AttrID:       "a_header",
 							types.AttrCustomID: false,
@@ -33,11 +33,11 @@ var _ = Describe("sections - preflight", func() {
 		It("header with many spaces around content", func() {
 			source := "= a header   "
 			doctitle := types.InlineElements{
-				&types.StringElement{Content: "a header   "},
+				types.StringElement{Content: "a header   "},
 			}
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.Section{
+					types.Section{
 						Attributes: types.ElementAttributes{
 							types.AttrID:       "a_header",
 							types.AttrCustomID: false,
@@ -57,11 +57,11 @@ var _ = Describe("sections - preflight", func() {
 and a paragraph`
 
 			doctitle := types.InlineElements{
-				&types.StringElement{Content: "a header"},
+				types.StringElement{Content: "a header"},
 			}
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.Section{
+					types.Section{
 						Attributes: types.ElementAttributes{
 							types.AttrID:       "a_header",
 							types.AttrCustomID: false,
@@ -70,12 +70,12 @@ and a paragraph`
 						Title:    doctitle,
 						Elements: []interface{}{},
 					},
-					&types.BlankLine{},
-					&types.Paragraph{
+					types.BlankLine{},
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: "and a paragraph"},
+								types.StringElement{Content: "and a paragraph"},
 							},
 						},
 					},
@@ -89,15 +89,15 @@ and a paragraph`
 
 = a second header`
 			doctitle := types.InlineElements{
-				&types.StringElement{Content: "a first header"},
+				types.StringElement{Content: "a first header"},
 			}
 			otherDoctitle := types.InlineElements{
-				&types.StringElement{Content: "a second header"},
+				types.StringElement{Content: "a second header"},
 			}
 
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.Section{
+					types.Section{
 						Attributes: types.ElementAttributes{
 							types.AttrID:       "a_first_header",
 							types.AttrCustomID: false,
@@ -106,8 +106,8 @@ and a paragraph`
 						Title:    doctitle,
 						Elements: []interface{}{},
 					},
-					&types.BlankLine{},
-					&types.Section{
+					types.BlankLine{},
+					types.Section{
 						Attributes: types.ElementAttributes{
 							types.AttrID:       "a_second_header",
 							types.AttrCustomID: false,
@@ -124,11 +124,11 @@ and a paragraph`
 		It("section level 1 alone", func() {
 			source := `== section 1`
 			section1Title := types.InlineElements{
-				&types.StringElement{Content: "section 1"},
+				types.StringElement{Content: "section 1"},
 			}
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.Section{
+					types.Section{
 						Attributes: types.ElementAttributes{
 							types.AttrID:       "section_1",
 							types.AttrCustomID: false,
@@ -145,16 +145,16 @@ and a paragraph`
 		It("section level 1 with quoted text", func() {
 			source := `==  *2 spaces and bold content*`
 			sectionTitle := types.InlineElements{
-				&types.QuotedText{
+				types.QuotedText{
 					Kind: types.Bold,
 					Elements: types.InlineElements{
-						&types.StringElement{Content: "2 spaces and bold content"},
+						types.StringElement{Content: "2 spaces and bold content"},
 					},
 				},
 			}
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.Section{
+					types.Section{
 						Attributes: types.ElementAttributes{
 							types.AttrID:       "2_spaces_and_bold_content",
 							types.AttrCustomID: false,
@@ -173,14 +173,14 @@ and a paragraph`
 
 == section 1`
 			doctitle := types.InlineElements{
-				&types.StringElement{Content: "a header"},
+				types.StringElement{Content: "a header"},
 			}
 			section1Title := types.InlineElements{
-				&types.StringElement{Content: "section 1"},
+				types.StringElement{Content: "section 1"},
 			}
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.Section{
+					types.Section{
 						Attributes: types.ElementAttributes{
 							types.AttrID:       "a_header",
 							types.AttrCustomID: false,
@@ -189,8 +189,8 @@ and a paragraph`
 						Title:    doctitle,
 						Elements: []interface{}{},
 					},
-					&types.BlankLine{},
-					&types.Section{
+					types.BlankLine{},
+					types.Section{
 						Attributes: types.ElementAttributes{
 							types.AttrID:       "section_1",
 							types.AttrCustomID: false,
@@ -209,14 +209,14 @@ and a paragraph`
 
 === section 2`
 			doctitle := types.InlineElements{
-				&types.StringElement{Content: "a header"},
+				types.StringElement{Content: "a header"},
 			}
 			section2Title := types.InlineElements{
-				&types.StringElement{Content: "section 2"},
+				types.StringElement{Content: "section 2"},
 			}
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.Section{
+					types.Section{
 						Attributes: types.ElementAttributes{
 							types.AttrID:       "a_header",
 							types.AttrCustomID: false,
@@ -225,8 +225,8 @@ and a paragraph`
 						Title:    doctitle,
 						Elements: []interface{}{},
 					},
-					&types.BlankLine{},
-					&types.Section{
+					types.BlankLine{},
+					types.Section{
 						Attributes: types.ElementAttributes{
 							types.AttrID:       "section_2",
 							types.AttrCustomID: false,
@@ -244,11 +244,11 @@ and a paragraph`
 			source := `== a title
 and a paragraph`
 			section1Title := types.InlineElements{
-				&types.StringElement{Content: "a title"},
+				types.StringElement{Content: "a title"},
 			}
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.Section{
+					types.Section{
 						Attributes: types.ElementAttributes{
 							types.AttrID:       "a_title",
 							types.AttrCustomID: false,
@@ -257,11 +257,11 @@ and a paragraph`
 						Title:    section1Title,
 						Elements: []interface{}{},
 					},
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: "and a paragraph"},
+								types.StringElement{Content: "and a paragraph"},
 							},
 						},
 					},
@@ -275,11 +275,11 @@ and a paragraph`
 			
 and a paragraph`
 			section1Title := types.InlineElements{
-				&types.StringElement{Content: "a title"},
+				types.StringElement{Content: "a title"},
 			}
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.Section{
+					types.Section{
 						Attributes: types.ElementAttributes{
 							types.AttrID:       "a_title",
 							types.AttrCustomID: false,
@@ -288,12 +288,12 @@ and a paragraph`
 						Title:    section1Title,
 						Elements: []interface{}{},
 					},
-					&types.BlankLine{},
-					&types.Paragraph{
+					types.BlankLine{},
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: "and a paragraph"},
+								types.StringElement{Content: "and a paragraph"},
 							},
 						},
 					},
@@ -305,11 +305,11 @@ and a paragraph`
 		It("section level 1 with a paragraph separated by non-empty line", func() {
 			source := "== a title\n    \nand a paragraph"
 			section1Title := types.InlineElements{
-				&types.StringElement{Content: "a title"},
+				types.StringElement{Content: "a title"},
 			}
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.Section{
+					types.Section{
 						Attributes: types.ElementAttributes{
 							types.AttrID:       "a_title",
 							types.AttrCustomID: false,
@@ -318,12 +318,12 @@ and a paragraph`
 						Title:    section1Title,
 						Elements: []interface{}{},
 					},
-					&types.BlankLine{},
-					&types.Paragraph{
+					types.BlankLine{},
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: "and a paragraph"},
+								types.StringElement{Content: "and a paragraph"},
 							},
 						},
 					},
@@ -343,76 +343,76 @@ a paragraph
 
 == Section B
 a paragraph`
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.Section{
+					types.Section{
 						Attributes: types.ElementAttributes{
 							types.AttrID:       "a_header",
 							types.AttrCustomID: false,
 						},
 						Level: 0,
 						Title: types.InlineElements{
-							&types.StringElement{Content: "a header"},
+							types.StringElement{Content: "a header"},
 						},
 						Elements: []interface{}{},
 					},
-					&types.BlankLine{},
-					&types.Section{
+					types.BlankLine{},
+					types.Section{
 						Attributes: types.ElementAttributes{
 							types.AttrID:       "section_a",
 							types.AttrCustomID: false,
 						},
 						Level: 1,
 						Title: types.InlineElements{
-							&types.StringElement{Content: "Section A"},
+							types.StringElement{Content: "Section A"},
 						},
 						Elements: []interface{}{},
 					},
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: "a paragraph"},
+								types.StringElement{Content: "a paragraph"},
 							},
 						},
 					},
-					&types.BlankLine{},
-					&types.Section{
+					types.BlankLine{},
+					types.Section{
 						Attributes: types.ElementAttributes{
 							types.AttrID:       "section_a_a",
 							types.AttrCustomID: false,
 						},
 						Level: 2,
 						Title: types.InlineElements{
-							&types.StringElement{Content: "Section A.a"},
+							types.StringElement{Content: "Section A.a"},
 						},
 						Elements: []interface{}{},
 					},
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: "a paragraph"},
+								types.StringElement{Content: "a paragraph"},
 							},
 						},
 					},
-					&types.BlankLine{},
-					&types.Section{
+					types.BlankLine{},
+					types.Section{
 						Attributes: types.ElementAttributes{
 							types.AttrID:       "section_b",
 							types.AttrCustomID: false,
 						},
 						Level: 1,
 						Title: types.InlineElements{
-							&types.StringElement{Content: "Section B"},
+							types.StringElement{Content: "Section B"},
 						},
 						Elements: []interface{}{},
 					},
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: "a paragraph"},
+								types.StringElement{Content: "a paragraph"},
 							},
 						},
 					},
@@ -425,11 +425,11 @@ a paragraph`
 			source := `[[custom_header]]
 == a header`
 			sectionTitle := types.InlineElements{
-				&types.StringElement{Content: "a header"},
+				types.StringElement{Content: "a header"},
 			}
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.Section{
+					types.Section{
 						Attributes: types.ElementAttributes{
 							types.AttrID:       "custom_header",
 							types.AttrCustomID: true,
@@ -453,17 +453,17 @@ a paragraph`
 == Section B
 a paragraph`
 			doctitle := types.InlineElements{
-				&types.StringElement{Content: "a header"},
+				types.StringElement{Content: "a header"},
 			}
 			fooTitle := types.InlineElements{
-				&types.StringElement{Content: "Section F "},
+				types.StringElement{Content: "Section F "},
 			}
 			barTitle := types.InlineElements{
-				&types.StringElement{Content: "Section B"},
+				types.StringElement{Content: "Section B"},
 			}
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.Section{
+					types.Section{
 						Attributes: types.ElementAttributes{
 							types.AttrID:       "custom_header",
 							types.AttrCustomID: true,
@@ -472,8 +472,8 @@ a paragraph`
 						Title:    doctitle,
 						Elements: []interface{}{},
 					},
-					&types.BlankLine{},
-					&types.Section{
+					types.BlankLine{},
+					types.Section{
 						Attributes: types.ElementAttributes{
 							types.AttrID:       "foo",
 							types.AttrCustomID: true,
@@ -482,8 +482,8 @@ a paragraph`
 						Title:    fooTitle,
 						Elements: []interface{}{},
 					},
-					&types.BlankLine{},
-					&types.Section{
+					types.BlankLine{},
+					types.Section{
 						Attributes: types.ElementAttributes{
 							types.AttrID:       "bar",
 							types.AttrCustomID: true,
@@ -492,11 +492,11 @@ a paragraph`
 						Title:    barTitle,
 						Elements: []interface{}{},
 					},
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: "a paragraph"},
+								types.StringElement{Content: "a paragraph"},
 							},
 						},
 					},
@@ -510,14 +510,14 @@ a paragraph`
 
 == section 1`
 			section1aTitle := types.InlineElements{
-				&types.StringElement{Content: "section 1"},
+				types.StringElement{Content: "section 1"},
 			}
 			section1bTitle := types.InlineElements{
-				&types.StringElement{Content: "section 1"},
+				types.StringElement{Content: "section 1"},
 			}
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.Section{
+					types.Section{
 						Attributes: types.ElementAttributes{
 							types.AttrID:       "section_1",
 							types.AttrCustomID: false,
@@ -526,8 +526,8 @@ a paragraph`
 						Title:    section1aTitle,
 						Elements: []interface{}{},
 					},
-					&types.BlankLine{},
-					&types.Section{
+					types.BlankLine{},
+					types.Section{
 						Attributes: types.ElementAttributes{
 							types.AttrID:       "section_1", // duplicate ID will be processed afterwards
 							types.AttrCustomID: false,
@@ -545,13 +545,13 @@ a paragraph`
 	Context("invalid sections", func() {
 		It("header invalid - missing space", func() {
 			source := "=a header"
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: "=a header"},
+								types.StringElement{Content: "=a header"},
 							},
 						},
 					},
@@ -561,9 +561,9 @@ a paragraph`
 
 		It("header invalid - header space", func() {
 			source := " = a header with a prefix space"
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.LiteralBlock{
+					types.LiteralBlock{
 						Attributes: types.ElementAttributes{
 							types.AttrKind:             types.Literal,
 							types.AttrLiteralBlockType: types.LiteralBlockWithSpacesOnFirstLine,
@@ -582,11 +582,11 @@ a paragraph`
 
    == section with prefix space`
 			title := types.InlineElements{
-				&types.StringElement{Content: "a header"},
+				types.StringElement{Content: "a header"},
 			}
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.Section{
+					types.Section{
 						Attributes: types.ElementAttributes{
 							types.AttrID:       "a_header",
 							types.AttrCustomID: false,
@@ -595,8 +595,8 @@ a paragraph`
 						Title:    title,
 						Elements: []interface{}{},
 					},
-					&types.BlankLine{},
-					&types.LiteralBlock{
+					types.BlankLine{},
+					types.LiteralBlock{
 						Attributes: types.ElementAttributes{
 							types.AttrKind:             types.Literal,
 							types.AttrLiteralBlockType: types.LiteralBlockWithSpacesOnFirstLine,
@@ -618,23 +618,23 @@ a paragraph`
 			source := `Document Title
 ==============
 Doc Writer <thedoc@asciidoctor.org>`
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "Document Title",
 								},
 							},
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "==============",
 								},
 							},
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "Doc Writer <thedoc@asciidoctor.org>",
 								},
 							},
@@ -654,9 +654,9 @@ var _ = Describe("sections - document", func() {
 		It("header only", func() {
 			source := "= a header"
 			doctitle := types.InlineElements{
-				&types.StringElement{Content: "a header"},
+				types.StringElement{Content: "a header"},
 			}
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes: types.DocumentAttributes{},
 				ElementReferences: types.ElementReferences{
 					"a_header": doctitle,
@@ -664,7 +664,7 @@ var _ = Describe("sections - document", func() {
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.Section{
+					types.Section{
 						Attributes: types.ElementAttributes{
 							types.AttrID:       "a_header",
 							types.AttrCustomID: false,
@@ -681,9 +681,9 @@ var _ = Describe("sections - document", func() {
 		It("header with many spaces around content", func() {
 			source := "= a header   "
 			doctitle := types.InlineElements{
-				&types.StringElement{Content: "a header   "},
+				types.StringElement{Content: "a header   "},
 			}
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes: types.DocumentAttributes{},
 				ElementReferences: types.ElementReferences{
 					"a_header": doctitle,
@@ -691,7 +691,7 @@ var _ = Describe("sections - document", func() {
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.Section{
+					types.Section{
 						Attributes: types.ElementAttributes{
 							types.AttrID:       "a_header",
 							types.AttrCustomID: false,
@@ -711,9 +711,9 @@ var _ = Describe("sections - document", func() {
 and a paragraph`
 
 			doctitle := types.InlineElements{
-				&types.StringElement{Content: "a header"},
+				types.StringElement{Content: "a header"},
 			}
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes: types.DocumentAttributes{},
 				ElementReferences: types.ElementReferences{
 					"a_header": doctitle,
@@ -721,7 +721,7 @@ and a paragraph`
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.Section{
+					types.Section{
 						Attributes: types.ElementAttributes{
 							types.AttrID:       "a_header",
 							types.AttrCustomID: false,
@@ -729,11 +729,11 @@ and a paragraph`
 						Level: 0,
 						Title: doctitle,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "and a paragraph"},
+										types.StringElement{Content: "and a paragraph"},
 									},
 								},
 							},
@@ -749,13 +749,13 @@ and a paragraph`
 
 = a second header`
 			doctitle := types.InlineElements{
-				&types.StringElement{Content: "a first header"},
+				types.StringElement{Content: "a first header"},
 			}
 			otherDoctitle := types.InlineElements{
-				&types.StringElement{Content: "a second header"},
+				types.StringElement{Content: "a second header"},
 			}
 
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes: types.DocumentAttributes{},
 				ElementReferences: types.ElementReferences{
 					"a_first_header":  doctitle,
@@ -764,7 +764,7 @@ and a paragraph`
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.Section{
+					types.Section{
 						Attributes: types.ElementAttributes{
 							types.AttrID:       "a_first_header",
 							types.AttrCustomID: false,
@@ -773,7 +773,7 @@ and a paragraph`
 						Title:    doctitle,
 						Elements: []interface{}{},
 					},
-					&types.Section{
+					types.Section{
 						Attributes: types.ElementAttributes{
 							types.AttrID:       "a_second_header",
 							types.AttrCustomID: false,
@@ -790,9 +790,9 @@ and a paragraph`
 		It("section level 1 alone", func() {
 			source := `== section 1`
 			section1Title := types.InlineElements{
-				&types.StringElement{Content: "section 1"},
+				types.StringElement{Content: "section 1"},
 			}
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes: types.DocumentAttributes{},
 				ElementReferences: types.ElementReferences{
 					"section_1": section1Title,
@@ -800,7 +800,7 @@ and a paragraph`
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.Section{
+					types.Section{
 						Attributes: types.ElementAttributes{
 							types.AttrID:       "section_1",
 							types.AttrCustomID: false,
@@ -817,14 +817,14 @@ and a paragraph`
 		It("section level 1 with quoted text", func() {
 			source := `==  *2 spaces and bold content*`
 			sectionTitle := types.InlineElements{
-				&types.QuotedText{
+				types.QuotedText{
 					Kind: types.Bold,
 					Elements: types.InlineElements{
-						&types.StringElement{Content: "2 spaces and bold content"},
+						types.StringElement{Content: "2 spaces and bold content"},
 					},
 				},
 			}
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes: types.DocumentAttributes{},
 				ElementReferences: types.ElementReferences{
 					"2_spaces_and_bold_content": sectionTitle,
@@ -832,7 +832,7 @@ and a paragraph`
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.Section{
+					types.Section{
 						Attributes: types.ElementAttributes{
 							types.AttrID:       "2_spaces_and_bold_content",
 							types.AttrCustomID: false,
@@ -851,12 +851,12 @@ and a paragraph`
 
 == section 1`
 			doctitle := types.InlineElements{
-				&types.StringElement{Content: "a header"},
+				types.StringElement{Content: "a header"},
 			}
 			section1Title := types.InlineElements{
-				&types.StringElement{Content: "section 1"},
+				types.StringElement{Content: "section 1"},
 			}
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes: types.DocumentAttributes{},
 				ElementReferences: types.ElementReferences{
 					"a_header":  doctitle,
@@ -865,7 +865,7 @@ and a paragraph`
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.Section{
+					types.Section{
 						Attributes: types.ElementAttributes{
 							types.AttrID:       "a_header",
 							types.AttrCustomID: false,
@@ -873,7 +873,7 @@ and a paragraph`
 						Level: 0,
 						Title: doctitle,
 						Elements: []interface{}{
-							&types.Section{
+							types.Section{
 								Attributes: types.ElementAttributes{
 									types.AttrID:       "section_1",
 									types.AttrCustomID: false,
@@ -894,12 +894,12 @@ and a paragraph`
 
 === section 2`
 			doctitle := types.InlineElements{
-				&types.StringElement{Content: "a header"},
+				types.StringElement{Content: "a header"},
 			}
 			section2Title := types.InlineElements{
-				&types.StringElement{Content: "section 2"},
+				types.StringElement{Content: "section 2"},
 			}
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes: types.DocumentAttributes{},
 				ElementReferences: types.ElementReferences{
 					"a_header":  doctitle,
@@ -908,7 +908,7 @@ and a paragraph`
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.Section{
+					types.Section{
 						Attributes: types.ElementAttributes{
 							types.AttrID:       "a_header",
 							types.AttrCustomID: false,
@@ -916,7 +916,7 @@ and a paragraph`
 						Level: 0,
 						Title: doctitle,
 						Elements: []interface{}{
-							&types.Section{
+							types.Section{
 								Attributes: types.ElementAttributes{
 									types.AttrID:       "section_2",
 									types.AttrCustomID: false,
@@ -936,9 +936,9 @@ and a paragraph`
 			source := `== a title
 and a paragraph`
 			section1Title := types.InlineElements{
-				&types.StringElement{Content: "a title"},
+				types.StringElement{Content: "a title"},
 			}
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes: types.DocumentAttributes{},
 				ElementReferences: types.ElementReferences{
 					"a_title": section1Title,
@@ -946,7 +946,7 @@ and a paragraph`
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.Section{
+					types.Section{
 						Attributes: types.ElementAttributes{
 							types.AttrID:       "a_title",
 							types.AttrCustomID: false,
@@ -954,11 +954,11 @@ and a paragraph`
 						Level: 1,
 						Title: section1Title,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "and a paragraph"},
+										types.StringElement{Content: "and a paragraph"},
 									},
 								},
 							},
@@ -974,9 +974,9 @@ and a paragraph`
 			
 and a paragraph`
 			section1Title := types.InlineElements{
-				&types.StringElement{Content: "a title"},
+				types.StringElement{Content: "a title"},
 			}
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes: types.DocumentAttributes{},
 				ElementReferences: types.ElementReferences{
 					"a_title": section1Title,
@@ -984,7 +984,7 @@ and a paragraph`
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.Section{
+					types.Section{
 						Attributes: types.ElementAttributes{
 							types.AttrID:       "a_title",
 							types.AttrCustomID: false,
@@ -992,11 +992,11 @@ and a paragraph`
 						Level: 1,
 						Title: section1Title,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "and a paragraph"},
+										types.StringElement{Content: "and a paragraph"},
 									},
 								},
 							},
@@ -1010,9 +1010,9 @@ and a paragraph`
 		It("section level 1 with a paragraph separated by non-empty line", func() {
 			source := "== a title\n    \nand a paragraph"
 			section1Title := types.InlineElements{
-				&types.StringElement{Content: "a title"},
+				types.StringElement{Content: "a title"},
 			}
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes: types.DocumentAttributes{},
 				ElementReferences: types.ElementReferences{
 					"a_title": section1Title,
@@ -1020,7 +1020,7 @@ and a paragraph`
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.Section{
+					types.Section{
 						Attributes: types.ElementAttributes{
 							types.AttrID:       "a_title",
 							types.AttrCustomID: false,
@@ -1028,11 +1028,11 @@ and a paragraph`
 						Level: 1,
 						Title: section1Title,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "and a paragraph"},
+										types.StringElement{Content: "and a paragraph"},
 									},
 								},
 							},
@@ -1055,18 +1055,18 @@ a paragraph
 == Section B
 a paragraph`
 			doctitle := types.InlineElements{
-				&types.StringElement{Content: "a header"},
+				types.StringElement{Content: "a header"},
 			}
 			sectionATitle := types.InlineElements{
-				&types.StringElement{Content: "Section A"},
+				types.StringElement{Content: "Section A"},
 			}
 			sectionAaTitle := types.InlineElements{
-				&types.StringElement{Content: "Section A.a"},
+				types.StringElement{Content: "Section A.a"},
 			}
 			sectionBTitle := types.InlineElements{
-				&types.StringElement{Content: "Section B"},
+				types.StringElement{Content: "Section B"},
 			}
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes: types.DocumentAttributes{},
 				ElementReferences: types.ElementReferences{
 					"a_header":    doctitle,
@@ -1077,7 +1077,7 @@ a paragraph`
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.Section{
+					types.Section{
 						Attributes: types.ElementAttributes{
 							types.AttrID:       "a_header",
 							types.AttrCustomID: false,
@@ -1085,7 +1085,7 @@ a paragraph`
 						Level: 0,
 						Title: doctitle,
 						Elements: []interface{}{
-							&types.Section{
+							types.Section{
 								Attributes: types.ElementAttributes{
 									types.AttrID:       "section_a",
 									types.AttrCustomID: false,
@@ -1093,15 +1093,15 @@ a paragraph`
 								Level: 1,
 								Title: sectionATitle,
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{Content: "a paragraph"},
+												types.StringElement{Content: "a paragraph"},
 											},
 										},
 									},
-									&types.Section{
+									types.Section{
 										Attributes: types.ElementAttributes{
 											types.AttrID:       "section_a_a",
 											types.AttrCustomID: false,
@@ -1109,11 +1109,11 @@ a paragraph`
 										Level: 2,
 										Title: sectionAaTitle,
 										Elements: []interface{}{
-											&types.Paragraph{
+											types.Paragraph{
 												Attributes: types.ElementAttributes{},
 												Lines: []types.InlineElements{
 													{
-														&types.StringElement{Content: "a paragraph"},
+														types.StringElement{Content: "a paragraph"},
 													},
 												},
 											},
@@ -1121,7 +1121,7 @@ a paragraph`
 									},
 								},
 							},
-							&types.Section{
+							types.Section{
 								Attributes: types.ElementAttributes{
 									types.AttrID:       "section_b",
 									types.AttrCustomID: false,
@@ -1129,11 +1129,11 @@ a paragraph`
 								Level: 1,
 								Title: sectionBTitle,
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{Content: "a paragraph"},
+												types.StringElement{Content: "a paragraph"},
 											},
 										},
 									},
@@ -1150,9 +1150,9 @@ a paragraph`
 			source := `[[custom_header]]
 == a header`
 			sectionTitle := types.InlineElements{
-				&types.StringElement{Content: "a header"},
+				types.StringElement{Content: "a header"},
 			}
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes: types.DocumentAttributes{},
 				ElementReferences: types.ElementReferences{
 					"custom_header": sectionTitle,
@@ -1160,7 +1160,7 @@ a paragraph`
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.Section{
+					types.Section{
 						Attributes: types.ElementAttributes{
 							types.AttrID:       "custom_header",
 							types.AttrCustomID: true,
@@ -1184,15 +1184,15 @@ a paragraph`
 == Section B
 a paragraph`
 			doctitle := types.InlineElements{
-				&types.StringElement{Content: "a header"},
+				types.StringElement{Content: "a header"},
 			}
 			fooTitle := types.InlineElements{
-				&types.StringElement{Content: "Section F "},
+				types.StringElement{Content: "Section F "},
 			}
 			barTitle := types.InlineElements{
-				&types.StringElement{Content: "Section B"},
+				types.StringElement{Content: "Section B"},
 			}
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes: types.DocumentAttributes{},
 				ElementReferences: types.ElementReferences{
 					"custom_header": doctitle,
@@ -1202,7 +1202,7 @@ a paragraph`
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.Section{
+					types.Section{
 						Attributes: types.ElementAttributes{
 							types.AttrID:       "custom_header",
 							types.AttrCustomID: true,
@@ -1210,7 +1210,7 @@ a paragraph`
 						Level: 0,
 						Title: doctitle,
 						Elements: []interface{}{
-							&types.Section{
+							types.Section{
 								Attributes: types.ElementAttributes{
 									types.AttrID:       "foo",
 									types.AttrCustomID: true,
@@ -1219,7 +1219,7 @@ a paragraph`
 								Title:    fooTitle,
 								Elements: []interface{}{},
 							},
-							&types.Section{
+							types.Section{
 								Attributes: types.ElementAttributes{
 									types.AttrID:       "bar",
 									types.AttrCustomID: true,
@@ -1227,11 +1227,11 @@ a paragraph`
 								Level: 1,
 								Title: barTitle,
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{Content: "a paragraph"},
+												types.StringElement{Content: "a paragraph"},
 											},
 										},
 									},
@@ -1249,13 +1249,13 @@ a paragraph`
 
 == section 1`
 			section1aTitle := types.InlineElements{
-				&types.StringElement{Content: "section 1"},
+				types.StringElement{Content: "section 1"},
 			}
 			section1bTitle := types.InlineElements{
-				&types.StringElement{Content: "section 1"},
+				types.StringElement{Content: "section 1"},
 			}
 
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes: types.DocumentAttributes{},
 				ElementReferences: types.ElementReferences{
 					"section_1":   section1aTitle,
@@ -1264,7 +1264,7 @@ a paragraph`
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.Section{
+					types.Section{
 						Attributes: types.ElementAttributes{
 							types.AttrID:       "section_1",
 							types.AttrCustomID: false,
@@ -1273,7 +1273,7 @@ a paragraph`
 						Title:    section1aTitle,
 						Elements: []interface{}{},
 					},
-					&types.Section{
+					types.Section{
 						Attributes: types.ElementAttributes{
 							types.AttrID:       "section_1_2",
 							types.AttrCustomID: false,
@@ -1292,17 +1292,17 @@ a paragraph`
 
 		It("header invalid - too many spaces", func() {
 			source := "======= a header"
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: "======= a header"},
+								types.StringElement{Content: "======= a header"},
 							},
 						},
 					},
@@ -1312,17 +1312,17 @@ a paragraph`
 
 		It("header invalid - missing space", func() {
 			source := "=a header"
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: "=a header"},
+								types.StringElement{Content: "=a header"},
 							},
 						},
 					},
@@ -1332,13 +1332,13 @@ a paragraph`
 
 		It("header invalid - header space", func() {
 			source := " = a header with a prefix space"
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.LiteralBlock{
+					types.LiteralBlock{
 						Attributes: types.ElementAttributes{
 							types.AttrKind:             types.Literal,
 							types.AttrLiteralBlockType: types.LiteralBlockWithSpacesOnFirstLine,
@@ -1357,16 +1357,16 @@ a paragraph`
 
  == section with prefix space`
 			title := types.InlineElements{
-				&types.StringElement{Content: "a header"},
+				types.StringElement{Content: "a header"},
 			}
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes: types.DocumentAttributes{},
 				ElementReferences: types.ElementReferences{
 					"a_header": title,
 				}, Footnotes: types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.Section{
+					types.Section{
 						Attributes: types.ElementAttributes{
 							types.AttrID:       "a_header",
 							types.AttrCustomID: false,
@@ -1374,7 +1374,7 @@ a paragraph`
 						Level: 0,
 						Title: title,
 						Elements: []interface{}{
-							&types.LiteralBlock{
+							types.LiteralBlock{
 								Attributes: types.ElementAttributes{
 									types.AttrKind:             types.Literal,
 									types.AttrLiteralBlockType: types.LiteralBlockWithSpacesOnFirstLine,
@@ -1398,27 +1398,27 @@ a paragraph`
 			source := `Document Title
 ==============
 Doc Writer <thedoc@asciidoctor.org>`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "Document Title",
 								},
 							},
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "==============",
 								},
 							},
 							{
-								&types.StringElement{
+								types.StringElement{
 									Content: "Doc Writer <thedoc@asciidoctor.org>",
 								},
 							},

--- a/pkg/parser/table_test.go
+++ b/pkg/parser/table_test.go
@@ -12,34 +12,34 @@ var _ = Describe("tables", func() {
 | *foo* foo  | _bar_  
 |===
 `
-		expected := &types.Table{
+		expected := types.Table{
 			Attributes: types.ElementAttributes{},
-			Lines: []*types.TableLine{
+			Lines: []types.TableLine{
 				{
 					Cells: []types.InlineElements{
 						{
-							&types.QuotedText{
+							types.QuotedText{
 								Kind: types.Bold,
 								Elements: types.InlineElements{
-									&types.StringElement{
+									types.StringElement{
 										Content: "foo",
 									},
 								},
 							},
-							&types.StringElement{
+							types.StringElement{
 								Content: " foo  ",
 							},
 						},
 						{
-							&types.QuotedText{
+							types.QuotedText{
 								Kind: types.Italic,
 								Elements: types.InlineElements{
-									&types.StringElement{
+									types.StringElement{
 										Content: "bar",
 									},
 								},
 							},
-							&types.StringElement{
+							types.StringElement{
 								Content: "  ",
 							},
 						},
@@ -54,39 +54,39 @@ var _ = Describe("tables", func() {
 		source := `|===
 | *foo* foo  | _bar_  | baz
 |===`
-		expected := &types.Table{
+		expected := types.Table{
 			Attributes: types.ElementAttributes{},
-			Lines: []*types.TableLine{
+			Lines: []types.TableLine{
 				{
 					Cells: []types.InlineElements{
 						{
-							&types.QuotedText{
+							types.QuotedText{
 								Kind: types.Bold,
 								Elements: types.InlineElements{
-									&types.StringElement{
+									types.StringElement{
 										Content: "foo",
 									},
 								},
 							},
-							&types.StringElement{
+							types.StringElement{
 								Content: " foo  ",
 							},
 						},
 						{
-							&types.QuotedText{
+							types.QuotedText{
 								Kind: types.Italic,
 								Elements: types.InlineElements{
-									&types.StringElement{
+									types.StringElement{
 										Content: "bar",
 									},
 								},
 							},
-							&types.StringElement{
+							types.StringElement{
 								Content: "  ",
 							},
 						},
 						{
-							&types.StringElement{
+							types.StringElement{
 								Content: "baz",
 							},
 						},
@@ -108,35 +108,35 @@ var _ = Describe("tables", func() {
 |row 2, column 1
 |row 2, column 2
 |===`
-		expected := &types.Table{
+		expected := types.Table{
 			Attributes: types.ElementAttributes{
 				types.AttrTitle: "table title",
 			},
-			Header: &types.TableLine{
+			Header: types.TableLine{
 				Cells: []types.InlineElements{
 					{
-						&types.StringElement{
+						types.StringElement{
 							Content: "heading 1 ",
 						},
 					},
 					{
-						&types.StringElement{
+						types.StringElement{
 							Content: "heading 2",
 						},
 					},
 				},
 			},
 
-			Lines: []*types.TableLine{
+			Lines: []types.TableLine{
 				{
 					Cells: []types.InlineElements{
 						{
-							&types.StringElement{
+							types.StringElement{
 								Content: "row 1, column 1",
 							},
 						},
 						{
-							&types.StringElement{
+							types.StringElement{
 								Content: "row 1, column 2",
 							},
 						},
@@ -145,12 +145,12 @@ var _ = Describe("tables", func() {
 				{
 					Cells: []types.InlineElements{
 						{
-							&types.StringElement{
+							types.StringElement{
 								Content: "row 2, column 1",
 							},
 						},
 						{
-							&types.StringElement{
+							types.StringElement{
 								Content: "row 2, column 2",
 							},
 						},
@@ -164,9 +164,9 @@ var _ = Describe("tables", func() {
 	It("empty table ", func() {
 		source := `|===
 |===`
-		expected := &types.Table{
+		expected := types.Table{
 			Attributes: types.ElementAttributes{},
-			Lines:      []*types.TableLine{},
+			Lines:      []types.TableLine{},
 		}
 		verifyDocumentBlock(expected, source)
 	})

--- a/pkg/parser/unordered_list_test.go
+++ b/pkg/parser/unordered_list_test.go
@@ -11,19 +11,19 @@ var _ = Describe("unordered lists - preflight", func() {
 
 		It("unordered list with a basic single item", func() {
 			source := `* a list item`
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Attributes:  types.ElementAttributes{},
 						Level:       1,
 						BulletStyle: types.OneAsterisk,
 						CheckStyle:  types.NoCheck,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "a list item"},
+										types.StringElement{Content: "a list item"},
 									},
 								},
 							},
@@ -39,9 +39,9 @@ var _ = Describe("unordered lists - preflight", func() {
 [#listID]
 [.myrole]
 * a list item`
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Attributes: types.ElementAttributes{
 							types.AttrTitle:    "mytitle",
 							types.AttrID:       "listID",
@@ -52,11 +52,11 @@ var _ = Describe("unordered lists - preflight", func() {
 						BulletStyle: types.OneAsterisk,
 						CheckStyle:  types.NoCheck,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "a list item"},
+										types.StringElement{Content: "a list item"},
 									},
 								},
 							},
@@ -69,9 +69,9 @@ var _ = Describe("unordered lists - preflight", func() {
 		It("unordered list with a title and a single item", func() {
 			source := `.a title
 	* a list item`
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Attributes: types.ElementAttributes{
 							types.AttrTitle: "a title",
 						},
@@ -79,11 +79,11 @@ var _ = Describe("unordered lists - preflight", func() {
 						BulletStyle: types.OneAsterisk,
 						CheckStyle:  types.NoCheck,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "a list item"},
+										types.StringElement{Content: "a list item"},
 									},
 								},
 							},
@@ -97,39 +97,39 @@ var _ = Describe("unordered lists - preflight", func() {
 		It("unordered list with 2 items with stars", func() {
 			source := `* a first item
 					* a second item with *bold content*`
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Attributes:  types.ElementAttributes{},
 						Level:       1,
 						BulletStyle: types.OneAsterisk,
 						CheckStyle:  types.NoCheck,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "a first item"},
+										types.StringElement{Content: "a first item"},
 									},
 								},
 							},
 						},
 					},
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Attributes:  types.ElementAttributes{},
 						Level:       1,
 						BulletStyle: types.OneAsterisk,
 						CheckStyle:  types.NoCheck,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "a second item with "},
-										&types.QuotedText{
+										types.StringElement{Content: "a second item with "},
+										types.QuotedText{
 											Kind: types.Bold,
 											Elements: types.InlineElements{
-												&types.StringElement{Content: "bold content"},
+												types.StringElement{Content: "bold content"},
 											},
 										},
 									},
@@ -152,9 +152,9 @@ var _ = Describe("unordered lists - preflight", func() {
 		*** nested nested list item B.1
 		*** nested nested list item B.2
 		* list item 2`
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Attributes: types.ElementAttributes{
 							types.AttrTitle: "Unordered list title",
 						},
@@ -162,123 +162,123 @@ var _ = Describe("unordered lists - preflight", func() {
 						BulletStyle: types.OneAsterisk,
 						CheckStyle:  types.NoCheck,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "list item 1"},
+										types.StringElement{Content: "list item 1"},
 									},
 								},
 							},
 						},
 					},
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Attributes:  types.ElementAttributes{},
 						Level:       2,
 						BulletStyle: types.TwoAsterisks,
 						CheckStyle:  types.NoCheck,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "nested list item A"},
+										types.StringElement{Content: "nested list item A"},
 									},
 								},
 							},
 						},
 					},
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Attributes:  types.ElementAttributes{},
 						Level:       3,
 						BulletStyle: types.ThreeAsterisks,
 						CheckStyle:  types.NoCheck,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "nested nested list item A.1"},
+										types.StringElement{Content: "nested nested list item A.1"},
 									},
 								},
 							},
 						},
 					},
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Attributes:  types.ElementAttributes{},
 						Level:       3,
 						BulletStyle: types.ThreeAsterisks,
 						CheckStyle:  types.NoCheck,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "nested nested list item A.2"},
+										types.StringElement{Content: "nested nested list item A.2"},
 									},
 								},
 							},
 						},
 					},
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Attributes:  types.ElementAttributes{},
 						Level:       2,
 						BulletStyle: types.TwoAsterisks,
 						CheckStyle:  types.NoCheck,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "nested list item B"},
+										types.StringElement{Content: "nested list item B"},
 									},
 								},
 							},
 						},
 					},
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Attributes:  types.ElementAttributes{},
 						Level:       3,
 						BulletStyle: types.ThreeAsterisks,
 						CheckStyle:  types.NoCheck,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "nested nested list item B.1"},
+										types.StringElement{Content: "nested nested list item B.1"},
 									},
 								},
 							},
 						},
 					},
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Attributes:  types.ElementAttributes{},
 						Level:       3,
 						BulletStyle: types.ThreeAsterisks,
 						CheckStyle:  types.NoCheck,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "nested nested list item B.2"},
+										types.StringElement{Content: "nested nested list item B.2"},
 									},
 								},
 							},
 						},
 					},
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Attributes:  types.ElementAttributes{},
 						Level:       1,
 						BulletStyle: types.OneAsterisk,
 						CheckStyle:  types.NoCheck,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "list item 2"},
+										types.StringElement{Content: "list item 2"},
 									},
 								},
 							},
@@ -292,39 +292,39 @@ var _ = Describe("unordered lists - preflight", func() {
 		It("unordered list with 2 items with carets", func() {
 			source := "- a first item\n" +
 				"- a second item with *bold content*"
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Attributes:  types.ElementAttributes{},
 						Level:       1,
 						BulletStyle: types.Dash,
 						CheckStyle:  types.NoCheck,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "a first item"},
+										types.StringElement{Content: "a first item"},
 									},
 								},
 							},
 						},
 					},
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Attributes:  types.ElementAttributes{},
 						Level:       1,
 						BulletStyle: types.Dash,
 						CheckStyle:  types.NoCheck,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "a second item with "},
-										&types.QuotedText{
+										types.StringElement{Content: "a second item with "},
+										types.QuotedText{
 											Kind: types.Bold,
 											Elements: types.InlineElements{
-												&types.StringElement{Content: "bold content"},
+												types.StringElement{Content: "bold content"},
 											},
 										},
 									},
@@ -343,83 +343,83 @@ var _ = Describe("unordered lists - preflight", func() {
 					- another parent item
 					* another child item
 					** with a sub child item`
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Attributes:  types.ElementAttributes{},
 						Level:       1,
 						BulletStyle: types.Dash,
 						CheckStyle:  types.NoCheck,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "a parent item"},
+										types.StringElement{Content: "a parent item"},
 									},
 								},
 							},
 						},
 					},
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Attributes:  types.ElementAttributes{},
 						Level:       1,
 						BulletStyle: types.OneAsterisk,
 						CheckStyle:  types.NoCheck,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "a child item"},
+										types.StringElement{Content: "a child item"},
 									},
 								},
 							},
 						},
 					},
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Attributes:  types.ElementAttributes{},
 						Level:       1,
 						BulletStyle: types.Dash,
 						CheckStyle:  types.NoCheck,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "another parent item"},
+										types.StringElement{Content: "another parent item"},
 									},
 								},
 							},
 						},
 					},
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Attributes:  types.ElementAttributes{},
 						Level:       1,
 						BulletStyle: types.OneAsterisk,
 						CheckStyle:  types.NoCheck,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "another child item"},
+										types.StringElement{Content: "another child item"},
 									},
 								},
 							},
 						},
 					},
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Attributes:  types.ElementAttributes{},
 						Level:       2,
 						BulletStyle: types.TwoAsterisks,
 						CheckStyle:  types.NoCheck,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "with a sub child item"},
+										types.StringElement{Content: "with a sub child item"},
 									},
 								},
 							},
@@ -435,40 +435,40 @@ var _ = Describe("unordered lists - preflight", func() {
 			source := "* a first item\n" +
 				"\n" +
 				"* a second item with *bold content*"
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Attributes:  types.ElementAttributes{},
 						Level:       1,
 						BulletStyle: types.OneAsterisk,
 						CheckStyle:  types.NoCheck,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "a first item"},
+										types.StringElement{Content: "a first item"},
 									},
 								},
 							},
 						},
 					},
-					&types.BlankLine{},
-					&types.UnorderedListItem{
+					types.BlankLine{},
+					types.UnorderedListItem{
 						Attributes:  types.ElementAttributes{},
 						Level:       1,
 						BulletStyle: types.OneAsterisk,
 						CheckStyle:  types.NoCheck,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "a second item with "},
-										&types.QuotedText{
+										types.StringElement{Content: "a second item with "},
+										types.QuotedText{
 											Kind: types.Bold,
 											Elements: types.InlineElements{
-												&types.StringElement{Content: "bold content"},
+												types.StringElement{Content: "bold content"},
 											},
 										},
 									},
@@ -485,41 +485,41 @@ var _ = Describe("unordered lists - preflight", func() {
   on 2 lines.
 * item 2
 on 2 lines, too.`
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Attributes:  types.ElementAttributes{},
 						Level:       1,
 						BulletStyle: types.OneAsterisk,
 						CheckStyle:  types.NoCheck,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "item 1"},
+										types.StringElement{Content: "item 1"},
 									},
 									{
-										&types.StringElement{Content: "  on 2 lines."},
+										types.StringElement{Content: "  on 2 lines."},
 									},
 								},
 							},
 						},
 					},
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Attributes:  types.ElementAttributes{},
 						Level:       1,
 						BulletStyle: types.OneAsterisk,
 						CheckStyle:  types.NoCheck,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "item 2"},
+										types.StringElement{Content: "item 2"},
 									},
 									{
-										&types.StringElement{Content: "on 2 lines, too."},
+										types.StringElement{Content: "on 2 lines, too."},
 									},
 								},
 							},
@@ -534,37 +534,37 @@ on 2 lines, too.`
 			
 
 * an item in the second list`
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Attributes:  types.ElementAttributes{},
 						Level:       1,
 						BulletStyle: types.OneAsterisk,
 						CheckStyle:  types.NoCheck,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "an item in the first list"},
+										types.StringElement{Content: "an item in the first list"},
 									},
 								},
 							},
 						},
 					},
-					&types.BlankLine{},
-					&types.BlankLine{},
-					&types.UnorderedListItem{
+					types.BlankLine{},
+					types.BlankLine{},
+					types.UnorderedListItem{
 						Attributes:  types.ElementAttributes{},
 						Level:       1,
 						BulletStyle: types.OneAsterisk,
 						CheckStyle:  types.NoCheck,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "an item in the second list"},
+										types.StringElement{Content: "an item in the second list"},
 									},
 								},
 							},
@@ -584,131 +584,131 @@ on 2 lines, too.`
 	** item 1.4
 	* item 2
 	** item 2.1`
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Attributes:  types.ElementAttributes{},
 						Level:       1,
 						BulletStyle: types.OneAsterisk,
 						CheckStyle:  types.NoCheck,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "item 1"},
+										types.StringElement{Content: "item 1"},
 									},
 								},
 							},
 						},
 					},
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Attributes:  types.ElementAttributes{},
 						Level:       2,
 						BulletStyle: types.TwoAsterisks,
 						CheckStyle:  types.NoCheck,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "item 1.1"},
+										types.StringElement{Content: "item 1.1"},
 									},
 								},
 							},
 						},
 					},
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Attributes:  types.ElementAttributes{},
 						Level:       2,
 						BulletStyle: types.TwoAsterisks,
 						CheckStyle:  types.NoCheck,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "item 1.2"},
+										types.StringElement{Content: "item 1.2"},
 									},
 								},
 							},
 						},
 					},
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Attributes:  types.ElementAttributes{},
 						Level:       3,
 						BulletStyle: types.ThreeAsterisks,
 						CheckStyle:  types.NoCheck,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "item 1.2.1"},
+										types.StringElement{Content: "item 1.2.1"},
 									},
 								},
 							},
 						},
 					},
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Attributes:  types.ElementAttributes{},
 						Level:       2,
 						BulletStyle: types.TwoAsterisks,
 						CheckStyle:  types.NoCheck,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "item 1.3"},
+										types.StringElement{Content: "item 1.3"},
 									},
 								},
 							},
 						},
 					},
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Attributes:  types.ElementAttributes{},
 						Level:       2,
 						BulletStyle: types.TwoAsterisks,
 						CheckStyle:  types.NoCheck,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "item 1.4"},
+										types.StringElement{Content: "item 1.4"},
 									},
 								},
 							},
 						},
 					},
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Attributes:  types.ElementAttributes{},
 						Level:       1,
 						BulletStyle: types.OneAsterisk,
 						CheckStyle:  types.NoCheck,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "item 2"},
+										types.StringElement{Content: "item 2"},
 									},
 								},
 							},
 						},
 					},
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Attributes:  types.ElementAttributes{},
 						Level:       2,
 						BulletStyle: types.TwoAsterisks,
 						CheckStyle:  types.NoCheck,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "item 2.1"},
+										types.StringElement{Content: "item 2.1"},
 									},
 								},
 							},
@@ -727,9 +727,9 @@ on 2 lines, too.`
 **** level 4
 ***** level 5
 * level 1`
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Level:       1,
 						BulletStyle: types.OneAsterisk,
 						CheckStyle:  types.NoCheck,
@@ -737,11 +737,11 @@ on 2 lines, too.`
 							types.AttrTitle: "Unordered, max nesting",
 						},
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "level 1",
 										},
 									},
@@ -749,17 +749,17 @@ on 2 lines, too.`
 							},
 						},
 					},
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Level:       2,
 						BulletStyle: types.TwoAsterisks,
 						CheckStyle:  types.NoCheck,
 						Attributes:  types.ElementAttributes{},
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "level 2",
 										},
 									},
@@ -767,17 +767,17 @@ on 2 lines, too.`
 							},
 						},
 					},
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Level:       3,
 						BulletStyle: types.ThreeAsterisks,
 						CheckStyle:  types.NoCheck,
 						Attributes:  types.ElementAttributes{},
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "level 3",
 										},
 									},
@@ -785,17 +785,17 @@ on 2 lines, too.`
 							},
 						},
 					},
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Level:       4,
 						BulletStyle: types.FourAsterisks,
 						CheckStyle:  types.NoCheck,
 						Attributes:  types.ElementAttributes{},
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "level 4",
 										},
 									},
@@ -803,17 +803,17 @@ on 2 lines, too.`
 							},
 						},
 					},
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Level:       5,
 						BulletStyle: types.FiveAsterisks,
 						CheckStyle:  types.NoCheck,
 						Attributes:  types.ElementAttributes{},
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "level 5",
 										},
 									},
@@ -821,17 +821,17 @@ on 2 lines, too.`
 							},
 						},
 					},
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Level:       1,
 						BulletStyle: types.OneAsterisk,
 						CheckStyle:  types.NoCheck,
 						Attributes:  types.ElementAttributes{},
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "level 1",
 										},
 									},
@@ -852,9 +852,9 @@ on 2 lines, too.`
 **** level 4
 ***** level 5
 ** level 2`
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Attributes: types.ElementAttributes{
 							types.AttrTitle: "Unordered, max nesting",
 						},
@@ -862,11 +862,11 @@ on 2 lines, too.`
 						BulletStyle: types.OneAsterisk,
 						CheckStyle:  types.NoCheck,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "level 1",
 										},
 									},
@@ -874,17 +874,17 @@ on 2 lines, too.`
 							},
 						},
 					},
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Level:       2,
 						BulletStyle: types.TwoAsterisks,
 						CheckStyle:  types.NoCheck,
 						Attributes:  types.ElementAttributes{},
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "level 2",
 										},
 									},
@@ -892,17 +892,17 @@ on 2 lines, too.`
 							},
 						},
 					},
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Level:       3,
 						BulletStyle: types.ThreeAsterisks,
 						CheckStyle:  types.NoCheck,
 						Attributes:  types.ElementAttributes{},
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "level 3",
 										},
 									},
@@ -910,16 +910,16 @@ on 2 lines, too.`
 							},
 						},
 					},
-					&types.UnorderedListItem{Level: 4,
+					types.UnorderedListItem{Level: 4,
 						BulletStyle: types.FourAsterisks,
 						CheckStyle:  types.NoCheck,
 						Attributes:  types.ElementAttributes{},
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "level 4",
 										},
 									},
@@ -927,17 +927,17 @@ on 2 lines, too.`
 							},
 						},
 					},
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Level:       5,
 						BulletStyle: types.FiveAsterisks,
 						CheckStyle:  types.NoCheck,
 						Attributes:  types.ElementAttributes{},
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "level 5",
 										},
 									},
@@ -945,17 +945,17 @@ on 2 lines, too.`
 							},
 						},
 					},
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Level:       2,
 						BulletStyle: types.TwoAsterisks,
 						CheckStyle:  types.NoCheck,
 						Attributes:  types.ElementAttributes{},
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "level 2",
 										},
 									},
@@ -976,83 +976,83 @@ on 2 lines, too.`
 					*** item 1.1.1
 					** item 1.2
 					* item 2`
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Attributes:  types.ElementAttributes{},
 						Level:       1,
 						BulletStyle: types.OneAsterisk,
 						CheckStyle:  types.NoCheck,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "item 1"},
+										types.StringElement{Content: "item 1"},
 									},
 								},
 							},
 						},
 					},
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Attributes:  types.ElementAttributes{},
 						Level:       3,
 						BulletStyle: types.ThreeAsterisks,
 						CheckStyle:  types.NoCheck,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "item 1.1"},
+										types.StringElement{Content: "item 1.1"},
 									},
 								},
 							},
 						},
 					},
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Attributes:  types.ElementAttributes{},
 						Level:       3,
 						BulletStyle: types.ThreeAsterisks,
 						CheckStyle:  types.NoCheck,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "item 1.1.1"},
+										types.StringElement{Content: "item 1.1.1"},
 									},
 								},
 							},
 						},
 					},
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Attributes:  types.ElementAttributes{},
 						Level:       2,
 						BulletStyle: types.TwoAsterisks,
 						CheckStyle:  types.NoCheck,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "item 1.2"},
+										types.StringElement{Content: "item 1.2"},
 									},
 								},
 							},
 						},
 					},
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Attributes:  types.ElementAttributes{},
 						Level:       1,
 						BulletStyle: types.OneAsterisk,
 						CheckStyle:  types.NoCheck,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "item 2"},
+										types.StringElement{Content: "item 2"},
 									},
 								},
 							},
@@ -1065,13 +1065,13 @@ on 2 lines, too.`
 
 		It("invalid list item", func() {
 			source := "*an invalid list item"
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: "*an invalid list item"},
+								types.StringElement{Content: "*an invalid list item"},
 							},
 						},
 					},
@@ -1095,35 +1095,35 @@ another delimited block
 ----
 * bar
 `
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Attributes:  types.ElementAttributes{},
 						Level:       1,
 						BulletStyle: types.OneAsterisk,
 						CheckStyle:  types.NoCheck,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "foo"},
+										types.StringElement{Content: "foo"},
 									},
 								},
 							},
 						},
 					},
-					&types.ContinuedListItemElement{
+					types.ContinuedListItemElement{
 						Offset: 0,
-						Element: &types.DelimitedBlock{
+						Element: types.DelimitedBlock{
 							Attributes: types.ElementAttributes{},
 							Kind:       types.Listing,
 							Elements: []interface{}{
-								&types.Paragraph{
+								types.Paragraph{
 									Attributes: types.ElementAttributes{},
 									Lines: []types.InlineElements{
 										{
-											&types.StringElement{
+											types.StringElement{
 												Content: "a delimited block",
 											},
 										},
@@ -1132,17 +1132,17 @@ another delimited block
 							},
 						},
 					},
-					&types.ContinuedListItemElement{
+					types.ContinuedListItemElement{
 						Offset: 0,
-						Element: &types.DelimitedBlock{
+						Element: types.DelimitedBlock{
 							Attributes: types.ElementAttributes{},
 							Kind:       types.Listing,
 							Elements: []interface{}{
-								&types.Paragraph{
+								types.Paragraph{
 									Attributes: types.ElementAttributes{},
 									Lines: []types.InlineElements{
 										{
-											&types.StringElement{
+											types.StringElement{
 												Content: "another delimited block",
 											},
 										},
@@ -1151,17 +1151,17 @@ another delimited block
 							},
 						},
 					},
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Attributes:  types.ElementAttributes{},
 						Level:       1,
 						BulletStyle: types.OneAsterisk,
 						CheckStyle:  types.NoCheck,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "bar"},
+										types.StringElement{Content: "bar"},
 									},
 								},
 							},
@@ -1186,9 +1186,9 @@ The {plus} symbol is on a new line.
 
 ***** level 5
 `
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Level:       1,
 						BulletStyle: types.OneAsterisk,
 						CheckStyle:  types.NoCheck,
@@ -1196,11 +1196,11 @@ The {plus} symbol is on a new line.
 							types.AttrTitle: "Unordered, complex",
 						},
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "level 1",
 										},
 									},
@@ -1208,17 +1208,17 @@ The {plus} symbol is on a new line.
 							},
 						},
 					},
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Level:       2,
 						BulletStyle: types.TwoAsterisks,
 						CheckStyle:  types.NoCheck,
 						Attributes:  types.ElementAttributes{},
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "level 2",
 										},
 									},
@@ -1226,39 +1226,39 @@ The {plus} symbol is on a new line.
 							},
 						},
 					},
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Level:       3,
 						BulletStyle: types.ThreeAsterisks,
 						CheckStyle:  types.NoCheck,
 						Attributes:  types.ElementAttributes{},
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "level 3",
 										},
 									},
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "This is a new line inside an unordered list using ",
 										},
-										&types.DocumentAttributeSubstitution{
+										types.DocumentAttributeSubstitution{
 											Name: "plus",
 										},
-										&types.StringElement{
+										types.StringElement{
 											Content: " symbol.",
 										},
 									},
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "We can even force content to start on a separate line...",
 										},
-										&types.LineBreak{},
+										types.LineBreak{},
 									},
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "Amazing, isn't it?",
 										},
 									},
@@ -1266,17 +1266,17 @@ The {plus} symbol is on a new line.
 							},
 						},
 					},
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Level:       4,
 						BulletStyle: types.FourAsterisks,
 						CheckStyle:  types.NoCheck,
 						Attributes:  types.ElementAttributes{},
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "level 4",
 										},
 									},
@@ -1285,37 +1285,37 @@ The {plus} symbol is on a new line.
 						},
 					},
 					// the `+` continuation produces the second paragraph below
-					&types.ContinuedListItemElement{
+					types.ContinuedListItemElement{
 						Offset: 0,
-						Element: &types.Paragraph{
+						Element: types.Paragraph{
 							Attributes: types.ElementAttributes{},
 							Lines: []types.InlineElements{
 								{
-									&types.StringElement{
+									types.StringElement{
 										Content: "The ",
 									},
-									&types.DocumentAttributeSubstitution{
+									types.DocumentAttributeSubstitution{
 										Name: "plus",
 									},
-									&types.StringElement{
+									types.StringElement{
 										Content: " symbol is on a new line.",
 									},
 								},
 							},
 						},
 					},
-					&types.BlankLine{},
-					&types.UnorderedListItem{
+					types.BlankLine{},
+					types.UnorderedListItem{
 						Level:       5,
 						BulletStyle: types.FiveAsterisks,
 						CheckStyle:  types.NoCheck,
 						Attributes:  types.ElementAttributes{},
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "level 5",
 										},
 									},
@@ -1337,33 +1337,33 @@ a delimited block
 ----
 another delimited block
 ----`
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Attributes:  types.ElementAttributes{},
 						Level:       1,
 						BulletStyle: types.OneAsterisk,
 						CheckStyle:  types.NoCheck,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "foo"},
+										types.StringElement{Content: "foo"},
 									},
 								},
 							},
 						},
 					},
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{},
 						Kind:       types.Listing,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "a delimited block",
 										},
 									},
@@ -1371,31 +1371,31 @@ another delimited block
 							},
 						},
 					},
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Attributes:  types.ElementAttributes{},
 						Level:       1,
 						BulletStyle: types.OneAsterisk,
 						CheckStyle:  types.NoCheck,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "bar"},
+										types.StringElement{Content: "bar"},
 									},
 								},
 							},
 						},
 					},
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{},
 						Kind:       types.Listing,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "another delimited block",
 										},
 									},
@@ -1419,63 +1419,63 @@ another delimited block
 
 +
 paragraph attached to grand parent list item`
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Attributes:  types.ElementAttributes{},
 						Level:       1,
 						BulletStyle: types.OneAsterisk,
 						CheckStyle:  types.NoCheck,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "grand parent list item"},
+										types.StringElement{Content: "grand parent list item"},
 									},
 								},
 							},
 						},
 					},
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Attributes:  types.ElementAttributes{},
 						Level:       2,
 						BulletStyle: types.TwoAsterisks,
 						CheckStyle:  types.NoCheck,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "parent list item"},
+										types.StringElement{Content: "parent list item"},
 									},
 								},
 							},
 						},
 					},
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Attributes:  types.ElementAttributes{},
 						Level:       3,
 						BulletStyle: types.ThreeAsterisks,
 						CheckStyle:  types.NoCheck,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "child list item"},
+										types.StringElement{Content: "child list item"},
 									},
 								},
 							},
 						},
 					},
-					&types.ContinuedListItemElement{
+					types.ContinuedListItemElement{
 						Offset: -2,
-						Element: &types.Paragraph{
+						Element: types.Paragraph{
 							Attributes: types.ElementAttributes{},
 							Lines: []types.InlineElements{
 								{
-									&types.StringElement{Content: "paragraph attached to grand parent list item"},
+									types.StringElement{Content: "paragraph attached to grand parent list item"},
 								},
 							},
 						},
@@ -1492,63 +1492,63 @@ paragraph attached to grand parent list item`
 
 +
 paragraph attached to parent list item`
-			expected := &types.PreflightDocument{
+			expected := types.PreflightDocument{
 				Blocks: []interface{}{
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Attributes:  types.ElementAttributes{},
 						Level:       1,
 						BulletStyle: types.OneAsterisk,
 						CheckStyle:  types.NoCheck,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "grandparent list item"},
+										types.StringElement{Content: "grandparent list item"},
 									},
 								},
 							},
 						},
 					},
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Attributes:  types.ElementAttributes{},
 						Level:       2,
 						BulletStyle: types.TwoAsterisks,
 						CheckStyle:  types.NoCheck,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "parent list item"},
+										types.StringElement{Content: "parent list item"},
 									},
 								},
 							},
 						},
 					},
-					&types.UnorderedListItem{
+					types.UnorderedListItem{
 						Attributes:  types.ElementAttributes{},
 						Level:       3,
 						BulletStyle: types.ThreeAsterisks,
 						CheckStyle:  types.NoCheck,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{Content: "child list item"},
+										types.StringElement{Content: "child list item"},
 									},
 								},
 							},
 						},
 					},
-					&types.ContinuedListItemElement{
+					types.ContinuedListItemElement{
 						Offset: -1,
-						Element: &types.Paragraph{
+						Element: types.Paragraph{
 							Attributes: types.ElementAttributes{},
 							Lines: []types.InlineElements{
 								{
-									&types.StringElement{Content: "paragraph attached to parent list item"},
+									types.StringElement{Content: "paragraph attached to parent list item"},
 								},
 							},
 						},
@@ -1566,26 +1566,26 @@ var _ = Describe("unordered lists - document", func() {
 
 		It("unordered list with a basic single item", func() {
 			source := `* a list item`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.UnorderedList{
+					types.UnorderedList{
 						Attributes: types.ElementAttributes{},
-						Items: []*types.UnorderedListItem{
+						Items: []types.UnorderedListItem{
 							{
 								Attributes:  types.ElementAttributes{},
 								Level:       1,
 								BulletStyle: types.OneAsterisk,
 								CheckStyle:  types.NoCheck,
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{Content: "a list item"},
+												types.StringElement{Content: "a list item"},
 											},
 										},
 									},
@@ -1603,31 +1603,31 @@ var _ = Describe("unordered lists - document", func() {
 [#listID]
 [.myrole]
 * a list item`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.UnorderedList{
+					types.UnorderedList{
 						Attributes: types.ElementAttributes{
 							types.AttrID:       "listID",
 							types.AttrCustomID: true,
 							types.AttrTitle:    "mytitle",
 							types.AttrRole:     "myrole",
 						},
-						Items: []*types.UnorderedListItem{
+						Items: []types.UnorderedListItem{
 							{
 								Attributes:  types.ElementAttributes{},
 								Level:       1,
 								BulletStyle: types.OneAsterisk,
 								CheckStyle:  types.NoCheck,
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{Content: "a list item"},
+												types.StringElement{Content: "a list item"},
 											},
 										},
 									},
@@ -1642,28 +1642,28 @@ var _ = Describe("unordered lists - document", func() {
 		It("unordered list with a title and a single item", func() {
 			source := `.a title
 	* a list item`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.UnorderedList{
+					types.UnorderedList{
 						Attributes: types.ElementAttributes{
 							types.AttrTitle: "a title",
 						},
-						Items: []*types.UnorderedListItem{
+						Items: []types.UnorderedListItem{
 							{
 								Attributes:  types.ElementAttributes{},
 								Level:       1,
 								BulletStyle: types.OneAsterisk,
 								CheckStyle:  types.NoCheck,
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{Content: "a list item"},
+												types.StringElement{Content: "a list item"},
 											},
 										},
 									},
@@ -1679,26 +1679,26 @@ var _ = Describe("unordered lists - document", func() {
 		It("unordered list with 2 items with stars", func() {
 			source := `* a first item
 					* a second item with *bold content*`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.UnorderedList{
+					types.UnorderedList{
 						Attributes: types.ElementAttributes{},
-						Items: []*types.UnorderedListItem{
+						Items: []types.UnorderedListItem{
 							{
 								Attributes:  types.ElementAttributes{},
 								Level:       1,
 								BulletStyle: types.OneAsterisk,
 								CheckStyle:  types.NoCheck,
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{Content: "a first item"},
+												types.StringElement{Content: "a first item"},
 											},
 										},
 									},
@@ -1710,15 +1710,15 @@ var _ = Describe("unordered lists - document", func() {
 								BulletStyle: types.OneAsterisk,
 								CheckStyle:  types.NoCheck,
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{Content: "a second item with "},
-												&types.QuotedText{
+												types.StringElement{Content: "a second item with "},
+												types.QuotedText{
 													Kind: types.Bold,
 													Elements: types.InlineElements{
-														&types.StringElement{Content: "bold content"},
+														types.StringElement{Content: "bold content"},
 													},
 												},
 											},
@@ -1743,62 +1743,62 @@ var _ = Describe("unordered lists - document", func() {
 		*** nested nested list item B.1
 		*** nested nested list item B.2
 		* list item 2`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.UnorderedList{
+					types.UnorderedList{
 						Attributes: types.ElementAttributes{
 							types.AttrTitle: "Unordered list title",
 						},
-						Items: []*types.UnorderedListItem{
+						Items: []types.UnorderedListItem{
 							{
 								Attributes:  types.ElementAttributes{},
 								Level:       1,
 								BulletStyle: types.OneAsterisk,
 								CheckStyle:  types.NoCheck,
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{Content: "list item 1"},
+												types.StringElement{Content: "list item 1"},
 											},
 										},
 									},
-									&types.UnorderedList{
+									types.UnorderedList{
 										Attributes: types.ElementAttributes{},
-										Items: []*types.UnorderedListItem{
+										Items: []types.UnorderedListItem{
 											{
 												Attributes:  types.ElementAttributes{},
 												Level:       2,
 												BulletStyle: types.TwoAsterisks,
 												CheckStyle:  types.NoCheck,
 												Elements: []interface{}{
-													&types.Paragraph{
+													types.Paragraph{
 														Attributes: types.ElementAttributes{},
 														Lines: []types.InlineElements{
 															{
-																&types.StringElement{Content: "nested list item A"},
+																types.StringElement{Content: "nested list item A"},
 															},
 														},
 													},
-													&types.UnorderedList{
+													types.UnorderedList{
 														Attributes: types.ElementAttributes{},
-														Items: []*types.UnorderedListItem{
+														Items: []types.UnorderedListItem{
 															{
 																Attributes:  types.ElementAttributes{},
 																Level:       3,
 																BulletStyle: types.ThreeAsterisks,
 																CheckStyle:  types.NoCheck,
 																Elements: []interface{}{
-																	&types.Paragraph{
+																	types.Paragraph{
 																		Attributes: types.ElementAttributes{},
 																		Lines: []types.InlineElements{
 																			{
-																				&types.StringElement{Content: "nested nested list item A.1"},
+																				types.StringElement{Content: "nested nested list item A.1"},
 																			},
 																		},
 																	},
@@ -1810,11 +1810,11 @@ var _ = Describe("unordered lists - document", func() {
 																BulletStyle: types.ThreeAsterisks,
 																CheckStyle:  types.NoCheck,
 																Elements: []interface{}{
-																	&types.Paragraph{
+																	types.Paragraph{
 																		Attributes: types.ElementAttributes{},
 																		Lines: []types.InlineElements{
 																			{
-																				&types.StringElement{Content: "nested nested list item A.2"},
+																				types.StringElement{Content: "nested nested list item A.2"},
 																			},
 																		},
 																	},
@@ -1830,28 +1830,28 @@ var _ = Describe("unordered lists - document", func() {
 												BulletStyle: types.TwoAsterisks,
 												CheckStyle:  types.NoCheck,
 												Elements: []interface{}{
-													&types.Paragraph{
+													types.Paragraph{
 														Attributes: types.ElementAttributes{},
 														Lines: []types.InlineElements{
 															{
-																&types.StringElement{Content: "nested list item B"},
+																types.StringElement{Content: "nested list item B"},
 															},
 														},
 													},
-													&types.UnorderedList{
+													types.UnorderedList{
 														Attributes: types.ElementAttributes{},
-														Items: []*types.UnorderedListItem{
+														Items: []types.UnorderedListItem{
 															{
 																Attributes:  types.ElementAttributes{},
 																Level:       3,
 																BulletStyle: types.ThreeAsterisks,
 																CheckStyle:  types.NoCheck,
 																Elements: []interface{}{
-																	&types.Paragraph{
+																	types.Paragraph{
 																		Attributes: types.ElementAttributes{},
 																		Lines: []types.InlineElements{
 																			{
-																				&types.StringElement{Content: "nested nested list item B.1"},
+																				types.StringElement{Content: "nested nested list item B.1"},
 																			},
 																		},
 																	},
@@ -1863,11 +1863,11 @@ var _ = Describe("unordered lists - document", func() {
 																BulletStyle: types.ThreeAsterisks,
 																CheckStyle:  types.NoCheck,
 																Elements: []interface{}{
-																	&types.Paragraph{
+																	types.Paragraph{
 																		Attributes: types.ElementAttributes{},
 																		Lines: []types.InlineElements{
 																			{
-																				&types.StringElement{Content: "nested nested list item B.2"},
+																				types.StringElement{Content: "nested nested list item B.2"},
 																			},
 																		},
 																	},
@@ -1887,11 +1887,11 @@ var _ = Describe("unordered lists - document", func() {
 								BulletStyle: types.OneAsterisk,
 								CheckStyle:  types.NoCheck,
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{Content: "list item 2"},
+												types.StringElement{Content: "list item 2"},
 											},
 										},
 									},
@@ -1907,26 +1907,26 @@ var _ = Describe("unordered lists - document", func() {
 		It("unordered list with 2 items with carets", func() {
 			source := "- a first item\n" +
 				"- a second item with *bold content*"
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.UnorderedList{
+					types.UnorderedList{
 						Attributes: types.ElementAttributes{},
-						Items: []*types.UnorderedListItem{
+						Items: []types.UnorderedListItem{
 							{
 								Attributes:  types.ElementAttributes{},
 								Level:       1,
 								BulletStyle: types.Dash,
 								CheckStyle:  types.NoCheck,
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{Content: "a first item"},
+												types.StringElement{Content: "a first item"},
 											},
 										},
 									},
@@ -1938,15 +1938,15 @@ var _ = Describe("unordered lists - document", func() {
 								BulletStyle: types.Dash,
 								CheckStyle:  types.NoCheck,
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{Content: "a second item with "},
-												&types.QuotedText{
+												types.StringElement{Content: "a second item with "},
+												types.QuotedText{
 													Kind: types.Bold,
 													Elements: types.InlineElements{
-														&types.StringElement{Content: "bold content"},
+														types.StringElement{Content: "bold content"},
 													},
 												},
 											},
@@ -1967,43 +1967,43 @@ var _ = Describe("unordered lists - document", func() {
 					- another parent item
 					* another child item
 					** with a sub child item`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.UnorderedList{
+					types.UnorderedList{
 						Attributes: types.ElementAttributes{},
-						Items: []*types.UnorderedListItem{
+						Items: []types.UnorderedListItem{
 							{
 								Attributes:  types.ElementAttributes{},
 								Level:       1,
 								BulletStyle: types.Dash,
 								CheckStyle:  types.NoCheck,
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{Content: "a parent item"},
+												types.StringElement{Content: "a parent item"},
 											},
 										},
 									},
-									&types.UnorderedList{
+									types.UnorderedList{
 										Attributes: types.ElementAttributes{},
-										Items: []*types.UnorderedListItem{
+										Items: []types.UnorderedListItem{
 											{
 												Attributes:  types.ElementAttributes{},
 												Level:       2,
 												BulletStyle: types.OneAsterisk,
 												CheckStyle:  types.NoCheck,
 												Elements: []interface{}{
-													&types.Paragraph{
+													types.Paragraph{
 														Attributes: types.ElementAttributes{},
 														Lines: []types.InlineElements{
 															{
-																&types.StringElement{Content: "a child item"},
+																types.StringElement{Content: "a child item"},
 															},
 														},
 													},
@@ -2019,45 +2019,45 @@ var _ = Describe("unordered lists - document", func() {
 								BulletStyle: types.Dash,
 								CheckStyle:  types.NoCheck,
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{Content: "another parent item"},
+												types.StringElement{Content: "another parent item"},
 											},
 										},
 									},
-									&types.UnorderedList{
+									types.UnorderedList{
 										Attributes: types.ElementAttributes{},
-										Items: []*types.UnorderedListItem{
+										Items: []types.UnorderedListItem{
 											{
 												Attributes:  types.ElementAttributes{},
 												Level:       2,
 												BulletStyle: types.OneAsterisk,
 												CheckStyle:  types.NoCheck,
 												Elements: []interface{}{
-													&types.Paragraph{
+													types.Paragraph{
 														Attributes: types.ElementAttributes{},
 														Lines: []types.InlineElements{
 															{
-																&types.StringElement{Content: "another child item"},
+																types.StringElement{Content: "another child item"},
 															},
 														},
 													},
-													&types.UnorderedList{
+													types.UnorderedList{
 														Attributes: types.ElementAttributes{},
-														Items: []*types.UnorderedListItem{
+														Items: []types.UnorderedListItem{
 															{
 																Attributes:  types.ElementAttributes{},
 																Level:       3,
 																BulletStyle: types.TwoAsterisks,
 																CheckStyle:  types.NoCheck,
 																Elements: []interface{}{
-																	&types.Paragraph{
+																	types.Paragraph{
 																		Attributes: types.ElementAttributes{},
 																		Lines: []types.InlineElements{
 																			{
-																				&types.StringElement{Content: "with a sub child item"},
+																				types.StringElement{Content: "with a sub child item"},
 																			},
 																		},
 																	},
@@ -2083,26 +2083,26 @@ var _ = Describe("unordered lists - document", func() {
 			source := "* a first item\n" +
 				"\n" +
 				"* a second item with *bold content*"
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.UnorderedList{
+					types.UnorderedList{
 						Attributes: types.ElementAttributes{},
-						Items: []*types.UnorderedListItem{
+						Items: []types.UnorderedListItem{
 							{
 								Attributes:  types.ElementAttributes{},
 								Level:       1,
 								BulletStyle: types.OneAsterisk,
 								CheckStyle:  types.NoCheck,
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{Content: "a first item"},
+												types.StringElement{Content: "a first item"},
 											},
 										},
 									},
@@ -2114,15 +2114,15 @@ var _ = Describe("unordered lists - document", func() {
 								BulletStyle: types.OneAsterisk,
 								CheckStyle:  types.NoCheck,
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{Content: "a second item with "},
-												&types.QuotedText{
+												types.StringElement{Content: "a second item with "},
+												types.QuotedText{
 													Kind: types.Bold,
 													Elements: types.InlineElements{
-														&types.StringElement{Content: "bold content"},
+														types.StringElement{Content: "bold content"},
 													},
 												},
 											},
@@ -2141,29 +2141,29 @@ var _ = Describe("unordered lists - document", func() {
   on 2 lines.
 * item 2
 on 2 lines, too.`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.UnorderedList{
+					types.UnorderedList{
 						Attributes: types.ElementAttributes{},
-						Items: []*types.UnorderedListItem{
+						Items: []types.UnorderedListItem{
 							{
 								Attributes:  types.ElementAttributes{},
 								Level:       1,
 								BulletStyle: types.OneAsterisk,
 								CheckStyle:  types.NoCheck,
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{Content: "item 1"},
+												types.StringElement{Content: "item 1"},
 											},
 											{
-												&types.StringElement{Content: "  on 2 lines."},
+												types.StringElement{Content: "  on 2 lines."},
 											},
 										},
 									},
@@ -2175,14 +2175,14 @@ on 2 lines, too.`
 								BulletStyle: types.OneAsterisk,
 								CheckStyle:  types.NoCheck,
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{Content: "item 2"},
+												types.StringElement{Content: "item 2"},
 											},
 											{
-												&types.StringElement{Content: "on 2 lines, too."},
+												types.StringElement{Content: "on 2 lines, too."},
 											},
 										},
 									},
@@ -2200,26 +2200,26 @@ on 2 lines, too.`
 				"\n" +
 				"\n" +
 				"* an item in the second list"
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.UnorderedList{
+					types.UnorderedList{
 						Attributes: types.ElementAttributes{},
-						Items: []*types.UnorderedListItem{
+						Items: []types.UnorderedListItem{
 							{
 								Attributes:  types.ElementAttributes{},
 								Level:       1,
 								BulletStyle: types.OneAsterisk,
 								CheckStyle:  types.NoCheck,
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{Content: "an item in the first list"},
+												types.StringElement{Content: "an item in the first list"},
 											},
 										},
 									},
@@ -2231,11 +2231,11 @@ on 2 lines, too.`
 								BulletStyle: types.OneAsterisk,
 								CheckStyle:  types.NoCheck,
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{Content: "an item in the second list"},
+												types.StringElement{Content: "an item in the second list"},
 											},
 										},
 									},
@@ -2257,43 +2257,43 @@ on 2 lines, too.`
 	** item 1.4
 	* item 2
 	** item 2.1`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.UnorderedList{
+					types.UnorderedList{
 						Attributes: types.ElementAttributes{},
-						Items: []*types.UnorderedListItem{
+						Items: []types.UnorderedListItem{
 							{
 								Attributes:  types.ElementAttributes{},
 								Level:       1,
 								BulletStyle: types.OneAsterisk,
 								CheckStyle:  types.NoCheck,
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{Content: "item 1"},
+												types.StringElement{Content: "item 1"},
 											},
 										},
 									},
-									&types.UnorderedList{
+									types.UnorderedList{
 										Attributes: types.ElementAttributes{},
-										Items: []*types.UnorderedListItem{
+										Items: []types.UnorderedListItem{
 											{
 												Attributes:  types.ElementAttributes{},
 												Level:       2,
 												BulletStyle: types.TwoAsterisks,
 												CheckStyle:  types.NoCheck,
 												Elements: []interface{}{
-													&types.Paragraph{
+													types.Paragraph{
 														Attributes: types.ElementAttributes{},
 														Lines: []types.InlineElements{
 															{
-																&types.StringElement{Content: "item 1.1"},
+																types.StringElement{Content: "item 1.1"},
 															},
 														},
 													},
@@ -2305,28 +2305,28 @@ on 2 lines, too.`
 												BulletStyle: types.TwoAsterisks,
 												CheckStyle:  types.NoCheck,
 												Elements: []interface{}{
-													&types.Paragraph{
+													types.Paragraph{
 														Attributes: types.ElementAttributes{},
 														Lines: []types.InlineElements{
 															{
-																&types.StringElement{Content: "item 1.2"},
+																types.StringElement{Content: "item 1.2"},
 															},
 														},
 													},
-													&types.UnorderedList{
+													types.UnorderedList{
 														Attributes: types.ElementAttributes{},
-														Items: []*types.UnorderedListItem{
+														Items: []types.UnorderedListItem{
 															{
 																Attributes:  types.ElementAttributes{},
 																Level:       3,
 																BulletStyle: types.ThreeAsterisks,
 																CheckStyle:  types.NoCheck,
 																Elements: []interface{}{
-																	&types.Paragraph{
+																	types.Paragraph{
 																		Attributes: types.ElementAttributes{},
 																		Lines: []types.InlineElements{
 																			{
-																				&types.StringElement{Content: "item 1.2.1"},
+																				types.StringElement{Content: "item 1.2.1"},
 																			},
 																		},
 																	},
@@ -2342,11 +2342,11 @@ on 2 lines, too.`
 												BulletStyle: types.TwoAsterisks,
 												CheckStyle:  types.NoCheck,
 												Elements: []interface{}{
-													&types.Paragraph{
+													types.Paragraph{
 														Attributes: types.ElementAttributes{},
 														Lines: []types.InlineElements{
 															{
-																&types.StringElement{Content: "item 1.3"},
+																types.StringElement{Content: "item 1.3"},
 															},
 														},
 													},
@@ -2358,11 +2358,11 @@ on 2 lines, too.`
 												BulletStyle: types.TwoAsterisks,
 												CheckStyle:  types.NoCheck,
 												Elements: []interface{}{
-													&types.Paragraph{
+													types.Paragraph{
 														Attributes: types.ElementAttributes{},
 														Lines: []types.InlineElements{
 															{
-																&types.StringElement{Content: "item 1.4"},
+																types.StringElement{Content: "item 1.4"},
 															},
 														},
 													},
@@ -2378,28 +2378,28 @@ on 2 lines, too.`
 								BulletStyle: types.OneAsterisk,
 								CheckStyle:  types.NoCheck,
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{Content: "item 2"},
+												types.StringElement{Content: "item 2"},
 											},
 										},
 									},
-									&types.UnorderedList{
+									types.UnorderedList{
 										Attributes: types.ElementAttributes{},
-										Items: []*types.UnorderedListItem{
+										Items: []types.UnorderedListItem{
 											{
 												Attributes:  types.ElementAttributes{},
 												Level:       2,
 												BulletStyle: types.TwoAsterisks,
 												CheckStyle:  types.NoCheck,
 												Elements: []interface{}{
-													&types.Paragraph{
+													types.Paragraph{
 														Attributes: types.ElementAttributes{},
 														Lines: []types.InlineElements{
 															{
-																&types.StringElement{Content: "item 2.1"},
+																types.StringElement{Content: "item 2.1"},
 															},
 														},
 													},
@@ -2424,104 +2424,104 @@ on 2 lines, too.`
 **** level 4
 ***** level 5
 * level 1`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.UnorderedList{
+					types.UnorderedList{
 						Attributes: types.ElementAttributes{
 							types.AttrTitle: "Unordered, max nesting",
 						},
-						Items: []*types.UnorderedListItem{
+						Items: []types.UnorderedListItem{
 							{
 								Level:       1,
 								BulletStyle: types.OneAsterisk,
 								CheckStyle:  types.NoCheck,
 								Attributes:  types.ElementAttributes{},
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{
+												types.StringElement{
 													Content: "level 1",
 												},
 											},
 										},
 									},
-									&types.UnorderedList{
+									types.UnorderedList{
 										Attributes: types.ElementAttributes{},
-										Items: []*types.UnorderedListItem{
+										Items: []types.UnorderedListItem{
 											{
 												Level:       2,
 												BulletStyle: types.TwoAsterisks,
 												CheckStyle:  types.NoCheck,
 												Attributes:  types.ElementAttributes{},
 												Elements: []interface{}{
-													&types.Paragraph{
+													types.Paragraph{
 														Attributes: types.ElementAttributes{},
 														Lines: []types.InlineElements{
 															{
-																&types.StringElement{
+																types.StringElement{
 																	Content: "level 2",
 																},
 															},
 														},
 													},
-													&types.UnorderedList{
+													types.UnorderedList{
 														Attributes: types.ElementAttributes{},
-														Items: []*types.UnorderedListItem{
+														Items: []types.UnorderedListItem{
 															{
 																Level:       3,
 																BulletStyle: types.ThreeAsterisks,
 																CheckStyle:  types.NoCheck,
 																Attributes:  types.ElementAttributes{},
 																Elements: []interface{}{
-																	&types.Paragraph{
+																	types.Paragraph{
 																		Attributes: types.ElementAttributes{},
 																		Lines: []types.InlineElements{
 																			{
-																				&types.StringElement{
+																				types.StringElement{
 																					Content: "level 3",
 																				},
 																			},
 																		},
 																	},
-																	&types.UnorderedList{
+																	types.UnorderedList{
 																		Attributes: types.ElementAttributes{},
-																		Items: []*types.UnorderedListItem{
+																		Items: []types.UnorderedListItem{
 																			{
 																				Level:       4,
 																				BulletStyle: types.FourAsterisks,
 																				CheckStyle:  types.NoCheck,
 																				Attributes:  types.ElementAttributes{},
 																				Elements: []interface{}{
-																					&types.Paragraph{
+																					types.Paragraph{
 																						Attributes: types.ElementAttributes{},
 																						Lines: []types.InlineElements{
 																							{
-																								&types.StringElement{
+																								types.StringElement{
 																									Content: "level 4",
 																								},
 																							},
 																						},
 																					},
-																					&types.UnorderedList{
+																					types.UnorderedList{
 																						Attributes: types.ElementAttributes{},
-																						Items: []*types.UnorderedListItem{
+																						Items: []types.UnorderedListItem{
 																							{
 																								Level:       5,
 																								BulletStyle: types.FiveAsterisks,
 																								CheckStyle:  types.NoCheck,
 																								Attributes:  types.ElementAttributes{},
 																								Elements: []interface{}{
-																									&types.Paragraph{
+																									types.Paragraph{
 																										Attributes: types.ElementAttributes{},
 																										Lines: []types.InlineElements{
 																											{
-																												&types.StringElement{
+																												types.StringElement{
 																													Content: "level 5",
 																												},
 																											},
@@ -2551,11 +2551,11 @@ on 2 lines, too.`
 								CheckStyle:  types.NoCheck,
 								Attributes:  types.ElementAttributes{},
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{
+												types.StringElement{
 													Content: "level 1",
 												},
 											},
@@ -2578,104 +2578,104 @@ on 2 lines, too.`
 **** level 4
 ***** level 5
 ** level 2`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.UnorderedList{
+					types.UnorderedList{
 						Attributes: types.ElementAttributes{
 							types.AttrTitle: "Unordered, max nesting",
 						},
-						Items: []*types.UnorderedListItem{
+						Items: []types.UnorderedListItem{
 							{
 								Level:       1,
 								BulletStyle: types.OneAsterisk,
 								CheckStyle:  types.NoCheck,
 								Attributes:  types.ElementAttributes{},
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{
+												types.StringElement{
 													Content: "level 1",
 												},
 											},
 										},
 									},
-									&types.UnorderedList{
+									types.UnorderedList{
 										Attributes: types.ElementAttributes{},
-										Items: []*types.UnorderedListItem{
+										Items: []types.UnorderedListItem{
 											{
 												Level:       2,
 												BulletStyle: types.TwoAsterisks,
 												CheckStyle:  types.NoCheck,
 												Attributes:  types.ElementAttributes{},
 												Elements: []interface{}{
-													&types.Paragraph{
+													types.Paragraph{
 														Attributes: types.ElementAttributes{},
 														Lines: []types.InlineElements{
 															{
-																&types.StringElement{
+																types.StringElement{
 																	Content: "level 2",
 																},
 															},
 														},
 													},
-													&types.UnorderedList{
+													types.UnorderedList{
 														Attributes: types.ElementAttributes{},
-														Items: []*types.UnorderedListItem{
+														Items: []types.UnorderedListItem{
 															{
 																Level:       3,
 																BulletStyle: types.ThreeAsterisks,
 																CheckStyle:  types.NoCheck,
 																Attributes:  types.ElementAttributes{},
 																Elements: []interface{}{
-																	&types.Paragraph{
+																	types.Paragraph{
 																		Attributes: types.ElementAttributes{},
 																		Lines: []types.InlineElements{
 																			{
-																				&types.StringElement{
+																				types.StringElement{
 																					Content: "level 3",
 																				},
 																			},
 																		},
 																	},
-																	&types.UnorderedList{
+																	types.UnorderedList{
 																		Attributes: types.ElementAttributes{},
-																		Items: []*types.UnorderedListItem{
+																		Items: []types.UnorderedListItem{
 																			{
 																				Level:       4,
 																				BulletStyle: types.FourAsterisks,
 																				CheckStyle:  types.NoCheck,
 																				Attributes:  types.ElementAttributes{},
 																				Elements: []interface{}{
-																					&types.Paragraph{
+																					types.Paragraph{
 																						Attributes: types.ElementAttributes{},
 																						Lines: []types.InlineElements{
 																							{
-																								&types.StringElement{
+																								types.StringElement{
 																									Content: "level 4",
 																								},
 																							},
 																						},
 																					},
-																					&types.UnorderedList{
+																					types.UnorderedList{
 																						Attributes: types.ElementAttributes{},
-																						Items: []*types.UnorderedListItem{
+																						Items: []types.UnorderedListItem{
 																							{
 																								Level:       5,
 																								BulletStyle: types.FiveAsterisks,
 																								CheckStyle:  types.NoCheck,
 																								Attributes:  types.ElementAttributes{},
 																								Elements: []interface{}{
-																									&types.Paragraph{
+																									types.Paragraph{
 																										Attributes: types.ElementAttributes{},
 																										Lines: []types.InlineElements{
 																											{
-																												&types.StringElement{
+																												types.StringElement{
 																													Content: "level 5",
 																												},
 																											},
@@ -2701,11 +2701,11 @@ on 2 lines, too.`
 												CheckStyle:  types.NoCheck,
 												Attributes:  types.ElementAttributes{},
 												Elements: []interface{}{
-													&types.Paragraph{
+													types.Paragraph{
 														Attributes: types.ElementAttributes{},
 														Lines: []types.InlineElements{
 															{
-																&types.StringElement{
+																types.StringElement{
 																	Content: "level 2",
 																},
 															},
@@ -2732,60 +2732,60 @@ on 2 lines, too.`
 					*** item 1.1.1
 					** item 1.2
 					* item 2`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.UnorderedList{
+					types.UnorderedList{
 						Attributes: types.ElementAttributes{},
-						Items: []*types.UnorderedListItem{
+						Items: []types.UnorderedListItem{
 							{
 								Attributes:  types.ElementAttributes{},
 								Level:       1,
 								BulletStyle: types.OneAsterisk,
 								CheckStyle:  types.NoCheck,
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{Content: "item 1"},
+												types.StringElement{Content: "item 1"},
 											},
 										},
 									},
-									&types.UnorderedList{
+									types.UnorderedList{
 										Attributes: types.ElementAttributes{},
-										Items: []*types.UnorderedListItem{
+										Items: []types.UnorderedListItem{
 											{
 												Attributes:  types.ElementAttributes{},
 												Level:       2,
 												BulletStyle: types.TwoAsterisks,
 												CheckStyle:  types.NoCheck,
 												Elements: []interface{}{
-													&types.Paragraph{
+													types.Paragraph{
 														Attributes: types.ElementAttributes{},
 														Lines: []types.InlineElements{
 															{
-																&types.StringElement{Content: "item 1.1"},
+																types.StringElement{Content: "item 1.1"},
 															},
 														},
 													},
-													&types.UnorderedList{
+													types.UnorderedList{
 														Attributes: types.ElementAttributes{},
-														Items: []*types.UnorderedListItem{
+														Items: []types.UnorderedListItem{
 															{
 																Attributes:  types.ElementAttributes{},
 																Level:       3,
 																BulletStyle: types.ThreeAsterisks,
 																CheckStyle:  types.NoCheck,
 																Elements: []interface{}{
-																	&types.Paragraph{
+																	types.Paragraph{
 																		Attributes: types.ElementAttributes{},
 																		Lines: []types.InlineElements{
 																			{
-																				&types.StringElement{Content: "item 1.1.1"},
+																				types.StringElement{Content: "item 1.1.1"},
 																			},
 																		},
 																	},
@@ -2801,11 +2801,11 @@ on 2 lines, too.`
 												BulletStyle: types.TwoAsterisks,
 												CheckStyle:  types.NoCheck,
 												Elements: []interface{}{
-													&types.Paragraph{
+													types.Paragraph{
 														Attributes: types.ElementAttributes{},
 														Lines: []types.InlineElements{
 															{
-																&types.StringElement{Content: "item 1.2"},
+																types.StringElement{Content: "item 1.2"},
 															},
 														},
 													},
@@ -2821,11 +2821,11 @@ on 2 lines, too.`
 								BulletStyle: types.OneAsterisk,
 								CheckStyle:  types.NoCheck,
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{Content: "item 2"},
+												types.StringElement{Content: "item 2"},
 											},
 										},
 									},
@@ -2840,17 +2840,17 @@ on 2 lines, too.`
 
 		It("invalid list item", func() {
 			source := "*an invalid list item"
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.Paragraph{
+					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
 							{
-								&types.StringElement{Content: "*an invalid list item"},
+								types.StringElement{Content: "*an invalid list item"},
 							},
 						},
 					},
@@ -2874,38 +2874,38 @@ another delimited block
 ----
 * bar
 `
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.UnorderedList{
+					types.UnorderedList{
 						Attributes: types.ElementAttributes{},
-						Items: []*types.UnorderedListItem{
+						Items: []types.UnorderedListItem{
 							{
 								Attributes:  types.ElementAttributes{},
 								Level:       1,
 								BulletStyle: types.OneAsterisk,
 								CheckStyle:  types.NoCheck,
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{Content: "foo"},
+												types.StringElement{Content: "foo"},
 											},
 										},
 									},
-									&types.DelimitedBlock{
+									types.DelimitedBlock{
 										Attributes: types.ElementAttributes{},
 										Kind:       types.Listing,
 										Elements: []interface{}{
-											&types.Paragraph{
+											types.Paragraph{
 												Attributes: types.ElementAttributes{},
 												Lines: []types.InlineElements{
 													{
-														&types.StringElement{
+														types.StringElement{
 															Content: "a delimited block",
 														},
 													},
@@ -2913,15 +2913,15 @@ another delimited block
 											},
 										},
 									},
-									&types.DelimitedBlock{
+									types.DelimitedBlock{
 										Attributes: types.ElementAttributes{},
 										Kind:       types.Listing,
 										Elements: []interface{}{
-											&types.Paragraph{
+											types.Paragraph{
 												Attributes: types.ElementAttributes{},
 												Lines: []types.InlineElements{
 													{
-														&types.StringElement{
+														types.StringElement{
 															Content: "another delimited block",
 														},
 													},
@@ -2937,11 +2937,11 @@ another delimited block
 								BulletStyle: types.OneAsterisk,
 								CheckStyle:  types.NoCheck,
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{Content: "bar"},
+												types.StringElement{Content: "bar"},
 											},
 										},
 									},
@@ -2968,144 +2968,144 @@ The {plus} symbol is on a new line.
 
 ***** level 5
 `
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.UnorderedList{
+					types.UnorderedList{
 						Attributes: types.ElementAttributes{
 							types.AttrTitle: "Unordered, complex",
 						},
-						Items: []*types.UnorderedListItem{
+						Items: []types.UnorderedListItem{
 							{
 								Level:       1,
 								BulletStyle: types.OneAsterisk,
 								CheckStyle:  types.NoCheck,
 								Attributes:  types.ElementAttributes{},
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{
+												types.StringElement{
 													Content: "level 1",
 												},
 											},
 										},
 									},
-									&types.UnorderedList{
+									types.UnorderedList{
 										Attributes: types.ElementAttributes{},
-										Items: []*types.UnorderedListItem{
+										Items: []types.UnorderedListItem{
 											{
 												Level:       2,
 												BulletStyle: types.TwoAsterisks,
 												CheckStyle:  types.NoCheck,
 												Attributes:  types.ElementAttributes{},
 												Elements: []interface{}{
-													&types.Paragraph{
+													types.Paragraph{
 														Attributes: types.ElementAttributes{},
 														Lines: []types.InlineElements{
 															{
-																&types.StringElement{
+																types.StringElement{
 																	Content: "level 2",
 																},
 															},
 														},
 													},
-													&types.UnorderedList{
+													types.UnorderedList{
 														Attributes: types.ElementAttributes{},
-														Items: []*types.UnorderedListItem{
+														Items: []types.UnorderedListItem{
 															{
 																Level:       3,
 																BulletStyle: types.ThreeAsterisks,
 																CheckStyle:  types.NoCheck,
 																Attributes:  types.ElementAttributes{},
 																Elements: []interface{}{
-																	&types.Paragraph{
+																	types.Paragraph{
 																		Attributes: types.ElementAttributes{},
 																		Lines: []types.InlineElements{
 																			{
-																				&types.StringElement{
+																				types.StringElement{
 																					Content: "level 3",
 																				},
 																			},
 																			{
-																				&types.StringElement{
+																				types.StringElement{
 																					Content: "This is a new line inside an unordered list using ",
 																				},
-																				&types.DocumentAttributeSubstitution{
+																				types.DocumentAttributeSubstitution{
 																					Name: "plus",
 																				},
-																				&types.StringElement{
+																				types.StringElement{
 																					Content: " symbol.",
 																				},
 																			},
 																			{
-																				&types.StringElement{
+																				types.StringElement{
 																					Content: "We can even force content to start on a separate line...",
 																				},
-																				&types.LineBreak{},
+																				types.LineBreak{},
 																			},
 																			{
-																				&types.StringElement{
+																				types.StringElement{
 																					Content: "Amazing, isn't it?",
 																				},
 																			},
 																		},
 																	},
-																	&types.UnorderedList{
+																	types.UnorderedList{
 																		Attributes: types.ElementAttributes{},
-																		Items: []*types.UnorderedListItem{
+																		Items: []types.UnorderedListItem{
 																			{
 																				Level:       4,
 																				BulletStyle: types.FourAsterisks,
 																				CheckStyle:  types.NoCheck,
 																				Attributes:  types.ElementAttributes{},
 																				Elements: []interface{}{
-																					&types.Paragraph{
+																					types.Paragraph{
 																						Attributes: types.ElementAttributes{},
 																						Lines: []types.InlineElements{
 																							{
-																								&types.StringElement{
+																								types.StringElement{
 																									Content: "level 4",
 																								},
 																							},
 																						},
 																					},
 																					// the `+` continuation produces the second paragrap below
-																					&types.Paragraph{
+																					types.Paragraph{
 																						Attributes: types.ElementAttributes{},
 																						Lines: []types.InlineElements{
 																							{
-																								&types.StringElement{
+																								types.StringElement{
 																									Content: "The ",
 																								},
-																								&types.DocumentAttributeSubstitution{
+																								types.DocumentAttributeSubstitution{
 																									Name: "plus",
 																								},
-																								&types.StringElement{
+																								types.StringElement{
 																									Content: " symbol is on a new line.",
 																								},
 																							},
 																						},
 																					},
 
-																					&types.UnorderedList{
+																					types.UnorderedList{
 																						Attributes: types.ElementAttributes{},
-																						Items: []*types.UnorderedListItem{
+																						Items: []types.UnorderedListItem{
 																							{
 																								Level:       5,
 																								BulletStyle: types.FiveAsterisks,
 																								CheckStyle:  types.NoCheck,
 																								Attributes:  types.ElementAttributes{},
 																								Elements: []interface{}{
-																									&types.Paragraph{
+																									types.Paragraph{
 																										Attributes: types.ElementAttributes{},
 																										Lines: []types.InlineElements{
 																											{
-																												&types.StringElement{
+																												types.StringElement{
 																													Content: "level 5",
 																												},
 																											},
@@ -3145,26 +3145,26 @@ a delimited block
 ----
 another delimited block
 ----`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.UnorderedList{
+					types.UnorderedList{
 						Attributes: types.ElementAttributes{},
-						Items: []*types.UnorderedListItem{
+						Items: []types.UnorderedListItem{
 							{
 								Attributes:  types.ElementAttributes{},
 								Level:       1,
 								BulletStyle: types.OneAsterisk,
 								CheckStyle:  types.NoCheck,
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{Content: "foo"},
+												types.StringElement{Content: "foo"},
 											},
 										},
 									},
@@ -3172,15 +3172,15 @@ another delimited block
 							},
 						},
 					},
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{},
 						Kind:       types.Listing,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "a delimited block",
 										},
 									},
@@ -3188,20 +3188,20 @@ another delimited block
 							},
 						},
 					},
-					&types.UnorderedList{
+					types.UnorderedList{
 						Attributes: types.ElementAttributes{},
-						Items: []*types.UnorderedListItem{
+						Items: []types.UnorderedListItem{
 							{
 								Attributes:  types.ElementAttributes{},
 								Level:       1,
 								BulletStyle: types.OneAsterisk,
 								CheckStyle:  types.NoCheck,
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{Content: "bar"},
+												types.StringElement{Content: "bar"},
 											},
 										},
 									},
@@ -3209,15 +3209,15 @@ another delimited block
 							},
 						},
 					},
-					&types.DelimitedBlock{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{},
 						Kind:       types.Listing,
 						Elements: []interface{}{
-							&types.Paragraph{
+							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{
 									{
-										&types.StringElement{
+										types.StringElement{
 											Content: "another delimited block",
 										},
 									},
@@ -3241,60 +3241,60 @@ another delimited block
 
 +
 paragraph attached to grand parent list item`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.UnorderedList{
+					types.UnorderedList{
 						Attributes: types.ElementAttributes{},
-						Items: []*types.UnorderedListItem{
+						Items: []types.UnorderedListItem{
 							{
 								Attributes:  types.ElementAttributes{},
 								Level:       1,
 								BulletStyle: types.OneAsterisk,
 								CheckStyle:  types.NoCheck,
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{Content: "grand parent list item"},
+												types.StringElement{Content: "grand parent list item"},
 											},
 										},
 									},
-									&types.UnorderedList{
+									types.UnorderedList{
 										Attributes: types.ElementAttributes{},
-										Items: []*types.UnorderedListItem{
+										Items: []types.UnorderedListItem{
 											{
 												Attributes:  types.ElementAttributes{},
 												Level:       2,
 												BulletStyle: types.TwoAsterisks,
 												CheckStyle:  types.NoCheck,
 												Elements: []interface{}{
-													&types.Paragraph{
+													types.Paragraph{
 														Attributes: types.ElementAttributes{},
 														Lines: []types.InlineElements{
 															{
-																&types.StringElement{Content: "parent list item"},
+																types.StringElement{Content: "parent list item"},
 															},
 														},
 													},
-													&types.UnorderedList{
+													types.UnorderedList{
 														Attributes: types.ElementAttributes{},
-														Items: []*types.UnorderedListItem{
+														Items: []types.UnorderedListItem{
 															{
 																Attributes:  types.ElementAttributes{},
 																Level:       3,
 																BulletStyle: types.ThreeAsterisks,
 																CheckStyle:  types.NoCheck,
 																Elements: []interface{}{
-																	&types.Paragraph{
+																	types.Paragraph{
 																		Attributes: types.ElementAttributes{},
 																		Lines: []types.InlineElements{
 																			{
-																				&types.StringElement{Content: "child list item"},
+																				types.StringElement{Content: "child list item"},
 																			},
 																		},
 																	},
@@ -3306,11 +3306,11 @@ paragraph attached to grand parent list item`
 											},
 										},
 									},
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{Content: "paragraph attached to grand parent list item"},
+												types.StringElement{Content: "paragraph attached to grand parent list item"},
 											},
 										},
 									},
@@ -3330,60 +3330,60 @@ paragraph attached to grand parent list item`
 
 +
 paragraph attached to parent list item`
-			expected := &types.Document{
+			expected := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.UnorderedList{
+					types.UnorderedList{
 						Attributes: types.ElementAttributes{},
-						Items: []*types.UnorderedListItem{
+						Items: []types.UnorderedListItem{
 							{
 								Attributes:  types.ElementAttributes{},
 								Level:       1,
 								BulletStyle: types.OneAsterisk,
 								CheckStyle:  types.NoCheck,
 								Elements: []interface{}{
-									&types.Paragraph{
+									types.Paragraph{
 										Attributes: types.ElementAttributes{},
 										Lines: []types.InlineElements{
 											{
-												&types.StringElement{Content: "grandparent list item"},
+												types.StringElement{Content: "grandparent list item"},
 											},
 										},
 									},
-									&types.UnorderedList{
+									types.UnorderedList{
 										Attributes: types.ElementAttributes{},
-										Items: []*types.UnorderedListItem{
+										Items: []types.UnorderedListItem{
 											{
 												Attributes:  types.ElementAttributes{},
 												Level:       2,
 												BulletStyle: types.TwoAsterisks,
 												CheckStyle:  types.NoCheck,
 												Elements: []interface{}{
-													&types.Paragraph{
+													types.Paragraph{
 														Attributes: types.ElementAttributes{},
 														Lines: []types.InlineElements{
 															{
-																&types.StringElement{Content: "parent list item"},
+																types.StringElement{Content: "parent list item"},
 															},
 														},
 													},
-													&types.UnorderedList{
+													types.UnorderedList{
 														Attributes: types.ElementAttributes{},
-														Items: []*types.UnorderedListItem{
+														Items: []types.UnorderedListItem{
 															{
 																Attributes:  types.ElementAttributes{},
 																Level:       3,
 																BulletStyle: types.ThreeAsterisks,
 																CheckStyle:  types.NoCheck,
 																Elements: []interface{}{
-																	&types.Paragraph{
+																	types.Paragraph{
 																		Attributes: types.ElementAttributes{},
 																		Lines: []types.InlineElements{
 																			{
-																				&types.StringElement{Content: "child list item"},
+																				types.StringElement{Content: "child list item"},
 																			},
 																		},
 																	},
@@ -3391,11 +3391,11 @@ paragraph attached to parent list item`
 															},
 														},
 													},
-													&types.Paragraph{
+													types.Paragraph{
 														Attributes: types.ElementAttributes{},
 														Lines: []types.InlineElements{
 															{
-																&types.StringElement{Content: "paragraph attached to parent list item"},
+																types.StringElement{Content: "paragraph attached to parent list item"},
 															},
 														},
 													},

--- a/pkg/parser/user_macro_test.go
+++ b/pkg/parser/user_macro_test.go
@@ -11,14 +11,14 @@ var _ = Describe("user macros", func() {
 
 		It("inline macro empty", func() {
 			source := "AAA hello:[]"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{
+						types.StringElement{
 							Content: "AAA ",
 						},
-						&types.UserMacro{
+						types.UserMacro{
 							Kind:       types.InlineMacro,
 							Name:       "hello",
 							Value:      "",
@@ -33,14 +33,14 @@ var _ = Describe("user macros", func() {
 
 		It("inline macro with attribute", func() {
 			source := `AAA hello:[suffix="!!!!!"]`
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{
+						types.StringElement{
 							Content: "AAA ",
 						},
-						&types.UserMacro{
+						types.UserMacro{
 							Kind:  types.InlineMacro,
 							Name:  "hello",
 							Value: "",
@@ -57,14 +57,14 @@ var _ = Describe("user macros", func() {
 
 		It("inline macro with value", func() {
 			source := `AAA hello:John Doe[]`
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{
+						types.StringElement{
 							Content: "AAA ",
 						},
-						&types.UserMacro{
+						types.UserMacro{
 							Kind:       types.InlineMacro,
 							Name:       "hello",
 							Value:      "John Doe",
@@ -79,14 +79,14 @@ var _ = Describe("user macros", func() {
 
 		It("inline user macro with value and attributes", func() {
 			source := "repository: git:some/url.git[key1=value1,key2=value2]"
-			expected := &types.Paragraph{
+			expected := types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{
+						types.StringElement{
 							Content: "repository: ",
 						},
-						&types.UserMacro{
+						types.UserMacro{
 							Kind:  types.InlineMacro,
 							Name:  "git",
 							Value: "some/url.git",
@@ -108,7 +108,7 @@ var _ = Describe("user macros", func() {
 		It("user macro block without value", func() {
 
 			source := "git::[]"
-			expected := &types.UserMacro{
+			expected := types.UserMacro{
 				Kind:       types.BlockMacro,
 				Name:       "git",
 				Value:      "",
@@ -120,7 +120,7 @@ var _ = Describe("user macros", func() {
 
 		It("user block macro with value and attributes", func() {
 			source := "git::some/url.git[key1=value1,key2=value2]"
-			expected := &types.UserMacro{
+			expected := types.UserMacro{
 				Kind:  types.BlockMacro,
 				Name:  "git",
 				Value: "some/url.git",
@@ -135,7 +135,7 @@ var _ = Describe("user macros", func() {
 
 		It("user macro block with attribute", func() {
 			source := `git::[key1="value1"]`
-			expected := &types.UserMacro{
+			expected := types.UserMacro{
 				Kind:  types.BlockMacro,
 				Name:  "git",
 				Value: "",
@@ -149,7 +149,7 @@ var _ = Describe("user macros", func() {
 
 		It("user macro block with value", func() {
 			source := `git::some/url.git[]`
-			expected := &types.UserMacro{
+			expected := types.UserMacro{
 				Kind:       types.BlockMacro,
 				Name:       "git",
 				Value:      "some/url.git",

--- a/pkg/renderer/context.go
+++ b/pkg/renderer/context.go
@@ -19,13 +19,13 @@ type MacroTemplate interface {
 // which carries the types.Document which is being processed
 type Context struct {
 	context  context.Context
-	Document *types.Document
+	Document types.Document
 	options  map[string]interface{}
 	macros   map[string]MacroTemplate
 }
 
 // Wrap wraps the given `ctx` context into a new context which will contain the given `document` document.
-func Wrap(ctx context.Context, document *types.Document, options ...Option) *Context {
+func Wrap(ctx context.Context, document types.Document, options ...Option) *Context {
 	result := &Context{
 		context:  ctx,
 		Document: document,

--- a/pkg/renderer/document_metadata_test.go
+++ b/pkg/renderer/document_metadata_test.go
@@ -15,13 +15,13 @@ var _ = Describe("document metadata", func() {
 	Context("document authors", func() {
 
 		It("should include no author", func() {
-			source := &types.Document{
+			source := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.Section{
+					types.Section{
 						Level:      0,
 						Attributes: types.ElementAttributes{},
 						Title:      types.InlineElements{},
@@ -29,13 +29,13 @@ var _ = Describe("document metadata", func() {
 					},
 				},
 			}
-			expectedContent := &types.Document{
+			expectedContent := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.Section{
+					types.Section{
 						Level:      0,
 						Attributes: types.ElementAttributes{},
 						Title:      types.InlineElements{},
@@ -47,13 +47,13 @@ var _ = Describe("document metadata", func() {
 		})
 
 		It("should include single author without middlename", func() {
-			source := &types.Document{
+			source := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.Section{
+					types.Section{
 						Level: 0,
 						Attributes: types.ElementAttributes{
 							types.AttrAuthors: []types.DocumentAuthor{
@@ -68,7 +68,7 @@ var _ = Describe("document metadata", func() {
 					},
 				},
 			}
-			expectedContent := &types.Document{
+			expectedContent := types.Document{
 				Attributes: types.DocumentAttributes{
 					"author":         "Kismet Chameleon",
 					"firstname":      "Kismet",
@@ -80,7 +80,7 @@ var _ = Describe("document metadata", func() {
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.Section{
+					types.Section{
 						Level: 0,
 						Attributes: types.ElementAttributes{
 							types.AttrAuthors: []types.DocumentAuthor{
@@ -99,13 +99,13 @@ var _ = Describe("document metadata", func() {
 		})
 
 		It("should include single author without middlename, last name and email", func() {
-			source := &types.Document{
+			source := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.Section{
+					types.Section{
 						Level: 0,
 						Attributes: types.ElementAttributes{
 							types.AttrAuthors: []types.DocumentAuthor{
@@ -119,7 +119,7 @@ var _ = Describe("document metadata", func() {
 					},
 				},
 			}
-			expectedContent := &types.Document{
+			expectedContent := types.Document{
 				Attributes: types.DocumentAttributes{
 					"author":         "Kismet",
 					"firstname":      "Kismet",
@@ -129,7 +129,7 @@ var _ = Describe("document metadata", func() {
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.Section{
+					types.Section{
 						Level: 0,
 						Attributes: types.ElementAttributes{
 							types.AttrAuthors: []types.DocumentAuthor{
@@ -147,13 +147,13 @@ var _ = Describe("document metadata", func() {
 		})
 
 		It("should include multiple authors", func() {
-			source := &types.Document{
+			source := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.Section{
+					types.Section{
 						Level: 0,
 						Attributes: types.ElementAttributes{
 							types.AttrAuthors: []types.DocumentAuthor{
@@ -172,7 +172,7 @@ var _ = Describe("document metadata", func() {
 					},
 				},
 			}
-			expectedContent := &types.Document{
+			expectedContent := types.Document{
 				Attributes: types.DocumentAttributes{
 					"author":           "Kismet Rainbow Chameleon",
 					"firstname":        "Kismet",
@@ -190,7 +190,7 @@ var _ = Describe("document metadata", func() {
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.Section{
+					types.Section{
 						Level: 0,
 						Attributes: types.ElementAttributes{
 							types.AttrAuthors: []types.DocumentAuthor{
@@ -216,13 +216,13 @@ var _ = Describe("document metadata", func() {
 	Context("document revision", func() {
 
 		It("should include full revision", func() {
-			source := &types.Document{
+			source := types.Document{
 				Attributes:         types.DocumentAttributes{},
 				ElementReferences:  types.ElementReferences{},
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.Section{
+					types.Section{
 						Level: 0,
 						Attributes: types.ElementAttributes{
 							types.AttrAuthors: []types.DocumentAuthor{
@@ -241,7 +241,7 @@ var _ = Describe("document metadata", func() {
 					},
 				},
 			}
-			expectedContent := &types.Document{
+			expectedContent := types.Document{
 				Attributes: types.DocumentAttributes{
 					"author":         "Kismet",
 					"firstname":      "Kismet",
@@ -254,7 +254,7 @@ var _ = Describe("document metadata", func() {
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 				Elements: []interface{}{
-					&types.Section{
+					types.Section{
 						Level: 0,
 						Attributes: types.ElementAttributes{
 							types.AttrAuthors: []types.DocumentAuthor{
@@ -279,7 +279,7 @@ var _ = Describe("document metadata", func() {
 
 })
 
-func verifyDocumentMetadata(expected, source *types.Document) {
+func verifyDocumentMetadata(expected, source types.Document) {
 	ctx := renderer.Wrap(context.Background(), source)
 	renderer.ProcessDocumentHeader(ctx)
 	GinkgoT().Logf("actual document: `%s`", spew.Sdump(ctx.Document))

--- a/pkg/renderer/html5/article_adoc_test.go
+++ b/pkg/renderer/html5/article_adoc_test.go
@@ -27,6 +27,5 @@ var _ = Describe("article.adoc", func() {
 		rendererCtx := renderer.Wrap(context.Background(), doc)
 		_, err = html5.Render(rendererCtx, buff)
 		require.NoError(GinkgoT(), err)
-
 	})
 })

--- a/pkg/renderer/html5/attribution.go
+++ b/pkg/renderer/html5/attribution.go
@@ -10,13 +10,13 @@ type Attribution struct {
 
 // NewParagraphAttribution return a new attribution for the given paragraph.
 // Can be empty if no attribution was specified.
-func NewParagraphAttribution(p *types.Paragraph) Attribution {
+func NewParagraphAttribution(p types.Paragraph) Attribution {
 	return newAttribution(p.Attributes)
 }
 
 // NewDelimitedBlockAttribution return a new attribution for the given delimited block.
 // Can be empty if no attribution was specified.
-func NewDelimitedBlockAttribution(b *types.DelimitedBlock) Attribution {
+func NewDelimitedBlockAttribution(b types.DelimitedBlock) Attribution {
 	return newAttribution(b.Attributes)
 }
 

--- a/pkg/renderer/html5/blank_line.go
+++ b/pkg/renderer/html5/blank_line.go
@@ -5,7 +5,7 @@ import (
 	"github.com/bytesparadise/libasciidoc/pkg/types"
 )
 
-func renderBlankLine(ctx *renderer.Context, l *types.BlankLine) ([]byte, error) { //nolint:unparam
+func renderBlankLine(ctx *renderer.Context, l types.BlankLine) ([]byte, error) { //nolint:unparam
 	if ctx.IncludeBlankLine() {
 		return []byte("\n"), nil
 	}

--- a/pkg/renderer/html5/cross_reference.go
+++ b/pkg/renderer/html5/cross_reference.go
@@ -17,7 +17,7 @@ func init() {
 	crossReferenceTmpl = newTextTemplate("cross reference", `<a href="#{{ .ID }}">{{ .Label }}</a>`)
 }
 
-func renderCrossReference(ctx *renderer.Context, xref *types.CrossReference) ([]byte, error) {
+func renderCrossReference(ctx *renderer.Context, xref types.CrossReference) ([]byte, error) {
 	log.Debugf("rendering cross reference with ID: %s", xref.ID)
 	result := bytes.NewBuffer(nil)
 	var label string

--- a/pkg/renderer/html5/delimited_block.go
+++ b/pkg/renderer/html5/delimited_block.go
@@ -126,7 +126,7 @@ func init() {
 		})
 }
 
-func renderDelimitedBlock(ctx *renderer.Context, b *types.DelimitedBlock) ([]byte, error) {
+func renderDelimitedBlock(ctx *renderer.Context, b types.DelimitedBlock) ([]byte, error) {
 	log.Debugf("rendering delimited block of kind '%v'", b.Attributes[types.AttrKind])
 	var err error
 	kind := b.Kind
@@ -152,7 +152,7 @@ func renderDelimitedBlock(ctx *renderer.Context, b *types.DelimitedBlock) ([]byt
 	}
 }
 
-func renderFencedBlock(ctx *renderer.Context, b *types.DelimitedBlock) ([]byte, error) {
+func renderFencedBlock(ctx *renderer.Context, b types.DelimitedBlock) ([]byte, error) {
 	previouslyWithin := ctx.SetWithinDelimitedBlock(true)
 	previouslyInclude := ctx.SetIncludeBlankLine(true)
 	defer func() {
@@ -175,7 +175,7 @@ func renderFencedBlock(ctx *renderer.Context, b *types.DelimitedBlock) ([]byte, 
 	return result.Bytes(), err
 }
 
-func renderListingBlock(ctx *renderer.Context, b *types.DelimitedBlock) ([]byte, error) {
+func renderListingBlock(ctx *renderer.Context, b types.DelimitedBlock) ([]byte, error) {
 	previouslyWithin := ctx.SetWithinDelimitedBlock(true)
 	previouslyInclude := ctx.SetIncludeBlankLine(true)
 	defer func() {
@@ -198,7 +198,7 @@ func renderListingBlock(ctx *renderer.Context, b *types.DelimitedBlock) ([]byte,
 	return result.Bytes(), err
 }
 
-func renderSourceBlock(ctx *renderer.Context, b *types.DelimitedBlock) ([]byte, error) {
+func renderSourceBlock(ctx *renderer.Context, b types.DelimitedBlock) ([]byte, error) {
 	previouslyWithin := ctx.SetWithinDelimitedBlock(true)
 	previouslyInclude := ctx.SetIncludeBlankLine(true)
 	defer func() {
@@ -224,7 +224,7 @@ func renderSourceBlock(ctx *renderer.Context, b *types.DelimitedBlock) ([]byte, 
 	return result.Bytes(), err
 }
 
-func renderExampleBlock(ctx *renderer.Context, b *types.DelimitedBlock) ([]byte, error) {
+func renderExampleBlock(ctx *renderer.Context, b types.DelimitedBlock) ([]byte, error) {
 	result := bytes.NewBuffer(nil)
 	if k, ok := b.Attributes[types.AttrAdmonitionKind].(types.AdmonitionKind); ok {
 		err := admonitionBlockTmpl.Execute(result, ContextualPipeline{
@@ -267,7 +267,7 @@ func renderExampleBlock(ctx *renderer.Context, b *types.DelimitedBlock) ([]byte,
 	return result.Bytes(), err
 }
 
-func renderQuoteBlock(ctx *renderer.Context, b *types.DelimitedBlock) ([]byte, error) {
+func renderQuoteBlock(ctx *renderer.Context, b types.DelimitedBlock) ([]byte, error) {
 	result := bytes.NewBuffer(nil)
 	err := quoteBlockTmpl.Execute(result, ContextualPipeline{
 		Context: ctx,
@@ -286,16 +286,16 @@ func renderQuoteBlock(ctx *renderer.Context, b *types.DelimitedBlock) ([]byte, e
 	return result.Bytes(), err
 }
 
-func renderVerseBlock(ctx *renderer.Context, b *types.DelimitedBlock) ([]byte, error) {
+func renderVerseBlock(ctx *renderer.Context, b types.DelimitedBlock) ([]byte, error) {
 	var elements = make([]interface{}, 0)
 	if len(b.Elements) > 0 {
 		for _, element := range b.Elements {
 			switch e := element.(type) {
-			case *types.Paragraph:
+			case types.Paragraph:
 				for _, l := range e.Lines {
 					elements = append(elements, l)
 				}
-			case *types.BlankLine:
+			case types.BlankLine:
 				elements = append(elements, e)
 			default:
 				log.Warnf("unexpected type of element to include in verse block: %T", element)
@@ -322,12 +322,12 @@ func renderVerseBlock(ctx *renderer.Context, b *types.DelimitedBlock) ([]byte, e
 	return result.Bytes(), err
 }
 
-func renderCommentBlock(ctx *renderer.Context, b *types.DelimitedBlock) ([]byte, error) { //nolint: unparam
+func renderCommentBlock(ctx *renderer.Context, b types.DelimitedBlock) ([]byte, error) { //nolint: unparam
 	// comments block are not preserved during rendering
 	return []byte{}, nil
 }
 
-func renderSidebarBlock(ctx *renderer.Context, b *types.DelimitedBlock) ([]byte, error) {
+func renderSidebarBlock(ctx *renderer.Context, b types.DelimitedBlock) ([]byte, error) {
 	result := bytes.NewBuffer(nil)
 	err := sidebarBlockTmpl.Execute(result, ContextualPipeline{
 		Context: ctx,
@@ -352,7 +352,7 @@ func discardTrailingBlankLines(elements []interface{}) []interface{} {
 		if len(filteredElements) == 0 {
 			break
 		}
-		if _, ok := filteredElements[len(filteredElements)-1].(*types.BlankLine); ok {
+		if _, ok := filteredElements[len(filteredElements)-1].(types.BlankLine); ok {
 			log.Debugf("element of type '%T' at position %d is a blank line, discarding it", filteredElements[len(filteredElements)-1], len(filteredElements)-1)
 			// remove last element of the slice since it's a blankline
 			filteredElements = filteredElements[:len(filteredElements)-1]

--- a/pkg/renderer/html5/document.go
+++ b/pkg/renderer/html5/document.go
@@ -54,7 +54,7 @@ func renderDocument(ctx *renderer.Context, output io.Writer) (map[string]interfa
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to render full document")
 	}
-	log.Debugf("rendered title: '%s'\n", string(renderedTitle))
+	// log.Debugf("rendered title: '%s'\n", string(renderedTitle))
 	renderedHeader, err := renderDocumentHeader(ctx)
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to render full document")
@@ -116,7 +116,7 @@ func renderDocumentElements(ctx *renderer.Context) ([]byte, error) {
 	elements := []interface{}{}
 	if len(ctx.Document.Elements) > 0 {
 		// retrieve elements of the first section 0 (if available), plus remaining elements
-		if s, ok := ctx.Document.Elements[0].(*types.Section); ok && s.Level == 0 {
+		if s, ok := ctx.Document.Elements[0].(types.Section); ok && s.Level == 0 {
 			elements = append(elements, s.Elements)
 			if len(ctx.Document.Elements) > 1 {
 				elements = append(elements, ctx.Document.Elements[1:]...)
@@ -125,7 +125,7 @@ func renderDocumentElements(ctx *renderer.Context) ([]byte, error) {
 			elements = ctx.Document.Elements
 		}
 	}
-	log.Debugf("rendered document with %d element(s)...", len(elements))
+	// log.Debugf("rendered document with %d element(s)...", len(elements))
 	buff := bytes.NewBuffer(nil)
 	renderedElements, err := renderElements(ctx, elements)
 	if err != nil {

--- a/pkg/renderer/html5/document_attribute_substitution.go
+++ b/pkg/renderer/html5/document_attribute_substitution.go
@@ -7,17 +7,17 @@ import (
 	"github.com/bytesparadise/libasciidoc/pkg/types"
 )
 
-func processAttributeDeclaration(ctx *renderer.Context, attr *types.DocumentAttributeDeclaration) []byte {
+func processAttributeDeclaration(ctx *renderer.Context, attr types.DocumentAttributeDeclaration) []byte {
 	ctx.Document.Attributes.AddDeclaration(attr)
 	return []byte{}
 }
 
-func processAttributeReset(ctx *renderer.Context, attr *types.DocumentAttributeReset) []byte {
+func processAttributeReset(ctx *renderer.Context, attr types.DocumentAttributeReset) []byte {
 	ctx.Document.Attributes.Reset(attr)
 	return []byte{}
 }
 
-func renderAttributeSubstitution(ctx *renderer.Context, attr *types.DocumentAttributeSubstitution) []byte {
+func renderAttributeSubstitution(ctx *renderer.Context, attr types.DocumentAttributeSubstitution) []byte {
 	result := bytes.NewBuffer(nil)
 	if value, found := ctx.Document.Attributes.GetAsString(attr.Name); found {
 		result.WriteString(value)

--- a/pkg/renderer/html5/element_id_test.go
+++ b/pkg/renderer/html5/element_id_test.go
@@ -13,7 +13,7 @@ var _ = Describe("element ID generation", func() {
 	It("should generate ID with default prefix", func() {
 		// given
 		ctx := &renderer.Context{
-			Document: &types.Document{
+			Document: types.Document{
 				Attributes: types.DocumentAttributes{},
 			},
 		}
@@ -30,7 +30,7 @@ var _ = Describe("element ID generation", func() {
 	It("should generate ID with custom prefix", func() {
 		// given
 		ctx := &renderer.Context{
-			Document: &types.Document{
+			Document: types.Document{
 				Attributes: types.DocumentAttributes{
 					types.AttrIDPrefix: "id#",
 				},
@@ -49,7 +49,7 @@ var _ = Describe("element ID generation", func() {
 	It("should generate custom ID", func() {
 		// given
 		ctx := &renderer.Context{
-			Document: &types.Document{
+			Document: types.Document{
 				Attributes: types.DocumentAttributes{
 					types.AttrIDPrefix: "id#",
 				},
@@ -68,7 +68,7 @@ var _ = Describe("element ID generation", func() {
 	It("should generate empty ID from empty value", func() {
 		// given
 		ctx := &renderer.Context{
-			Document: &types.Document{
+			Document: types.Document{
 				Attributes: types.DocumentAttributes{
 					types.AttrIDPrefix: "id#",
 				},
@@ -87,7 +87,7 @@ var _ = Describe("element ID generation", func() {
 	It("should generate empty ID from missing value", func() {
 		// given
 		ctx := &renderer.Context{
-			Document: &types.Document{
+			Document: types.Document{
 				Attributes: types.DocumentAttributes{
 					types.AttrIDPrefix: "id#",
 				},

--- a/pkg/renderer/html5/external_link.go
+++ b/pkg/renderer/html5/external_link.go
@@ -17,7 +17,7 @@ func init() {
 	linkTmpl = newTextTemplate("external link", `<a href="{{ .URL }}"{{if .Class}} class="{{ .Class }}"{{ end }}>{{ .Text }}</a>`)
 }
 
-func renderLink(ctx *renderer.Context, l *types.InlineLink) ([]byte, error) { //nolint: unparam
+func renderLink(ctx *renderer.Context, l types.InlineLink) ([]byte, error) { //nolint: unparam
 	result := bytes.NewBuffer(nil)
 	location := l.Location.Resolve(ctx.Document.Attributes)
 	var text []byte
@@ -44,6 +44,6 @@ func renderLink(ctx *renderer.Context, l *types.InlineLink) ([]byte, error) { //
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to render external link")
 	}
-	log.Debugf("rendered external link: %s", result.Bytes())
+	log.Debugf("/rendered external link: %s", result.Bytes())
 	return result.Bytes(), nil
 }

--- a/pkg/renderer/html5/footnote.go
+++ b/pkg/renderer/html5/footnote.go
@@ -51,7 +51,7 @@ func renderFootnoteIndex(idx int) string {
 	return strconv.Itoa(idx + 1)
 }
 
-func renderFootnote(ctx *renderer.Context, note *types.Footnote) ([]byte, error) {
+func renderFootnote(ctx *renderer.Context, note types.Footnote) ([]byte, error) {
 	result := bytes.NewBuffer(nil)
 	ref := ""
 	noteRef, hasRef := ctx.Document.FootnoteReferences[note.Ref]

--- a/pkg/renderer/html5/image.go
+++ b/pkg/renderer/html5/image.go
@@ -11,7 +11,6 @@ import (
 	"github.com/bytesparadise/libasciidoc/pkg/renderer"
 	"github.com/bytesparadise/libasciidoc/pkg/types"
 	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
 )
 
 var blockImageTmpl texttemplate.Template
@@ -35,7 +34,7 @@ func init() {
 		})
 }
 
-func renderImageBlock(ctx *renderer.Context, img *types.ImageBlock) ([]byte, error) {
+func renderImageBlock(ctx *renderer.Context, img types.ImageBlock) ([]byte, error) {
 	result := bytes.NewBuffer(nil)
 	title := ""
 	if t := img.Attributes.GetAsString(types.AttrTitle); t != "" {
@@ -64,11 +63,11 @@ func renderImageBlock(ctx *renderer.Context, img *types.ImageBlock) ([]byte, err
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to render block image")
 	}
-	log.Debugf("rendered block image: %s", result.Bytes())
+	// log.Debugf("rendered block image: %s", result.Bytes())
 	return result.Bytes(), nil
 }
 
-func renderInlineImage(ctx *renderer.Context, img *types.InlineImage) ([]byte, error) {
+func renderInlineImage(ctx *renderer.Context, img types.InlineImage) ([]byte, error) {
 	result := bytes.NewBuffer(nil)
 	err := inlineImageTmpl.Execute(result, struct {
 		Role   string
@@ -90,7 +89,7 @@ func renderInlineImage(ctx *renderer.Context, img *types.InlineImage) ([]byte, e
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to render inline image")
 	}
-	log.Debugf("rendered inline image: %s", result.Bytes())
+	// log.Debugf("rendered inline image: %s", result.Bytes())
 	return result.Bytes(), nil
 }
 

--- a/pkg/renderer/html5/inline_elements.go
+++ b/pkg/renderer/html5/inline_elements.go
@@ -35,7 +35,7 @@ func renderLines(ctx *renderer.Context, elements []types.InlineElements, renderE
 		}
 
 		if i < len(elements)-1 && (len(renderedElement) > 0 || ctx.WithinDelimitedBlock()) {
-			log.Debugf("rendered line is not the last one in the slice")
+			// log.Debugf("rendered line is not the last one in the slice")
 			var err error
 			if hardbreak {
 				_, err = buff.WriteString("<br>\n")
@@ -47,7 +47,7 @@ func renderLines(ctx *renderer.Context, elements []types.InlineElements, renderE
 			}
 		}
 	}
-	log.Debugf("rendered lines: '%s'", buff.String())
+	// log.Debugf("rendered lines: '%s'", buff.String())
 	return buff.Bytes(), nil
 }
 
@@ -62,7 +62,7 @@ func renderLine(ctx *renderer.Context, elements types.InlineElements, renderElem
 			return nil, errors.Wrapf(err, "unable to render line")
 		}
 		if i == len(elements)-1 {
-			if _, ok := element.(*types.StringElement); ok { // TODO: only for StringElement? or for any kind of element?
+			if _, ok := element.(types.StringElement); ok { // TODO: only for StringElement? or for any kind of element?
 				// trim trailing spaces before returning the line
 				buff.WriteString(strings.TrimRight(string(renderedElement), " "))
 				log.Debugf("trimmed spaces on '%v'", string(renderedElement))
@@ -74,7 +74,7 @@ func renderLine(ctx *renderer.Context, elements types.InlineElements, renderElem
 		}
 	}
 
-	log.Debugf("rendered line elements after 1st pass: '%s'", buff.String())
+	// log.Debugf("rendered line elements after 1st pass: '%s'", buff.String())
 
 	// check if the line has some substitution
 	if !hasSubstitutions(elements) {
@@ -94,7 +94,7 @@ func renderLine(ctx *renderer.Context, elements types.InlineElements, renderElem
 	// render all elements of the line, but StringElement must be rendered plain-text now, to avoid double HTML escape
 	for i, element := range elements {
 		switch element := element.(type) {
-		case *types.StringElement:
+		case types.StringElement:
 			if i == len(elements)-1 {
 				buff.WriteString(strings.TrimRight(element.Content, " "))
 			} else {
@@ -108,15 +108,14 @@ func renderLine(ctx *renderer.Context, elements types.InlineElements, renderElem
 			buff.Write(renderedElement)
 		}
 	}
-
-	log.Debugf("rendered line elements: '%s'", buff.String())
+	// log.Debugf("rendered line elements: '%s'", buff.String())
 	return buff.Bytes(), nil
 }
 
 // check if there's at least on substitution before doing the whole process
 func hasSubstitutions(e types.InlineElements) bool {
 	for _, element := range e {
-		if _, ok := element.(*types.DocumentAttributeSubstitution); ok {
+		if _, ok := element.(types.DocumentAttributeSubstitution); ok {
 			return true
 		}
 	}

--- a/pkg/renderer/html5/labeled_list.go
+++ b/pkg/renderer/html5/labeled_list.go
@@ -8,7 +8,6 @@ import (
 	"github.com/bytesparadise/libasciidoc/pkg/renderer"
 	"github.com/bytesparadise/libasciidoc/pkg/types"
 	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
 )
 
 var defaultLabeledListTmpl texttemplate.Template
@@ -72,7 +71,7 @@ func init() {
 
 }
 
-func renderLabeledList(ctx *renderer.Context, l *types.LabeledList) ([]byte, error) {
+func renderLabeledList(ctx *renderer.Context, l types.LabeledList) ([]byte, error) {
 	var tmpl texttemplate.Template
 	tmpl, err := getLabeledListTmpl(l)
 	if err != nil {
@@ -87,7 +86,7 @@ func renderLabeledList(ctx *renderer.Context, l *types.LabeledList) ([]byte, err
 			ID    string
 			Title string
 			Role  string
-			Items []*types.LabeledListItem
+			Items []types.LabeledListItem
 		}{
 			ID:    generateID(ctx, l.Attributes),
 			Title: getTitle(l.Attributes),
@@ -98,11 +97,11 @@ func renderLabeledList(ctx *renderer.Context, l *types.LabeledList) ([]byte, err
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to render labeled list")
 	}
-	log.Debugf("rendered labeled list: %s", result.Bytes())
+	// log.Debugf("rendered labeled list: %s", result.Bytes())
 	return result.Bytes(), nil
 }
 
-func getLabeledListTmpl(l *types.LabeledList) (texttemplate.Template, error) {
+func getLabeledListTmpl(l types.LabeledList) (texttemplate.Template, error) {
 	if layout, ok := l.Attributes["layout"]; ok {
 		switch layout {
 		case "horizontal":

--- a/pkg/renderer/html5/literal_blocks.go
+++ b/pkg/renderer/html5/literal_blocks.go
@@ -28,7 +28,7 @@ func init() {
 	})
 }
 
-func renderLiteralBlock(ctx *renderer.Context, b *types.LiteralBlock) ([]byte, error) {
+func renderLiteralBlock(ctx *renderer.Context, b types.LiteralBlock) ([]byte, error) {
 	log.Debugf("rendering delimited block with content: %s", b.Lines)
 	var lines []string
 	switch b.Attributes.GetAsString(types.AttrLiteralBlockType) {

--- a/pkg/renderer/html5/ordered_list.go
+++ b/pkg/renderer/html5/ordered_list.go
@@ -31,7 +31,7 @@ func init() {
 
 }
 
-func renderOrderedList(ctx *renderer.Context, l *types.OrderedList) ([]byte, error) {
+func renderOrderedList(ctx *renderer.Context, l types.OrderedList) ([]byte, error) {
 	result := bytes.NewBuffer(nil)
 	err := orderedListTmpl.Execute(result, ContextualPipeline{
 		Context: ctx,
@@ -41,7 +41,7 @@ func renderOrderedList(ctx *renderer.Context, l *types.OrderedList) ([]byte, err
 			Role           string
 			NumberingStyle string
 			Start          string
-			Items          []*types.OrderedListItem
+			Items          []types.OrderedListItem
 		}{
 			generateID(ctx, l.Attributes),
 			l.Attributes.GetAsString(types.AttrTitle),
@@ -57,7 +57,7 @@ func renderOrderedList(ctx *renderer.Context, l *types.OrderedList) ([]byte, err
 	return result.Bytes(), nil
 }
 
-func getNumberingStyle(l *types.OrderedList) string {
+func getNumberingStyle(l types.OrderedList) string {
 	if s := l.Attributes.GetAsString(types.AttrNumberingStyle); s != "" {
 		return s
 	}

--- a/pkg/renderer/html5/paragraph.go
+++ b/pkg/renderer/html5/paragraph.go
@@ -95,7 +95,7 @@ func init() {
 		})
 }
 
-func renderParagraph(ctx *renderer.Context, p *types.Paragraph) ([]byte, error) {
+func renderParagraph(ctx *renderer.Context, p types.Paragraph) ([]byte, error) {
 	if len(p.Lines) == 0 {
 		return make([]byte, 0), nil
 	}
@@ -132,11 +132,11 @@ func renderParagraph(ctx *renderer.Context, p *types.Paragraph) ([]byte, error) 
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to render paragraph")
 	}
-	log.Debugf("rendered paragraph: '%s'", result.String())
+	// log.Debugf("rendered paragraph: '%s'", result.String())
 	return result.Bytes(), nil
 }
 
-func renderAdmonitionParagraph(ctx *renderer.Context, p *types.Paragraph) ([]byte, error) {
+func renderAdmonitionParagraph(ctx *renderer.Context, p types.Paragraph) ([]byte, error) {
 	log.Debug("rendering admonition paragraph...")
 	result := bytes.NewBuffer(nil)
 	k, ok := p.Attributes[types.AttrAdmonitionKind].(types.AdmonitionKind)
@@ -164,7 +164,7 @@ func renderAdmonitionParagraph(ctx *renderer.Context, p *types.Paragraph) ([]byt
 	return result.Bytes(), err
 }
 
-func renderSourceParagraph(ctx *renderer.Context, p *types.Paragraph) ([]byte, error) {
+func renderSourceParagraph(ctx *renderer.Context, p types.Paragraph) ([]byte, error) {
 	log.Debug("rendering source paragraph...")
 	result := bytes.NewBuffer(nil)
 	err := sourceParagraphTmpl.Execute(result, ContextualPipeline{
@@ -184,7 +184,7 @@ func renderSourceParagraph(ctx *renderer.Context, p *types.Paragraph) ([]byte, e
 	return result.Bytes(), err
 }
 
-func renderVerseParagraph(ctx *renderer.Context, p *types.Paragraph) ([]byte, error) {
+func renderVerseParagraph(ctx *renderer.Context, p types.Paragraph) ([]byte, error) {
 	log.Debug("rendering verse paragraph...")
 	result := bytes.NewBuffer(nil)
 	err := verseParagraphTmpl.Execute(result, ContextualPipeline{
@@ -204,7 +204,7 @@ func renderVerseParagraph(ctx *renderer.Context, p *types.Paragraph) ([]byte, er
 	return result.Bytes(), err
 }
 
-func renderQuoteParagraph(ctx *renderer.Context, p *types.Paragraph) ([]byte, error) {
+func renderQuoteParagraph(ctx *renderer.Context, p types.Paragraph) ([]byte, error) {
 	log.Debug("rendering quote paragraph...")
 	result := bytes.NewBuffer(nil)
 	err := quoteParagraphTmpl.Execute(result, ContextualPipeline{
@@ -224,7 +224,7 @@ func renderQuoteParagraph(ctx *renderer.Context, p *types.Paragraph) ([]byte, er
 	return result.Bytes(), err
 }
 
-func renderDelimitedBlockParagraph(ctx *renderer.Context, p *types.Paragraph) ([]byte, error) {
+func renderDelimitedBlockParagraph(ctx *renderer.Context, p types.Paragraph) ([]byte, error) {
 	log.Debugf("rendering paragraph with %d lines within a delimited block or a list", len(p.Lines))
 	result := bytes.NewBuffer(nil)
 	err := listParagraphTmpl.Execute(result, ContextualPipeline{

--- a/pkg/renderer/html5/passthrough.go
+++ b/pkg/renderer/html5/passthrough.go
@@ -9,7 +9,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func renderPassthrough(ctx *renderer.Context, p *types.Passthrough) ([]byte, error) {
+func renderPassthrough(ctx *renderer.Context, p types.Passthrough) ([]byte, error) {
 	renderedContent, err := renderPassthroughContent(ctx, p)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to render passthrough")
@@ -26,11 +26,11 @@ func renderPassthrough(ctx *renderer.Context, p *types.Passthrough) ([]byte, err
 }
 
 // renderPassthroughMacro renders the passthrough content in ist raw from
-func renderPassthroughContent(ctx *renderer.Context, p *types.Passthrough) ([]byte, error) {
+func renderPassthroughContent(ctx *renderer.Context, p types.Passthrough) ([]byte, error) {
 	buf := bytes.NewBuffer(nil)
 	for _, element := range p.Elements {
 		switch element := element.(type) {
-		case *types.StringElement:
+		case types.StringElement:
 			// "string" elements must be rendered as-is, ie, without any HTML escaping.
 			_, err := buf.WriteString(element.Content)
 			if err != nil {

--- a/pkg/renderer/html5/quoted_text.go
+++ b/pkg/renderer/html5/quoted_text.go
@@ -8,7 +8,6 @@ import (
 	"github.com/bytesparadise/libasciidoc/pkg/renderer"
 	"github.com/bytesparadise/libasciidoc/pkg/types"
 	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
 )
 
 var boldTextTmpl texttemplate.Template
@@ -26,7 +25,7 @@ func init() {
 	superscriptTextTmpl = newTextTemplate("superscript text", "<sup>{{ . }}</sup>")
 }
 
-func renderQuotedText(ctx *renderer.Context, t *types.QuotedText) ([]byte, error) {
+func renderQuotedText(ctx *renderer.Context, t types.QuotedText) ([]byte, error) {
 	elementsBuffer := bytes.NewBuffer(nil)
 	for _, element := range t.Elements {
 		b, err := renderElement(ctx, element)
@@ -58,6 +57,6 @@ func renderQuotedText(ctx *renderer.Context, t *types.QuotedText) ([]byte, error
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to render monospaced quote")
 	}
-	log.Debugf("rendered bold quote: %s", result.Bytes())
+	// log.Debugf("rendered bold quote: %s", result.Bytes())
 	return result.Bytes(), nil
 }

--- a/pkg/renderer/html5/renderer.go
+++ b/pkg/renderer/html5/renderer.go
@@ -23,7 +23,7 @@ func renderElements(ctx *renderer.Context, elements []interface{}) ([]byte, erro
 	buff := bytes.NewBuffer(nil)
 	hasContent := false
 	if !ctx.IncludeHeaderFooter() && len(elements) > 0 {
-		if s, ok := elements[0].(*types.Section); ok && s.Level == 0 {
+		if s, ok := elements[0].(types.Section); ok && s.Level == 0 {
 			// don't render the top-level section, but only its elements (plus the rest if there's anything)
 			if len(elements) > 1 {
 				elements = append(s.Elements, elements[1:])
@@ -38,7 +38,7 @@ func renderElements(ctx *renderer.Context, elements []interface{}) ([]byte, erro
 			return nil, errors.Wrapf(err, "unable to render an element")
 		}
 		// insert new line if there's already some content (except for BlankLine)
-		_, isBlankline := element.(*types.BlankLine)
+		_, isBlankline := element.(types.BlankLine)
 		if !isBlankline && hasContent && len(renderedElement) > 0 {
 			buff.WriteString("\n")
 		}
@@ -87,57 +87,57 @@ func renderElement(ctx *renderer.Context, element interface{}) ([]byte, error) {
 	switch e := element.(type) {
 	case []interface{}:
 		return renderElements(ctx, e)
-	case *types.TableOfContentsMacro:
+	case types.TableOfContentsMacro:
 		return renderTableOfContents(ctx, e)
-	case *types.Section:
+	case types.Section:
 		return renderSection(ctx, e)
-	case *types.Preamble:
+	case types.Preamble:
 		return renderPreamble(ctx, e)
-	case *types.BlankLine:
+	case types.BlankLine:
 		return renderBlankLine(ctx, e)
-	case *types.LabeledList:
+	case types.LabeledList:
 		return renderLabeledList(ctx, e)
-	case *types.OrderedList:
+	case types.OrderedList:
 		return renderOrderedList(ctx, e)
-	case *types.UnorderedList:
+	case types.UnorderedList:
 		return renderUnorderedList(ctx, e)
-	case *types.Paragraph:
+	case types.Paragraph:
 		return renderParagraph(ctx, e)
-	case *types.CrossReference:
+	case types.CrossReference:
 		return renderCrossReference(ctx, e)
-	case *types.QuotedText:
+	case types.QuotedText:
 		return renderQuotedText(ctx, e)
-	case *types.Passthrough:
+	case types.Passthrough:
 		return renderPassthrough(ctx, e)
-	case *types.ImageBlock:
+	case types.ImageBlock:
 		return renderImageBlock(ctx, e)
-	case *types.InlineImage:
+	case types.InlineImage:
 		return renderInlineImage(ctx, e)
-	case *types.DelimitedBlock:
+	case types.DelimitedBlock:
 		return renderDelimitedBlock(ctx, e)
-	case *types.Table:
+	case types.Table:
 		return renderTable(ctx, e)
-	case *types.LiteralBlock:
+	case types.LiteralBlock:
 		return renderLiteralBlock(ctx, e)
 	case types.InlineElements:
 		return renderLine(ctx, e, renderElement)
-	case *types.InlineLink:
+	case types.InlineLink:
 		return renderLink(ctx, e)
-	case *types.StringElement:
+	case types.StringElement:
 		return renderStringElement(ctx, e)
-	case *types.Footnote:
+	case types.Footnote:
 		return renderFootnote(ctx, e)
-	case *types.DocumentAttributeDeclaration:
+	case types.DocumentAttributeDeclaration:
 		return processAttributeDeclaration(ctx, e), nil
-	case *types.DocumentAttributeReset:
+	case types.DocumentAttributeReset:
 		return processAttributeReset(ctx, e), nil
-	case *types.DocumentAttributeSubstitution:
+	case types.DocumentAttributeSubstitution:
 		return renderAttributeSubstitution(ctx, e), nil
-	case *types.LineBreak:
+	case types.LineBreak:
 		return renderLineBreak()
-	case *types.UserMacro:
+	case types.UserMacro:
 		return renderUserMacro(ctx, e)
-	case *types.SingleLineComment:
+	case types.SingleLineComment:
 		return nil, nil // nothing to do
 	default:
 		return nil, errors.Errorf("unsupported type of element: %T", element)
@@ -148,22 +148,22 @@ func renderElement(ctx *renderer.Context, element interface{}) ([]byte, error) {
 func renderPlainString(ctx *renderer.Context, element interface{}) ([]byte, error) {
 	log.Debugf("rendering plain string for element of type %T", element)
 	switch element := element.(type) {
-	case *types.SectionTitle:
+	case types.SectionTitle:
 		return renderPlainString(ctx, element.Elements)
-	case *types.QuotedText:
+	case types.QuotedText:
 		return renderPlainString(ctx, element.Elements)
-	case *types.InlineImage:
+	case types.InlineImage:
 		return []byte(element.Attributes.GetAsString(types.AttrImageAlt)), nil
-	case *types.InlineLink:
+	case types.InlineLink:
 		if alt, ok := element.Attributes[types.AttrInlineLinkText].(types.InlineElements); ok {
 			return renderPlainString(ctx, alt)
 		}
 		return []byte(element.Location.Resolve(ctx.Document.Attributes)), nil
-	case *types.BlankLine:
+	case types.BlankLine:
 		return []byte("\n\n"), nil
-	case *types.StringElement:
+	case types.StringElement:
 		return []byte(element.Content), nil
-	case *types.Paragraph:
+	case types.Paragraph:
 		return renderLines(ctx, element.Lines, renderPlainString, false)
 	case types.InlineElements:
 		return renderLine(ctx, element, renderPlainString)

--- a/pkg/renderer/html5/section.go
+++ b/pkg/renderer/html5/section.go
@@ -51,7 +51,7 @@ func init() {
 		`<h{{ .Level }} id="{{ .ID }}">{{ .Content }}</h{{ .Level }}>`)
 }
 
-func renderPreamble(ctx *renderer.Context, p *types.Preamble) ([]byte, error) {
+func renderPreamble(ctx *renderer.Context, p types.Preamble) ([]byte, error) {
 	log.Debugf("rendering preamble...")
 	result := bytes.NewBuffer(nil)
 	// the <div id="preamble"> wrapper is only necessary
@@ -73,11 +73,11 @@ func renderPreamble(ctx *renderer.Context, p *types.Preamble) ([]byte, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "error while rendering preamble")
 	}
-	log.Debugf("rendered preamble: %s", result.Bytes())
+	// log.Debugf("rendered preamble: %s", result.Bytes())
 	return result.Bytes(), nil
 }
 
-func renderSection(ctx *renderer.Context, s *types.Section) ([]byte, error) {
+func renderSection(ctx *renderer.Context, s types.Section) ([]byte, error) {
 	log.Debugf("rendering section level %d", s.Level)
 	renderedSectionTitle, err := renderSectionTitle(ctx, s)
 	if err != nil {
@@ -105,11 +105,11 @@ func renderSection(ctx *renderer.Context, s *types.Section) ([]byte, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "error while rendering section")
 	}
-	log.Debugf("rendered section: %s", result.Bytes())
+	// log.Debugf("rendered section: %s", result.Bytes())
 	return result.Bytes(), nil
 }
 
-func renderSectionTitle(ctx *renderer.Context, s *types.Section) (string, error) {
+func renderSectionTitle(ctx *renderer.Context, s types.Section) (string, error) {
 	result := bytes.NewBuffer(nil)
 	renderedContent, err := renderElement(ctx, s.Title)
 	if err != nil {

--- a/pkg/renderer/html5/string.go
+++ b/pkg/renderer/html5/string.go
@@ -11,7 +11,7 @@ import (
 
 var stringTmpl = newHTMLTemplate("string element", "{{ . }}")
 
-func renderStringElement(ctx *renderer.Context, str *types.StringElement) ([]byte, error) { //nolint: unparam
+func renderStringElement(ctx *renderer.Context, str types.StringElement) ([]byte, error) { //nolint: unparam
 	buf := bytes.NewBuffer(nil)
 	err := stringTmpl.Execute(buf, str.Content)
 	if err != nil {

--- a/pkg/renderer/html5/table.go
+++ b/pkg/renderer/html5/table.go
@@ -40,7 +40,7 @@ func init() {
 		})
 }
 
-func renderTable(ctx *renderer.Context, t *types.Table) ([]byte, error) {
+func renderTable(ctx *renderer.Context, t types.Table) ([]byte, error) {
 	result := bytes.NewBuffer(nil)
 	// inspect first line to obtain cell width ratio
 	widths := []string{}
@@ -69,8 +69,8 @@ func renderTable(ctx *renderer.Context, t *types.Table) ([]byte, error) {
 		Data: struct {
 			Title      string
 			CellWidths []string
-			Header     *types.TableLine
-			Lines      []*types.TableLine
+			Header     types.TableLine
+			Lines      []types.TableLine
 		}{
 			Title:      title,
 			CellWidths: widths,

--- a/pkg/renderer/html5/table_of_contents.go
+++ b/pkg/renderer/html5/table_of_contents.go
@@ -36,7 +36,7 @@ type TableOfContents struct {
 // TableOfContentsSectionGroup a group of sections in the table of contents
 type TableOfContentsSectionGroup struct {
 	Level    int
-	Elements []*TableOfContentsSection
+	Elements []TableOfContentsSection
 }
 
 // TableOfContentsSection a section in the table of contents
@@ -47,7 +47,7 @@ type TableOfContentsSection struct {
 	Elements template.HTML
 }
 
-func renderTableOfContents(ctx *renderer.Context, m *types.TableOfContentsMacro) ([]byte, error) { //nolint:unparam
+func renderTableOfContents(ctx *renderer.Context, m types.TableOfContentsMacro) ([]byte, error) { //nolint:unparam
 	log.Debug("rendering table of contents...")
 	renderedSections, err := renderTableOfContentsSections(ctx, ctx.Document.Elements, 1)
 	if err != nil {
@@ -64,16 +64,16 @@ func renderTableOfContents(ctx *renderer.Context, m *types.TableOfContentsMacro)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error while rendering table of content")
 	}
-	log.Debugf("rendered TOC: %s", result.Bytes())
+	// log.Debugf("rendered TOC: %s", result.Bytes())
 	return result.Bytes(), nil
 }
 
 func renderTableOfContentsSections(ctx *renderer.Context, elements []interface{}, currentLevel int) (template.HTML, error) {
-	sections := make([]*TableOfContentsSection, 0)
+	sections := make([]TableOfContentsSection, 0)
 	for _, element := range elements {
 		log.Debugf("traversing document element of type %T", element)
 		switch section := element.(type) {
-		case *types.Section:
+		case types.Section:
 			// do not render document header in ToC
 			if section.Level == 0 {
 				return renderTableOfContentsSections(ctx, section.Elements, currentLevel)
@@ -95,7 +95,7 @@ func renderTableOfContentsSections(ctx *renderer.Context, elements []interface{}
 			}
 			id := generateID(ctx, section.Attributes)
 			renderedTitleStr := strings.TrimSpace(string(renderedTitle))
-			sections = append(sections, &TableOfContentsSection{
+			sections = append(sections, TableOfContentsSection{
 				Level:    section.Level,
 				Href:     id,
 				Title:    template.HTML(renderedTitleStr), //nolint: gosec
@@ -118,7 +118,7 @@ func renderTableOfContentsSections(ctx *renderer.Context, elements []interface{}
 	return template.HTML(resultBuf.String()), nil //nolint: gosec
 }
 
-func getTocLevels(doc *types.Document) (int, error) {
+func getTocLevels(doc types.Document) (int, error) {
 	if d, found := types.SearchAttributeDeclaration(doc.Elements, types.AttrTableOfContentsLevels); found {
 		return strconv.Atoi(d.Value)
 	}

--- a/pkg/renderer/html5/unordered_list.go
+++ b/pkg/renderer/html5/unordered_list.go
@@ -8,7 +8,6 @@ import (
 	"github.com/bytesparadise/libasciidoc/pkg/renderer"
 	"github.com/bytesparadise/libasciidoc/pkg/types"
 	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
 )
 
 var unorderedListTmpl texttemplate.Template
@@ -30,7 +29,7 @@ func init() {
 		})
 }
 
-func renderUnorderedList(ctx *renderer.Context, l *types.UnorderedList) ([]byte, error) {
+func renderUnorderedList(ctx *renderer.Context, l types.UnorderedList) ([]byte, error) {
 	// make sure nested elements are aware of that their rendering occurs within a list
 	checkList := false
 	if len(l.Items) > 0 {
@@ -47,7 +46,7 @@ func renderUnorderedList(ctx *renderer.Context, l *types.UnorderedList) ([]byte,
 			Title     string
 			Role      string
 			Checklist bool
-			Items     []*types.UnorderedListItem
+			Items     []types.UnorderedListItem
 		}{
 			ID:        generateID(ctx, l.Attributes),
 			Title:     getTitle(l.Attributes),
@@ -59,6 +58,6 @@ func renderUnorderedList(ctx *renderer.Context, l *types.UnorderedList) ([]byte,
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to render unordered list")
 	}
-	log.Debugf("rendered unordered list of items: %s", result.Bytes())
+	// log.Debugf("rendered unordered list of items: %s", result.Bytes())
 	return result.Bytes(), nil
 }

--- a/pkg/renderer/html5/user_macro.go
+++ b/pkg/renderer/html5/user_macro.go
@@ -7,7 +7,7 @@ import (
 	"github.com/bytesparadise/libasciidoc/pkg/types"
 )
 
-func renderUserMacro(ctx *renderer.Context, um *types.UserMacro) ([]byte, error) {
+func renderUserMacro(ctx *renderer.Context, um types.UserMacro) ([]byte, error) {
 	buf := bytes.NewBuffer([]byte{})
 	macro, err := ctx.MacroTemplate(um.Name)
 	if err != nil {
@@ -15,7 +15,7 @@ func renderUserMacro(ctx *renderer.Context, um *types.UserMacro) ([]byte, error)
 			// fallback to paragraph
 			p, _ := types.NewParagraph([]interface{}{
 				types.InlineElements{
-					&types.StringElement{Content: um.RawText},
+					types.StringElement{Content: um.RawText},
 				},
 			}, nil)
 			return renderParagraph(ctx, p)

--- a/pkg/renderer/options.go
+++ b/pkg/renderer/options.go
@@ -58,7 +58,7 @@ func (ctx *Context) LastUpdated() string {
 	return time.Now().Format(LastUpdatedFormat)
 }
 
-// IncludeHeaderFooter returns the value of the 'LastUpdated' Option if it was present,
+// IncludeHeaderFooter returns the value of the 'IncludeHeaderFooter' Option if it was present,
 // otherwise it returns `false`
 func (ctx *Context) IncludeHeaderFooter() bool {
 	if includeHeaderFooter, found := ctx.options[keyIncludeHeaderFooter]; found {

--- a/pkg/renderer/preamble.go
+++ b/pkg/renderer/preamble.go
@@ -18,10 +18,12 @@ func IncludePreamble(ctx *Context) {
 
 func insertPreamble(blocks []interface{}) []interface{} {
 	log.Debugf("generating preamble from %d blocks", len(blocks))
-	preamble := types.NewEmptyPreamble()
+	preamble := types.Preamble{
+		Elements: make([]interface{}, 0),
+	}
 	for _, block := range blocks {
 		switch block.(type) {
-		case *types.Section:
+		case types.Section:
 			break
 		default:
 			preamble.Elements = append(preamble.Elements, block)

--- a/pkg/renderer/preamble_test.go
+++ b/pkg/renderer/preamble_test.go
@@ -12,15 +12,15 @@ import (
 var _ = Describe("preambles", func() {
 
 	sectionATitle := types.InlineElements{
-		&types.StringElement{Content: "Section A"},
+		types.StringElement{Content: "Section A"},
 	}
 
 	sectionBTitle := types.InlineElements{
-		&types.StringElement{Content: "Section B"},
+		types.StringElement{Content: "Section B"},
 	}
 
 	It("doc without sections", func() {
-		source := &types.Document{
+		source := types.Document{
 			Attributes: types.DocumentAttributes{
 				types.AttrTitle: "foo",
 			},
@@ -31,26 +31,26 @@ var _ = Describe("preambles", func() {
 			Footnotes:          types.Footnotes{},
 			FootnoteReferences: types.FootnoteReferences{},
 			Elements: []interface{}{
-				&types.Paragraph{
+				types.Paragraph{
 					Attributes: types.ElementAttributes{},
 					Lines: []types.InlineElements{
 						{
-							&types.StringElement{Content: "a short paragraph"},
+							types.StringElement{Content: "a short paragraph"},
 						},
 					},
 				},
 				types.BlankLine{},
-				&types.Paragraph{
+				types.Paragraph{
 					Attributes: types.ElementAttributes{},
 					Lines: []types.InlineElements{
 						{
-							&types.StringElement{Content: "another short paragraph"},
+							types.StringElement{Content: "another short paragraph"},
 						},
 					},
 				},
 			},
 		}
-		expectedContent := &types.Document{
+		expectedContent := types.Document{
 			Attributes: types.DocumentAttributes{
 				types.AttrTitle: "foo",
 			},
@@ -61,20 +61,20 @@ var _ = Describe("preambles", func() {
 			Footnotes:          types.Footnotes{},
 			FootnoteReferences: types.FootnoteReferences{},
 			Elements: []interface{}{
-				&types.Paragraph{
+				types.Paragraph{
 					Attributes: types.ElementAttributes{},
 					Lines: []types.InlineElements{
 						{
-							&types.StringElement{Content: "a short paragraph"},
+							types.StringElement{Content: "a short paragraph"},
 						},
 					},
 				},
 				types.BlankLine{},
-				&types.Paragraph{
+				types.Paragraph{
 					Attributes: types.ElementAttributes{},
 					Lines: []types.InlineElements{
 						{
-							&types.StringElement{Content: "another short paragraph"},
+							types.StringElement{Content: "another short paragraph"},
 						},
 					},
 				},
@@ -84,7 +84,7 @@ var _ = Describe("preambles", func() {
 	})
 
 	It("doc with 1-paragraph preamble", func() {
-		source := &types.Document{
+		source := types.Document{
 			Attributes: types.DocumentAttributes{
 				types.AttrTitle: "foo",
 			},
@@ -95,16 +95,16 @@ var _ = Describe("preambles", func() {
 			Footnotes:          types.Footnotes{},
 			FootnoteReferences: types.FootnoteReferences{},
 			Elements: []interface{}{
-				&types.Paragraph{
+				types.Paragraph{
 					Attributes: types.ElementAttributes{},
 					Lines: []types.InlineElements{
 						{
-							&types.StringElement{Content: "a short paragraph"},
+							types.StringElement{Content: "a short paragraph"},
 						},
 					},
 				},
 				types.BlankLine{},
-				&types.Section{
+				types.Section{
 					Level: 1,
 					Title: sectionATitle,
 					Attributes: types.ElementAttributes{
@@ -114,7 +114,7 @@ var _ = Describe("preambles", func() {
 
 					Elements: []interface{}{},
 				},
-				&types.Section{
+				types.Section{
 					Level: 1,
 					Title: sectionBTitle,
 					Attributes: types.ElementAttributes{
@@ -125,7 +125,7 @@ var _ = Describe("preambles", func() {
 				},
 			},
 		}
-		expectedContent := &types.Document{
+		expectedContent := types.Document{
 			Attributes: types.DocumentAttributes{
 				types.AttrTitle: "foo",
 			},
@@ -136,20 +136,20 @@ var _ = Describe("preambles", func() {
 			Footnotes:          types.Footnotes{},
 			FootnoteReferences: types.FootnoteReferences{},
 			Elements: []interface{}{
-				&types.Preamble{
+				types.Preamble{
 					Elements: []interface{}{
-						&types.Paragraph{
+						types.Paragraph{
 							Attributes: types.ElementAttributes{},
 							Lines: []types.InlineElements{
 								{
-									&types.StringElement{Content: "a short paragraph"},
+									types.StringElement{Content: "a short paragraph"},
 								},
 							},
 						},
 						types.BlankLine{},
 					},
 				},
-				&types.Section{
+				types.Section{
 					Level: 1,
 					Title: sectionATitle,
 					Attributes: types.ElementAttributes{
@@ -159,7 +159,7 @@ var _ = Describe("preambles", func() {
 
 					Elements: []interface{}{},
 				},
-				&types.Section{
+				types.Section{
 					Level: 1,
 					Title: sectionBTitle,
 					Attributes: types.ElementAttributes{
@@ -174,7 +174,7 @@ var _ = Describe("preambles", func() {
 	})
 
 	It("doc with 2-paragraph preamble", func() {
-		source := &types.Document{
+		source := types.Document{
 			Attributes: types.DocumentAttributes{
 				types.AttrTitle: "foo",
 			},
@@ -185,25 +185,25 @@ var _ = Describe("preambles", func() {
 			Footnotes:          types.Footnotes{},
 			FootnoteReferences: types.FootnoteReferences{},
 			Elements: []interface{}{
-				&types.Paragraph{
+				types.Paragraph{
 					Attributes: types.ElementAttributes{},
 					Lines: []types.InlineElements{
 						{
-							&types.StringElement{Content: "a short paragraph"},
+							types.StringElement{Content: "a short paragraph"},
 						},
 					},
 				},
 				types.BlankLine{},
-				&types.Paragraph{
+				types.Paragraph{
 					Attributes: types.ElementAttributes{},
 					Lines: []types.InlineElements{
 						{
-							&types.StringElement{Content: "another short paragraph"},
+							types.StringElement{Content: "another short paragraph"},
 						},
 					},
 				},
 				types.BlankLine{},
-				&types.Section{
+				types.Section{
 					Level: 1,
 					Title: sectionATitle,
 					Attributes: types.ElementAttributes{
@@ -213,7 +213,7 @@ var _ = Describe("preambles", func() {
 
 					Elements: []interface{}{},
 				},
-				&types.Section{
+				types.Section{
 					Level: 1,
 					Title: sectionBTitle,
 					Attributes: types.ElementAttributes{
@@ -224,7 +224,7 @@ var _ = Describe("preambles", func() {
 				},
 			},
 		}
-		expectedContent := &types.Document{
+		expectedContent := types.Document{
 			Attributes: types.DocumentAttributes{
 				types.AttrTitle: "foo",
 			},
@@ -235,29 +235,29 @@ var _ = Describe("preambles", func() {
 			Footnotes:          types.Footnotes{},
 			FootnoteReferences: types.FootnoteReferences{},
 			Elements: []interface{}{
-				&types.Preamble{
+				types.Preamble{
 					Elements: []interface{}{
-						&types.Paragraph{
+						types.Paragraph{
 							Attributes: types.ElementAttributes{},
 							Lines: []types.InlineElements{
 								{
-									&types.StringElement{Content: "a short paragraph"},
+									types.StringElement{Content: "a short paragraph"},
 								},
 							},
 						},
 						types.BlankLine{},
-						&types.Paragraph{
+						types.Paragraph{
 							Attributes: types.ElementAttributes{},
 							Lines: []types.InlineElements{
 								{
-									&types.StringElement{Content: "another short paragraph"},
+									types.StringElement{Content: "another short paragraph"},
 								},
 							},
 						},
 						types.BlankLine{},
 					},
 				},
-				&types.Section{
+				types.Section{
 					Level: 1,
 					Title: sectionATitle,
 					Attributes: types.ElementAttributes{
@@ -267,7 +267,7 @@ var _ = Describe("preambles", func() {
 
 					Elements: []interface{}{},
 				},
-				&types.Section{
+				types.Section{
 					Level: 1,
 					Title: sectionBTitle,
 					Attributes: types.ElementAttributes{
@@ -283,7 +283,7 @@ var _ = Describe("preambles", func() {
 
 })
 
-func verifyPreamble(expectedContent, source *types.Document) {
+func verifyPreamble(expectedContent, source types.Document) {
 	ctx := renderer.Wrap(context.Background(), source)
 	renderer.IncludePreamble(ctx)
 	assert.Equal(GinkgoT(), expectedContent, ctx.Document)

--- a/pkg/renderer/table_of_contents.go
+++ b/pkg/renderer/table_of_contents.go
@@ -9,17 +9,17 @@ import (
 // if the `toc` attribute is present
 func IncludeTableOfContents(ctx *Context) {
 	if d, found := types.SearchAttributeDeclaration(ctx.Document.Elements, types.AttrTableOfContents); found {
-		insertTableOfContents(ctx.Document, d.Value)
+		ctx.Document = insertTableOfContents(ctx.Document, d.Value)
 	}
 }
 
-func insertTableOfContents(doc *types.Document, location string) {
+func insertTableOfContents(doc types.Document, location string) types.Document {
 	log.Debugf("inserting a table of contents at location `%s`", location)
 	// insert a TableOfContentsMacro element if `toc` value is:
 	// - "auto" (or empty)
 	// - "preamble"
 	log.Debugf("inserting ToC macro with placement: '%s'", location)
-	toc := &types.TableOfContentsMacro{}
+	toc := types.TableOfContentsMacro{}
 	switch location {
 	case "", "auto":
 		// insert TableOfContentsMacro at first position (in section0 if it exists)
@@ -44,11 +44,12 @@ func insertTableOfContents(doc *types.Document, location string) {
 	default:
 		log.Warnf("invalid or unsupported value for 'toc' attribute: '%s'", location)
 	}
+	return doc
 }
 
 func lookupPreamble(elements []interface{}) (int, bool) {
 	for i, e := range elements {
-		if _, ok := e.(*types.Preamble); ok {
+		if _, ok := e.(types.Preamble); ok {
 			return i, true
 		}
 	}

--- a/pkg/renderer/table_of_contents_test.go
+++ b/pkg/renderer/table_of_contents_test.go
@@ -15,42 +15,42 @@ var _ = Describe("table of contents", func() {
 	doctitle := types.InlineElements{
 		types.StringElement{Content: "A Title"},
 	}
-	toc := &types.DocumentAttributeDeclaration{
+	toc := types.DocumentAttributeDeclaration{
 		Name: "toc",
 	}
-	preambletoc := &types.DocumentAttributeDeclaration{
+	preambletoc := types.DocumentAttributeDeclaration{
 		Name:  "toc",
 		Value: "preamble",
 	}
-	preamble := &types.Preamble{
+	preamble := types.Preamble{
 		Elements: []interface{}{
-			&types.BlankLine{},
-			&types.Paragraph{
+			types.BlankLine{},
+			types.Paragraph{
 				Attributes: types.ElementAttributes{},
 				Lines: []types.InlineElements{
 					{
-						&types.StringElement{Content: "A short preamble"},
+						types.StringElement{Content: "A short preamble"},
 					},
 				},
 			},
-			&types.BlankLine{},
+			types.BlankLine{},
 		},
 	}
-	section := &types.Section{
+	section := types.Section{
 		Level: 1,
 		Attributes: types.ElementAttributes{
 			types.AttrID:       "section_1",
 			types.AttrCustomID: false,
 		},
 		Title: types.InlineElements{
-			&types.StringElement{Content: "section 1"},
+			types.StringElement{Content: "section 1"},
 		},
 		Elements: []interface{}{},
 	}
-	tableOfContents := &types.TableOfContentsMacro{}
+	tableOfContents := types.TableOfContentsMacro{}
 
 	It("table of contents with default placement and no header with content", func() {
-		source := &types.Document{
+		source := types.Document{
 			Attributes:         types.DocumentAttributes{},
 			ElementReferences:  types.ElementReferences{}, // can leave empty for this test
 			Footnotes:          types.Footnotes{},
@@ -61,7 +61,7 @@ var _ = Describe("table of contents", func() {
 				section,
 			},
 		}
-		expected := &types.Document{
+		expected := types.Document{
 			Attributes:         types.DocumentAttributes{},
 			ElementReferences:  types.ElementReferences{},
 			Footnotes:          types.Footnotes{},
@@ -77,13 +77,13 @@ var _ = Describe("table of contents", func() {
 	})
 
 	It("table of contents with default placement and a header with content", func() {
-		source := &types.Document{
+		source := types.Document{
 			Attributes:         types.DocumentAttributes{},
 			ElementReferences:  types.ElementReferences{}, // can leave empty for this test
 			Footnotes:          types.Footnotes{},
 			FootnoteReferences: types.FootnoteReferences{},
 			Elements: []interface{}{
-				&types.Section{
+				types.Section{
 					Level: 0,
 					Title: doctitle,
 					Attributes: types.ElementAttributes{
@@ -98,13 +98,13 @@ var _ = Describe("table of contents", func() {
 				},
 			},
 		}
-		expected := &types.Document{
+		expected := types.Document{
 			Attributes:         types.DocumentAttributes{},
 			ElementReferences:  types.ElementReferences{}, // can leave empty for this test
 			Footnotes:          types.Footnotes{},
 			FootnoteReferences: types.FootnoteReferences{},
 			Elements: []interface{}{
-				&types.Section{
+				types.Section{
 					Level: 0,
 					Title: doctitle,
 					Attributes: types.ElementAttributes{
@@ -124,13 +124,13 @@ var _ = Describe("table of contents", func() {
 	})
 
 	It("table of contents with default placement and a header without content", func() {
-		source := &types.Document{
+		source := types.Document{
 			Attributes:         types.DocumentAttributes{},
 			ElementReferences:  types.ElementReferences{}, // can leave empty for this test
 			Footnotes:          types.Footnotes{},
 			FootnoteReferences: types.FootnoteReferences{},
 			Elements: []interface{}{
-				&types.Section{
+				types.Section{
 					Level: 0,
 					Title: doctitle,
 					Attributes: types.ElementAttributes{
@@ -144,13 +144,13 @@ var _ = Describe("table of contents", func() {
 				},
 			},
 		}
-		expected := &types.Document{
+		expected := types.Document{
 			Attributes:         types.DocumentAttributes{},
 			ElementReferences:  types.ElementReferences{}, // can leave empty for this test
 			Footnotes:          types.Footnotes{},
 			FootnoteReferences: types.FootnoteReferences{},
 			Elements: []interface{}{
-				&types.Section{
+				types.Section{
 					Level: 0,
 					Title: doctitle,
 					Attributes: types.ElementAttributes{
@@ -169,7 +169,7 @@ var _ = Describe("table of contents", func() {
 	})
 
 	It("table of contents with preamble placement and no header with content", func() {
-		source := &types.Document{
+		source := types.Document{
 			Attributes:         types.DocumentAttributes{},
 			ElementReferences:  types.ElementReferences{},
 			Footnotes:          types.Footnotes{},
@@ -180,7 +180,7 @@ var _ = Describe("table of contents", func() {
 				section,
 			},
 		}
-		expected := &types.Document{
+		expected := types.Document{
 			Attributes:         types.DocumentAttributes{},
 			ElementReferences:  types.ElementReferences{},
 			Footnotes:          types.Footnotes{},
@@ -196,13 +196,13 @@ var _ = Describe("table of contents", func() {
 	})
 
 	It("table of contents with preamble placement and header with content", func() {
-		source := &types.Document{
+		source := types.Document{
 			Attributes:         types.DocumentAttributes{},
 			ElementReferences:  types.ElementReferences{},
 			Footnotes:          types.Footnotes{},
 			FootnoteReferences: types.FootnoteReferences{},
 			Elements: []interface{}{
-				&types.Section{
+				types.Section{
 					Level: 0,
 					Title: doctitle,
 					Attributes: types.ElementAttributes{
@@ -217,13 +217,13 @@ var _ = Describe("table of contents", func() {
 				},
 			},
 		}
-		expected := &types.Document{
+		expected := types.Document{
 			Attributes:         types.DocumentAttributes{},
 			ElementReferences:  types.ElementReferences{},
 			Footnotes:          types.Footnotes{},
 			FootnoteReferences: types.FootnoteReferences{},
 			Elements: []interface{}{
-				&types.Section{
+				types.Section{
 					Level: 0,
 					Title: doctitle,
 					Attributes: types.ElementAttributes{
@@ -243,13 +243,13 @@ var _ = Describe("table of contents", func() {
 	})
 
 	It("table of contents with preamble placement and header without content", func() {
-		source := &types.Document{
+		source := types.Document{
 			Attributes:         types.DocumentAttributes{},
 			ElementReferences:  types.ElementReferences{},
 			Footnotes:          types.Footnotes{},
 			FootnoteReferences: types.FootnoteReferences{},
 			Elements: []interface{}{
-				&types.Section{
+				types.Section{
 					Level: 0,
 					Title: doctitle,
 					Attributes: types.ElementAttributes{
@@ -263,13 +263,13 @@ var _ = Describe("table of contents", func() {
 				},
 			},
 		}
-		expected := &types.Document{
+		expected := types.Document{
 			Attributes:         types.DocumentAttributes{},
 			ElementReferences:  types.ElementReferences{},
 			Footnotes:          types.Footnotes{},
 			FootnoteReferences: types.FootnoteReferences{},
 			Elements: []interface{}{
-				&types.Section{
+				types.Section{
 					Level: 0,
 					Title: doctitle,
 					Attributes: types.ElementAttributes{
@@ -289,7 +289,7 @@ var _ = Describe("table of contents", func() {
 
 })
 
-func verifyTableOfContents(expectedContent, source *types.Document) {
+func verifyTableOfContents(expectedContent, source types.Document) {
 	ctx := renderer.Wrap(context.Background(), source)
 	renderer.IncludeTableOfContents(ctx)
 	assert.Equal(GinkgoT(), expectedContent, ctx.Document)

--- a/pkg/types/document_attributes.go
+++ b/pkg/types/document_attributes.go
@@ -59,12 +59,12 @@ func (a DocumentAttributes) AddNonEmpty(key string, value interface{}) {
 
 // AddDeclaration adds the given attribute
 // TODO: raise a warning if there was already a name/value
-func (a DocumentAttributes) AddDeclaration(attr *DocumentAttributeDeclaration) {
+func (a DocumentAttributes) AddDeclaration(attr DocumentAttributeDeclaration) {
 	a.Add(attr.Name, attr.Value)
 }
 
 // Reset resets the given attribute
-func (a DocumentAttributes) Reset(attr *DocumentAttributeReset) {
+func (a DocumentAttributes) Reset(attr DocumentAttributeReset) {
 	delete(a, attr.Name)
 }
 

--- a/pkg/types/element_attributes.go
+++ b/pkg/types/element_attributes.go
@@ -65,7 +65,7 @@ type ElementWithAttributes interface {
 
 // NewElementID initializes a new attribute map with a single entry for the ID using the given value
 func NewElementID(id string) (ElementAttributes, error) {
-	log.Debugf("initializing a new ElementID with ID=%s", id)
+	// log.Debugf("initializing a new ElementID with ID=%s", id)
 	return ElementAttributes{
 		AttrID:       id,
 		AttrCustomID: true,
@@ -88,7 +88,7 @@ func NewElementTitle(title string) (ElementAttributes, error) {
 
 // NewElementRole initializes a new attribute map with a single entry for the title using the given value
 func NewElementRole(role string) (ElementAttributes, error) {
-	log.Debugf("initializing a new ElementRole with content=%s", role)
+	// log.Debugf("initializing a new ElementRole with content=%s", role)
 	return ElementAttributes{
 		AttrRole: role,
 	}, nil
@@ -293,7 +293,7 @@ func (a ElementAttributes) AddNonEmpty(key string, value interface{}) {
 func NewElementAttributes(attributes []interface{}, extras ...ElementAttributes) ElementAttributes {
 	attrs := ElementAttributes{}
 	for _, attr := range attributes {
-		log.Debugf("processing attribute %[1]v (%[1]T)", attr)
+		// log.Debugf("processing attribute %[1]v (%[1]T)", attr)
 		switch attr := attr.(type) {
 		case []interface{}:
 			// nested case, because of the grammar syntax,

--- a/pkg/types/footnotes_collector.go
+++ b/pkg/types/footnotes_collector.go
@@ -7,7 +7,7 @@ import (
 // Footnotes the footnotes of a document. Footnotes are "collected"
 // during the parsing phase and displayed at the bottom of the document
 // during the rendering.
-type Footnotes []*Footnote
+type Footnotes []Footnote
 
 // FootnotesContainer interface for all types which may contain footnotes
 type FootnotesContainer interface {
@@ -15,7 +15,7 @@ type FootnotesContainer interface {
 }
 
 // IndexOf returns the index of the given note in the footnotes.
-func (f Footnotes) IndexOf(note *Footnote) (int, bool) {
+func (f Footnotes) IndexOf(note Footnote) (int, bool) {
 	for i, n := range f {
 		if n.ID == note.ID {
 			return i, true
@@ -25,7 +25,7 @@ func (f Footnotes) IndexOf(note *Footnote) (int, bool) {
 }
 
 // FootnoteReferences some footnote have a ref to be re-used in the document
-type FootnoteReferences map[string]*Footnote
+type FootnoteReferences map[string]Footnote
 
 // FootnotesCollector the visitor that traverses the whole document structure in search for footnotes
 type FootnotesCollector struct {
@@ -38,14 +38,14 @@ var _ Visitor = &FootnotesCollector{}
 // NewFootnotesCollector initializes a new FootnotesCollector
 func NewFootnotesCollector() *FootnotesCollector {
 	return &FootnotesCollector{
-		Footnotes:          make([]*Footnote, 0),
-		FootnoteReferences: make(map[string]*Footnote),
+		Footnotes:          make([]Footnote, 0),
+		FootnoteReferences: make(map[string]Footnote),
 	}
 }
 
 // Visit Implements Visitable#Visit()
 func (c *FootnotesCollector) Visit(element Visitable) error {
-	if note, ok := element.(*Footnote); ok {
+	if note, ok := element.(Footnote); ok {
 		if len(note.Elements) > 0 { // a foot note with some content
 			c.Footnotes = append(c.Footnotes, note)
 			log.Debugf("indexed footnote to %d", len(c.Footnotes))

--- a/pkg/types/footnotes_collector_test.go
+++ b/pkg/types/footnotes_collector_test.go
@@ -12,28 +12,28 @@ var _ = Describe("footnotes collector", func() {
 
 	It("index footnotes without reference", func() {
 		// given
-		footnote1 := &types.Footnote{
+		footnote1 := types.Footnote{
 			ID: 0,
 			Elements: types.InlineElements{
-				&types.StringElement{
+				types.StringElement{
 					Content: "a note",
 				},
 			},
 		}
-		footnote2 := &types.Footnote{
+		footnote2 := types.Footnote{
 			ID: 1,
 			Elements: types.InlineElements{
-				&types.StringElement{
+				types.StringElement{
 					Content: "another note",
 				},
 			},
 		}
 		content := types.InlineElements{
-			&types.StringElement{
+			types.StringElement{
 				Content: "foo",
 			},
 			footnote1,
-			&types.StringElement{
+			types.StringElement{
 				Content: "bar",
 			},
 			footnote2,
@@ -51,26 +51,26 @@ var _ = Describe("footnotes collector", func() {
 
 	It("index footnotes with reference", func() {
 		// given
-		footnote1 := &types.Footnote{
+		footnote1 := types.Footnote{
 			Ref: "ref",
 			Elements: types.InlineElements{
-				&types.StringElement{
+				types.StringElement{
 					Content: "a note",
 				},
 			},
 		}
-		footnote2 := &types.Footnote{
+		footnote2 := types.Footnote{
 			Ref: "ref",
 		}
-		footnote3 := &types.Footnote{
+		footnote3 := types.Footnote{
 			Ref: "ref",
 		}
 		content := types.InlineElements{
-			&types.StringElement{
+			types.StringElement{
 				Content: "foo",
 			},
 			footnote1,
-			&types.StringElement{
+			types.StringElement{
 				Content: "bar",
 			},
 			footnote2,

--- a/pkg/types/grammar_types_test.go
+++ b/pkg/types/grammar_types_test.go
@@ -107,17 +107,17 @@ var _ = Describe("Location resolution", func() {
 			Expect(f.Location.Resolve(attrs)).Should(Equal(expectation))
 		},
 		Entry("includes/file.ext", types.Location{
-			&types.StringElement{Content: "includes/file.ext"},
+			types.StringElement{Content: "includes/file.ext"},
 		}, "includes/file.ext"),
 		Entry("./{includedir}/file.ext", types.Location{
-			&types.StringElement{Content: "./"},
-			&types.DocumentAttributeSubstitution{Name: "includedir"},
-			&types.StringElement{Content: "/file.ext"},
+			types.StringElement{Content: "./"},
+			types.DocumentAttributeSubstitution{Name: "includedir"},
+			types.StringElement{Content: "/file.ext"},
 		}, "./includes/file.ext"),
 		Entry("./{unknown}/file.ext", types.Location{
-			&types.StringElement{Content: "./"},
-			&types.DocumentAttributeSubstitution{Name: "unknown"},
-			&types.StringElement{Content: "/file.ext"},
+			types.StringElement{Content: "./"},
+			types.DocumentAttributeSubstitution{Name: "unknown"},
+			types.StringElement{Content: "/file.ext"},
 		}, "./{unknown}/file.ext"),
 	)
 })

--- a/pkg/types/grammar_types_utils.go
+++ b/pkg/types/grammar_types_utils.go
@@ -144,22 +144,22 @@ func toString(lines []interface{}) ([]string, error) {
 }
 
 // SearchAttributeDeclaration returns the value of the DocumentAttributeDeclaration whose name is given
-func SearchAttributeDeclaration(elements []interface{}, name string) (*DocumentAttributeDeclaration, bool) {
+func SearchAttributeDeclaration(elements []interface{}, name string) (DocumentAttributeDeclaration, bool) {
 	for _, e := range elements {
 		switch e := e.(type) {
-		case *Section:
+		case Section:
 			if result, found := SearchAttributeDeclaration(e.Elements, name); found {
 				return result, found
 			}
-		case *Preamble:
+		case Preamble:
 			if result, found := SearchAttributeDeclaration(e.Elements, name); found {
 				return result, found
 			}
-		case *DocumentAttributeDeclaration:
+		case DocumentAttributeDeclaration:
 			if e.Name == name {
 				return e, true
 			}
 		}
 	}
-	return nil, false
+	return DocumentAttributeDeclaration{}, false
 }

--- a/pkg/types/grammar_types_utils_test.go
+++ b/pkg/types/grammar_types_utils_test.go
@@ -11,11 +11,11 @@ var _ = Describe("convert to inline elements", func() {
 
 	It("inline content without trailing spaces", func() {
 		source := []interface{}{
-			&StringElement{Content: "hello"},
-			&StringElement{Content: "world"},
+			StringElement{Content: "hello"},
+			StringElement{Content: "world"},
 		}
 		expected := InlineElements{
-			&StringElement{Content: "helloworld"},
+			StringElement{Content: "helloworld"},
 		}
 		// when
 		result := mergeElements(source...)
@@ -24,11 +24,11 @@ var _ = Describe("convert to inline elements", func() {
 	})
 	It("inline content with trailing spaces", func() {
 		source := []interface{}{
-			&StringElement{Content: "hello, "},
-			&StringElement{Content: "world   "},
+			StringElement{Content: "hello, "},
+			StringElement{Content: "world   "},
 		}
 		expected := InlineElements{
-			&StringElement{Content: "hello, world   "},
+			StringElement{Content: "hello, world   "},
 		}
 		// when
 		result := mergeElements(source...)
@@ -41,35 +41,35 @@ var _ = Describe("normalizing string", func() {
 
 	It("hello", func() {
 		source := InlineElements{
-			&StringElement{Content: "hello"},
+			StringElement{Content: "hello"},
 		}
 		verify(GinkgoT(), "hello", source)
 	})
 
 	It("héllo with an accent", func() {
 		source := InlineElements{
-			&StringElement{Content: "  héllo 1.2   and 3 Spaces"},
+			StringElement{Content: "  héllo 1.2   and 3 Spaces"},
 		}
 		verify(GinkgoT(), "héllo_1_2_and_3_spaces", source)
 	})
 
 	It("a an accent and a swedish character", func() {
 		source := InlineElements{
-			&StringElement{Content: `A à ⌘`},
+			StringElement{Content: `A à ⌘`},
 		}
 		verify(GinkgoT(), `a_à`, source)
 	})
 
 	It("AŁA", func() {
 		source := InlineElements{
-			&StringElement{Content: `AŁA 0.1 ?`},
+			StringElement{Content: `AŁA 0.1 ?`},
 		}
 		verify(GinkgoT(), `ała_0_1`, source)
 	})
 
 	It("it's  2 spaces, here !", func() {
 		source := InlineElements{
-			&StringElement{Content: `it's  2 spaces, here !`},
+			StringElement{Content: `it's  2 spaces, here !`},
 		}
 		verify(GinkgoT(), `it_s_2_spaces_here`, source)
 	})
@@ -77,11 +77,11 @@ var _ = Describe("normalizing string", func() {
 	It("content with <strong> markup", func() {
 		// == a section title, with *bold content*
 		source := InlineElements{
-			&StringElement{Content: "a section title, with"},
+			StringElement{Content: "a section title, with"},
 			QuotedText{
 				Kind: Bold,
 				Elements: []interface{}{
-					&StringElement{Content: "bold content"},
+					StringElement{Content: "bold content"},
 				},
 			},
 		}
@@ -105,19 +105,19 @@ var _ = Describe("filter elements", func() {
 		source := []interface{}{
 			BlankLine{},
 			Preamble{},
-			&StringElement{
+			StringElement{
 				Content: "foo",
 			},
 			Preamble{
 				Elements: []interface{}{
-					&StringElement{
+					StringElement{
 						Content: "bar",
 					},
 				},
 			},
 			[]interface{}{
 				BlankLine{},
-				&StringElement{
+				StringElement{
 					Content: "baz",
 				},
 			},
@@ -126,17 +126,17 @@ var _ = Describe("filter elements", func() {
 		result := filterEmptyElements(source, filterBlankLine(), filterEmptyPreamble())
 		// then
 		expected := []interface{}{
-			&StringElement{
+			StringElement{
 				Content: "foo",
 			},
 			Preamble{
 				Elements: []interface{}{
-					&StringElement{
+					StringElement{
 						Content: "bar",
 					},
 				},
 			},
-			&StringElement{
+			StringElement{
 				Content: "baz",
 			},
 		}


### PR DESCRIPTION
Impacts parser and renderer.
No effect on overall performances, but make code
easier to read and test.

updates #361

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>