### PR TITLE
test(renderer): verify log output when error is logged

### DIFF
--- a/pkg/renderer/html5/file_inclusion_test.go
+++ b/pkg/renderer/html5/file_inclusion_test.go
@@ -582,27 +582,41 @@ last line of grandchild</pre>
 		Context("in standalone block", func() {
 
 			It("should replace with string element if file is missing", func() {
+				// setup logger to write in a buffer so we can check the output
+				console, reset := configureLogger()
+				defer reset()
 
 				source := `include::../../../test/includes/unknown.adoc[leveloffset=+1]`
 				expected := `<div class="paragraph">
 <p>Unresolved directive in foo.adoc - include::../../../test/includes/unknown.adoc[leveloffset=&#43;1]</p>
 </div>`
 				verify("foo.adoc", expected, source)
+				// verify error in logs
+				verifyConsoleOutput(console, "failed to include '../../../test/includes/unknown.adoc'")
 			})
 
 			It("should replace with string element if file with attribute in path is not resolved", func() {
+				// setup logger to write in a buffer so we can check the output
+				console, reset := configureLogger()
+				defer reset()
 
 				source := `include::{includedir}/unknown.adoc[leveloffset=+1]`
 				expected := `<div class="paragraph">
 <p>Unresolved directive in foo.adoc - include::{includedir}/unknown.adoc[leveloffset=&#43;1]</p>
 </div>`
 				verify("foo.adoc", expected, source)
+				// verify error in logs
+				verifyConsoleOutput(console, "failed to include '{includedir}/unknown.adoc'")
 			})
 		})
 
 		Context("in listing block", func() {
 
 			It("should replace with string element if file is missing", func() {
+				// setup logger to write in a buffer so we can check the output
+				console, reset := configureLogger()
+				defer reset()
+
 				source := `----
 include::../../../test/includes/unknown.adoc[leveloffset=+1]
 ----`
@@ -612,9 +626,15 @@ include::../../../test/includes/unknown.adoc[leveloffset=+1]
 </div>
 </div>`
 				verify("foo.adoc", expected, source)
+				// verify error in logs
+				verifyConsoleOutput(console, "failed to include '../../../test/includes/unknown.adoc'")
 			})
 
 			It("should replace with string element if file with attribute in path is not resolved", func() {
+				// setup logger to write in a buffer so we can check the output
+				console, reset := configureLogger()
+				defer reset()
+
 				source := `----
 include::{includedir}/unknown.adoc[leveloffset=+1]
 ----`
@@ -624,6 +644,8 @@ include::{includedir}/unknown.adoc[leveloffset=+1]
 </div>
 </div>`
 				verify("foo.adoc", expected, source)
+				// verify error in logs
+				verifyConsoleOutput(console, "failed to include '{includedir}/unknown.adoc'")
 			})
 		})
 	})

--- a/pkg/renderer/html5/html5_test.go
+++ b/pkg/renderer/html5/html5_test.go
@@ -3,16 +3,20 @@ package html5_test
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"strings"
+	"os"
 
 	"github.com/bytesparadise/libasciidoc/pkg/parser"
 	"github.com/bytesparadise/libasciidoc/pkg/renderer"
 	"github.com/bytesparadise/libasciidoc/pkg/renderer/html5"
 	"github.com/davecgh/go-spew/spew"
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	"github.com/sergi/go-diff/diffmatchpatch"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	log "github.com/sirupsen/logrus"
 )
 
 func verify(filename, expected, content string, rendererOpts ...renderer.Option) {
@@ -37,4 +41,32 @@ func verify(filename, expected, content string, rendererOpts ...renderer.Option)
 	dmp := diffmatchpatch.New()
 	diffs := dmp.DiffMain(result, expected, true)
 	assert.Equal(GinkgoT(), expected, result, dmp.DiffPrettyText(diffs))
+}
+
+func verifyConsoleOutput(console Readable, errorMsg string) {
+	GinkgoT().Logf(console.String())
+	out := make(map[string]interface{})
+	err := json.Unmarshal(console.Bytes(), &out)
+	Expect(err).ShouldNot(HaveOccurred())
+	Expect(out["level"]).Should(Equal("error"))
+	Expect(out["msg"]).Should(Equal(errorMsg))
+}
+
+func configureLogger() (Readable, func()) {
+	fmtr := log.StandardLogger().Formatter
+
+	buf := bytes.NewBuffer(nil)
+	log.SetOutput(buf)
+	log.SetFormatter(&log.JSONFormatter{
+		DisableTimestamp: true,
+	})
+	return buf, func() {
+		log.SetOutput(os.Stdout)
+		log.SetFormatter(fmtr)
+	}
+}
+
+type Readable interface {
+	Bytes() []byte
+	String() string
 }


### PR DESCRIPTION
same assertions as in `pkg/parser`, but in `pkg/renderer/html5`
this time.

fixes #394

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>