### PR TITLE
chore(project): configure codecov with range and threshold

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,14 +4,16 @@ codecov:
     require_ci_to_pass: yes
 
 coverage:
-  precision: 2
-  round: down
-  range: "70...100"
-
   status:
-    project: yes
+    project:
+      default:
+        # basic
+        target: 80
+        threshold: 2
     patch: yes
     changes: no
+  precision: 2
+  round: down
 
 parsers:
   gcov:


### PR DESCRIPTION
Require a coverage of 80% and allow for up to 2% of drop in PRs

Fixes #414

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>