### PR TITLE
test(parser): verify that no message is logged when file inclusion works

### DIFF
--- a/pkg/parser/file_inclusion_test.go
+++ b/pkg/parser/file_inclusion_test.go
@@ -81,6 +81,8 @@ var _ = Describe("file location", func() {
 var _ = Describe("file inclusions - preflight with preprocessing", func() {
 
 	It("should include adoc file without leveloffset", func() {
+		console, reset := ConfigureLogger()
+		defer reset()
 		source := "include::../../test/includes/chapter-a.adoc[]"
 		expected := types.PreflightDocument{
 			Blocks: []interface{}{
@@ -111,9 +113,14 @@ var _ = Describe("file inclusions - preflight with preprocessing", func() {
 			},
 		}
 		Expect(source).To(BecomePreflightDocument(expected))
+		// verify no error/warning in logs
+		Expect(console).ToNot(ContainAnyMessageWithLevels(log.ErrorLevel, log.WarnLevel))
+
 	})
 
 	It("should include adoc file with leveloffset", func() {
+		console, reset := ConfigureLogger()
+		defer reset()
 		source := "include::../../test/includes/chapter-a.adoc[leveloffset=+1]"
 		expected := types.PreflightDocument{
 			Blocks: []interface{}{
@@ -144,6 +151,8 @@ var _ = Describe("file inclusions - preflight with preprocessing", func() {
 			},
 		}
 		Expect(source).To(BecomePreflightDocument(expected))
+		// verify no error/warning in logs
+		Expect(console).ToNot(ContainAnyMessageWithLevels(log.ErrorLevel, log.WarnLevel))
 	})
 
 	Context("file inclusions in delimited blocks", func() {
@@ -550,6 +559,8 @@ include::../../test/includes/chapter-a.adoc[]
 		Context("file inclusions with quoted line ranges", func() {
 
 			It("file inclusion with single quoted line", func() {
+				console, reset := ConfigureLogger()
+				defer reset()
 				source := `include::../../test/includes/chapter-a.adoc[lines="1"]`
 				expected := types.PreflightDocument{
 					Blocks: []interface{}{
@@ -569,6 +580,8 @@ include::../../test/includes/chapter-a.adoc[]
 					},
 				}
 				Expect(source).To(BecomePreflightDocument(expected))
+				// verify no error/warning in logs
+				Expect(console).ToNot(ContainAnyMessageWithLevels(log.ErrorLevel, log.WarnLevel))
 			})
 
 			It("file inclusion with multiple quoted lines", func() {
@@ -716,6 +729,8 @@ include::../../test/includes/chapter-a.adoc[]
 	Context("file inclusions with tag ranges", func() {
 
 		It("file inclusion with single tag", func() {
+			console, reset := ConfigureLogger()
+			defer reset()
 			source := `include::../../test/includes/tag-include.adoc[tag=section]`
 			expected := types.PreflightDocument{
 				Blocks: []interface{}{
@@ -735,9 +750,13 @@ include::../../test/includes/chapter-a.adoc[]
 				},
 			}
 			Expect(source).To(BecomePreflightDocument(expected))
+			// verify no error/warning in logs
+			Expect(console).ToNot(ContainAnyMessageWithLevels(log.ErrorLevel, log.WarnLevel))
 		})
 
 		It("file inclusion with surrounding tag", func() {
+			console, reset := ConfigureLogger()
+			defer reset()
 			source := `include::../../test/includes/tag-include.adoc[tag=doc]`
 			expected := types.PreflightDocument{
 				Blocks: []interface{}{
@@ -770,6 +789,8 @@ include::../../test/includes/chapter-a.adoc[]
 				},
 			}
 			Expect(source).To(BecomePreflightDocument(expected))
+			// verify no error/warning in logs
+			Expect(console).ToNot(ContainAnyMessageWithLevels(log.ErrorLevel, log.WarnLevel))
 		})
 
 		It("file inclusion with unclosed tag", func() {

--- a/testsupport/console_matcher.go
+++ b/testsupport/console_matcher.go
@@ -13,6 +13,29 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// ConfigureLogger configures the logger to write to a `Readable`.
+// Also returns a func that can be used to reset the logger at the
+// end of the test.
+func ConfigureLogger() (io.Reader, func()) {
+	fmtr := log.StandardLogger().Formatter
+	// level := log.StandardLogger().Level
+	buf := bytes.NewBuffer(nil)
+	// log.SetLevel(log.WarnLevel)
+	log.SetOutput(buf)
+	log.SetFormatter(&log.JSONFormatter{
+		DisableTimestamp: true,
+	})
+	return buf, func() {
+		log.SetOutput(os.Stdout)
+		log.SetFormatter(fmtr)
+		// log.SetLevel(level)
+	}
+}
+
+// ---------------------------
+// ContainMessageWithLevel
+// ---------------------------
+
 // ContainMessageWithLevel a custom Matcher to verify that a message with at a given level was logged
 func ContainMessageWithLevel(level log.Level, msg string) types.GomegaMatcher {
 	return &containMessageMatcher{
@@ -59,21 +82,49 @@ func (m *containMessageMatcher) NegatedFailureMessage(actual interface{}) (messa
 	return fmt.Sprintf("expected console not to contain message '%s' with level '%v'", m.msg, m.level)
 }
 
-// ConfigureLogger configures the logger to write to a `Readable`.
-// Also returns a func that can be used to reset the logger at the
-// end of the test.
-func ConfigureLogger() (io.Reader, func()) {
-	fmtr := log.StandardLogger().Formatter
-	// level := log.StandardLogger().Level
-	buf := bytes.NewBuffer(nil)
-	// log.SetLevel(log.WarnLevel)
-	log.SetOutput(buf)
-	log.SetFormatter(&log.JSONFormatter{
-		DisableTimestamp: true,
-	})
-	return buf, func() {
-		log.SetOutput(os.Stdout)
-		log.SetFormatter(fmtr)
-		// log.SetLevel(level)
+// ---------------------------
+// ContainAnyMessageWithLevels
+// ---------------------------
+
+// ContainAnyMessageWithLevels a custom Matcher to verify that no message with the any of the given levels was logged
+func ContainAnyMessageWithLevels(level log.Level, otherLevels ...log.Level) types.GomegaMatcher {
+	return &containAnyMessageMatcher{
+		levels: append([]log.Level{level}, otherLevels...),
 	}
+}
+
+type containAnyMessageMatcher struct {
+	levels []log.Level
+}
+
+func (m *containAnyMessageMatcher) Match(actual interface{}) (success bool, err error) {
+	console, ok := actual.(io.Reader)
+	if !ok {
+		return false, errors.Errorf("ContainAnyMessageWithLevels matcher expects an io.Reader (actual: %T)", actual)
+	}
+	scanner := bufio.NewScanner(console)
+	for scanner.Scan() {
+		out := make(map[string]interface{})
+		err := json.Unmarshal(scanner.Bytes(), &out)
+		if err != nil {
+			return false, errors.Wrapf(err, "failed to decode console line")
+		}
+		if level, ok := out["level"].(string); ok {
+			for _, l := range m.levels {
+				if l.String() == level {
+					return true, nil
+				}
+			}
+		}
+	}
+	// no match found
+	return false, nil
+}
+
+func (m *containAnyMessageMatcher) FailureMessage(actual interface{}) (message string) {
+	return fmt.Sprintf("expected console to contain a message at level '%v'", m.levels)
+}
+
+func (m *containAnyMessageMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+	return fmt.Sprintf("expected console not to contain a message at level '%v'", m.levels)
 }

--- a/testsupport/console_matcher_test.go
+++ b/testsupport/console_matcher_test.go
@@ -19,50 +19,110 @@ var _ = Describe("console assertions", func() {
 {"error":"open unknown.adoc: no such file or directory","level":"error","msg":"failed to include '../../test/includes/unknown.adoc'"}
 {"level":"debug","msg":"restoring current working dir to: github.com/bytesparadise/libasciidoc/pkg/parser"}`
 
-	It("should find expected level/message", func() {
-		// given
-		matcher := testsupport.ContainMessageWithLevel(log.ErrorLevel, "failed to include '../../test/includes/unknown.adoc'")
-		// when
-		result, err := matcher.Match(strings.NewReader(console))
-		// then
-		Expect(err).ToNot(HaveOccurred())
-		Expect(result).To(BeTrue())
+	Context("with message and level", func() {
+
+		It("should find expected level/message", func() {
+			// given
+			matcher := testsupport.ContainMessageWithLevel(log.ErrorLevel, "failed to include '../../test/includes/unknown.adoc'")
+			// when
+			result, err := matcher.Match(strings.NewReader(console))
+			// then
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(BeTrue())
+		})
+
+		It("should not find expected level/message with wrong level", func() {
+			// given
+			matcher := testsupport.ContainMessageWithLevel(log.WarnLevel, "failed to include '../../test/includes/unknown.adoc'") // wrong level
+			// when
+			result, err := matcher.Match(strings.NewReader(console))
+			// then
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(BeFalse())
+			// also verify the messages
+
+		})
+
+		It("should not find expected level/message with wrong msg", func() {
+			// given
+			matcher := testsupport.ContainMessageWithLevel(log.ErrorLevel, "foo") // unknown message
+			// when
+			result, err := matcher.Match(strings.NewReader(console))
+			// then
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(BeFalse())
+			// also verify the messages
+			Expect(matcher.FailureMessage(strings.NewReader(console))).To(Equal(fmt.Sprintf("expected console to contain message '%s' with level '%v'", "foo", log.ErrorLevel)))
+			Expect(matcher.NegatedFailureMessage(strings.NewReader(console))).To(Equal(fmt.Sprintf("expected console not to contain message '%s' with level '%v'", "foo", log.ErrorLevel)))
+		})
+
+		It("should return error when invalid type is input", func() {
+			// given
+			matcher := testsupport.ContainMessageWithLevel(log.ErrorLevel, "foo") // unknown message
+			// when
+			result, err := matcher.Match(1) // not a reader
+			// then
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("ContainMessageWithLevel matcher expects an io.Reader (actual: int)"))
+			Expect(result).To(BeFalse())
+		})
 	})
 
-	It("should not find expected level/message with wrong level", func() {
-		// given
-		matcher := testsupport.ContainMessageWithLevel(log.WarnLevel, "failed to include '../../test/includes/unknown.adoc'") // wrong level
-		// when
-		result, err := matcher.Match(strings.NewReader(console))
-		// then
-		Expect(err).ToNot(HaveOccurred())
-		Expect(result).To(BeFalse())
-		// also verify the messages
+	Context("with level only", func() {
 
-	})
+		It("should find with single given level", func() {
+			// given
+			matcher := testsupport.ContainAnyMessageWithLevels(log.ErrorLevel)
+			// when
+			result, err := matcher.Match(strings.NewReader(console))
+			// then
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(BeTrue())
+		})
 
-	It("should not find expected level/message with wrong msg", func() {
-		// given
-		matcher := testsupport.ContainMessageWithLevel(log.ErrorLevel, "foo") // unknown message
-		// when
-		result, err := matcher.Match(strings.NewReader(console))
-		// then
-		Expect(err).ToNot(HaveOccurred())
-		Expect(result).To(BeFalse())
-		// also verify the messages
-		Expect(matcher.FailureMessage(strings.NewReader(console))).To(Equal(fmt.Sprintf("expected console to contain message '%s' with level '%v'", "foo", log.ErrorLevel)))
-		Expect(matcher.NegatedFailureMessage(strings.NewReader(console))).To(Equal(fmt.Sprintf("expected console not to contain message '%s' with level '%v'", "foo", log.ErrorLevel)))
-	})
+		It("should find with multiple given levels", func() {
+			// given
+			matcher := testsupport.ContainAnyMessageWithLevels(log.ErrorLevel, log.WarnLevel)
+			// when
+			result, err := matcher.Match(strings.NewReader(console))
+			// then
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(BeTrue())
+		})
 
-	It("should return error when invalid type is input", func() {
-		// given
-		matcher := testsupport.ContainMessageWithLevel(log.ErrorLevel, "foo") // unknown message
-		// when
-		result, err := matcher.Match(1) // not a reader
-		// then
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(Equal("ContainMessageWithLevel matcher expects an io.Reader (actual: int)"))
-		Expect(result).To(BeFalse())
+		It("should not find with single given level", func() {
+			// given
+			matcher := testsupport.ContainAnyMessageWithLevels(log.WarnLevel)
+			// when
+			result, err := matcher.Match(strings.NewReader(console))
+			// then
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(BeFalse())
+			// also verify the messages
+		})
+
+		It("should not find with multiple given levels", func() {
+			// given
+			matcher := testsupport.ContainAnyMessageWithLevels(log.WarnLevel, log.InfoLevel)
+			// when
+			result, err := matcher.Match(strings.NewReader(console))
+			// then
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(BeFalse())
+			// also verify the messages
+
+		})
+
+		It("should return error when invalid type is input", func() {
+			// given
+			matcher := testsupport.ContainAnyMessageWithLevels(log.ErrorLevel) // unknown message
+			// when
+			result, err := matcher.Match(1) // not a reader
+			// then
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("ContainAnyMessageWithLevels matcher expects an io.Reader (actual: int)"))
+			Expect(result).To(BeFalse())
+		})
 	})
 
 })


### PR DESCRIPTION
added a Gomega matcher to verify that no message with any of the given
levels was logged

added checks to some use-cases

fixes #408

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>