### PR TITLE
refactor(test): rename `Equal...` to `Become...` matchers

### DIFF
--- a/pkg/parser/check_list_test.go
+++ b/pkg/parser/check_list_test.go
@@ -109,7 +109,7 @@ var _ = Describe("checked lists - document", func() {
 				},
 			},
 		}
-		Expect(source).To(EqualDocument(expected))
+		Expect(source).To(BecomeDocument(expected))
 	})
 
 	It("parent checklist with title and nested checklist", func() {
@@ -237,7 +237,7 @@ var _ = Describe("checked lists - document", func() {
 				},
 			},
 		}
-		Expect(source).To(EqualDocument(expected))
+		Expect(source).To(BecomeDocument(expected))
 	})
 
 	It("parent checklist with title and nested normal list", func() {
@@ -340,6 +340,6 @@ var _ = Describe("checked lists - document", func() {
 				},
 			},
 		}
-		Expect(source).To(EqualDocument(expected))
+		Expect(source).To(BecomeDocument(expected))
 	})
 })

--- a/pkg/parser/comment_test.go
+++ b/pkg/parser/comment_test.go
@@ -17,7 +17,7 @@ var _ = Describe("comments - draft", func() {
 			expected := types.SingleLineComment{
 				Content: " A single-line comment.",
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("single line comment with prefixing spaces alone", func() {
@@ -25,7 +25,7 @@ var _ = Describe("comments - draft", func() {
 			expected := types.SingleLineComment{
 				Content: " A single-line comment.",
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("single line comment with prefixing tabs alone", func() {
@@ -33,7 +33,7 @@ var _ = Describe("comments - draft", func() {
 			expected := types.SingleLineComment{
 				Content: " A single-line comment.",
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("single line comment at end of line", func() {
@@ -46,7 +46,7 @@ var _ = Describe("comments - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("single line comment within a paragraph", func() {
@@ -67,7 +67,7 @@ another line`
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("single line comment within a paragraph with tab", func() {
@@ -88,7 +88,7 @@ another line`
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 	})
 
@@ -111,7 +111,7 @@ with multiple lines
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("comment block with paragraphs around", func() {

--- a/pkg/parser/cross_reference_test.go
+++ b/pkg/parser/cross_reference_test.go
@@ -154,7 +154,7 @@ with some content linked to <<thetitle>>!`
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("cross-reference with custom id and label", func() {
@@ -207,7 +207,7 @@ with some content linked to <<thetitle,a label to the title>>!`
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 	})
 })

--- a/pkg/parser/delimited_block_test.go
+++ b/pkg/parser/delimited_block_test.go
@@ -31,7 +31,7 @@ var _ = Describe("delimited blocks - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("fenced block with no line", func() {
@@ -41,7 +41,7 @@ var _ = Describe("delimited blocks - draft", func() {
 				Kind:       types.Fenced,
 				Elements:   []interface{}{},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("fenced block with multiple lines alone", func() {
@@ -78,7 +78,7 @@ var _ = Describe("delimited blocks - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("fenced block with multiple lines then a paragraph", func() {
@@ -182,7 +182,7 @@ var _ = Describe("delimited blocks - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("fenced block with external link inside - without attributes", func() {
@@ -225,7 +225,7 @@ var _ = Describe("delimited blocks - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("fenced block with external link inside - with attributes", func() {
@@ -268,7 +268,7 @@ var _ = Describe("delimited blocks - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 	})
 
@@ -294,7 +294,7 @@ some listing code
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("listing block with no line", func() {
@@ -305,7 +305,7 @@ some listing code
 				Kind:       types.Listing,
 				Elements:   []interface{}{},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("listing block with multiple lines alone", func() {
@@ -342,7 +342,7 @@ in the middle
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("listing block with unrendered list", func() {
@@ -377,7 +377,7 @@ in the middle
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("listing block with multiple lines then a paragraph", func() {
@@ -485,7 +485,7 @@ End of file here.`
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 	})
 
@@ -511,7 +511,7 @@ some listing code
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("example block with single line starting with a dot", func() {
@@ -534,7 +534,7 @@ some listing code
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("example block with multiple lines", func() {
@@ -598,7 +598,7 @@ with *bold content*
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("example block with unclosed delimiter", func() {
@@ -620,7 +620,7 @@ End of file here`
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("example block with title", func() {
@@ -646,7 +646,7 @@ foo
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("example block starting delimiter only", func() {
@@ -656,7 +656,7 @@ foo
 				Kind:       types.Example,
 				Elements:   []interface{}{},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 	})
 
@@ -685,7 +685,7 @@ foo
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 
 		})
 
@@ -767,7 +767,7 @@ ____`
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("multi-line quote with author only", func() {
@@ -841,7 +841,7 @@ ____
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("single-line quote with title only", func() {
@@ -869,7 +869,7 @@ ____
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("multi-line quote with rendered lists and block and without author and title", func() {
@@ -941,7 +941,7 @@ ____`
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("multi-line quote with rendered list and without author and title", func() {
@@ -1021,7 +1021,7 @@ ____`
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("empty quote without author and title", func() {
@@ -1035,7 +1035,7 @@ ____`
 				Kind:     types.Quote,
 				Elements: []interface{}{},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("unclosed quote without author and title", func() {
@@ -1061,7 +1061,7 @@ foo
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 	})
 
@@ -1103,7 +1103,7 @@ ____`
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("multi-line verse with unrendered list and author only", func() {
@@ -1143,7 +1143,7 @@ ____
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("multi-line verse with title only", func() {
@@ -1171,7 +1171,7 @@ ____
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("multi-line verse with unrendered lists and block without author and title", func() {
@@ -1221,7 +1221,7 @@ ____`
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("multi-line verse with unrendered list without author and title", func() {
@@ -1262,7 +1262,7 @@ ____`
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("empty verse without author and title", func() {
@@ -1276,7 +1276,7 @@ ____`
 				Kind:     types.Verse,
 				Elements: []interface{}{},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("unclosed verse without author and title", func() {
@@ -1302,7 +1302,7 @@ foo
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 	})
 
@@ -1351,7 +1351,7 @@ end
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("with title, source and languages attributes", func() {
@@ -1400,7 +1400,7 @@ end
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("with id, title, source and languages attributes", func() {
@@ -1452,7 +1452,7 @@ end
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 	})
 
@@ -1489,7 +1489,7 @@ some *verse* content
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("sidebar block with title, paragraph and sourcecode block", func() {
@@ -1551,7 +1551,7 @@ bar
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 	})
 })
@@ -1587,7 +1587,7 @@ var _ = Describe("delimited blocks - document", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("fenced block with no line", func() {
@@ -1605,7 +1605,7 @@ var _ = Describe("delimited blocks - document", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("fenced block with multiple lines alone", func() {
@@ -1650,7 +1650,7 @@ var _ = Describe("delimited blocks - document", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("fenced block with multiple lines then a paragraph", func() {
@@ -1703,7 +1703,7 @@ var _ = Describe("delimited blocks - document", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("fenced block after a paragraph", func() {
@@ -1741,7 +1741,7 @@ var _ = Describe("delimited blocks - document", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("fenced block with unclosed delimiter", func() {
@@ -1770,7 +1770,7 @@ var _ = Describe("delimited blocks - document", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("fenced block with external link inside", func() {
@@ -1822,7 +1822,7 @@ var _ = Describe("delimited blocks - document", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 	})
 
@@ -1856,7 +1856,7 @@ some listing code
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("listing block with no line", func() {
@@ -1875,7 +1875,7 @@ some listing code
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("listing block with multiple lines alone", func() {
@@ -1920,7 +1920,7 @@ in the middle
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("listing block with unrendered list", func() {
@@ -1963,7 +1963,7 @@ in the middle
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("listing block with multiple lines then a paragraph", func() {
@@ -2017,7 +2017,7 @@ then a normal paragraph.`
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("listing block just after a paragraph", func() {
@@ -2057,7 +2057,7 @@ some listing code
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("listing block with unclosed delimiter", func() {
@@ -2087,7 +2087,7 @@ End of file here.`
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 	})
 
@@ -2121,7 +2121,7 @@ some listing code
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("example block with single line starting with a dot", func() {
@@ -2152,7 +2152,7 @@ some listing code
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("example block with multiple lines", func() {
@@ -2229,7 +2229,7 @@ with *bold content*
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("example block with unclosed delimiter", func() {
@@ -2259,7 +2259,7 @@ End of file here`
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("example block with title", func() {
@@ -2293,7 +2293,7 @@ foo
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("example block starting delimiter only", func() {
@@ -2311,7 +2311,7 @@ foo
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 	})
 
@@ -2348,7 +2348,7 @@ foo
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 
 		})
 
@@ -2392,7 +2392,7 @@ paragraphs
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 	})
 
@@ -2442,7 +2442,7 @@ ____`
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("multi-line quote with author only", func() {
@@ -2529,7 +2529,7 @@ ____
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("single-line quote with title only", func() {
@@ -2565,7 +2565,7 @@ ____
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("multi-line quote with rendered lists and block and without author and title", func() {
@@ -2655,7 +2655,7 @@ ____`
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("multi-line quote with rendered list and without author and title", func() {
@@ -2744,7 +2744,7 @@ ____`
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("empty quote without author and title", func() {
@@ -2766,7 +2766,7 @@ ____`
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("unclosed quote without author and title", func() {
@@ -2800,7 +2800,7 @@ foo
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 	})
 
@@ -2850,7 +2850,7 @@ ____`
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("multi-line verse with unrendered list and author only", func() {
@@ -2898,7 +2898,7 @@ ____
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("multi-line verse with title only", func() {
@@ -2934,7 +2934,7 @@ ____
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("multi-line verse with unrendered lists and block without author and title", func() {
@@ -2992,7 +2992,7 @@ ____`
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("multi-line verse with unrendered list without author and title", func() {
@@ -3041,7 +3041,7 @@ ____`
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("empty verse without author and title", func() {
@@ -3063,7 +3063,7 @@ ____`
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("unclosed verse without author and title", func() {
@@ -3097,7 +3097,7 @@ foo
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 	})
 
@@ -3154,7 +3154,7 @@ end
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("with title, source and languages attributes", func() {
@@ -3211,7 +3211,7 @@ end
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("with id, title, source and languages attributes", func() {
@@ -3271,7 +3271,7 @@ end
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 	})
 
@@ -3316,7 +3316,7 @@ some *verse* content
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("sidebar block with title, paragraph and sourcecode block", func() {
@@ -3386,7 +3386,7 @@ bar
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 	})
 })

--- a/pkg/parser/document_attributes_test.go
+++ b/pkg/parser/document_attributes_test.go
@@ -48,7 +48,7 @@ This journey begins on a bleary Monday morning.`
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		Context("document authors", func() {
@@ -88,7 +88,7 @@ Kismet  Rainbow Chameleon  <kismet@asciidoctor.org>`
 							},
 						},
 					}
-					Expect(source).To(EqualDocument(expected))
+					Expect(source).To(BecomeDocument(expected))
 				})
 
 				It("lastname with underscores", func() {
@@ -124,7 +124,7 @@ Lazarus het_Draeke <lazarus@asciidoctor.org>`
 							},
 						},
 					}
-					Expect(source).To(EqualDocument(expected))
+					Expect(source).To(BecomeDocument(expected))
 				})
 
 				It("firstname and lastname only", func() {
@@ -160,7 +160,7 @@ Kismet Chameleon`
 							},
 						},
 					}
-					Expect(source).To(EqualDocument(expected))
+					Expect(source).To(BecomeDocument(expected))
 				})
 
 				It("firstname only", func() {
@@ -196,7 +196,7 @@ Chameleon`
 							},
 						},
 					}
-					Expect(source).To(EqualDocument(expected))
+					Expect(source).To(BecomeDocument(expected))
 				})
 
 				It("alternate author input", func() {
@@ -232,7 +232,7 @@ Chameleon`
 							},
 						},
 					}
-					Expect(source).To(EqualDocument(expected))
+					Expect(source).To(BecomeDocument(expected))
 				})
 			})
 
@@ -275,7 +275,7 @@ Kismet  Rainbow Chameleon  <kismet@asciidoctor.org>; Lazarus het_Draeke <lazarus
 							},
 						},
 					}
-					Expect(source).To(EqualDocument(expected))
+					Expect(source).To(BecomeDocument(expected))
 				})
 			})
 		})
@@ -321,7 +321,7 @@ Kismet  Rainbow Chameleon  <kismet@asciidoctor.org>; Lazarus het_Draeke <lazarus
 						},
 					},
 				}
-				Expect(source).To(EqualDocument(expected))
+				Expect(source).To(BecomeDocument(expected))
 			})
 
 			It("revision with revnumber and revdate only", func() {
@@ -363,7 +363,7 @@ Kismet  Rainbow Chameleon  <kismet@asciidoctor.org>; Lazarus het_Draeke <lazarus
 						},
 					},
 				}
-				Expect(source).To(EqualDocument(expected))
+				Expect(source).To(BecomeDocument(expected))
 			})
 
 			It("revision with revnumber and revdate - with colon separator", func() {
@@ -405,7 +405,7 @@ Kismet  Rainbow Chameleon  <kismet@asciidoctor.org>; Lazarus het_Draeke <lazarus
 						},
 					},
 				}
-				Expect(source).To(EqualDocument(expected))
+				Expect(source).To(BecomeDocument(expected))
 			})
 			It("revision with revnumber only - comma suffix", func() {
 				source := `= title
@@ -446,7 +446,7 @@ Kismet  Rainbow Chameleon  <kismet@asciidoctor.org>; Lazarus het_Draeke <lazarus
 						},
 					},
 				}
-				Expect(source).To(EqualDocument(expected))
+				Expect(source).To(BecomeDocument(expected))
 			})
 
 			It("revision with revdate as number - spaces and no prefix no suffix", func() {
@@ -488,7 +488,7 @@ Kismet  Rainbow Chameleon  <kismet@asciidoctor.org>; Lazarus het_Draeke <lazarus
 						},
 					},
 				}
-				Expect(source).To(EqualDocument(expected))
+				Expect(source).To(BecomeDocument(expected))
 			})
 
 			It("revision with revdate as alphanum - spaces and no prefix no suffix", func() {
@@ -530,7 +530,7 @@ Kismet  Rainbow Chameleon  <kismet@asciidoctor.org>; Lazarus het_Draeke <lazarus
 						},
 					},
 				}
-				Expect(source).To(EqualDocument(expected))
+				Expect(source).To(BecomeDocument(expected))
 			})
 
 			It("revision with revnumber only", func() {
@@ -572,7 +572,7 @@ Kismet  Rainbow Chameleon  <kismet@asciidoctor.org>; Lazarus het_Draeke <lazarus
 						},
 					},
 				}
-				Expect(source).To(EqualDocument(expected))
+				Expect(source).To(BecomeDocument(expected))
 			})
 
 			It("revision with spaces and capital revnumber ", func() {
@@ -614,7 +614,7 @@ Kismet  Rainbow Chameleon  <kismet@asciidoctor.org>; Lazarus het_Draeke <lazarus
 						},
 					},
 				}
-				Expect(source).To(EqualDocument(expected))
+				Expect(source).To(BecomeDocument(expected))
 			})
 
 			It("revision only - with comma separator", func() {
@@ -656,7 +656,7 @@ Kismet  Rainbow Chameleon  <kismet@asciidoctor.org>; Lazarus het_Draeke <lazarus
 						},
 					},
 				}
-				Expect(source).To(EqualDocument(expected))
+				Expect(source).To(BecomeDocument(expected))
 			})
 
 			It("revision with revnumber plus comma and colon separators", func() {
@@ -698,7 +698,7 @@ Kismet  Rainbow Chameleon  <kismet@asciidoctor.org>; Lazarus het_Draeke <lazarus
 						},
 					},
 				}
-				Expect(source).To(EqualDocument(expected))
+				Expect(source).To(BecomeDocument(expected))
 			})
 
 			It("revision with revnumber plus colon separator", func() {
@@ -740,7 +740,7 @@ v1.0:`
 						},
 					},
 				}
-				Expect(source).To(EqualDocument(expected))
+				Expect(source).To(BecomeDocument(expected))
 			})
 
 		})
@@ -768,7 +768,7 @@ v1.0:`
 						types.DocumentAttributeDeclaration{Name: "Auth0r", Value: "Xavier"},
 					},
 				}
-				Expect(source).To(EqualDocument(expected))
+				Expect(source).To(BecomeDocument(expected))
 			})
 
 			It("attributes and paragraph without blank line in-between", func() {
@@ -797,7 +797,7 @@ a paragraph`
 						},
 					},
 				}
-				Expect(source).To(EqualDocument(expected))
+				Expect(source).To(BecomeDocument(expected))
 			})
 
 			It("contiguous attributes and paragraph with blank line in-between", func() {
@@ -825,7 +825,7 @@ a paragraph`
 						},
 					},
 				}
-				Expect(source).To(EqualDocument(expected))
+				Expect(source).To(BecomeDocument(expected))
 			})
 
 			It("splitted attributes and paragraph with blank line in-between", func() {
@@ -857,7 +857,7 @@ a paragraph`
 						},
 					},
 				}
-				Expect(source).To(EqualDocument(expected))
+				Expect(source).To(BecomeDocument(expected))
 			})
 
 			It("no header and attributes in body", func() {
@@ -885,7 +885,7 @@ a paragraph`
 						types.DocumentAttributeDeclaration{Name: "author", Value: "Xavier"},
 					},
 				}
-				Expect(source).To(EqualDocument(expected))
+				Expect(source).To(BecomeDocument(expected))
 			})
 		})
 
@@ -914,7 +914,7 @@ a paragraph written by {author}.`
 						},
 					},
 				}
-				Expect(source).To(EqualDocument(expected))
+				Expect(source).To(BecomeDocument(expected))
 			})
 
 			It("paragraph with attribute resets", func() {
@@ -944,7 +944,7 @@ a paragraph written by {author}.`
 						},
 					},
 				}
-				Expect(source).To(EqualDocument(expected))
+				Expect(source).To(BecomeDocument(expected))
 			})
 		})
 
@@ -1010,7 +1010,7 @@ This journey begins on a bleary Monday morning.`
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("header section inline with bold quote", func() {
@@ -1072,7 +1072,7 @@ a paragraph with *bold content*`
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 	})
 
@@ -1108,7 +1108,7 @@ a paragraph with *bold content*`
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("invalid attribute names", func() {
@@ -1133,7 +1133,7 @@ a paragraph with *bold content*`
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 	})
 })

--- a/pkg/parser/element_attributes_test.go
+++ b/pkg/parser/element_attributes_test.go
@@ -28,7 +28,7 @@ a paragraph`
 						},
 					},
 				}
-				Expect(source).To(EqualDocumentBlock(expected))
+				Expect(source).To(BecomeDocumentBlock(expected))
 			})
 			It("spaces in link", func() {
 				source := `[link= http://foo.bar  ]
@@ -45,7 +45,7 @@ a paragraph`
 						},
 					},
 				}
-				Expect(source).To(EqualDocumentBlock(expected))
+				Expect(source).To(BecomeDocumentBlock(expected))
 			})
 		})
 
@@ -68,7 +68,7 @@ a paragraph`
 						},
 					},
 				}
-				Expect(source).To(EqualDocumentBlock(expected))
+				Expect(source).To(BecomeDocumentBlock(expected))
 			})
 
 			It("unbalanced brackets", func() {
@@ -89,7 +89,7 @@ a paragraph`
 						},
 					},
 				}
-				Expect(source).To(EqualDocumentBlock(expected))
+				Expect(source).To(BecomeDocumentBlock(expected))
 			})
 		})
 	})
@@ -114,7 +114,7 @@ a paragraph`
 						},
 					},
 				}
-				Expect(source).To(EqualDocumentBlock(expected))
+				Expect(source).To(BecomeDocumentBlock(expected))
 			})
 
 			It("short-hand syntax", func() {
@@ -133,7 +133,7 @@ a paragraph`
 						},
 					},
 				}
-				Expect(source).To(EqualDocumentBlock(expected))
+				Expect(source).To(BecomeDocumentBlock(expected))
 			})
 		})
 
@@ -157,7 +157,7 @@ a paragraph`
 						},
 					},
 				}
-				Expect(source).To(EqualDocumentBlock(expected))
+				Expect(source).To(BecomeDocumentBlock(expected))
 			})
 
 			It("unbalanced brackets", func() {
@@ -178,7 +178,7 @@ a paragraph`
 						},
 					},
 				}
-				Expect(source).To(EqualDocumentBlock(expected))
+				Expect(source).To(BecomeDocumentBlock(expected))
 			})
 		})
 	})
@@ -202,7 +202,7 @@ a paragraph`
 						},
 					},
 				}
-				Expect(source).To(EqualDocumentBlock(expected))
+				Expect(source).To(BecomeDocumentBlock(expected))
 			})
 		})
 
@@ -233,7 +233,7 @@ a list item!`
 						},
 					},
 				}
-				Expect(source).To(EqualDocumentBlock(expected))
+				Expect(source).To(BecomeDocumentBlock(expected))
 			})
 
 			It("not a dot", func() {
@@ -255,7 +255,7 @@ a paragraph`
 						},
 					},
 				}
-				Expect(source).To(EqualDocumentBlock(expected))
+				Expect(source).To(BecomeDocumentBlock(expected))
 			})
 		})
 	})
@@ -279,7 +279,7 @@ a paragraph`
 						},
 					},
 				}
-				Expect(source).To(EqualDocumentBlock(expected))
+				Expect(source).To(BecomeDocumentBlock(expected))
 			})
 
 			It("full role syntax", func() {
@@ -297,7 +297,7 @@ a paragraph`
 						},
 					},
 				}
-				Expect(source).To(EqualDocumentBlock(expected))
+				Expect(source).To(BecomeDocumentBlock(expected))
 			})
 		})
 	})

--- a/pkg/parser/file_inclusion_test.go
+++ b/pkg/parser/file_inclusion_test.go
@@ -2217,7 +2217,7 @@ var _ = Describe("file inclusions - final document", func() {
 				},
 			},
 		}
-		Expect(source).To(EqualDocument(expected))
+		Expect(source).To(BecomeDocument(expected))
 	})
 
 	It("should include child and grandchild content with relative then absolute level offset", func() {
@@ -2377,7 +2377,7 @@ var _ = Describe("file inclusions - final document", func() {
 				},
 			},
 		}
-		Expect(source).To(EqualDocument(expected))
+		Expect(source).To(BecomeDocument(expected))
 	})
 
 })

--- a/pkg/parser/footnote_test.go
+++ b/pkg/parser/footnote_test.go
@@ -360,7 +360,7 @@ var _ = Describe("footnotes - document", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected)) // need to get the whole document here
+			Expect(source).To(BecomeDocument(expected)) // need to get the whole document here
 		})
 
 		It("footnote with single-line rich content", func() {
@@ -419,7 +419,7 @@ var _ = Describe("footnotes - document", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected)) // need to get the whole document here
+			Expect(source).To(BecomeDocument(expected)) // need to get the whole document here
 		})
 
 		It("footnote in a paragraph", func() {
@@ -453,7 +453,7 @@ var _ = Describe("footnotes - document", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected)) // need to get the whole document here
+			Expect(source).To(BecomeDocument(expected)) // need to get the whole document here
 		})
 
 	})
@@ -508,7 +508,7 @@ var _ = Describe("footnotes - document", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("footnoteref with unknown reference", func() {
@@ -560,7 +560,7 @@ var _ = Describe("footnotes - document", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 	})
 
@@ -670,6 +670,6 @@ a paragraph with another footnote:[baz]`
 				},
 			},
 		}
-		Expect(source).To(EqualDocument(expected)) // need to get the whole document here
+		Expect(source).To(BecomeDocument(expected)) // need to get the whole document here
 	})
 })

--- a/pkg/parser/frontmatter_test.go
+++ b/pkg/parser/frontmatter_test.go
@@ -98,7 +98,7 @@ first paragraph`
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("empty front-matter", func() {
@@ -122,7 +122,7 @@ first paragraph`
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 	})
 

--- a/pkg/parser/image_test.go
+++ b/pkg/parser/image_test.go
@@ -22,7 +22,7 @@ var _ = Describe("images", func() {
 					},
 					Path: "images/foo.png",
 				}
-				Expect(source).To(EqualDocumentBlock(expected))
+				Expect(source).To(BecomeDocumentBlock(expected))
 			})
 
 			It("block image with empty alt and trailing spaces", func() {
@@ -33,7 +33,7 @@ var _ = Describe("images", func() {
 					},
 					Path: "images/foo.png",
 				}
-				Expect(source).To(EqualDocumentBlock(expected))
+				Expect(source).To(BecomeDocumentBlock(expected))
 			})
 
 			It("block image with line return", func() {
@@ -46,7 +46,7 @@ var _ = Describe("images", func() {
 					},
 					Path: "images/foo.png",
 				}
-				Expect(source).To(EqualDocumentBlock(expected))
+				Expect(source).To(BecomeDocumentBlock(expected))
 			})
 
 			It("block image with 1 empty blank line", func() {
@@ -59,7 +59,7 @@ var _ = Describe("images", func() {
 					},
 					Path: "images/foo.png",
 				}
-				Expect(source).To(EqualDocumentBlock(expected))
+				Expect(source).To(BecomeDocumentBlock(expected))
 			})
 
 			It("block image with 2 blank lines with spaces and tabs", func() {
@@ -71,7 +71,7 @@ var _ = Describe("images", func() {
 					},
 					Path: "images/foo.png",
 				}
-				Expect(source).To(EqualDocumentBlock(expected))
+				Expect(source).To(BecomeDocumentBlock(expected))
 			})
 
 			It("block image with alt", func() {
@@ -82,7 +82,7 @@ var _ = Describe("images", func() {
 					},
 					Path: "images/foo.png",
 				}
-				Expect(source).To(EqualDocumentBlock(expected))
+				Expect(source).To(BecomeDocumentBlock(expected))
 			})
 
 			It("block image with dimensions and id link title meta", func() {
@@ -102,7 +102,7 @@ image::images/foo.png[the foo.png image, 600, 400]`
 					},
 					Path: "images/foo.png",
 				}
-				Expect(source).To(EqualDocumentBlock(expected))
+				Expect(source).To(BecomeDocumentBlock(expected))
 			})
 
 			It("2 block images", func() {
@@ -145,7 +145,7 @@ image::appa.png[]`
 							},
 						},
 					}
-					Expect(source).To(EqualDocumentBlock(expected))
+					Expect(source).To(BecomeDocumentBlock(expected))
 				})
 			})
 
@@ -190,7 +190,7 @@ image::appa.png[]`
 						},
 					},
 				}
-				Expect(source).To(EqualDocumentBlock(expected))
+				Expect(source).To(BecomeDocumentBlock(expected))
 			})
 
 			It("inline image with empty alt and trailing spaces", func() {
@@ -211,7 +211,7 @@ image::appa.png[]`
 						},
 					},
 				}
-				Expect(source).To(EqualDocumentBlock(expected))
+				Expect(source).To(BecomeDocumentBlock(expected))
 			})
 
 			It("inline image surrounded with test", func() {
@@ -235,7 +235,7 @@ image::appa.png[]`
 						},
 					},
 				}
-				Expect(source).To(EqualDocumentBlock(expected))
+				Expect(source).To(BecomeDocumentBlock(expected))
 			})
 
 			It("inline image with alt alone", func() {
@@ -253,7 +253,7 @@ image::appa.png[]`
 						},
 					},
 				}
-				Expect(source).To(EqualDocumentBlock(expected))
+				Expect(source).To(BecomeDocumentBlock(expected))
 			})
 
 			It("inline image with alt and width", func() {
@@ -272,7 +272,7 @@ image::appa.png[]`
 						},
 					},
 				}
-				Expect(source).To(EqualDocumentBlock(expected))
+				Expect(source).To(BecomeDocumentBlock(expected))
 			})
 
 			It("inline image with alt, width and height", func() {
@@ -292,7 +292,7 @@ image::appa.png[]`
 						},
 					},
 				}
-				Expect(source).To(EqualDocumentBlock(expected))
+				Expect(source).To(BecomeDocumentBlock(expected))
 			})
 
 			It("inline image with alt, but empty width and height", func() {
@@ -310,7 +310,7 @@ image::appa.png[]`
 						},
 					},
 				}
-				Expect(source).To(EqualDocumentBlock(expected))
+				Expect(source).To(BecomeDocumentBlock(expected))
 			})
 
 			It("inline image with single other attribute only", func() {
@@ -330,7 +330,7 @@ image::appa.png[]`
 						},
 					},
 				}
-				Expect(source).To(EqualDocumentBlock(expected))
+				Expect(source).To(BecomeDocumentBlock(expected))
 			})
 
 			It("inline image with multiple other attributes only", func() {
@@ -352,7 +352,7 @@ image::appa.png[]`
 						},
 					},
 				}
-				Expect(source).To(EqualDocumentBlock(expected))
+				Expect(source).To(BecomeDocumentBlock(expected))
 			})
 
 			It("inline image with alt, width, height and other attributes", func() {
@@ -376,7 +376,7 @@ image::appa.png[]`
 						},
 					},
 				}
-				Expect(source).To(EqualDocumentBlock(expected))
+				Expect(source).To(BecomeDocumentBlock(expected))
 			})
 
 			It("inline image in a paragraph with space after colon", func() {
@@ -397,7 +397,7 @@ image::appa.png[]`
 						},
 					},
 				}
-				Expect(source).To(EqualDocumentBlock(expected))
+				Expect(source).To(BecomeDocumentBlock(expected))
 			})
 
 			It("inline image in a paragraph without space keyword", func() {
@@ -419,7 +419,7 @@ image::appa.png[]`
 					},
 				}
 
-				Expect(source).To(EqualDocumentBlock(expected))
+				Expect(source).To(BecomeDocumentBlock(expected))
 			})
 		})
 		Context("errors", func() {
@@ -436,7 +436,7 @@ image::appa.png[]`
 						},
 					},
 				}
-				Expect(source).To(EqualDocumentBlock(expected))
+				Expect(source).To(BecomeDocumentBlock(expected))
 			})
 		})
 	})

--- a/pkg/parser/inline_elements_test.go
+++ b/pkg/parser/inline_elements_test.go
@@ -25,7 +25,7 @@ var _ = Describe("inline elements", func() {
 				},
 			},
 		}
-		Expect(source).To(EqualDocumentBlock(expected))
+		Expect(source).To(BecomeDocumentBlock(expected))
 	})
 
 	It("bold text within parenthesis", func() {
@@ -45,7 +45,7 @@ var _ = Describe("inline elements", func() {
 				},
 			},
 		}
-		Expect(source).To(EqualDocumentBlock(expected))
+		Expect(source).To(BecomeDocumentBlock(expected))
 	})
 
 	It("bold text within words", func() {
@@ -58,7 +58,7 @@ var _ = Describe("inline elements", func() {
 				},
 			},
 		}
-		Expect(source).To(EqualDocumentBlock(expected))
+		Expect(source).To(BecomeDocumentBlock(expected))
 	})
 
 	It("invalid bold portion of text", func() {
@@ -71,7 +71,7 @@ var _ = Describe("inline elements", func() {
 				},
 			},
 		}
-		Expect(source).To(EqualDocumentBlock(expected))
+		Expect(source).To(BecomeDocumentBlock(expected))
 	})
 
 	It("valid bold portion of text", func() {
@@ -90,7 +90,7 @@ var _ = Describe("inline elements", func() {
 				},
 			},
 		}
-		Expect(source).To(EqualDocumentBlock(expected))
+		Expect(source).To(BecomeDocumentBlock(expected))
 	})
 
 	It("latin characters", func() {
@@ -103,6 +103,6 @@ var _ = Describe("inline elements", func() {
 				},
 			},
 		}
-		Expect(source).To(EqualDocumentBlock(expected))
+		Expect(source).To(BecomeDocumentBlock(expected))
 	})
 })

--- a/pkg/parser/labeled_list_test.go
+++ b/pkg/parser/labeled_list_test.go
@@ -752,7 +752,7 @@ on 2 lines`
 				},
 			},
 		}
-		Expect(source).To(EqualDocument(expected))
+		Expect(source).To(BecomeDocument(expected))
 	})
 
 	It("labeled list with a single term and no description", func() {
@@ -776,7 +776,7 @@ on 2 lines`
 				},
 			},
 		}
-		Expect(source).To(EqualDocument(expected))
+		Expect(source).To(BecomeDocument(expected))
 	})
 
 	It("labeled list with a horizontal layout attribute", func() {
@@ -812,7 +812,7 @@ Item1:: foo`
 				},
 			},
 		}
-		Expect(source).To(EqualDocument(expected))
+		Expect(source).To(BecomeDocument(expected))
 	})
 
 	It("labeled list with a single term and a blank line", func() {
@@ -837,7 +837,7 @@ Item1:: foo`
 				},
 			},
 		}
-		Expect(source).To(EqualDocument(expected))
+		Expect(source).To(BecomeDocument(expected))
 	})
 
 	It("labeled list with multiple sibling items", func() {
@@ -905,7 +905,7 @@ Item 3 description`
 				},
 			},
 		}
-		Expect(source).To(EqualDocument(expected))
+		Expect(source).To(BecomeDocument(expected))
 	})
 
 	It("labeled list with multiple nested items", func() {
@@ -983,7 +983,7 @@ Item 3 description`
 				},
 			},
 		}
-		Expect(source).To(EqualDocument(expected))
+		Expect(source).To(BecomeDocument(expected))
 	})
 
 	It("labeled list with nested unordered list - case 1", func() {
@@ -1064,7 +1064,7 @@ Item with description:: something simple`
 			},
 		}
 
-		Expect(source).To(EqualDocument(expected))
+		Expect(source).To(BecomeDocument(expected))
 	})
 
 	It("labeled list with a single item and paragraph", func() {
@@ -1112,7 +1112,7 @@ a normal paragraph.`
 				},
 			},
 		}
-		Expect(source).To(EqualDocument(expected))
+		Expect(source).To(BecomeDocument(expected))
 	})
 
 	It("labeled list with item continuation", func() {
@@ -1194,7 +1194,7 @@ another fenced block
 			},
 		}
 
-		Expect(source).To(EqualDocument(expected))
+		Expect(source).To(BecomeDocument(expected))
 	})
 
 	It("labeled list without item continuation", func() {
@@ -1277,7 +1277,7 @@ another fenced block
 				},
 			},
 		}
-		Expect(source).To(EqualDocument(expected))
+		Expect(source).To(BecomeDocument(expected))
 	})
 
 	It("labeled list with nested unordered list - case 2", func() {
@@ -1324,7 +1324,7 @@ another fenced block
 				},
 			},
 		}
-		Expect(source).To(EqualDocument(expected))
+		Expect(source).To(BecomeDocument(expected))
 	})
 
 	It("labeled list with title", func() {
@@ -1380,7 +1380,7 @@ second term:: definition of the second term`
 				},
 			},
 		}
-		Expect(source).To(EqualDocument(expected))
+		Expect(source).To(BecomeDocument(expected))
 	})
 
 	It("max level of labeled items - case 1", func() {
@@ -1482,7 +1482,7 @@ level 1:: description 1`
 				},
 			},
 		}
-		Expect(source).To(EqualDocument(expected))
+		Expect(source).To(BecomeDocument(expected))
 	})
 
 	It("max level of labeled items - case 2", func() {
@@ -1584,6 +1584,6 @@ level 2::: description 2`
 				},
 			},
 		}
-		Expect(source).To(EqualDocument(expected))
+		Expect(source).To(BecomeDocument(expected))
 	})
 })

--- a/pkg/parser/link_test.go
+++ b/pkg/parser/link_test.go
@@ -30,7 +30,7 @@ var _ = Describe("links - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("external link with empty text", func() {
@@ -51,7 +51,7 @@ var _ = Describe("links - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("external link with text only", func() {
@@ -79,7 +79,7 @@ var _ = Describe("links - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("external link with text and extra attributes", func() {
@@ -107,7 +107,7 @@ var _ = Describe("links - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("external link inside a multiline paragraph -  without attributes", func() {
@@ -143,7 +143,7 @@ next lines`
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("external link inside a multiline paragraph -  with attributes", func() {
@@ -179,7 +179,7 @@ next lines`
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		Context("text attribute with comma", func() {
@@ -208,7 +208,7 @@ next lines`
 						},
 					},
 				}
-				Expect(source).To(EqualDocumentBlock(expected))
+				Expect(source).To(BecomeDocumentBlock(expected))
 			})
 
 			It("relative link only with doublequoted text having comma", func() {
@@ -235,7 +235,7 @@ next lines`
 						},
 					},
 				}
-				Expect(source).To(EqualDocumentBlock(expected))
+				Expect(source).To(BecomeDocumentBlock(expected))
 			})
 
 			It("relative link with doublequoted text having comma and other attrs", func() {
@@ -263,7 +263,7 @@ next lines`
 						},
 					},
 				}
-				Expect(source).To(EqualDocumentBlock(expected))
+				Expect(source).To(BecomeDocumentBlock(expected))
 			})
 
 			It("relative link with text having comma and other attributes", func() {
@@ -293,7 +293,7 @@ next lines`
 						},
 					},
 				}
-				Expect(source).To(EqualDocumentBlock(expected))
+				Expect(source).To(BecomeDocumentBlock(expected))
 			})
 		})
 
@@ -319,7 +319,7 @@ next lines`
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("relative link to doc with text", func() {
@@ -346,7 +346,7 @@ next lines`
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("relative link to external URL with text only", func() {
@@ -373,7 +373,7 @@ next lines`
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("relative link to external URL with text and extra attributes", func() {
@@ -401,7 +401,7 @@ next lines`
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("relative link to external URL with extra attributes only", func() {
@@ -424,7 +424,7 @@ next lines`
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("invalid relative link to doc", func() {
@@ -439,7 +439,7 @@ next lines`
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("relative link with quoted text", func() {
@@ -495,7 +495,7 @@ next lines`
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("relative link with all valid characters", func() {
@@ -522,7 +522,7 @@ next lines`
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("relative link with encoded space", func() {
@@ -553,7 +553,7 @@ Test 2: link:/test/a%20b[with encoded space]`
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		Context("text attribute with comma", func() {
@@ -582,7 +582,7 @@ Test 2: link:/test/a%20b[with encoded space]`
 						},
 					},
 				}
-				Expect(source).To(EqualDocumentBlock(expected))
+				Expect(source).To(BecomeDocumentBlock(expected))
 			})
 
 			It("relative link only with doublequoted text having comma", func() {
@@ -609,7 +609,7 @@ Test 2: link:/test/a%20b[with encoded space]`
 						},
 					},
 				}
-				Expect(source).To(EqualDocumentBlock(expected))
+				Expect(source).To(BecomeDocumentBlock(expected))
 			})
 
 			It("relative link with doublequoted text having comma and other attrs", func() {
@@ -637,7 +637,7 @@ Test 2: link:/test/a%20b[with encoded space]`
 						},
 					},
 				}
-				Expect(source).To(EqualDocumentBlock(expected))
+				Expect(source).To(BecomeDocumentBlock(expected))
 			})
 
 			It("relative link with text having comma and other attributes", func() {
@@ -667,7 +667,7 @@ Test 2: link:/test/a%20b[with encoded space]`
 						},
 					},
 				}
-				Expect(source).To(EqualDocumentBlock(expected))
+				Expect(source).To(BecomeDocumentBlock(expected))
 			})
 		})
 

--- a/pkg/parser/literal_block_test.go
+++ b/pkg/parser/literal_block_test.go
@@ -23,7 +23,7 @@ var _ = Describe("literal blocks - draft", func() {
 					" some literal content",
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("literal block from paragraph with single space on first line", func() {
@@ -41,7 +41,7 @@ lines.`
 					"lines.",
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("mixing literal block with attributes followed by a paragraph ", func() {
@@ -97,7 +97,7 @@ some content
 					"some content",
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("literal block with delimited and attributes followed by 1-line paragraph", func() {

--- a/pkg/parser/mixed_lists_test.go
+++ b/pkg/parser/mixed_lists_test.go
@@ -136,7 +136,7 @@ var _ = Describe("mixed lists - document", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 	})
 
@@ -371,7 +371,7 @@ var _ = Describe("mixed lists - document", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("complex case 2 - mixed lists", func() {
@@ -777,7 +777,7 @@ ii) ordered 1.2.ii
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("complex case 4 - mixed lists", func() {
@@ -852,7 +852,7 @@ Operating Systems::
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("complex case 5 - mixed lists and a paragraph", func() {
@@ -1176,7 +1176,7 @@ a paragraph
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 	})
 
@@ -1259,7 +1259,7 @@ a paragraph
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("same list with custom number style on sublist", func() {
@@ -1361,7 +1361,7 @@ a paragraph
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("distinct lists with blankline and item attribute - case 1", func() {
@@ -1450,7 +1450,7 @@ a paragraph
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("distinct lists with blankline and item attribute - case 2", func() {
@@ -1556,7 +1556,7 @@ a paragraph
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("same list with single comment line inside", func() {
@@ -1613,7 +1613,7 @@ a paragraph
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("same list with multiple comment lines inside", func() {
@@ -1678,7 +1678,7 @@ a paragraph
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("distinct lists separated by single comment line", func() {
@@ -1741,7 +1741,7 @@ a paragraph
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("distinct lists separated by multiple comment lines", func() {
@@ -1812,7 +1812,7 @@ a paragraph
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 	})
 })

--- a/pkg/parser/ordered_list_test.go
+++ b/pkg/parser/ordered_list_test.go
@@ -972,7 +972,7 @@ var _ = Describe("ordered lists - document", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("ordered list item with arabic numbering style", func() {
@@ -996,7 +996,7 @@ var _ = Describe("ordered lists - document", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("ordered list item with lower alpha numbering style", func() {
@@ -1020,7 +1020,7 @@ var _ = Describe("ordered lists - document", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("ordered list item with upper alpha numbering style", func() {
@@ -1045,7 +1045,7 @@ var _ = Describe("ordered lists - document", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("ordered list item with lower roman numbering style", func() {
@@ -1069,7 +1069,7 @@ var _ = Describe("ordered lists - document", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("ordered list item with upper roman numbering style", func() {
@@ -1094,7 +1094,7 @@ var _ = Describe("ordered lists - document", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("ordered list item with explicit numbering style", func() {
@@ -1128,7 +1128,7 @@ var _ = Describe("ordered lists - document", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("ordered list item with explicit start only", func() {
@@ -1155,7 +1155,7 @@ var _ = Describe("ordered lists - document", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("ordered list item with explicit quoted numbering and start", func() {
@@ -1183,7 +1183,7 @@ var _ = Describe("ordered lists - document", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("max level of ordered items - case 1", func() {
@@ -1331,7 +1331,7 @@ var _ = Describe("ordered lists - document", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("max level of ordered items - case 2", func() {
@@ -1479,7 +1479,7 @@ var _ = Describe("ordered lists - document", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 	})
 
@@ -1532,7 +1532,7 @@ var _ = Describe("ordered lists - document", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("ordered list with unnumbered items", func() {
@@ -1582,7 +1582,7 @@ var _ = Describe("ordered lists - document", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("ordered list with custom numbering on child items with tabs ", func() {
@@ -1731,7 +1731,7 @@ var _ = Describe("ordered lists - document", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("ordered list with all default styles and blank lines", func() {
@@ -1857,7 +1857,7 @@ var _ = Describe("ordered lists - document", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 	})
 
@@ -1909,7 +1909,7 @@ var _ = Describe("ordered lists - document", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("ordered list with numbered items", func() {
@@ -2000,7 +2000,7 @@ b. item 2.a`
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 	})
 
@@ -2093,7 +2093,7 @@ another delimited block
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 	})
 })

--- a/pkg/parser/paragraph_test.go
+++ b/pkg/parser/paragraph_test.go
@@ -22,7 +22,7 @@ var _ = Describe("paragraphs - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("paragraph with few words and ending with spaces", func() {
@@ -35,7 +35,7 @@ var _ = Describe("paragraphs - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("paragraph with bold content and spaces", func() {
@@ -55,7 +55,7 @@ var _ = Describe("paragraphs - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("paragraph with non-alphnum character before bold text", func() {
@@ -74,7 +74,7 @@ var _ = Describe("paragraphs - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("paragraph with id and title", func() {
@@ -93,7 +93,7 @@ a paragraph`
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("paragraph with words and dots on same line", func() {
@@ -107,7 +107,7 @@ a paragraph`
 				},
 			}
 
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 		It("paragraph with words and dots on two lines", func() {
 			source := `foo. 
@@ -123,7 +123,7 @@ bar.`
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 	})
 
@@ -148,7 +148,7 @@ baz`
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("with paragraph attribute", func() {
@@ -172,7 +172,7 @@ baz`
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 	})
@@ -193,7 +193,7 @@ baz`
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("warning admonition paragraph", func() {
@@ -216,7 +216,7 @@ warning!`
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("admonition note paragraph with id and title", func() {
@@ -238,7 +238,7 @@ NOTE: this is a note.`
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("caution admonition paragraph with single line", func() {
@@ -256,7 +256,7 @@ this is a caution!`
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("multiline caution admonition paragraph with title and id", func() {
@@ -293,7 +293,7 @@ this is a
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("multiple admonition paragraphs", func() {
@@ -354,7 +354,7 @@ I am a verse paragraph.`
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("paragraph as a verse with author, title and other attributes", func() {
@@ -379,7 +379,7 @@ I am a verse paragraph.`
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("paragraph as a verse with empty title", func() {
@@ -398,7 +398,7 @@ I am a verse paragraph.`
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("paragraph as a verse without title", func() {
@@ -417,7 +417,7 @@ I am a verse paragraph.`
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("paragraph as a verse with empty author", func() {
@@ -435,7 +435,7 @@ I am a verse paragraph.`
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("paragraph as a verse without author", func() {
@@ -453,7 +453,7 @@ I am a verse paragraph.`
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("image block as a verse", func() {
@@ -473,7 +473,7 @@ image::foo.png[]`
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 	})
 
@@ -496,7 +496,7 @@ I am a quote paragraph.`
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("paragraph as a quote with author, title and other attributes", func() {
@@ -521,7 +521,7 @@ I am a quote paragraph.`
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("paragraph as a quote with empty title", func() {
@@ -540,7 +540,7 @@ I am a quote paragraph.`
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("paragraph as a quote without title", func() {
@@ -559,7 +559,7 @@ I am a quote paragraph.`
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("paragraph as a quote with empty author", func() {
@@ -577,7 +577,7 @@ I am a quote paragraph.`
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("paragraph as a quote without author", func() {
@@ -595,7 +595,7 @@ I am a quote paragraph.`
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("inline image within a quote", func() {
@@ -621,7 +621,7 @@ a foo image:foo.png[]`
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("image block is NOT a quote", func() {
@@ -637,7 +637,7 @@ image::foo.png[]`
 				},
 				Path: "foo.png",
 			}
-			Expect(source).To(EqualDocumentBlock(expected)) //, parser.Debug(true))
+			Expect(source).To(BecomeDocumentBlock(expected)) //, parser.Debug(true))
 		})
 	})
 })

--- a/pkg/parser/passthrough_test.go
+++ b/pkg/parser/passthrough_test.go
@@ -29,7 +29,7 @@ var _ = Describe("passthroughs - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("tripleplus empty passthrough ", func() {
@@ -45,7 +45,7 @@ var _ = Describe("passthroughs - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("tripleplus passthrough with spaces", func() {
@@ -65,7 +65,7 @@ var _ = Describe("passthroughs - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("tripleplus passthrough with only spaces", func() {
@@ -85,7 +85,7 @@ var _ = Describe("passthroughs - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("tripleplus passthrough with line breaks", func() {
@@ -105,7 +105,7 @@ var _ = Describe("passthroughs - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("tripleplus passthrough in paragraph", func() {
@@ -127,7 +127,7 @@ var _ = Describe("passthroughs - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("tripleplus passthrough with embedded image", func() {
@@ -147,7 +147,7 @@ var _ = Describe("passthroughs - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 	})
@@ -171,7 +171,7 @@ var _ = Describe("passthroughs - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("singleplus empty passthrough", func() {
@@ -186,7 +186,7 @@ var _ = Describe("passthroughs - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("singleplus passthrough with embedded image", func() {
@@ -206,7 +206,7 @@ var _ = Describe("passthroughs - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("invalid singleplus passthrough with spaces - case 1", func() {
@@ -233,7 +233,7 @@ var _ = Describe("passthroughs - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("invalid singleplus passthrough with spaces - case 2", func() {
@@ -259,7 +259,7 @@ var _ = Describe("passthroughs - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("invalid singleplus passthrough with spaces - case 3", func() {
@@ -286,7 +286,7 @@ var _ = Describe("passthroughs - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("invalid singleplus passthrough with line break", func() {
@@ -306,7 +306,7 @@ var _ = Describe("passthroughs - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 	})
@@ -332,7 +332,7 @@ var _ = Describe("passthroughs - draft", func() {
 						},
 					},
 				}
-				Expect(source).To(EqualDocumentBlock(expected))
+				Expect(source).To(BecomeDocumentBlock(expected))
 			})
 
 			It("passthrough macro with words", func() {
@@ -352,7 +352,7 @@ var _ = Describe("passthroughs - draft", func() {
 						},
 					},
 				}
-				Expect(source).To(EqualDocumentBlock(expected))
+				Expect(source).To(BecomeDocumentBlock(expected))
 			})
 
 			It("empty passthrough macro", func() {
@@ -368,7 +368,7 @@ var _ = Describe("passthroughs - draft", func() {
 						},
 					},
 				}
-				Expect(source).To(EqualDocumentBlock(expected))
+				Expect(source).To(BecomeDocumentBlock(expected))
 			})
 
 			It("passthrough macro with spaces", func() {
@@ -388,7 +388,7 @@ var _ = Describe("passthroughs - draft", func() {
 						},
 					},
 				}
-				Expect(source).To(EqualDocumentBlock(expected))
+				Expect(source).To(BecomeDocumentBlock(expected))
 			})
 
 			It("passthrough macro with line break", func() {
@@ -408,7 +408,7 @@ var _ = Describe("passthroughs - draft", func() {
 						},
 					},
 				}
-				Expect(source).To(EqualDocumentBlock(expected))
+				Expect(source).To(BecomeDocumentBlock(expected))
 			})
 		})
 
@@ -436,7 +436,7 @@ var _ = Describe("passthroughs - draft", func() {
 						},
 					},
 				}
-				Expect(source).To(EqualDocumentBlock(expected))
+				Expect(source).To(BecomeDocumentBlock(expected))
 			})
 
 			It("passthrough macro with quoted word in sentence", func() {
@@ -467,7 +467,7 @@ var _ = Describe("passthroughs - draft", func() {
 						},
 					},
 				}
-				Expect(source).To(EqualDocumentBlock(expected))
+				Expect(source).To(BecomeDocumentBlock(expected))
 			})
 		})
 	})

--- a/pkg/parser/q_a_list_test.go
+++ b/pkg/parser/q_a_list_test.go
@@ -67,6 +67,6 @@ What is the answer to the Ultimate Question?:: 42`
 				},
 			},
 		}
-		Expect(source).To(EqualDocument(expected))
+		Expect(source).To(BecomeDocument(expected))
 	})
 })

--- a/pkg/parser/quoted_text_test.go
+++ b/pkg/parser/quoted_text_test.go
@@ -132,7 +132,7 @@ var _ = Describe("quoted texts - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("invalid superscript text with 3 words", func() {
@@ -145,7 +145,7 @@ var _ = Describe("quoted texts - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("bold text within italic text", func() {
@@ -227,7 +227,7 @@ var _ = Describe("quoted texts - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("subscript text attached", func() {
@@ -247,7 +247,7 @@ var _ = Describe("quoted texts - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("superscript text attached", func() {
@@ -267,7 +267,7 @@ var _ = Describe("quoted texts - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("invalid subscript text with 3 words", func() {
@@ -280,7 +280,7 @@ var _ = Describe("quoted texts - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 	})
@@ -435,7 +435,7 @@ var _ = Describe("quoted texts - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("inline content with invalid bold text - use case 1", func() {
@@ -448,7 +448,7 @@ var _ = Describe("quoted texts - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("inline content with invalid bold text - use case 2", func() {
@@ -461,7 +461,7 @@ var _ = Describe("quoted texts - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("inline content with invalid bold text - use case 3", func() {
@@ -474,7 +474,7 @@ var _ = Describe("quoted texts - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("invalid italic text within bold text", func() {
@@ -495,7 +495,7 @@ var _ = Describe("quoted texts - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("italic text within invalid bold text", func() {
@@ -515,7 +515,7 @@ var _ = Describe("quoted texts - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("inline content with invalid subscript text - use case 1", func() {
@@ -528,7 +528,7 @@ var _ = Describe("quoted texts - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("inline content with invalid subscript text - use case 2", func() {
@@ -541,7 +541,7 @@ var _ = Describe("quoted texts - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("inline content with invalid subscript text - use case 3", func() {
@@ -554,7 +554,7 @@ var _ = Describe("quoted texts - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("inline content with invalid superscript text - use case 1", func() {
@@ -568,7 +568,7 @@ var _ = Describe("quoted texts - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("inline content with invalid superscript text - use case 2", func() {
@@ -582,7 +582,7 @@ var _ = Describe("quoted texts - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("inline content with invalid superscript text - use case 3", func() {
@@ -596,7 +596,7 @@ var _ = Describe("quoted texts - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 	})
 
@@ -626,7 +626,7 @@ var _ = Describe("quoted texts - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("single-quote bold within single-quote bold text", func() {
@@ -646,7 +646,7 @@ var _ = Describe("quoted texts - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("double-quote bold within double-quote bold text", func() {
@@ -672,7 +672,7 @@ var _ = Describe("quoted texts - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("single-quote bold within double-quote bold text", func() {
@@ -698,7 +698,7 @@ var _ = Describe("quoted texts - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("double-quote bold within single-quote bold text", func() {
@@ -724,7 +724,7 @@ var _ = Describe("quoted texts - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("single-quote italic within single-quote italic text", func() {
@@ -744,7 +744,7 @@ var _ = Describe("quoted texts - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("double-quote italic within double-quote italic text", func() {
@@ -770,7 +770,7 @@ var _ = Describe("quoted texts - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("single-quote italic within double-quote italic text", func() {
@@ -796,7 +796,7 @@ var _ = Describe("quoted texts - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("double-quote italic within single-quote italic text", func() {
@@ -822,7 +822,7 @@ var _ = Describe("quoted texts - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("single-quote monospace within single-quote monospace text", func() {
@@ -842,7 +842,7 @@ var _ = Describe("quoted texts - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("double-quote monospace within double-quote monospace text", func() {
@@ -868,7 +868,7 @@ var _ = Describe("quoted texts - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("single-quote monospace within double-quote monospace text", func() {
@@ -894,7 +894,7 @@ var _ = Describe("quoted texts - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("double-quote monospace within single-quote monospace text", func() {
@@ -920,7 +920,7 @@ var _ = Describe("quoted texts - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("unbalanced bold in monospace - case 1", func() {
@@ -938,7 +938,7 @@ var _ = Describe("quoted texts - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("unbalanced bold in monospace - case 2", func() {
@@ -956,7 +956,7 @@ var _ = Describe("quoted texts - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("italic in monospace", func() {
@@ -979,7 +979,7 @@ var _ = Describe("quoted texts - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("unbalanced italic in monospace", func() {
@@ -997,7 +997,7 @@ var _ = Describe("quoted texts - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("unparsed bold in monospace", func() {
@@ -1015,7 +1015,7 @@ var _ = Describe("quoted texts - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("parsed subscript in monospace", func() {
@@ -1039,7 +1039,7 @@ var _ = Describe("quoted texts - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("multiline in single quoted monospace - case 1", func() {
@@ -1057,7 +1057,7 @@ var _ = Describe("quoted texts - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("multiline in double quoted monospace - case 1", func() {
@@ -1075,7 +1075,7 @@ var _ = Describe("quoted texts - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("multiline in single quoted  monospace - case 2", func() {
@@ -1099,7 +1099,7 @@ var _ = Describe("quoted texts - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("multiline in double quoted  monospace - case 2", func() {
@@ -1123,7 +1123,7 @@ var _ = Describe("quoted texts - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("link in bold", func() {
@@ -1155,7 +1155,7 @@ var _ = Describe("quoted texts - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("image in bold", func() {
@@ -1179,7 +1179,7 @@ var _ = Describe("quoted texts - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("singleplus passthrough in bold", func() {
@@ -1203,7 +1203,7 @@ var _ = Describe("quoted texts - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("tripleplus passthrough in bold", func() {
@@ -1227,7 +1227,7 @@ var _ = Describe("quoted texts - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("link in italic", func() {
@@ -1259,7 +1259,7 @@ var _ = Describe("quoted texts - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("image in italic", func() {
@@ -1283,7 +1283,7 @@ var _ = Describe("quoted texts - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("singleplus passthrough in italic", func() {
@@ -1307,7 +1307,7 @@ var _ = Describe("quoted texts - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("tripleplus passthrough in italic", func() {
@@ -1331,7 +1331,7 @@ var _ = Describe("quoted texts - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("link in monospace", func() {
@@ -1363,7 +1363,7 @@ var _ = Describe("quoted texts - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("image in monospace", func() {
@@ -1387,7 +1387,7 @@ var _ = Describe("quoted texts - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("singleplus passthrough in monospace", func() {
@@ -1412,7 +1412,7 @@ var _ = Describe("quoted texts - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("tripleplus passthrough in monospace", func() {
@@ -1437,7 +1437,7 @@ var _ = Describe("quoted texts - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 	})
@@ -1462,7 +1462,7 @@ var _ = Describe("quoted texts - draft", func() {
 						},
 					},
 				}
-				Expect(source).To(EqualDocumentBlock(expected))
+				Expect(source).To(BecomeDocumentBlock(expected))
 			})
 
 			It("unbalanced bold text - extra on right", func() {
@@ -1482,7 +1482,7 @@ var _ = Describe("quoted texts - draft", func() {
 						},
 					},
 				}
-				Expect(source).To(EqualDocumentBlock(expected))
+				Expect(source).To(BecomeDocumentBlock(expected))
 			})
 		})
 
@@ -1504,7 +1504,7 @@ var _ = Describe("quoted texts - draft", func() {
 						},
 					},
 				}
-				Expect(source).To(EqualDocumentBlock(expected))
+				Expect(source).To(BecomeDocumentBlock(expected))
 			})
 
 			It("unbalanced italic text - extra on right", func() {
@@ -1523,7 +1523,7 @@ var _ = Describe("quoted texts - draft", func() {
 						},
 					},
 				}
-				Expect(source).To(EqualDocumentBlock(expected))
+				Expect(source).To(BecomeDocumentBlock(expected))
 			})
 		})
 
@@ -1545,7 +1545,7 @@ var _ = Describe("quoted texts - draft", func() {
 						},
 					},
 				}
-				Expect(source).To(EqualDocumentBlock(expected))
+				Expect(source).To(BecomeDocumentBlock(expected))
 			})
 
 			It("unbalanced monospace text - extra on right", func() {
@@ -1564,7 +1564,7 @@ var _ = Describe("quoted texts - draft", func() {
 						},
 					},
 				}
-				Expect(source).To(EqualDocumentBlock(expected))
+				Expect(source).To(BecomeDocumentBlock(expected))
 			})
 		})
 
@@ -1578,7 +1578,7 @@ var _ = Describe("quoted texts - draft", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 	})
@@ -1599,7 +1599,7 @@ var _ = Describe("quoted texts - draft", func() {
 							},
 						},
 					}
-					Expect(source).To(EqualDocumentBlock(expected))
+					Expect(source).To(BecomeDocumentBlock(expected))
 				})
 
 				It("escaped bold text with multiple backslashes", func() {
@@ -1612,7 +1612,7 @@ var _ = Describe("quoted texts - draft", func() {
 							},
 						},
 					}
-					Expect(source).To(EqualDocumentBlock(expected))
+					Expect(source).To(BecomeDocumentBlock(expected))
 				})
 
 				It("escaped bold text with double quote", func() {
@@ -1625,7 +1625,7 @@ var _ = Describe("quoted texts - draft", func() {
 							},
 						},
 					}
-					Expect(source).To(EqualDocumentBlock(expected))
+					Expect(source).To(BecomeDocumentBlock(expected))
 				})
 
 				It("escaped bold text with double quote and more backslashes", func() {
@@ -1638,7 +1638,7 @@ var _ = Describe("quoted texts - draft", func() {
 							},
 						},
 					}
-					Expect(source).To(EqualDocumentBlock(expected))
+					Expect(source).To(BecomeDocumentBlock(expected))
 				})
 
 				It("escaped bold text with unbalanced double quote", func() {
@@ -1651,7 +1651,7 @@ var _ = Describe("quoted texts - draft", func() {
 							},
 						},
 					}
-					Expect(source).To(EqualDocumentBlock(expected))
+					Expect(source).To(BecomeDocumentBlock(expected))
 				})
 
 				It("escaped bold text with unbalanced double quote and more backslashes", func() {
@@ -1664,7 +1664,7 @@ var _ = Describe("quoted texts - draft", func() {
 							},
 						},
 					}
-					Expect(source).To(EqualDocumentBlock(expected))
+					Expect(source).To(BecomeDocumentBlock(expected))
 				})
 			})
 
@@ -1687,7 +1687,7 @@ var _ = Describe("quoted texts - draft", func() {
 							},
 						},
 					}
-					Expect(source).To(EqualDocumentBlock(expected))
+					Expect(source).To(BecomeDocumentBlock(expected))
 				})
 
 				It("escaped bold text with unbalanced double quote and nested italic test", func() {
@@ -1707,7 +1707,7 @@ var _ = Describe("quoted texts - draft", func() {
 							},
 						},
 					}
-					Expect(source).To(EqualDocumentBlock(expected))
+					Expect(source).To(BecomeDocumentBlock(expected))
 				})
 
 				It("escaped bold text with nested italic", func() {
@@ -1727,7 +1727,7 @@ var _ = Describe("quoted texts - draft", func() {
 							},
 						},
 					}
-					Expect(source).To(EqualDocumentBlock(expected))
+					Expect(source).To(BecomeDocumentBlock(expected))
 				})
 			})
 
@@ -1747,7 +1747,7 @@ var _ = Describe("quoted texts - draft", func() {
 							},
 						},
 					}
-					Expect(source).To(EqualDocumentBlock(expected))
+					Expect(source).To(BecomeDocumentBlock(expected))
 				})
 
 				It("escaped italic text with single quote and more backslashes", func() {
@@ -1760,7 +1760,7 @@ var _ = Describe("quoted texts - draft", func() {
 							},
 						},
 					}
-					Expect(source).To(EqualDocumentBlock(expected))
+					Expect(source).To(BecomeDocumentBlock(expected))
 				})
 
 				It("escaped italic text with double quote with 2 backslashes", func() {
@@ -1773,7 +1773,7 @@ var _ = Describe("quoted texts - draft", func() {
 							},
 						},
 					}
-					Expect(source).To(EqualDocumentBlock(expected))
+					Expect(source).To(BecomeDocumentBlock(expected))
 				})
 
 				It("escaped italic text with double quote with 3 backslashes", func() {
@@ -1786,7 +1786,7 @@ var _ = Describe("quoted texts - draft", func() {
 							},
 						},
 					}
-					Expect(source).To(EqualDocumentBlock(expected))
+					Expect(source).To(BecomeDocumentBlock(expected))
 				})
 
 				It("escaped italic text with unbalanced double quote", func() {
@@ -1799,7 +1799,7 @@ var _ = Describe("quoted texts - draft", func() {
 							},
 						},
 					}
-					Expect(source).To(EqualDocumentBlock(expected))
+					Expect(source).To(BecomeDocumentBlock(expected))
 				})
 
 				It("escaped italic text with unbalanced double quote and more backslashes", func() {
@@ -1812,7 +1812,7 @@ var _ = Describe("quoted texts - draft", func() {
 							},
 						},
 					}
-					Expect(source).To(EqualDocumentBlock(expected))
+					Expect(source).To(BecomeDocumentBlock(expected))
 				})
 			})
 
@@ -1835,7 +1835,7 @@ var _ = Describe("quoted texts - draft", func() {
 							},
 						},
 					}
-					Expect(source).To(EqualDocumentBlock(expected))
+					Expect(source).To(BecomeDocumentBlock(expected))
 				})
 
 				It("escaped italic text with unbalanced double quote and nested bold test", func() {
@@ -1855,7 +1855,7 @@ var _ = Describe("quoted texts - draft", func() {
 							},
 						},
 					}
-					Expect(source).To(EqualDocumentBlock(expected))
+					Expect(source).To(BecomeDocumentBlock(expected))
 				})
 
 				It("escaped italic text with nested bold text", func() {
@@ -1875,7 +1875,7 @@ var _ = Describe("quoted texts - draft", func() {
 							},
 						},
 					}
-					Expect(source).To(EqualDocumentBlock(expected))
+					Expect(source).To(BecomeDocumentBlock(expected))
 				})
 			})
 		})
@@ -1894,7 +1894,7 @@ var _ = Describe("quoted texts - draft", func() {
 							},
 						},
 					}
-					Expect(source).To(EqualDocumentBlock(expected))
+					Expect(source).To(BecomeDocumentBlock(expected))
 				})
 
 				It("escaped monospace text with single quote and more backslashes", func() {
@@ -1907,7 +1907,7 @@ var _ = Describe("quoted texts - draft", func() {
 							},
 						},
 					}
-					Expect(source).To(EqualDocumentBlock(expected))
+					Expect(source).To(BecomeDocumentBlock(expected))
 				})
 
 				It("escaped monospace text with double quote", func() {
@@ -1920,7 +1920,7 @@ var _ = Describe("quoted texts - draft", func() {
 							},
 						},
 					}
-					Expect(source).To(EqualDocumentBlock(expected))
+					Expect(source).To(BecomeDocumentBlock(expected))
 				})
 
 				It("escaped monospace text with double quote and more backslashes", func() {
@@ -1933,7 +1933,7 @@ var _ = Describe("quoted texts - draft", func() {
 							},
 						},
 					}
-					Expect(source).To(EqualDocumentBlock(expected))
+					Expect(source).To(BecomeDocumentBlock(expected))
 				})
 
 				It("escaped monospace text with unbalanced double quote", func() {
@@ -1946,7 +1946,7 @@ var _ = Describe("quoted texts - draft", func() {
 							},
 						},
 					}
-					Expect(source).To(EqualDocumentBlock(expected))
+					Expect(source).To(BecomeDocumentBlock(expected))
 				})
 
 				It("escaped monospace text with unbalanced double quote and more backslashes", func() {
@@ -1959,7 +1959,7 @@ var _ = Describe("quoted texts - draft", func() {
 							},
 						},
 					}
-					Expect(source).To(EqualDocumentBlock(expected))
+					Expect(source).To(BecomeDocumentBlock(expected))
 				})
 			})
 
@@ -1982,7 +1982,7 @@ var _ = Describe("quoted texts - draft", func() {
 							},
 						},
 					}
-					Expect(source).To(EqualDocumentBlock(expected))
+					Expect(source).To(BecomeDocumentBlock(expected))
 				})
 
 				It("escaped monospace text with unbalanced double backquote and nested bold test", func() {
@@ -2002,7 +2002,7 @@ var _ = Describe("quoted texts - draft", func() {
 							},
 						},
 					}
-					Expect(source).To(EqualDocumentBlock(expected))
+					Expect(source).To(BecomeDocumentBlock(expected))
 				})
 
 				It("escaped monospace text with nested bold text", func() {
@@ -2022,7 +2022,7 @@ var _ = Describe("quoted texts - draft", func() {
 							},
 						},
 					}
-					Expect(source).To(EqualDocumentBlock(expected))
+					Expect(source).To(BecomeDocumentBlock(expected))
 				})
 			})
 		})
@@ -2041,7 +2041,7 @@ var _ = Describe("quoted texts - draft", func() {
 							},
 						},
 					}
-					Expect(source).To(EqualDocumentBlock(expected))
+					Expect(source).To(BecomeDocumentBlock(expected))
 				})
 
 				It("escaped subscript text with single quote and more backslashes", func() {
@@ -2054,7 +2054,7 @@ var _ = Describe("quoted texts - draft", func() {
 							},
 						},
 					}
-					Expect(source).To(EqualDocumentBlock(expected))
+					Expect(source).To(BecomeDocumentBlock(expected))
 				})
 
 			})
@@ -2078,7 +2078,7 @@ var _ = Describe("quoted texts - draft", func() {
 							},
 						},
 					}
-					Expect(source).To(EqualDocumentBlock(expected))
+					Expect(source).To(BecomeDocumentBlock(expected))
 				})
 
 				It("escaped subscript text with nested bold text", func() {
@@ -2098,7 +2098,7 @@ var _ = Describe("quoted texts - draft", func() {
 							},
 						},
 					}
-					Expect(source).To(EqualDocumentBlock(expected))
+					Expect(source).To(BecomeDocumentBlock(expected))
 				})
 			})
 		})
@@ -2117,7 +2117,7 @@ var _ = Describe("quoted texts - draft", func() {
 							},
 						},
 					}
-					Expect(source).To(EqualDocumentBlock(expected))
+					Expect(source).To(BecomeDocumentBlock(expected))
 				})
 
 				It("escaped superscript text with single quote and more backslashes", func() {
@@ -2130,7 +2130,7 @@ var _ = Describe("quoted texts - draft", func() {
 							},
 						},
 					}
-					Expect(source).To(EqualDocumentBlock(expected))
+					Expect(source).To(BecomeDocumentBlock(expected))
 				})
 
 			})
@@ -2154,7 +2154,7 @@ var _ = Describe("quoted texts - draft", func() {
 							},
 						},
 					}
-					Expect(source).To(EqualDocumentBlock(expected))
+					Expect(source).To(BecomeDocumentBlock(expected))
 				})
 
 				It("escaped superscript text with unbalanced double backquote and nested bold test", func() {
@@ -2174,7 +2174,7 @@ var _ = Describe("quoted texts - draft", func() {
 							},
 						},
 					}
-					Expect(source).To(EqualDocumentBlock(expected))
+					Expect(source).To(BecomeDocumentBlock(expected))
 				})
 
 				It("escaped superscript text with nested bold text - case 2", func() {
@@ -2194,7 +2194,7 @@ var _ = Describe("quoted texts - draft", func() {
 							},
 						},
 					}
-					Expect(source).To(EqualDocumentBlock(expected))
+					Expect(source).To(BecomeDocumentBlock(expected))
 				})
 			})
 		})

--- a/pkg/parser/section_test.go
+++ b/pkg/parser/section_test.go
@@ -678,7 +678,7 @@ var _ = Describe("sections - document", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("header with many spaces around content", func() {
@@ -705,7 +705,7 @@ var _ = Describe("sections - document", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("header and paragraph", func() {
@@ -744,7 +744,7 @@ and a paragraph`
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("two sections with level 0", func() {
@@ -787,7 +787,7 @@ and a paragraph`
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("section level 1 alone", func() {
@@ -814,7 +814,7 @@ and a paragraph`
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("section level 1 with quoted text", func() {
@@ -846,7 +846,7 @@ and a paragraph`
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("section level 0 with nested section level 1", func() {
@@ -889,7 +889,7 @@ and a paragraph`
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("section level 0 with nested section level 2", func() {
@@ -932,7 +932,7 @@ and a paragraph`
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("section level 1 with immediate paragraph", func() {
@@ -969,7 +969,7 @@ and a paragraph`
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("section level 1 with a paragraph separated by empty line", func() {
@@ -1007,7 +1007,7 @@ and a paragraph`
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("section level 1 with a paragraph separated by non-empty line", func() {
@@ -1043,7 +1043,7 @@ and a paragraph`
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("section levels 1, 2, 3, 2", func() {
@@ -1146,7 +1146,7 @@ a paragraph`
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("section levels 1, 2, 3, 3", func() {
@@ -1249,7 +1249,7 @@ a paragraph`
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("section levels 1, 3, 4, 4", func() {
@@ -1352,7 +1352,7 @@ a paragraph`
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("single section with custom IDs", func() {
@@ -1380,7 +1380,7 @@ a paragraph`
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("multiple sections with custom IDs", func() {
@@ -1450,7 +1450,7 @@ a paragraph`
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("sections with same title", func() {
@@ -1493,7 +1493,7 @@ a paragraph`
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 	})
 
@@ -1516,7 +1516,7 @@ a paragraph`
 						},
 					},
 				}}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("header invalid - missing space", func() {
@@ -1536,7 +1536,7 @@ a paragraph`
 						},
 					},
 				}}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("header invalid - header space", func() {
@@ -1558,7 +1558,7 @@ a paragraph`
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("header with invalid section1", func() {
@@ -1596,7 +1596,7 @@ a paragraph`
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 	})
@@ -1635,7 +1635,7 @@ Doc Writer <thedoc@asciidoctor.org>`
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 	})
 })

--- a/pkg/parser/table_test.go
+++ b/pkg/parser/table_test.go
@@ -50,7 +50,7 @@ var _ = Describe("tables", func() {
 				},
 			},
 		}
-		Expect(source).To(EqualDocumentBlock(expected))
+		Expect(source).To(BecomeDocumentBlock(expected))
 	})
 
 	It("1-line table with 3 cells", func() {
@@ -97,7 +97,7 @@ var _ = Describe("tables", func() {
 				},
 			},
 		}
-		Expect(source).To(EqualDocumentBlock(expected))
+		Expect(source).To(BecomeDocumentBlock(expected))
 	})
 
 	It("table with title, headers and 1 line per cell", func() {
@@ -161,7 +161,7 @@ var _ = Describe("tables", func() {
 				},
 			},
 		}
-		Expect(source).To(EqualDocumentBlock(expected))
+		Expect(source).To(BecomeDocumentBlock(expected))
 	})
 
 	It("empty table ", func() {
@@ -171,6 +171,6 @@ var _ = Describe("tables", func() {
 			Attributes: types.ElementAttributes{},
 			Lines:      []types.TableLine{},
 		}
-		Expect(source).To(EqualDocumentBlock(expected))
+		Expect(source).To(BecomeDocumentBlock(expected))
 	})
 })

--- a/pkg/parser/unordered_list_test.go
+++ b/pkg/parser/unordered_list_test.go
@@ -1598,7 +1598,7 @@ var _ = Describe("unordered lists - document", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("unordered list with ID, title, role and a single item", func() {
@@ -1640,7 +1640,7 @@ var _ = Describe("unordered lists - document", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 		It("unordered list with a title and a single item", func() {
 			source := `.a title
@@ -1676,7 +1676,7 @@ var _ = Describe("unordered lists - document", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("unordered list with 2 items with stars", func() {
@@ -1733,7 +1733,7 @@ var _ = Describe("unordered lists - document", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("unordered list based on article.adoc (with heading spaces)", func() {
@@ -1904,7 +1904,7 @@ var _ = Describe("unordered lists - document", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("unordered list with 2 items with carets", func() {
@@ -1961,7 +1961,7 @@ var _ = Describe("unordered lists - document", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("unordered list with items with mixed styles", func() {
@@ -2078,7 +2078,7 @@ var _ = Describe("unordered lists - document", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("unordered list with 2 items with empty line in-between", func() {
@@ -2137,7 +2137,7 @@ var _ = Describe("unordered lists - document", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 		It("unordered list with 2 items on multiple lines", func() {
 			source := `* item 1
@@ -2195,7 +2195,7 @@ on 2 lines, too.`
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 		It("unordered lists with 2 empty lines in-between", func() {
 			// the first blank lines after the first list is swallowed (for the list item)
@@ -2248,7 +2248,7 @@ on 2 lines, too.`
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected)) // parse the whole document to get 2 lists
+			Expect(source).To(BecomeDocument(expected)) // parse the whole document to get 2 lists
 		})
 
 		It("unordered list with items on 3 levels", func() {
@@ -2416,7 +2416,7 @@ on 2 lines, too.`
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("max level of unordered items - case 1", func() {
@@ -2570,7 +2570,7 @@ on 2 lines, too.`
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("max level of unordered items - case 2", func() {
@@ -2724,7 +2724,7 @@ on 2 lines, too.`
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 	})
 
@@ -2838,7 +2838,7 @@ on 2 lines, too.`
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("invalid list item", func() {
@@ -2859,7 +2859,7 @@ on 2 lines, too.`
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 	})
 
@@ -2954,7 +2954,7 @@ another delimited block
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("unordered list with item continuation - case 2", func() {
@@ -3136,7 +3136,7 @@ The {plus} symbol is on a new line.
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("unordered list without item continuation", func() {
@@ -3230,7 +3230,7 @@ another delimited block
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 	})
 
@@ -3323,7 +3323,7 @@ paragraph attached to grand parent list item`
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 
 		It("attach to parent item", func() {
@@ -3412,7 +3412,7 @@ paragraph attached to parent list item`
 					},
 				},
 			}
-			Expect(source).To(EqualDocument(expected))
+			Expect(source).To(BecomeDocument(expected))
 		})
 	})
 })

--- a/pkg/parser/user_macro_test.go
+++ b/pkg/parser/user_macro_test.go
@@ -31,7 +31,7 @@ var _ = Describe("user macros", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("inline macro with attribute", func() {
@@ -55,7 +55,7 @@ var _ = Describe("user macros", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("inline macro with value", func() {
@@ -77,7 +77,7 @@ var _ = Describe("user macros", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("inline user macro with value and attributes", func() {
@@ -102,7 +102,7 @@ var _ = Describe("user macros", func() {
 					},
 				},
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 	})
 
@@ -118,7 +118,7 @@ var _ = Describe("user macros", func() {
 				Attributes: types.ElementAttributes{},
 				RawText:    "git::[]",
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("user block macro with value and attributes", func() {
@@ -133,7 +133,7 @@ var _ = Describe("user macros", func() {
 				},
 				RawText: "git::some/url.git[key1=value1,key2=value2]",
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("user macro block with attribute", func() {
@@ -147,7 +147,7 @@ var _ = Describe("user macros", func() {
 				},
 				RawText: `git::[key1="value1"]`,
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 		It("user macro block with value", func() {
@@ -159,7 +159,7 @@ var _ = Describe("user macros", func() {
 				Attributes: types.ElementAttributes{},
 				RawText:    "git::some/url.git[]",
 			}
-			Expect(source).To(EqualDocumentBlock(expected))
+			Expect(source).To(BecomeDocumentBlock(expected))
 		})
 
 	})

--- a/testsupport/document_block_matcher.go
+++ b/testsupport/document_block_matcher.go
@@ -10,8 +10,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-// EqualDocumentBlock a custom matcher to verify that a document block matches the expectation
-func EqualDocumentBlock(expected interface{}) types.GomegaMatcher {
+// BecomeDocumentBlock a custom matcher to verify that a document block matches the expectation
+func BecomeDocumentBlock(expected interface{}) types.GomegaMatcher {
 	return &documentBlockMatcher{
 		expected: expected,
 	}
@@ -26,7 +26,7 @@ type documentBlockMatcher struct {
 func (m *documentBlockMatcher) Match(actual interface{}) (success bool, err error) {
 	content, ok := actual.(string)
 	if !ok {
-		return false, errors.Errorf("EqualDocumentBlock matcher expects a string (actual: %T)", actual)
+		return false, errors.Errorf("BecomeDocumentBlock matcher expects a string (actual: %T)", actual)
 	}
 	r := strings.NewReader(content)
 	opts := []parser.Option{parser.Entrypoint("DocumentBlock")}

--- a/testsupport/document_block_matcher_test.go
+++ b/testsupport/document_block_matcher_test.go
@@ -25,7 +25,7 @@ var _ = Describe("document block assertions", func() {
 
 	It("should match", func() {
 		// given
-		matcher := testsupport.EqualDocumentBlock(expected)
+		matcher := testsupport.BecomeDocumentBlock(expected)
 		actual := "hello, world!"
 		// when
 		result, err := matcher.Match(actual)
@@ -36,7 +36,7 @@ var _ = Describe("document block assertions", func() {
 
 	It("should not match", func() {
 		// given
-		matcher := testsupport.EqualDocumentBlock(expected)
+		matcher := testsupport.BecomeDocumentBlock(expected)
 		actual := "foo"
 		// when
 		result, err := matcher.Match(actual)
@@ -60,12 +60,12 @@ var _ = Describe("document block assertions", func() {
 
 	It("should return error when invalid type is input", func() {
 		// given
-		matcher := testsupport.EqualDocumentBlock(expected)
+		matcher := testsupport.BecomeDocumentBlock(expected)
 		// when
 		result, err := matcher.Match(1) // not a string
 		// then
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(Equal("EqualDocumentBlock matcher expects a string (actual: int)"))
+		Expect(err.Error()).To(Equal("BecomeDocumentBlock matcher expects a string (actual: int)"))
 		Expect(result).To(BeFalse())
 	})
 })

--- a/testsupport/document_matcher.go
+++ b/testsupport/document_matcher.go
@@ -11,8 +11,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-// EqualDocument a custom matcher to verify that a document matches the expectation
-func EqualDocument(expected types.Document) gomegatypes.GomegaMatcher {
+// BecomeDocument a custom matcher to verify that a document matches the expectation
+func BecomeDocument(expected types.Document) gomegatypes.GomegaMatcher {
 	return &documentMatcher{
 		expected: expected,
 	}
@@ -27,7 +27,7 @@ type documentMatcher struct {
 func (m *documentMatcher) Match(actual interface{}) (success bool, err error) {
 	content, ok := actual.(string)
 	if !ok {
-		return false, errors.Errorf("EqualDocument matcher expects a string (actual: %T)", actual)
+		return false, errors.Errorf("BecomeDocument matcher expects a string (actual: %T)", actual)
 	}
 	r := strings.NewReader(content)
 	m.actual, err = parser.ParseDocument("", r)

--- a/testsupport/document_matcher_test.go
+++ b/testsupport/document_matcher_test.go
@@ -34,7 +34,7 @@ var _ = Describe("document assertions", func() {
 	It("should match", func() {
 		// given
 		actual := "hello, world!"
-		matcher := testsupport.EqualDocument(expected)
+		matcher := testsupport.BecomeDocument(expected)
 		// when
 		result, err := matcher.Match(actual)
 		// then
@@ -45,7 +45,7 @@ var _ = Describe("document assertions", func() {
 	It("should not match", func() {
 		// given
 		actual := "foo"
-		matcher := testsupport.EqualDocument(expected)
+		matcher := testsupport.BecomeDocument(expected)
 		// when
 		result, err := matcher.Match(actual)
 		// then
@@ -77,14 +77,14 @@ var _ = Describe("document assertions", func() {
 	It("should return error when invalid type is input", func() {
 		// given
 		actual := "foo"
-		matcher := testsupport.EqualDocument(types.Document{})
+		matcher := testsupport.BecomeDocument(types.Document{})
 		_, err := matcher.Match(actual)
 		Expect(err).ToNot(HaveOccurred())
 		// when
 		result, err := matcher.Match(1) // not a string
 		// then
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(Equal("EqualDocument matcher expects a string (actual: int)"))
+		Expect(err.Error()).To(Equal("BecomeDocument matcher expects a string (actual: int)"))
 		Expect(result).To(BeFalse())
 	})
 })

--- a/testsupport/draft_document_matcher.go
+++ b/testsupport/draft_document_matcher.go
@@ -42,7 +42,7 @@ func (m *draftDocumentMatcher) setFilename(f string) {
 func (m *draftDocumentMatcher) Match(actual interface{}) (success bool, err error) {
 	content, ok := actual.(string)
 	if !ok {
-		return false, errors.Errorf("EqualDocumentBlock matcher expects a string (actual: %T)", actual)
+		return false, errors.Errorf("BecomeDocumentBlock matcher expects a string (actual: %T)", actual)
 	}
 	r := strings.NewReader(content)
 	if !m.preprocessing {

--- a/testsupport/draft_document_matcher_test.go
+++ b/testsupport/draft_document_matcher_test.go
@@ -75,7 +75,7 @@ var _ = Describe("draft document assertions", func() {
 			_, err := matcher.Match(1) // not a string
 			// then
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("EqualDocumentBlock matcher expects a string (actual: int)"))
+			Expect(err.Error()).To(Equal("BecomeDocumentBlock matcher expects a string (actual: int)"))
 		})
 	})
 


### PR DESCRIPTION
Fixes #439

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>