### PR TITLE
refactor(test): support multiple lines in console assertions

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,6 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
-github.com/mna/pigeon v1.0.1-0.20190506201543-b16e08c107ab h1:19Cpo96rw6zXDezl+lUTTD2IjvpLTwJ5ZPzGBEeLMj4=
-github.com/mna/pigeon v1.0.1-0.20190506201543-b16e08c107ab/go.mod h1:Iym28+kJVnC1hfQvv5MUtI6AiFFzvQjHcvI4RFTG/04=
 github.com/mna/pigeon v1.0.1-0.20190909211542-7ee56e19b15c h1:QRaadf9Fu8xAfNDS8PvaM0VmY2FnYHlddtnIExKj68k=
 github.com/mna/pigeon v1.0.1-0.20190909211542-7ee56e19b15c/go.mod h1:rkFeDZ0gc+YbnrXPw0q2RlI0QRuKBBPu67fgYIyGRNg=
 github.com/modocache/gover v0.0.0-20171022184752-b58185e213c5 h1:8Q0qkMVC/MmWkpIdlvZgcv2o2jrlF6zqVOh7W5YHdMA=
@@ -68,8 +66,6 @@ golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190830223141-573d9926052a/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
-golang.org/x/tools v0.0.0-20190910165522-3cd124fa3ebb h1:q+qmsnbeqlfXORhdAMhfM1mQ9y8XT9v3q89kodyX9zo=
-golang.org/x/tools v0.0.0-20190910165522-3cd124fa3ebb/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20190911174233-4f2ddba30aff h1:On1qIo75ByTwFJ4/W2bIqHcwJ9XAqtSWUs8GwRrIhtc=
 golang.org/x/tools v0.0.0-20190911174233-4f2ddba30aff/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/pkg/parser/file_inclusion_test.go
+++ b/pkg/parser/file_inclusion_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -807,7 +808,11 @@ include::../../test/includes/chapter-a.adoc[]
 			}
 			verifyPreflight("test.adoc", expected, source)
 			// verify error in logs
-			testsupport.VerifyConsoleOutput(console, log.ErrorLevel, "detected unclosed tag 'unclosed' starting at line 6 of include file: ../../test/includes/tag-include.adoc")
+			Expect(console).To(
+				testsupport.ContainMessageWithLevel(
+					log.ErrorLevel,
+					"detected unclosed tag 'unclosed' starting at line 6 of include file: ../../test/includes/tag-include.adoc",
+				))
 		})
 
 		It("file inclusion with unknown tag", func() {
@@ -822,7 +827,11 @@ include::../../test/includes/chapter-a.adoc[]
 			// when/then
 			verifyPreflight("test.adoc", expected, source)
 			// verify error in logs
-			testsupport.VerifyConsoleOutput(console, log.ErrorLevel, "tag 'unknown' not found in include file: ../../test/includes/tag-include.adoc")
+			Expect(console).To(
+				testsupport.ContainMessageWithLevel(
+					log.ErrorLevel,
+					"tag 'unknown' not found in include file: ../../test/includes/tag-include.adoc",
+				))
 		})
 
 		It("file inclusion with no tag", func() {
@@ -896,7 +905,11 @@ include::../../test/includes/chapter-a.adoc[]
 			}
 			verifyPreflight("foo.adoc", expected, source)
 			// verify error in logs
-			testsupport.VerifyConsoleOutput(console, log.ErrorLevel, "failed to include '{unknown}/unknown.adoc'")
+			Expect(console).To(
+				testsupport.ContainMessageWithLevel(
+					log.ErrorLevel,
+					"failed to include '{unknown}/unknown.adoc'",
+				))
 		})
 
 		It("should replace with string element if file is missing in standalone block", func() {
@@ -921,7 +934,11 @@ include::../../test/includes/chapter-a.adoc[]
 			}
 			verifyPreflight("foo.adoc", expected, source)
 			// verify error in logs
-			testsupport.VerifyConsoleOutput(console, log.ErrorLevel, "failed to include '../../test/includes/unknown.adoc'")
+			Expect(console).To(
+				testsupport.ContainMessageWithLevel(
+					log.ErrorLevel,
+					"failed to include '../../test/includes/unknown.adoc'",
+				))
 		})
 
 		It("should replace with string element if file is missing in delimited block", func() {
@@ -954,7 +971,11 @@ include::../../test/includes/unknown.adoc[leveloffset=+1]
 			}
 			verifyPreflight("foo.adoc", expected, source)
 			// verify error in logs
-			testsupport.VerifyConsoleOutput(console, log.ErrorLevel, "failed to include '../../test/includes/unknown.adoc'")
+			Expect(console).To(
+				testsupport.ContainMessageWithLevel(
+					log.ErrorLevel,
+					"failed to include '../../test/includes/unknown.adoc'",
+				))
 		})
 	})
 

--- a/pkg/parser/file_inclusion_test.go
+++ b/pkg/parser/file_inclusion_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
+	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -806,7 +807,7 @@ include::../../test/includes/chapter-a.adoc[]
 			}
 			verifyPreflight("test.adoc", expected, source)
 			// verify error in logs
-			testsupport.VerifyConsoleOutput(console, "detected unclosed tag 'unclosed' starting at line 6 of include file: ../../test/includes/tag-include.adoc")
+			testsupport.VerifyConsoleOutput(console, log.ErrorLevel, "detected unclosed tag 'unclosed' starting at line 6 of include file: ../../test/includes/tag-include.adoc")
 		})
 
 		It("file inclusion with unknown tag", func() {
@@ -821,7 +822,7 @@ include::../../test/includes/chapter-a.adoc[]
 			// when/then
 			verifyPreflight("test.adoc", expected, source)
 			// verify error in logs
-			testsupport.VerifyConsoleOutput(console, "tag 'unknown' not found in include file: ../../test/includes/tag-include.adoc")
+			testsupport.VerifyConsoleOutput(console, log.ErrorLevel, "tag 'unknown' not found in include file: ../../test/includes/tag-include.adoc")
 		})
 
 		It("file inclusion with no tag", func() {
@@ -895,7 +896,7 @@ include::../../test/includes/chapter-a.adoc[]
 			}
 			verifyPreflight("foo.adoc", expected, source)
 			// verify error in logs
-			testsupport.VerifyConsoleOutput(console, "failed to include '{unknown}/unknown.adoc'")
+			testsupport.VerifyConsoleOutput(console, log.ErrorLevel, "failed to include '{unknown}/unknown.adoc'")
 		})
 
 		It("should replace with string element if file is missing in standalone block", func() {
@@ -920,7 +921,7 @@ include::../../test/includes/chapter-a.adoc[]
 			}
 			verifyPreflight("foo.adoc", expected, source)
 			// verify error in logs
-			testsupport.VerifyConsoleOutput(console, "failed to include '../../test/includes/unknown.adoc'")
+			testsupport.VerifyConsoleOutput(console, log.ErrorLevel, "failed to include '../../test/includes/unknown.adoc'")
 		})
 
 		It("should replace with string element if file is missing in delimited block", func() {
@@ -953,7 +954,7 @@ include::../../test/includes/unknown.adoc[leveloffset=+1]
 			}
 			verifyPreflight("foo.adoc", expected, source)
 			// verify error in logs
-			testsupport.VerifyConsoleOutput(console, "failed to include '../../test/includes/unknown.adoc'")
+			testsupport.VerifyConsoleOutput(console, log.ErrorLevel, "failed to include '../../test/includes/unknown.adoc'")
 		})
 	})
 

--- a/pkg/renderer/html5/file_inclusion_test.go
+++ b/pkg/renderer/html5/file_inclusion_test.go
@@ -4,6 +4,7 @@ import (
 	"github.com/bytesparadise/libasciidoc/testsupport"
 
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -477,7 +478,11 @@ func helloworld() {
 </div>`
 			verify("test.adoc", expected, source)
 			// verify error in logs
-			testsupport.VerifyConsoleOutput(console, log.ErrorLevel, "detected unclosed tag 'unclosed' starting at line 6 of include file: ../../../test/includes/tag-include.adoc")
+			Expect(console).To(
+				testsupport.ContainMessageWithLevel(
+					log.ErrorLevel,
+					"detected unclosed tag 'unclosed' starting at line 6 of include file: ../../../test/includes/tag-include.adoc",
+				))
 		})
 
 		It("file inclusion with unknown tag", func() {
@@ -488,7 +493,11 @@ func helloworld() {
 			// TODO: verify error in logs
 			verify("test.adoc", expected, source)
 			// verify error in logs
-			testsupport.VerifyConsoleOutput(console, log.ErrorLevel, "tag 'unknown' not found in include file: ../../../test/includes/tag-include.adoc")
+			Expect(console).To(
+				testsupport.ContainMessageWithLevel(
+					log.ErrorLevel,
+					"tag 'unknown' not found in include file: ../../../test/includes/tag-include.adoc",
+				))
 		})
 
 		It("file inclusion with no tag", func() {
@@ -603,7 +612,11 @@ last line of grandchild</pre>
 </div>`
 				verify("foo.adoc", expected, source)
 				// verify error in logs
-				testsupport.VerifyConsoleOutput(console, log.ErrorLevel, "failed to include '../../../test/includes/unknown.adoc'")
+				Expect(console).To(
+					testsupport.ContainMessageWithLevel(
+						log.ErrorLevel,
+						"failed to include '../../../test/includes/unknown.adoc'",
+					))
 			})
 
 			It("should replace with string element if file with attribute in path is not resolved", func() {
@@ -617,7 +630,11 @@ last line of grandchild</pre>
 </div>`
 				verify("foo.adoc", expected, source)
 				// verify error in logs
-				testsupport.VerifyConsoleOutput(console, log.ErrorLevel, "failed to include '{includedir}/unknown.adoc'")
+				Expect(console).To(
+					testsupport.ContainMessageWithLevel(
+						log.ErrorLevel,
+						"failed to include '{includedir}/unknown.adoc'",
+					))
 			})
 		})
 
@@ -638,7 +655,11 @@ include::../../../test/includes/unknown.adoc[leveloffset=+1]
 </div>`
 				verify("foo.adoc", expected, source)
 				// verify error in logs
-				testsupport.VerifyConsoleOutput(console, log.ErrorLevel, "failed to include '../../../test/includes/unknown.adoc'")
+				Expect(console).To(
+					testsupport.ContainMessageWithLevel(
+						log.ErrorLevel,
+						"failed to include '../../../test/includes/unknown.adoc'",
+					))
 			})
 
 			It("should replace with string element if file with attribute in path is not resolved", func() {
@@ -656,7 +677,11 @@ include::{includedir}/unknown.adoc[leveloffset=+1]
 </div>`
 				verify("foo.adoc", expected, source)
 				// verify error in logs
-				testsupport.VerifyConsoleOutput(console, log.ErrorLevel, "failed to include '{includedir}/unknown.adoc'")
+				Expect(console).To(
+					testsupport.ContainMessageWithLevel(
+						log.ErrorLevel,
+						"failed to include '{includedir}/unknown.adoc'",
+					))
 			})
 		})
 	})

--- a/pkg/renderer/html5/file_inclusion_test.go
+++ b/pkg/renderer/html5/file_inclusion_test.go
@@ -2,7 +2,9 @@ package html5_test
 
 import (
 	"github.com/bytesparadise/libasciidoc/testsupport"
+
 	. "github.com/onsi/ginkgo"
+	log "github.com/sirupsen/logrus"
 )
 
 var _ = Describe("file inclusions", func() {
@@ -475,7 +477,7 @@ func helloworld() {
 </div>`
 			verify("test.adoc", expected, source)
 			// verify error in logs
-			testsupport.VerifyConsoleOutput(console, "detected unclosed tag 'unclosed' starting at line 6 of include file: ../../../test/includes/tag-include.adoc")
+			testsupport.VerifyConsoleOutput(console, log.ErrorLevel, "detected unclosed tag 'unclosed' starting at line 6 of include file: ../../../test/includes/tag-include.adoc")
 		})
 
 		It("file inclusion with unknown tag", func() {
@@ -486,7 +488,7 @@ func helloworld() {
 			// TODO: verify error in logs
 			verify("test.adoc", expected, source)
 			// verify error in logs
-			testsupport.VerifyConsoleOutput(console, "tag 'unknown' not found in include file: ../../../test/includes/tag-include.adoc")
+			testsupport.VerifyConsoleOutput(console, log.ErrorLevel, "tag 'unknown' not found in include file: ../../../test/includes/tag-include.adoc")
 		})
 
 		It("file inclusion with no tag", func() {
@@ -601,7 +603,7 @@ last line of grandchild</pre>
 </div>`
 				verify("foo.adoc", expected, source)
 				// verify error in logs
-				testsupport.VerifyConsoleOutput(console, "failed to include '../../../test/includes/unknown.adoc'")
+				testsupport.VerifyConsoleOutput(console, log.ErrorLevel, "failed to include '../../../test/includes/unknown.adoc'")
 			})
 
 			It("should replace with string element if file with attribute in path is not resolved", func() {
@@ -615,7 +617,7 @@ last line of grandchild</pre>
 </div>`
 				verify("foo.adoc", expected, source)
 				// verify error in logs
-				testsupport.VerifyConsoleOutput(console, "failed to include '{includedir}/unknown.adoc'")
+				testsupport.VerifyConsoleOutput(console, log.ErrorLevel, "failed to include '{includedir}/unknown.adoc'")
 			})
 		})
 
@@ -636,7 +638,7 @@ include::../../../test/includes/unknown.adoc[leveloffset=+1]
 </div>`
 				verify("foo.adoc", expected, source)
 				// verify error in logs
-				testsupport.VerifyConsoleOutput(console, "failed to include '../../../test/includes/unknown.adoc'")
+				testsupport.VerifyConsoleOutput(console, log.ErrorLevel, "failed to include '../../../test/includes/unknown.adoc'")
 			})
 
 			It("should replace with string element if file with attribute in path is not resolved", func() {
@@ -654,7 +656,7 @@ include::{includedir}/unknown.adoc[leveloffset=+1]
 </div>`
 				verify("foo.adoc", expected, source)
 				// verify error in logs
-				testsupport.VerifyConsoleOutput(console, "failed to include '{includedir}/unknown.adoc'")
+				testsupport.VerifyConsoleOutput(console, log.ErrorLevel, "failed to include '{includedir}/unknown.adoc'")
 			})
 		})
 	})

--- a/pkg/types/types_test.go
+++ b/pkg/types/types_test.go
@@ -16,15 +16,15 @@ var _ = Describe("line ranges", func() {
 		)
 
 		It("should not match line 1", func() {
-			Expect(ranges.Match(1)).Should(BeFalse())
+			Expect(ranges.Match(1)).To(BeFalse())
 		})
 
 		It("should match line 2", func() {
-			Expect(ranges.Match(2)).Should(BeTrue())
+			Expect(ranges.Match(2)).To(BeTrue())
 		})
 
 		It("should not match line 5", func() {
-			Expect(ranges.Match(1)).Should(BeFalse())
+			Expect(ranges.Match(1)).To(BeFalse())
 		})
 	})
 
@@ -37,19 +37,19 @@ var _ = Describe("line ranges", func() {
 		)
 
 		It("should match line 1", func() {
-			Expect(ranges.Match(1)).Should(BeTrue())
+			Expect(ranges.Match(1)).To(BeTrue())
 		})
 
 		It("should not match line 2", func() {
-			Expect(ranges.Match(2)).Should(BeFalse())
+			Expect(ranges.Match(2)).To(BeFalse())
 		})
 
 		It("should match line 6", func() {
-			Expect(ranges.Match(6)).Should(BeTrue())
+			Expect(ranges.Match(6)).To(BeTrue())
 		})
 
 		It("should match line 100", func() {
-			Expect(ranges.Match(100)).Should(BeTrue())
+			Expect(ranges.Match(100)).To(BeTrue())
 		})
 	})
 
@@ -81,7 +81,7 @@ var _ = Describe("file inclusions", func() {
 
 	DescribeTable("check asciidoc file",
 		func(path string, expectation bool) {
-			Expect(types.IsAsciidoc(path)).Should(Equal(expectation))
+			Expect(types.IsAsciidoc(path)).To(Equal(expectation))
 		},
 		Entry("foo.adoc", "foo.adoc", true),
 		Entry("foo.asc", "foo.asc", true),
@@ -104,7 +104,7 @@ var _ = Describe("Location resolution", func() {
 			f := types.FileInclusion{
 				Location: location,
 			}
-			Expect(f.Location.Resolve(attrs)).Should(Equal(expectation))
+			Expect(f.Location.Resolve(attrs)).To(Equal(expectation))
 		},
 		Entry("includes/file.ext", types.Location{
 			types.StringElement{Content: "includes/file.ext"},

--- a/testsupport/console.go
+++ b/testsupport/console.go
@@ -1,8 +1,11 @@
 package testsupport
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/json"
+	"io"
+	"io/ioutil"
 	"os"
 
 	. "github.com/onsi/ginkgo"
@@ -11,24 +14,39 @@ import (
 )
 
 // VerifyConsoleOutput verifies that the readable 'console' contains the exact given msg
-func VerifyConsoleOutput(console Readable, msg string) { // TODO also add a param for the log level associated with the msg
-	GinkgoT().Logf(console.String())
-	out := make(map[string]interface{})
-	// TODO: wrap the content of 'console` in a JSON document to avoid parsing error if there are multiple lines
-	err := json.Unmarshal(console.Bytes(), &out)
+func VerifyConsoleOutput(console io.Reader, expectedLevel log.Level, expectedMsg string) { // TODO also add a param for the log level associated with the msg
+	// fmt.Printf("console: %s\n", console.String())
+	// read each line of the console as a separate document
+	scanner := bufio.NewScanner(console)
+	for scanner.Scan() {
+		out := make(map[string]interface{})
+		err := json.Unmarshal(scanner.Bytes(), &out)
+		Expect(err).ShouldNot(HaveOccurred())
+		GinkgoT().Logf("out: %v", out)
+		if level, ok := out["level"].(string); !ok || level != expectedLevel.String() {
+			continue
+		}
+		if msg, ok := out["msg"].(string); !ok || msg != expectedMsg {
+			continue
+		}
+		// match found
+		return
+	}
+	c, err := ioutil.ReadAll(console)
 	Expect(err).ShouldNot(HaveOccurred())
-	Expect(out["level"]).Should(Equal("error"))
-	Expect(out["msg"]).Should(Equal(msg))
+	GinkgoT().Logf("console: %v", string(c))
+	// no match found
+	Fail("no match found in the console")
 }
 
 // ConfigureLogger configures the logger to write to a `Readable`.
 // Also returns a func that can be used to reset the logger at the
 // end of the test.
-func ConfigureLogger() (Readable, func()) {
+func ConfigureLogger() (io.Reader, func()) {
 	fmtr := log.StandardLogger().Formatter
-	level := log.StandardLogger().Level
+	// level := log.StandardLogger().Level
 	buf := bytes.NewBuffer(nil)
-	log.SetLevel(log.WarnLevel)
+	// log.SetLevel(log.WarnLevel)
 	log.SetOutput(buf)
 	log.SetFormatter(&log.JSONFormatter{
 		DisableTimestamp: true,
@@ -36,12 +54,6 @@ func ConfigureLogger() (Readable, func()) {
 	return buf, func() {
 		log.SetOutput(os.Stdout)
 		log.SetFormatter(fmtr)
-		log.SetLevel(level)
+		// log.SetLevel(level)
 	}
-}
-
-// Readable an interface for types which can return strings or arrays of bytes
-type Readable interface {
-	Bytes() []byte
-	String() string
 }

--- a/testsupport/console_test.go
+++ b/testsupport/console_test.go
@@ -1,0 +1,51 @@
+package testsupport_test
+
+import (
+	"strings"
+
+	"github.com/bytesparadise/libasciidoc/testsupport"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	log "github.com/sirupsen/logrus"
+)
+
+var _ = Describe("console assertions", func() {
+
+	console := `{"level":"debug","msg":"processing foo.adoc: ----\ninclude::../../test/includes/unknown.adoc[leveloffset=+1]\n----"}
+{"level":"debug","msg":"initializing a new PreflightDocument with 1 block element(s)"}
+{"level":"debug","msg":"parsing '../../test/includes/unknown.adoc'..."}
+{"error":"open unknown.adoc: no such file or directory","level":"error","msg":"failed to include '../../test/includes/unknown.adoc'"}
+{"level":"debug","msg":"restoring current working dir to: github.com/bytesparadise/libasciidoc/pkg/parser"}`
+
+	It("should find expected level/message", func() {
+		// given
+		matcher := testsupport.ContainMessageWithLevel(log.ErrorLevel, "failed to include '../../test/includes/unknown.adoc'")
+		// when
+		result, err := matcher.Match(strings.NewReader(console))
+		// then
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(BeTrue())
+	})
+
+	It("should not find expected level/message with wrong level", func() {
+		// given
+		matcher := testsupport.ContainMessageWithLevel(log.WarnLevel, "failed to include '../../test/includes/unknown.adoc'") // wrong level
+		// when
+		result, err := matcher.Match(strings.NewReader(console))
+		// then
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(BeFalse())
+	})
+
+	It("should not find expected level/message with wrong msg", func() {
+		// given
+		matcher := testsupport.ContainMessageWithLevel(log.ErrorLevel, "foo") // unknown message
+		// when
+		result, err := matcher.Match(strings.NewReader(console))
+		// then
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(BeFalse())
+	})
+
+})

--- a/testsupport/testsupport_suite_test.go
+++ b/testsupport/testsupport_suite_test.go
@@ -1,0 +1,13 @@
+package testsupport_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestTestsupport(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Testsupport Suite")
+}


### PR DESCRIPTION
allows support for 'debug' output in console

fixes #410

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>