### PR TITLE
fix(renderer): do not include section 0 element

### DIFF
--- a/pkg/parser/file_inclusion_test.go
+++ b/pkg/parser/file_inclusion_test.go
@@ -191,6 +191,81 @@ var _ = Describe("file inclusions - preflight with preprocessing", func() {
 		Expect(console).ToNot(ContainAnyMessageWithLevels(log.ErrorLevel, log.WarnLevel))
 	})
 
+	It("should include section 0 by default", func() {
+		source := "include::../../test/includes/chapter-a.adoc[]"
+		// at this level (parsing), it is expected that the Section 0 is part of the Prefligh document
+		expected := types.PreflightDocument{
+			Blocks: []interface{}{
+				types.Section{
+					Attributes: types.ElementAttributes{
+						types.AttrID:       "chapter_a",
+						types.AttrCustomID: false,
+					},
+					Level: 0,
+					Title: types.InlineElements{
+						types.StringElement{
+							Content: "Chapter A",
+						},
+					},
+					Elements: []interface{}{},
+				},
+				types.BlankLine{},
+				types.Paragraph{
+					Attributes: types.ElementAttributes{},
+					Lines: []types.InlineElements{
+						{
+							types.StringElement{
+								Content: "content",
+							},
+						},
+					},
+				},
+			},
+		}
+		Expect(source).To(BecomePreflightDocument(expected))
+	})
+
+	It("should not include section 0 when attribute exists", func() {
+		source := `:includedir: ../../test/includes
+
+include::{includedir}/chapter-a.adoc[]`
+		// at this level (parsing), it is expected that the Section 0 is part of the Prefligh document
+		expected := types.PreflightDocument{
+			Blocks: []interface{}{
+				types.DocumentAttributeDeclaration{
+					Name:  "includedir",
+					Value: "../../test/includes",
+				},
+				types.BlankLine{},
+				types.Section{
+					Attributes: types.ElementAttributes{
+						types.AttrID:       "chapter_a",
+						types.AttrCustomID: false,
+					},
+					Level: 0,
+					Title: types.InlineElements{
+						types.StringElement{
+							Content: "Chapter A",
+						},
+					},
+					Elements: []interface{}{},
+				},
+				types.BlankLine{},
+				types.Paragraph{
+					Attributes: types.ElementAttributes{},
+					Lines: []types.InlineElements{
+						{
+							types.StringElement{
+								Content: "content",
+							},
+						},
+					},
+				},
+			},
+		}
+		Expect(source).To(BecomePreflightDocument(expected))
+	})
+
 	Context("file inclusions in delimited blocks", func() {
 
 		It("should include adoc file within fenced block", func() {

--- a/pkg/renderer/html5/file_inclusion_test.go
+++ b/pkg/renderer/html5/file_inclusion_test.go
@@ -65,6 +65,24 @@ include::../../../test/includes/chapter-a.adoc[leveloffset=+1]`
 		Expect(source).To(RenderHTML5Body(expected))
 	})
 
+	It("should not include section 0 by default", func() {
+		source := `include::../../../test/includes/chapter-a.adoc[]`
+		expected := `<div class="paragraph">
+<p>content</p>
+</div>`
+		Expect(source).To(RenderHTML5Body(expected))
+	})
+
+	It("should not include section 0 when attribute exists", func() {
+		source := `:includedir: ../../../test/includes
+
+include::{includedir}/chapter-a.adoc[]`
+		expected := `<div class="paragraph">
+<p>content</p>
+</div>`
+		Expect(source).To(RenderHTML5Body(expected))
+	})
+
 	It("include non adoc file", func() {
 		source := `= Master Document
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -353,6 +353,20 @@ type Preamble struct {
 	Elements []interface{}
 }
 
+// HasContent returns `true` if this Preamble has at least one element which is neither a
+// BlankLine nor a DocumentAttributeDeclaration
+func (p Preamble) HasContent() bool {
+	for _, pe := range p.Elements {
+		switch pe.(type) {
+		case DocumentAttributeDeclaration, BlankLine:
+			continue
+		default:
+			return true
+		}
+	}
+	return false
+}
+
 // ------------------------------------------
 // Front Matter
 // ------------------------------------------

--- a/testsupport/console_matcher.go
+++ b/testsupport/console_matcher.go
@@ -38,7 +38,9 @@ type tee struct {
 }
 
 func (t tee) Write(p []byte) (n int, err error) {
-	t.out.Write(p)
+	if log.IsLevelEnabled(log.DebugLevel) {
+		t.out.Write(p)
+	}
 	return t.buf.Write(p)
 }
 


### PR DESCRIPTION
unless there's a relevant element before. Otherwise,
just retain the section elements

fixes #425

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>