### PR TITLE
feat(parser): support nested relative level offset in file inclusions

### DIFF
--- a/libasciidoc_test.go
+++ b/libasciidoc_test.go
@@ -149,22 +149,32 @@ a paragraph with _italic content_`
 
 		It("should include adoc file without leveloffset from local file", func() {
 			source := "include::test/includes/grandchild-include.adoc[]"
-			expected := `<div class="paragraph">
+			expected := `<div class="sect1">
+<h2 id="_grandchild_title">grandchild title</h2>
+<div class="sectionbody">
+<div class="paragraph">
 <p>first line of grandchild</p>
 </div>
 <div class="paragraph">
 <p>last line of grandchild</p>
+</div>
+</div>
 </div>`
 			Expect(source).To(RenderHTML5Body(expected, WithFilename("foo.adoc")))
 		})
 
 		It("should include adoc file without leveloffset from relative file", func() {
 			source := "include::../test/includes/grandchild-include.adoc[]"
-			expected := `<div class="paragraph">
+			expected := `<div class="sect1">
+<h2 id="_grandchild_title">grandchild title</h2>
+<div class="sectionbody">
+<div class="paragraph">
 <p>first line of grandchild</p>
 </div>
 <div class="paragraph">
 <p>last line of grandchild</p>
+</div>
+</div>
 </div>`
 
 			Expect(source).To(RenderHTML5Body(expected, WithFilename("tmp/foo.adoc")))

--- a/pkg/parser/document_preprocessing.go
+++ b/pkg/parser/document_preprocessing.go
@@ -2,11 +2,9 @@ package parser
 
 import (
 	"io"
-	"strconv"
 
 	"github.com/bytesparadise/libasciidoc/pkg/types"
 
-	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -19,17 +17,17 @@ const LevelOffset ContextKey = "leveloffset"
 // ParseDraftDocument parses a document's content and applies the preprocessing directives (file inclusions)
 func ParseDraftDocument(filename string, r io.Reader, opts ...Option) (types.DraftDocument, error) {
 	opts = append(opts, Entrypoint("DraftAsciidocDocument"))
-	return parseDraftDocument(filename, r, "", opts...)
+	return parseDraftDocument(filename, r, []levelOffset{}, opts...)
 }
 
-func parseDraftDocument(filename string, r io.Reader, levelOffset string, opts ...Option) (types.DraftDocument, error) {
+func parseDraftDocument(filename string, r io.Reader, levelOffsets []levelOffset, opts ...Option) (types.DraftDocument, error) {
 	d, err := ParseReader(filename, r, opts...)
 	if err != nil {
 		return types.DraftDocument{}, err
 	}
 	doc := d.(types.DraftDocument)
 	attrs := types.DocumentAttributes{}
-	blocks, err := parseElements(filename, doc.Blocks, attrs, levelOffset, opts...)
+	blocks, err := parseElements(filename, doc.Blocks, attrs, levelOffsets, opts...)
 	if err != nil {
 		return types.DraftDocument{}, err
 	}
@@ -38,7 +36,7 @@ func parseDraftDocument(filename string, r io.Reader, levelOffset string, opts .
 }
 
 // parseElements resolves the file inclusions if any is found in the given elements
-func parseElements(filename string, elements []interface{}, attrs types.DocumentAttributes, levelOffset string, opts ...Option) ([]interface{}, error) {
+func parseElements(filename string, elements []interface{}, attrs types.DocumentAttributes, levelOffsets []levelOffset, opts ...Option) ([]interface{}, error) {
 	result := []interface{}{}
 	for _, e := range elements {
 		switch e := e.(type) {
@@ -47,14 +45,14 @@ func parseElements(filename string, elements []interface{}, attrs types.Document
 			result = append(result, e)
 		case types.FileInclusion:
 			// read the file and include its content
-			embedded, err := parseFileToInclude(filename, e, attrs, opts...)
+			embedded, err := parseFileToInclude(filename, e, attrs, levelOffsets, opts...)
 			if err != nil {
 				// do not fail, but instead report the error in the console
 				log.Errorf("failed to include file '%s': %v", e.Location, err)
 			}
 			result = append(result, embedded.Blocks...)
 		case types.DelimitedBlock:
-			elmts, err := parseElements(filename, e.Elements, attrs, levelOffset,
+			elmts, err := parseElements(filename, e.Elements, attrs, levelOffsets,
 				// use a new var to avoid overridding the current one which needs to stay as-is for the rest of the doc parsing
 				append(opts, Entrypoint("DraftAsciidocDocumentWithinDelimitedBlock"))...)
 			if err != nil {
@@ -66,13 +64,8 @@ func parseElements(filename string, elements []interface{}, attrs types.Document
 				Elements:   elmts,
 			})
 		case types.Section:
-			if levelOffset != "" {
-				log.Debugf("applying level offset '%s'", levelOffset)
-				offset, err := strconv.Atoi(levelOffset)
-				if err != nil {
-					return nil, errors.Wrapf(err, "failed to preparse '%s'", filename)
-				}
-				e.Level += offset
+			for _, offset := range levelOffsets {
+				offset(&e)
 			}
 			result = append(result, e)
 		default:

--- a/pkg/parser/file_inclusion_test.go
+++ b/pkg/parser/file_inclusion_test.go
@@ -324,6 +324,166 @@ include::{includedir}/include.foo[]`
 		Expect(source).To(BecomeDraftDocument(expected, WithFilename("foo.bar"))) // parent doc may not need to be a '.adoc'
 	})
 
+	It("should include grandchild content", func() {
+		source := `include::../../test/includes/grandchild-include.adoc[]`
+		expected := types.DraftDocument{
+			Blocks: []interface{}{
+				types.Section{
+					Attributes: types.ElementAttributes{
+						types.AttrCustomID: false,
+						types.AttrID:       "grandchild_title",
+					},
+					Level: 1,
+					Title: types.InlineElements{
+						types.StringElement{
+							Content: "grandchild title",
+						},
+					},
+					Elements: []interface{}{},
+				},
+				types.BlankLine{},
+				types.Paragraph{
+					Attributes: types.ElementAttributes{},
+					Lines: []types.InlineElements{
+						{
+							types.StringElement{
+								Content: "first line of grandchild",
+							},
+						},
+					},
+				},
+				types.BlankLine{},
+				types.Paragraph{
+					Attributes: types.ElementAttributes{},
+					Lines: []types.InlineElements{
+						{
+							types.StringElement{
+								Content: "last line of grandchild",
+							},
+						},
+					},
+				},
+			},
+		}
+		Expect(source).To(BecomeDraftDocument(expected, WithFilename("test.adoc")))
+	})
+
+	It("should include child and grandchild content with level offset", func() {
+		source := `include::../../test/includes/parent-include-offset.adoc[leveloffset=+1]`
+		expected := types.DraftDocument{
+			Blocks: []interface{}{
+				types.Section{
+					Attributes: types.ElementAttributes{
+						types.AttrCustomID: false,
+						types.AttrID:       "parent_title",
+					},
+					Level: 1,
+					Title: types.InlineElements{
+						types.StringElement{
+							Content: "parent title",
+						},
+					},
+					Elements: []interface{}{},
+				},
+				types.BlankLine{},
+				types.Paragraph{
+					Attributes: types.ElementAttributes{},
+					Lines: []types.InlineElements{
+						{
+							types.StringElement{
+								Content: "first line of parent",
+							},
+						},
+					},
+				},
+				types.BlankLine{},
+				types.Section{
+					Attributes: types.ElementAttributes{
+						types.AttrCustomID: false,
+						types.AttrID:       "child_title",
+					},
+					Level: 2,
+					Title: types.InlineElements{
+						types.StringElement{
+							Content: "child title",
+						},
+					},
+					Elements: []interface{}{},
+				},
+				types.BlankLine{},
+				types.Paragraph{
+					Attributes: types.ElementAttributes{},
+					Lines: []types.InlineElements{
+						{
+							types.StringElement{
+								Content: "first line of child",
+							},
+						},
+					},
+				},
+				types.BlankLine{},
+				types.Section{
+					Attributes: types.ElementAttributes{
+						types.AttrCustomID: false,
+						types.AttrID:       "grandchild_title",
+					},
+					Level: 3,
+					Title: types.InlineElements{
+						types.StringElement{
+							Content: "grandchild title",
+						},
+					},
+					Elements: []interface{}{},
+				},
+				types.BlankLine{},
+				types.Paragraph{
+					Attributes: types.ElementAttributes{},
+					Lines: []types.InlineElements{
+						{
+							types.StringElement{
+								Content: "first line of grandchild",
+							},
+						},
+					},
+				},
+				types.BlankLine{},
+				types.Paragraph{
+					Attributes: types.ElementAttributes{},
+					Lines: []types.InlineElements{
+						{
+							types.StringElement{
+								Content: "last line of grandchild",
+							},
+						},
+					},
+				},
+				types.BlankLine{},
+				types.Paragraph{
+					Attributes: types.ElementAttributes{},
+					Lines: []types.InlineElements{
+						{
+							types.StringElement{
+								Content: "last line of child",
+							},
+						},
+					},
+				},
+				types.BlankLine{},
+				types.Paragraph{
+					Attributes: types.ElementAttributes{},
+					Lines: []types.InlineElements{
+						{
+							types.StringElement{
+								Content: "last line of parent",
+							},
+						},
+					},
+				},
+			},
+		}
+		Expect(source).To(BecomeDraftDocument(expected, WithFilename("test.adoc")))
+	})
+
 	Context("file inclusions in delimited blocks", func() {
 
 		It("should include adoc file within fenced block", func() {
@@ -1404,6 +1564,20 @@ include::{includedir}/grandchild-include.adoc[]`
 						Value: "../../test/includes",
 					},
 					types.BlankLine{},
+					types.Section{
+						Attributes: types.ElementAttributes{
+							types.AttrID:       "grandchild_title",
+							types.AttrCustomID: false,
+						},
+						Level: 1,
+						Title: types.InlineElements{
+							types.StringElement{
+								Content: "grandchild title",
+							},
+						},
+						Elements: []interface{}{},
+					},
+					types.BlankLine{},
 					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: []types.InlineElements{
@@ -1439,6 +1613,20 @@ include::{includedir}/grandchild-include.adoc[]`
 					types.DocumentAttributeDeclaration{
 						Name:  "includedir",
 						Value: "../../../test/includes",
+					},
+					types.BlankLine{},
+					types.Section{
+						Attributes: types.ElementAttributes{
+							types.AttrID:       "grandchild_title",
+							types.AttrCustomID: false,
+						},
+						Level: 1,
+						Title: types.InlineElements{
+							types.StringElement{
+								Content: "grandchild title",
+							},
+						},
+						Elements: []interface{}{},
 					},
 					types.BlankLine{},
 					types.Paragraph{
@@ -1484,6 +1672,17 @@ include::{includedir}/grandchild-include.adoc[]
 						Attributes: types.ElementAttributes{},
 						Kind:       types.Listing,
 						Elements: []interface{}{
+							types.Paragraph{
+								Attributes: types.ElementAttributes{},
+								Lines: []types.InlineElements{
+									{
+										types.StringElement{
+											Content: "== grandchild title",
+										},
+									},
+								},
+							},
+							types.BlankLine{},
 							types.Paragraph{
 								Attributes: types.ElementAttributes{},
 								Lines: []types.InlineElements{

--- a/pkg/renderer/html5/file_inclusion_test.go
+++ b/pkg/renderer/html5/file_inclusion_test.go
@@ -14,11 +14,16 @@ var _ = Describe("file inclusions", func() {
 		console, reset := ConfigureLogger()
 		defer reset()
 		source := "include::../../../test/includes/grandchild-include.adoc[]"
-		expected := `<div class="paragraph">
+		expected := `<div class="sect1">
+<h2 id="_grandchild_title">grandchild title</h2>
+<div class="sectionbody">
+<div class="paragraph">
 <p>first line of grandchild</p>
 </div>
 <div class="paragraph">
 <p>last line of grandchild</p>
+</div>
+</div>
 </div>`
 		Expect(source).To(RenderHTML5Body(expected, WithFilename("foo.adoc")))
 		// verify no error/warning in logs
@@ -29,13 +34,17 @@ var _ = Describe("file inclusions", func() {
 		console, reset := ConfigureLogger()
 		defer reset()
 		source := "include::../../../../test/includes/grandchild-include.adoc[]"
-		expected := `<div class="paragraph">
+		expected := `<div class="sect1">
+<h2 id="_grandchild_title">grandchild title</h2>
+<div class="sectionbody">
+<div class="paragraph">
 <p>first line of grandchild</p>
 </div>
 <div class="paragraph">
 <p>last line of grandchild</p>
+</div>
+</div>
 </div>`
-
 		Expect(source).To(RenderHTML5Body(expected, WithFilename("tmp/foo.adoc")))
 		// verify no error/warning in logs
 		Expect(console).ToNot(ContainAnyMessageWithLevels(log.ErrorLevel, log.WarnLevel))
@@ -127,9 +136,16 @@ preamble
 include::../../../test/includes/grandchild-include.adoc[]
 
 include::../../../test/includes/hello_world.go.txt[]`
-		expected := `<div class="paragraph">
+		expected := `<div id="preamble">
+<div class="sectionbody">
+<div class="paragraph">
 <p>preamble</p>
 </div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_grandchild_title">grandchild title</h2>
+<div class="sectionbody">
 <div class="paragraph">
 <p>first line of grandchild</p>
 </div>
@@ -146,6 +162,8 @@ include::../../../test/includes/hello_world.go.txt[]`
 <p>func helloworld() {
 	fmt.Println(&#34;hello, world!&#34;)
 }</p>
+</div>
+</div>
 </div>`
 		Expect(source).To(RenderHTML5Body(expected))
 	})
@@ -670,13 +688,23 @@ func helloworld() {
 	Context("recursive file inclusions", func() {
 
 		It("should include child and grandchild content in paragraphs", func() {
-			source := `include::../../../test/includes/parent-include.adoc[]`
-			expected := `<div class="paragraph">
+			source := `include::../../../test/includes/parent-include.adoc[leveloffset=+1]`
+			expected := `<div class="sect1">
+<h2 id="_parent_title">parent title</h2>
+<div class="sectionbody">
+<div class="paragraph">
 <p>first line of parent</p>
 </div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_child_title">child title</h2>
+<div class="sectionbody">
 <div class="paragraph">
 <p>first line of child</p>
 </div>
+<div class="sect2">
+<h3 id="_grandchild_title">grandchild title</h3>
 <div class="paragraph">
 <p>first line of grandchild</p>
 </div>
@@ -688,19 +716,28 @@ func helloworld() {
 </div>
 <div class="paragraph">
 <p>last line of parent</p>
+</div>
+</div>
+</div>
 </div>`
 			Expect(source).To(RenderHTML5Body(expected))
 		})
 
 		It("should include child and grandchild content in listing block", func() {
 			source := `----
-include::../../../test/includes/parent-include.adoc[]
+include::../../../test/includes/parent-include.adoc[leveloffset=+1]
 ----`
 			expected := `<div class="listingblock">
 <div class="content">
-<pre>first line of parent
+<pre>= parent title
+
+first line of parent
+
+= child title
 
 first line of child
+
+== grandchild title
 
 first line of grandchild
 
@@ -721,11 +758,16 @@ last line of parent</pre>
 			source := `:includedir: ../../../test/includes
 			
 include::{includedir}/grandchild-include.adoc[]`
-			expected := `<div class="paragraph">
+			expected := `<div class="sect1">
+<h2 id="_grandchild_title">grandchild title</h2>
+<div class="sectionbody">
+<div class="paragraph">
 <p>first line of grandchild</p>
 </div>
 <div class="paragraph">
 <p>last line of grandchild</p>
+</div>
+</div>
 </div>`
 			Expect(source).To(RenderHTML5Body(expected))
 		})
@@ -738,7 +780,9 @@ include::{includedir}/grandchild-include.adoc[]
 ----`
 			expected := `<div class="listingblock">
 <div class="content">
-<pre>first line of grandchild
+<pre>== grandchild title
+
+first line of grandchild
 
 last line of grandchild</pre>
 </div>

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -444,7 +444,7 @@ func (s Section) Footnotes() (Footnotes, FootnoteReferences, error) {
 
 // NewDocumentHeader initializes a new Section with level 0 which can have authors and a revision, among other attributes
 func NewDocumentHeader(title InlineElements, authors interface{}, revision interface{}) (Section, error) {
-	log.Debugf("initializing a new Section0 with authors '%v' and revision '%v'", authors, revision)
+	log.Debugf("initializing a new Section level 0 with authors '%v' and revision '%v'", authors, revision)
 	section, err := NewSection(0, title, nil, nil)
 	if err != nil {
 		return Section{}, err

--- a/test/includes/child-include.adoc
+++ b/test/includes/child-include.adoc
@@ -1,3 +1,5 @@
+= child title
+
 first line of child
 
 include::grandchild-include.adoc[]

--- a/test/includes/grandchild-include.adoc
+++ b/test/includes/grandchild-include.adoc
@@ -1,3 +1,5 @@
+== grandchild title
+
 first line of grandchild
 
 last line of grandchild

--- a/test/includes/parent-include-offset.adoc
+++ b/test/includes/parent-include-offset.adoc
@@ -2,6 +2,6 @@
 
 first line of parent
 
-include::child-include.adoc[]
+include::child-include.adoc[leveloffset=+1]
 
 last line of parent


### PR DESCRIPTION
Uses a func type to proceed with the cumulated level offsets,
which should pave the road to support absolute level offsets, too.

Fixes #434

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>