### PR TITLE
fix(parser/renderer): use main file path to start inclusions

### DIFF
--- a/libasciidoc.go
+++ b/libasciidoc.go
@@ -35,14 +35,14 @@ func ConvertFileToHTML(ctx context.Context, filename string, output io.Writer, o
 		return nil, errors.Wrapf(err, "error opening %s", filename)
 	}
 	defer file.Close()
-	return ConvertToHTML(ctx, file, output, options...)
+	return ConvertToHTML(ctx, filename, file, output, options...)
 }
 
 // ConvertToHTML converts the content of the given reader `r` into a full HTML document, written in the given writer `output`.
 // Returns an error if a problem occurred
-func ConvertToHTML(ctx context.Context, r io.Reader, output io.Writer, options ...renderer.Option) (map[string]interface{}, error) {
+func ConvertToHTML(ctx context.Context, filename string, r io.Reader, output io.Writer, options ...renderer.Option) (map[string]interface{}, error) {
 	log.Debugf("parsing the asciidoc source...")
-	doc, err := parser.ParseDocument("", r)
+	doc, err := parser.ParseDocument(filename, r)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error while parsing the document")
 	}

--- a/libasciidoc_test.go
+++ b/libasciidoc_test.go
@@ -146,6 +146,29 @@ a paragraph with _italic content_`
 			Expect(source).To(RenderHTML5Body(expectedContent))
 			Expect(source).To(RenderHTML5Title(expectedTitle))
 		})
+
+		It("should include adoc file without leveloffset from local file", func() {
+			source := "include::test/includes/grandchild-include.adoc[]"
+			expected := `<div class="paragraph">
+<p>first line of grandchild</p>
+</div>
+<div class="paragraph">
+<p>last line of grandchild</p>
+</div>`
+			Expect(source).To(RenderHTML5Body(expected, WithFilename("foo.adoc")))
+		})
+
+		It("should include adoc file without leveloffset from relative file", func() {
+			source := "include::../test/includes/grandchild-include.adoc[]"
+			expected := `<div class="paragraph">
+<p>first line of grandchild</p>
+</div>
+<div class="paragraph">
+<p>last line of grandchild</p>
+</div>`
+
+			Expect(source).To(RenderHTML5Body(expected, WithFilename("tmp/foo.adoc")))
+		})
 	})
 
 	Context("complete Document ", func() {

--- a/pkg/parser/file_inclusion.go
+++ b/pkg/parser/file_inclusion.go
@@ -26,9 +26,10 @@ func init() {
 
 func parseFileToInclude(filename string, incl types.FileInclusion, attrs types.DocumentAttributes, opts ...Option) (types.PreflightDocument, error) {
 	path := incl.Location.Resolve(attrs)
-	log.Debugf("parsing '%s'...", path)
+	currentDir := filepath.Dir(filename)
+	log.Debugf("parsing '%s' from '%s' (%s)", path, currentDir, filename)
 	log.Debugf("file inclusion attributes: %s", spew.Sdump(incl.Attributes))
-	f, absPath, done, err := open(path)
+	f, absPath, done, err := open(filepath.Join(currentDir, path))
 	defer done()
 	if err != nil {
 		return invalidFileErrMsg(filename, path, incl.RawText, err)
@@ -211,6 +212,7 @@ func open(path string) (*os.File, string, func(), error) {
 		return nil, "", func() {}, err
 	}
 	absPath, err := filepath.Abs(path)
+	log.Debugf("file path: %s", absPath)
 	if err != nil {
 		return nil, "", func() {
 			log.Debugf("restoring current working dir to: %s", wd)

--- a/pkg/renderer/html5/file_inclusion_test.go
+++ b/pkg/renderer/html5/file_inclusion_test.go
@@ -10,6 +10,37 @@ import (
 
 var _ = Describe("file inclusions", func() {
 
+	It("should include adoc file without leveloffset from local file", func() {
+		console, reset := ConfigureLogger()
+		defer reset()
+		source := "include::../../../test/includes/grandchild-include.adoc[]"
+		expected := `<div class="paragraph">
+<p>first line of grandchild</p>
+</div>
+<div class="paragraph">
+<p>last line of grandchild</p>
+</div>`
+		Expect(source).To(RenderHTML5Element(expected, WithFilename("foo.adoc")))
+		// verify no error/warning in logs
+		Expect(console).ToNot(ContainAnyMessageWithLevels(log.ErrorLevel, log.WarnLevel))
+	})
+
+	It("should include adoc file without leveloffset from relative file", func() {
+		console, reset := ConfigureLogger()
+		defer reset()
+		source := "include::../../../../test/includes/grandchild-include.adoc[]"
+		expected := `<div class="paragraph">
+<p>first line of grandchild</p>
+</div>
+<div class="paragraph">
+<p>last line of grandchild</p>
+</div>`
+
+		Expect(source).To(RenderHTML5Element(expected, WithFilename("tmp/foo.adoc")))
+		// verify no error/warning in logs
+		Expect(console).ToNot(ContainAnyMessageWithLevels(log.ErrorLevel, log.WarnLevel))
+	})
+
 	It("include adoc file with leveloffset attribute", func() {
 		source := `= Master Document
 

--- a/pkg/types/types_suite_test.go
+++ b/pkg/types/types_suite_test.go
@@ -1,12 +1,12 @@
 package types_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-
 	"testing"
 
 	_ "github.com/bytesparadise/libasciidoc/testsupport"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
 
 func TestTypes(t *testing.T) {

--- a/testsupport/comparison.go
+++ b/testsupport/comparison.go
@@ -27,6 +27,6 @@ func compare(actual interface{}, expected interface{}) comparison {
 	}
 	GinkgoT().Logf("actual:\n%s", c.actual)
 	GinkgoT().Logf("expected:\n%s", c.expected)
-	GinkgoT().Logf("diff:\n%s", c.diffs)
+	// GinkgoT().Logf("diff:\n%s", c.diffs)
 	return c
 }

--- a/testsupport/html5_rendering_matcher.go
+++ b/testsupport/html5_rendering_matcher.go
@@ -22,15 +22,29 @@ import (
 // --------------------
 
 // RenderHTML5Element a custom matcher to verify that a block renders as the expectation
-func RenderHTML5Element(expected string, opts ...renderer.Option) gomegatypes.GomegaMatcher {
-	return &html5ElementMatcher{
+func RenderHTML5Element(expected string, options ...interface{}) gomegatypes.GomegaMatcher {
+	m := &html5ElementMatcher{
 		expected: expected,
-		opts:     opts,
+		filename: "test.adoc",
+		opts:     []renderer.Option{},
 	}
+	for _, o := range options {
+		if configure, ok := o.(FilenameOption); ok {
+			configure(m)
+		} else if opt, ok := o.(renderer.Option); ok {
+			m.opts = append(m.opts, opt)
+		}
+	}
+	return m
+}
+
+func (m *html5ElementMatcher) setFilename(f string) {
+	m.filename = f
 }
 
 type html5ElementMatcher struct {
 	opts       []renderer.Option
+	filename   string
 	expected   string
 	actual     string
 	comparison comparison
@@ -42,7 +56,7 @@ func (m *html5ElementMatcher) Match(actual interface{}) (success bool, err error
 		return false, errors.Errorf("RenderHTML5Element matcher expects a string (actual: %T)", actual)
 	}
 	r := strings.NewReader(content)
-	doc, err := parser.ParseDocument("test.adoc", r)
+	doc, err := parser.ParseDocument(m.filename, r)
 	if err != nil {
 		return false, err
 	}
@@ -78,14 +92,25 @@ func (m *html5ElementMatcher) NegatedFailureMessage(_ interface{}) (message stri
 // --------------------
 
 // RenderHTML5Body a custom matcher to verify that a block renders as the expectation
-func RenderHTML5Body(expected string, opts ...renderer.Option) gomegatypes.GomegaMatcher {
-	return &html5BodyMatcher{
+func RenderHTML5Body(expected string, options ...interface{}) gomegatypes.GomegaMatcher {
+	m := &html5BodyMatcher{
 		expected: expected,
-		opts:     opts,
+		filename: "test.adoc",
 	}
+	for _, o := range options {
+		if configure, ok := o.(FilenameOption); ok {
+			configure(m)
+		}
+	}
+	return m
+}
+
+func (m *html5BodyMatcher) setFilename(f string) {
+	m.filename = f
 }
 
 type html5BodyMatcher struct {
+	filename string
 	expected string
 	actual   string
 	opts     []renderer.Option
@@ -98,7 +123,7 @@ func (m *html5BodyMatcher) Match(actual interface{}) (success bool, err error) {
 	}
 	contentReader := strings.NewReader(content)
 	resultWriter := bytes.NewBuffer(nil)
-	_, err = libasciidoc.ConvertToHTML(context.Background(), contentReader, resultWriter, renderer.IncludeHeaderFooter(false))
+	_, err = libasciidoc.ConvertToHTML(context.Background(), m.filename, contentReader, resultWriter, renderer.IncludeHeaderFooter(false))
 	if err != nil {
 		return false, err
 	}
@@ -119,17 +144,27 @@ func (m *html5BodyMatcher) NegatedFailureMessage(_ interface{}) (message string)
 // --------------------
 
 // RenderHTML5Title a custom matcher to verify that a block renders as the expectation
-func RenderHTML5Title(expected interface{}, opts ...renderer.Option) gomegatypes.GomegaMatcher {
-	return &html5TitleMatcher{
+func RenderHTML5Title(expected interface{}, options ...interface{}) gomegatypes.GomegaMatcher {
+	m := &html5TitleMatcher{
 		expected: expected,
-		opts:     opts,
+		filename: "test.adoc",
 	}
+	for _, o := range options {
+		if configure, ok := o.(FilenameOption); ok {
+			configure(m)
+		}
+	}
+	return m
+}
+
+func (m *html5TitleMatcher) setFilename(f string) {
+	m.filename = f
 }
 
 type html5TitleMatcher struct {
+	filename string
 	expected interface{}
 	actual   interface{}
-	opts     []renderer.Option
 }
 
 func (m *html5TitleMatcher) Match(actual interface{}) (success bool, err error) {
@@ -139,7 +174,7 @@ func (m *html5TitleMatcher) Match(actual interface{}) (success bool, err error) 
 	}
 	contentReader := strings.NewReader(content)
 	resultWriter := bytes.NewBuffer(nil)
-	metadata, err := libasciidoc.ConvertToHTML(context.Background(), contentReader, resultWriter, renderer.IncludeHeaderFooter(false))
+	metadata, err := libasciidoc.ConvertToHTML(context.Background(), m.filename, contentReader, resultWriter, renderer.IncludeHeaderFooter(false))
 	if err != nil {
 		return false, err
 	}
@@ -173,17 +208,27 @@ func (m *html5TitleMatcher) NegatedFailureMessage(_ interface{}) (message string
 // ---------------------
 
 // RenderHTML5Document a custom matcher to verify that a block renders as the expectation
-func RenderHTML5Document(expected string, opts ...renderer.Option) gomegatypes.GomegaMatcher {
-	return &html5DocumentMatcher{
+func RenderHTML5Document(expected string, options ...interface{}) gomegatypes.GomegaMatcher {
+	m := &html5DocumentMatcher{
 		expected: expected,
-		opts:     opts,
+		filename: "test.adoc",
 	}
+	for _, o := range options {
+		if configure, ok := o.(FilenameOption); ok {
+			configure(m)
+		}
+	}
+	return m
+}
+
+func (m *html5DocumentMatcher) setFilename(f string) {
+	m.filename = f
 }
 
 type html5DocumentMatcher struct {
+	filename string
 	expected string
 	actual   string
-	opts     []renderer.Option
 }
 
 func (m *html5DocumentMatcher) Match(actual interface{}) (success bool, err error) {
@@ -194,7 +239,7 @@ func (m *html5DocumentMatcher) Match(actual interface{}) (success bool, err erro
 	contentReader := strings.NewReader(content)
 	resultWriter := bytes.NewBuffer(nil)
 	lastUpdated := time.Now()
-	_, err = libasciidoc.ConvertToHTML(context.Background(), contentReader, resultWriter, renderer.IncludeHeaderFooter(true))
+	_, err = libasciidoc.ConvertToHTML(context.Background(), m.filename, contentReader, resultWriter, renderer.IncludeHeaderFooter(true))
 	if err != nil {
 		return false, err
 	}

--- a/testsupport/log_init.go
+++ b/testsupport/log_init.go
@@ -12,7 +12,7 @@ func init() {
 	logsupport.Setup()
 	if debugMode() {
 		log.SetLevel(log.DebugLevel)
-		log.Warn("Running test with logs in DEBUG level")
+		log.Info("Running test with logs in DEBUG level")
 	}
 }
 

--- a/testsupport/matcher_options.go
+++ b/testsupport/matcher_options.go
@@ -1,0 +1,25 @@
+package testsupport
+
+type filenameMatcher interface {
+	setFilename(string)
+}
+
+// FilenameOption an option to set the name of the file being treated by the matcher
+type FilenameOption func(m filenameMatcher)
+
+// WithFilename configures the filename, which can be absolute or relative
+func WithFilename(filename string) FilenameOption {
+	return func(m filenameMatcher) {
+		m.setFilename(filename)
+	}
+}
+
+// BecomePreflightDocumentOption an option to configure the BecomePreflightDocument matcher
+type BecomePreflightDocumentOption func(m *preflightDocumentMatcher)
+
+// WithoutPreprocessing disables document preprocessing
+func WithoutPreprocessing() BecomePreflightDocumentOption {
+	return func(m *preflightDocumentMatcher) {
+		m.preprocessing = false
+	}
+}

--- a/testsupport/preflight_document_matcher_test.go
+++ b/testsupport/preflight_document_matcher_test.go
@@ -70,7 +70,7 @@ var _ = Describe("preflight document assertions", func() {
 
 		It("should return error when invalid type is input", func() {
 			// given
-			matcher := testsupport.BecomePreflightDocumentWithoutPreprocessing("")
+			matcher := testsupport.BecomePreflightDocument("", testsupport.WithoutPreprocessing())
 			// when
 			_, err := matcher.Match(1) // not a string
 			// then
@@ -98,7 +98,7 @@ var _ = Describe("preflight document assertions", func() {
 
 		It("should match", func() {
 			// given
-			matcher := testsupport.BecomePreflightDocumentWithoutPreprocessing(expected)
+			matcher := testsupport.BecomePreflightDocument(expected, testsupport.WithoutPreprocessing())
 			// when
 			result, err := matcher.Match("hello, world!")
 			// then
@@ -108,7 +108,7 @@ var _ = Describe("preflight document assertions", func() {
 
 		It("should not match", func() {
 			// given
-			matcher := testsupport.BecomePreflightDocumentWithoutPreprocessing(expected)
+			matcher := testsupport.BecomePreflightDocument(expected, testsupport.WithoutPreprocessing())
 			actual := "foo"
 			// when
 			result, err := matcher.Match(actual)

--- a/testsupport/testsupport_suite_test.go
+++ b/testsupport/testsupport_suite_test.go
@@ -3,6 +3,8 @@ package testsupport_test
 import (
 	"testing"
 
+	_ "github.com/bytesparadise/libasciidoc/testsupport"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )


### PR DESCRIPTION
use the base dir of the top/root parent as the starting dir
when processing file inclusions

modify matchers to support optional filename

fixes #424

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>