### PR TITLE
feat(parser/renderer): support document attrs in image URL

### DIFF
--- a/docs/design.adoc
+++ b/docs/design.adoc
@@ -1,0 +1,13 @@
+= Libasciidoc Design
+
+This document brifley explains how the library works, from parsing to rendering in HTML.
+
+== Parsing the document
+
+The first step is to parse a document. The parser (generated after the link:../pkg/parser/parser.peg[grammar] returns a "draft document" in which the sections are not embedded in a hierarchical manner, other blocks are also not attached to their parent section, blanklines are present, but in which the file inclusions have been processed. 
+
+This so-called "draft document" is then processed to return a "final document" in which the sections are in a hierarchical organization, with their blocks (paragraphs, delimited blocks, etc.) attached to them. Also, all document attribute substitutions have been processed (sometimes resulting in new elements such as links). Blank line elements have been stripped off, too.
+
+== HTMl5 Rendering
+
+The HTML5 renderer takes the final document and applies templates for each element. Having the sections in a hierarchical manner makes life easier in term of surrounding `<div>` tags.

--- a/pkg/parser/delimited_block_test.go
+++ b/pkg/parser/delimited_block_test.go
@@ -205,8 +205,10 @@ var _ = Describe("delimited blocks - draft", func() {
 								types.InlineLink{
 									Attributes: types.ElementAttributes{},
 									Location: types.Location{
-										types.StringElement{
-											Content: "http://website.com",
+										Elements: []interface{}{
+											types.StringElement{
+												Content: "http://website.com",
+											},
 										},
 									},
 								},
@@ -248,8 +250,10 @@ var _ = Describe("delimited blocks - draft", func() {
 								types.InlineLink{
 									Attributes: types.ElementAttributes{},
 									Location: types.Location{
-										types.StringElement{
-											Content: "http://website.com",
+										Elements: []interface{}{
+											types.StringElement{
+												Content: "http://website.com",
+											},
 										},
 									},
 								},
@@ -1556,7 +1560,7 @@ bar
 	})
 })
 
-var _ = Describe("delimited blocks - document", func() {
+var _ = Describe("delimited blocks - final document", func() {
 
 	Context("fenced blocks", func() {
 
@@ -1800,8 +1804,10 @@ var _ = Describe("delimited blocks - document", func() {
 										types.InlineLink{
 											Attributes: types.ElementAttributes{},
 											Location: types.Location{
-												types.StringElement{
-													Content: "http://website.com",
+												Elements: []interface{}{
+													types.StringElement{
+														Content: "http://website.com",
+													},
 												},
 											},
 										},

--- a/pkg/parser/document_attributes_test.go
+++ b/pkg/parser/document_attributes_test.go
@@ -745,7 +745,7 @@ v1.0:`
 
 		})
 
-		Context("document Header Attributes", func() {
+		Context("document header Attributes", func() {
 
 			It("valid attribute names", func() {
 				source := `:a:
@@ -942,134 +942,100 @@ a paragraph written by {author}.`
 				}
 				Expect(source).To(BecomeDocument(expected))
 			})
-		})
 
-		It("header with 2 authors, revision and attributes", func() {
-			source := `= The Dangerous and Thrilling Documentation Chronicles
+			It("header with 2 authors, revision and attributes", func() {
+				source := `= The Dangerous and Thrilling Documentation Chronicles
 Kismet Rainbow Chameleon <kismet@asciidoctor.org>; Lazarus het_Draeke <lazarus@asciidoctor.org>
 v1.0, June 19, 2017: First incarnation
 :toc:
 :keywords: documentation, team, obstacles, journey, victory
 
 This journey begins on a bleary Monday morning.`
-			title := types.InlineElements{
-				types.StringElement{Content: "The Dangerous and Thrilling Documentation Chronicles"},
-			}
-			expected := types.Document{
-				Attributes: types.DocumentAttributes{},
-				ElementReferences: types.ElementReferences{
-					"the_dangerous_and_thrilling_documentation_chronicles": title,
-				},
-				Footnotes:          types.Footnotes{},
-				FootnoteReferences: types.FootnoteReferences{},
-				Elements: []interface{}{
-					types.Section{
-						Level: 0,
-						Attributes: types.ElementAttributes{
-							types.AttrID:       "the_dangerous_and_thrilling_documentation_chronicles",
-							types.AttrCustomID: false,
-							types.AttrAuthors: []types.DocumentAuthor{
-								{
-									FullName: "Kismet Rainbow Chameleon ",
-									Email:    "kismet@asciidoctor.org",
-								},
-								{
-									FullName: "Lazarus het_Draeke ",
-									Email:    "lazarus@asciidoctor.org",
-								},
-							},
-							types.AttrRevision: types.DocumentRevision{
-								Revnumber: "1.0",
-								Revdate:   "June 19, 2017",
-								Revremark: "First incarnation",
-							},
-						},
-						Title: title,
-						Elements: []interface{}{
-							types.DocumentAttributeDeclaration{
-								Name:  "toc",
-								Value: "",
-							},
-							types.DocumentAttributeDeclaration{
-								Name:  "keywords",
-								Value: "documentation, team, obstacles, journey, victory",
-							},
-							types.Paragraph{
-								Attributes: types.ElementAttributes{},
-								Lines: []types.InlineElements{
+				title := types.InlineElements{
+					types.StringElement{Content: "The Dangerous and Thrilling Documentation Chronicles"},
+				}
+				expected := types.Document{
+					Attributes: types.DocumentAttributes{},
+					ElementReferences: types.ElementReferences{
+						"the_dangerous_and_thrilling_documentation_chronicles": title,
+					},
+					Footnotes:          types.Footnotes{},
+					FootnoteReferences: types.FootnoteReferences{},
+					Elements: []interface{}{
+						types.Section{
+							Level: 0,
+							Attributes: types.ElementAttributes{
+								types.AttrID:       "the_dangerous_and_thrilling_documentation_chronicles",
+								types.AttrCustomID: false,
+								types.AttrAuthors: []types.DocumentAuthor{
 									{
-										types.StringElement{Content: "This journey begins on a bleary Monday morning."},
+										FullName: "Kismet Rainbow Chameleon ",
+										Email:    "kismet@asciidoctor.org",
+									},
+									{
+										FullName: "Lazarus het_Draeke ",
+										Email:    "lazarus@asciidoctor.org",
 									},
 								},
-							},
-						},
-					},
-				},
-			}
-			Expect(source).To(BecomeDocument(expected))
-		})
-
-		It("header section inline with bold quote", func() {
-
-			source := `= a header
-				
-== section 1
-
-a paragraph with *bold content*`
-
-			title := types.InlineElements{
-				types.StringElement{Content: "a header"},
-			}
-			section1Title := types.InlineElements{
-				types.StringElement{Content: "section 1"},
-			}
-			expected := types.Document{
-				Attributes: types.DocumentAttributes{},
-				ElementReferences: types.ElementReferences{
-					"a_header":  title,
-					"section_1": section1Title,
-				},
-				Footnotes:          types.Footnotes{},
-				FootnoteReferences: types.FootnoteReferences{},
-				Elements: []interface{}{
-					types.Section{
-						Level: 0,
-						Attributes: types.ElementAttributes{
-							types.AttrID:       "a_header",
-							types.AttrCustomID: false,
-						},
-						Title: title,
-						Elements: []interface{}{
-							types.Section{
-								Level: 1,
-								Title: section1Title,
-								Attributes: types.ElementAttributes{
-									types.AttrID:       "section_1",
-									types.AttrCustomID: false,
+								types.AttrRevision: types.DocumentRevision{
+									Revnumber: "1.0",
+									Revdate:   "June 19, 2017",
+									Revremark: "First incarnation",
 								},
-								Elements: []interface{}{
-									types.Paragraph{
-										Attributes: types.ElementAttributes{},
-										Lines: []types.InlineElements{
-											{
-												types.StringElement{Content: "a paragraph with "},
-												types.QuotedText{
-													Kind: types.Bold,
-													Elements: types.InlineElements{
-														types.StringElement{Content: "bold content"},
-													},
-												},
-											},
+							},
+							Title: title,
+							Elements: []interface{}{
+								types.DocumentAttributeDeclaration{
+									Name:  "toc",
+									Value: "",
+								},
+								types.DocumentAttributeDeclaration{
+									Name:  "keywords",
+									Value: "documentation, team, obstacles, journey, victory",
+								},
+								types.Paragraph{
+									Attributes: types.ElementAttributes{},
+									Lines: []types.InlineElements{
+										{
+											types.StringElement{Content: "This journey begins on a bleary Monday morning."},
 										},
 									},
 								},
 							},
 						},
 					},
-				},
-			}
-			Expect(source).To(BecomeDocument(expected))
+				}
+				Expect(source).To(BecomeDocument(expected))
+			})
+
+			It("paragraph with attribute substitution from front-matter", func() {
+				source := `---
+author: Xavier
+---
+			
+a paragraph written by {author}.`
+				expected := types.Document{
+					Attributes: types.DocumentAttributes{
+						"author": "Xavier",
+					},
+					ElementReferences:  types.ElementReferences{},
+					Footnotes:          types.Footnotes{},
+					FootnoteReferences: types.FootnoteReferences{},
+					Elements: []interface{}{
+						types.Paragraph{
+							Attributes: types.ElementAttributes{},
+							Lines: []types.InlineElements{
+								{
+									types.StringElement{Content: "a paragraph written by Xavier."},
+								},
+							},
+						},
+					},
+				}
+				Expect(source).To(BecomeDocument(expected))
+			})
 		})
+
 	})
 
 	Context("invalid document attributes", func() {
@@ -1123,9 +1089,7 @@ a paragraph with *bold content*`
 								types.StringElement{Content: ":@date: 2017-01-01"},
 							},
 							{
-								types.StringElement{Content: ":"},
-								types.DocumentAttributeSubstitution{Name: "author"},
-								types.StringElement{Content: ": Xavier"},
+								types.StringElement{Content: ":{author}: Xavier"},
 							},
 						},
 					},

--- a/pkg/parser/document_preprocessing.go
+++ b/pkg/parser/document_preprocessing.go
@@ -26,7 +26,7 @@ func parseDraftDocument(filename string, r io.Reader, levelOffsets []levelOffset
 		return types.DraftDocument{}, err
 	}
 	doc := d.(types.DraftDocument)
-	attrs := types.DocumentAttributes{}
+	attrs := map[string]string{}
 	blocks, err := parseElements(filename, doc.Blocks, attrs, levelOffsets, opts...)
 	if err != nil {
 		return types.DraftDocument{}, err
@@ -36,7 +36,7 @@ func parseDraftDocument(filename string, r io.Reader, levelOffsets []levelOffset
 }
 
 // parseElements resolves the file inclusions if any is found in the given elements
-func parseElements(filename string, elements []interface{}, attrs types.DocumentAttributes, levelOffsets []levelOffset, opts ...Option) ([]interface{}, error) {
+func parseElements(filename string, elements []interface{}, attrs map[string]string, levelOffsets []levelOffset, opts ...Option) ([]interface{}, error) {
 	result := []interface{}{}
 	for _, e := range elements {
 		switch e := e.(type) {

--- a/pkg/parser/document_processing.go
+++ b/pkg/parser/document_processing.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/bytesparadise/libasciidoc/pkg/types"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
@@ -18,10 +17,6 @@ func ParseDocument(filename string, r io.Reader, opts ...Option) (types.Document
 	draftDoc, err := ParseDraftDocument(filename, r, opts...)
 	if err != nil {
 		return types.Document{}, err
-	}
-	if log.IsLevelEnabled(log.DebugLevel) {
-		log.Debug("draft document")
-		spew.Dump(draftDoc)
 	}
 	attrs := make(map[string]string)
 	// add all predefined attributes
@@ -58,18 +53,14 @@ func ParseDocument(filename string, r io.Reader, opts ...Option) (types.Document
 			doc.Attributes[k] = v
 		}
 	}
-	if log.IsLevelEnabled(log.DebugLevel) {
-		log.Debug("final document")
-		spew.Dump(doc)
-	}
 	return doc, nil
 }
 
-// applyAttributeSubstitutions applies the document attribute substitutions
+// ApplyDocumentAttributeSubstitutions applies the document attribute substitutions
 // and re-parse the paragraphs that were affected
 func ApplyDocumentAttributeSubstitutions(element interface{}, attrs map[string]string) (interface{}, error) {
 	// the document attributes, as they are resolved while processing the blocks
-	log.Debugf("applying document substitutions on block of type %T", element)
+	// log.Debugf("applying document substitutions on block of type %T", element)
 	switch e := element.(type) {
 	case types.DocumentAttributeDeclaration:
 		attrs[e.Name] = e.Value

--- a/pkg/parser/document_processing_test.go
+++ b/pkg/parser/document_processing_test.go
@@ -1,0 +1,109 @@
+package parser_test
+
+import (
+	"github.com/bytesparadise/libasciidoc/pkg/parser"
+	"github.com/bytesparadise/libasciidoc/pkg/types"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("attribute subsititutions", func() {
+
+	It("should replace with new StringElement on first position", func() {
+		// given
+		e := types.InlineElements{
+			types.DocumentAttributeSubstitution{
+				Name: "foo",
+			},
+			types.StringElement{
+				Content: " and more content.",
+			},
+		}
+		// when
+		result, err := parser.ApplyDocumentAttributeSubstitutions(e, map[string]string{
+			"foo": "bar",
+		})
+		// then
+		Expect(result).To(Equal(types.InlineElements{
+			types.StringElement{
+				Content: "bar and more content.",
+			},
+		}))
+		Expect(err).To(Not(HaveOccurred()))
+	})
+
+	It("should replace with new StringElement on middle position", func() {
+		// given
+		e := types.InlineElements{
+			types.StringElement{
+				Content: "baz, ",
+			},
+			types.DocumentAttributeSubstitution{
+				Name: "foo",
+			},
+			types.StringElement{
+				Content: " and more content.",
+			},
+		}
+		// when
+		result, err := parser.ApplyDocumentAttributeSubstitutions(e, map[string]string{
+			"foo": "bar",
+		})
+		// then
+		Expect(result).To(Equal(types.InlineElements{
+			types.StringElement{
+				Content: "baz, bar and more content.",
+			},
+		}))
+		Expect(err).To(Not(HaveOccurred()))
+	})
+
+	It("should replace with undefined attribute", func() {
+		// given
+		e := types.InlineElements{
+			types.StringElement{
+				Content: "baz, ",
+			},
+			types.DocumentAttributeSubstitution{
+				Name: "foo",
+			},
+			types.StringElement{
+				Content: " and more content.",
+			},
+		}
+		// when
+		result, err := parser.ApplyDocumentAttributeSubstitutions(e, map[string]string{})
+		// then
+		Expect(result).To(Equal(types.InlineElements{
+			types.StringElement{
+				Content: "baz, {foo} and more content.",
+			},
+		}))
+		Expect(err).To(Not(HaveOccurred()))
+	})
+
+	It("should merge without substitution", func() {
+		// given
+		e := types.InlineElements{
+			types.StringElement{
+				Content: "baz, ",
+			},
+			types.StringElement{
+				Content: "foo",
+			},
+			types.StringElement{
+				Content: " and more content.",
+			},
+		}
+		// when
+		result, err := parser.ApplyDocumentAttributeSubstitutions(e, map[string]string{})
+		// then
+		Expect(result).To(Equal(types.InlineElements{
+			types.StringElement{
+				Content: "baz, foo and more content.",
+			},
+		}))
+		Expect(err).To(Not(HaveOccurred()))
+	})
+})

--- a/pkg/parser/file_inclusion.go
+++ b/pkg/parser/file_inclusion.go
@@ -55,8 +55,8 @@ func absoluteOffset(offset int) levelOffset {
 	}
 }
 
-func parseFileToInclude(filename string, incl types.FileInclusion, attrs types.DocumentAttributes, levelOffsets []levelOffset, opts ...Option) (types.DraftDocument, error) {
-	path := incl.Location.Resolve(attrs)
+func parseFileToInclude(filename string, incl types.FileInclusion, attrs map[string]string, levelOffsets []levelOffset, opts ...Option) (types.DraftDocument, error) {
+	path := incl.Location.Resolve(attrs).String()
 	currentDir := filepath.Dir(filename)
 	log.Debugf("parsing '%s' from '%s' (%s)", path, currentDir, filename)
 	log.Debugf("file inclusion attributes: %s", spew.Sdump(incl.Attributes))

--- a/pkg/parser/file_inclusion_test.go
+++ b/pkg/parser/file_inclusion_test.go
@@ -26,53 +26,67 @@ var _ = Describe("file location", func() {
 			Expect(actual).To(Equal(expected))
 		},
 		Entry("'chapter'", "chapter", types.Location{
-			types.StringElement{
-				Content: "chapter",
+			Elements: []interface{}{
+				types.StringElement{
+					Content: "chapter",
+				},
 			},
 		}),
 		Entry("'chapter.adoc'", "chapter.adoc", types.Location{
-			types.StringElement{
-				Content: "chapter.adoc",
+			Elements: []interface{}{
+				types.StringElement{
+					Content: "chapter.adoc",
+				},
 			},
 		}),
 		Entry("'chapter-a.adoc'", "chapter-a.adoc", types.Location{
-			types.StringElement{
-				Content: "chapter-a.adoc",
+			Elements: []interface{}{
+				types.StringElement{
+					Content: "chapter-a.adoc",
+				},
 			},
 		}),
 		Entry("'chapter_a.adoc'", "chapter_a.adoc", types.Location{
-			types.StringElement{
-				Content: "chapter_a.adoc",
+			Elements: []interface{}{
+				types.StringElement{
+					Content: "chapter_a.adoc",
+				},
 			},
 		}),
 		Entry("'../../test/includes/chapter_a.adoc'", "../../test/includes/chapter_a.adoc", types.Location{
-			types.StringElement{
-				Content: "../../test/includes/chapter_a.adoc",
+			Elements: []interface{}{
+				types.StringElement{
+					Content: "../../test/includes/chapter_a.adoc",
+				},
 			},
 		}),
 		Entry("'chapter-{foo}.adoc'", "chapter-{foo}.adoc", types.Location{
-			types.StringElement{
-				Content: "chapter-",
-			},
-			types.DocumentAttributeSubstitution{
-				Name: "foo",
-			},
-			types.StringElement{
-				Content: ".adoc",
+			Elements: []interface{}{
+				types.StringElement{
+					Content: "chapter-",
+				},
+				types.DocumentAttributeSubstitution{
+					Name: "foo",
+				},
+				types.StringElement{
+					Content: ".adoc",
+				},
 			},
 		}),
 		Entry("'{includedir}/chapter-{foo}.adoc'", "{includedir}/chapter-{foo}.adoc", types.Location{
-			types.DocumentAttributeSubstitution{
-				Name: "includedir",
-			},
-			types.StringElement{
-				Content: "/chapter-",
-			},
-			types.DocumentAttributeSubstitution{
-				Name: "foo",
-			},
-			types.StringElement{
-				Content: ".adoc",
+			Elements: []interface{}{
+				types.DocumentAttributeSubstitution{
+					Name: "includedir",
+				},
+				types.StringElement{
+					Content: "/chapter-",
+				},
+				types.DocumentAttributeSubstitution{
+					Name: "foo",
+				},
+				types.StringElement{
+					Content: ".adoc",
+				},
 			},
 		}),
 	)
@@ -976,27 +990,31 @@ include::../../test/includes/chapter-a.adoc[]
 			source := `++++
 include::../../test/includes/chapter-a.adoc[]
 ++++`
-			expected := types.DelimitedBlock{
-				Attributes: types.ElementAttributes{},
-				// Kind:       types.Passthrough,
-				Elements: []interface{}{
-					types.Paragraph{
+			expected := types.DraftDocument{
+				Blocks: []interface{}{
+					types.DelimitedBlock{
 						Attributes: types.ElementAttributes{},
-						Lines: []types.InlineElements{
-							{
-								types.StringElement{
-									Content: "= Chapter A",
+						// Kind:       types.Passthrough,
+						Elements: []interface{}{
+							types.Paragraph{
+								Attributes: types.ElementAttributes{},
+								Lines: []types.InlineElements{
+									{
+										types.StringElement{
+											Content: "= Chapter A",
+										},
+									},
 								},
 							},
-						},
-					},
-					types.BlankLine{},
-					types.Paragraph{
-						Attributes: types.ElementAttributes{},
-						Lines: []types.InlineElements{
-							{
-								types.StringElement{
-									Content: "content",
+							types.BlankLine{},
+							types.Paragraph{
+								Attributes: types.ElementAttributes{},
+								Lines: []types.InlineElements{
+									{
+										types.StringElement{
+											Content: "content",
+										},
+									},
 								},
 							},
 						},
@@ -2393,8 +2411,10 @@ var _ = Describe("file inclusions - draft without preprocessing", func() {
 				types.FileInclusion{
 					Attributes: types.ElementAttributes{},
 					Location: types.Location{
-						types.StringElement{
-							Content: "../../test/includes/chapter-a.adoc",
+						Elements: []interface{}{
+							types.StringElement{
+								Content: "../../test/includes/chapter-a.adoc",
+							},
 						},
 					},
 					RawText: source,
@@ -2415,8 +2435,10 @@ var _ = Describe("file inclusions - draft without preprocessing", func() {
 				types.FileInclusion{
 					Attributes: types.ElementAttributes{},
 					Location: types.Location{
-						types.StringElement{
-							Content: "../../../test/includes/chapter-a.adoc",
+						Elements: []interface{}{
+							types.StringElement{
+								Content: "../../../test/includes/chapter-a.adoc",
+							},
 						},
 					},
 					RawText: source,
@@ -2437,8 +2459,10 @@ var _ = Describe("file inclusions - draft without preprocessing", func() {
 						types.AttrLevelOffset: "+1",
 					},
 					Location: types.Location{
-						types.StringElement{
-							Content: "../../test/includes/chapter-a.adoc",
+						Elements: []interface{}{
+							types.StringElement{
+								Content: "../../test/includes/chapter-a.adoc",
+							},
 						},
 					},
 					RawText: source,
@@ -2463,8 +2487,10 @@ var _ = Describe("file inclusions - draft without preprocessing", func() {
 							types.FileInclusion{
 								Attributes: types.ElementAttributes{},
 								Location: types.Location{
-									types.StringElement{
-										Content: "../../test/includes/chapter-a.adoc",
+									Elements: []interface{}{
+										types.StringElement{
+											Content: "../../test/includes/chapter-a.adoc",
+										},
 									},
 								},
 								RawText: `include::../../test/includes/chapter-a.adoc[]`,
@@ -2489,8 +2515,10 @@ include::../../test/includes/chapter-a.adoc[]
 							types.FileInclusion{
 								Attributes: types.ElementAttributes{},
 								Location: types.Location{
-									types.StringElement{
-										Content: "../../test/includes/chapter-a.adoc",
+									Elements: []interface{}{
+										types.StringElement{
+											Content: "../../test/includes/chapter-a.adoc",
+										},
 									},
 								},
 								RawText: `include::../../test/includes/chapter-a.adoc[]`,
@@ -2515,8 +2543,10 @@ include::../../test/includes/chapter-a.adoc[]
 							types.FileInclusion{
 								Attributes: types.ElementAttributes{},
 								Location: types.Location{
-									types.StringElement{
-										Content: "../../test/includes/chapter-a.adoc",
+									Elements: []interface{}{
+										types.StringElement{
+											Content: "../../test/includes/chapter-a.adoc",
+										},
 									},
 								},
 								RawText: `include::../../test/includes/chapter-a.adoc[]`,
@@ -2541,8 +2571,10 @@ ____`
 							types.FileInclusion{
 								Attributes: types.ElementAttributes{},
 								Location: types.Location{
-									types.StringElement{
-										Content: "../../test/includes/chapter-a.adoc",
+									Elements: []interface{}{
+										types.StringElement{
+											Content: "../../test/includes/chapter-a.adoc",
+										},
 									},
 								},
 								RawText: `include::../../test/includes/chapter-a.adoc[]`,
@@ -2570,8 +2602,10 @@ ____`
 							types.FileInclusion{
 								Attributes: types.ElementAttributes{},
 								Location: types.Location{
-									types.StringElement{
-										Content: "../../test/includes/chapter-a.adoc",
+									Elements: []interface{}{
+										types.StringElement{
+											Content: "../../test/includes/chapter-a.adoc",
+										},
 									},
 								},
 								RawText: `include::../../test/includes/chapter-a.adoc[]`,
@@ -2596,8 +2630,10 @@ include::../../test/includes/chapter-a.adoc[]
 							types.FileInclusion{
 								Attributes: types.ElementAttributes{},
 								Location: types.Location{
-									types.StringElement{
-										Content: "../../test/includes/chapter-a.adoc",
+									Elements: []interface{}{
+										types.StringElement{
+											Content: "../../test/includes/chapter-a.adoc",
+										},
 									},
 								},
 								RawText: `include::../../test/includes/chapter-a.adoc[]`,
@@ -2623,8 +2659,10 @@ include::../../test/includes/chapter-a.adoc[]
 							types.FileInclusion{
 								Attributes: types.ElementAttributes{},
 								Location: types.Location{
-									types.StringElement{
-										Content: "../../test/includes/chapter-a.adoc",
+									Elements: []interface{}{
+										types.StringElement{
+											Content: "../../test/includes/chapter-a.adoc",
+										},
 									},
 								},
 								RawText: `include::../../test/includes/chapter-a.adoc[]`,
@@ -2652,8 +2690,10 @@ include::../../test/includes/chapter-a.adoc[]
 								},
 							},
 							Location: types.Location{
-								types.StringElement{
-									Content: "../../test/includes/chapter-a.adoc",
+								Elements: []interface{}{
+									types.StringElement{
+										Content: "../../test/includes/chapter-a.adoc",
+									},
 								},
 							},
 							RawText: `include::../../test/includes/chapter-a.adoc[lines=1]`,
@@ -2674,8 +2714,10 @@ include::../../test/includes/chapter-a.adoc[]
 								},
 							},
 							Location: types.Location{
-								types.StringElement{
-									Content: "../../test/includes/chapter-a.adoc",
+								Elements: []interface{}{
+									types.StringElement{
+										Content: "../../test/includes/chapter-a.adoc",
+									},
 								},
 							},
 							RawText: `include::../../test/includes/chapter-a.adoc[lines=1..2]`,
@@ -2698,8 +2740,10 @@ include::../../test/includes/chapter-a.adoc[]
 								},
 							},
 							Location: types.Location{
-								types.StringElement{
-									Content: "../../test/includes/chapter-a.adoc",
+								Elements: []interface{}{
+									types.StringElement{
+										Content: "../../test/includes/chapter-a.adoc",
+									},
 								},
 							},
 							RawText: `include::../../test/includes/chapter-a.adoc[lines=1;3..4;6..-1]`,
@@ -2718,8 +2762,10 @@ include::../../test/includes/chapter-a.adoc[]
 								types.AttrLineRanges: `1;3..4;6..foo`,
 							},
 							Location: types.Location{
-								types.StringElement{
-									Content: "../../test/includes/chapter-a.adoc",
+								Elements: []interface{}{
+									types.StringElement{
+										Content: "../../test/includes/chapter-a.adoc",
+									},
 								},
 							},
 							RawText: `include::../../test/includes/chapter-a.adoc[lines=1;3..4;6..foo]`,
@@ -2742,8 +2788,10 @@ include::../../test/includes/chapter-a.adoc[]
 								"6..-1": nil,
 							},
 							Location: types.Location{
-								types.StringElement{
-									Content: "../../test/includes/chapter-a.adoc",
+								Elements: []interface{}{
+									types.StringElement{
+										Content: "../../test/includes/chapter-a.adoc",
+									},
 								},
 							},
 							RawText: `include::../../test/includes/chapter-a.adoc[lines=1,3..4,6..-1]`,
@@ -2762,8 +2810,10 @@ include::../../test/includes/chapter-a.adoc[]
 								types.AttrLineRanges: "foo",
 							},
 							Location: types.Location{
-								types.StringElement{
-									Content: "../../test/includes/chapter-a.adoc",
+								Elements: []interface{}{
+									types.StringElement{
+										Content: "../../test/includes/chapter-a.adoc",
+									},
 								},
 							},
 							RawText: `include::../../test/includes/chapter-a.adoc[lines=foo]`,
@@ -2787,8 +2837,10 @@ include::../../test/includes/chapter-a.adoc[]
 								},
 							},
 							Location: types.Location{
-								types.StringElement{
-									Content: "../../test/includes/chapter-a.adoc",
+								Elements: []interface{}{
+									types.StringElement{
+										Content: "../../test/includes/chapter-a.adoc",
+									},
 								},
 							},
 							RawText: `include::../../test/includes/chapter-a.adoc[lines="1"]`,
@@ -2809,8 +2861,10 @@ include::../../test/includes/chapter-a.adoc[]
 								},
 							},
 							Location: types.Location{
-								types.StringElement{
-									Content: "../../test/includes/chapter-a.adoc",
+								Elements: []interface{}{
+									types.StringElement{
+										Content: "../../test/includes/chapter-a.adoc",
+									},
 								},
 							},
 							RawText: `include::../../test/includes/chapter-a.adoc[lines="1..2"]`,
@@ -2833,8 +2887,10 @@ include::../../test/includes/chapter-a.adoc[]
 								},
 							},
 							Location: types.Location{
-								types.StringElement{
-									Content: "../../test/includes/chapter-a.adoc",
+								Elements: []interface{}{
+									types.StringElement{
+										Content: "../../test/includes/chapter-a.adoc",
+									},
 								},
 							},
 							RawText: `include::../../test/includes/chapter-a.adoc[lines="1,3..4,6..-1"]`,
@@ -2855,8 +2911,10 @@ include::../../test/includes/chapter-a.adoc[]
 								"6..foo":             nil,
 							},
 							Location: types.Location{
-								types.StringElement{
-									Content: "../../test/includes/chapter-a.adoc",
+								Elements: []interface{}{
+									types.StringElement{
+										Content: "../../test/includes/chapter-a.adoc",
+									},
 								},
 							},
 							RawText: `include::../../test/includes/chapter-a.adoc[lines="1,3..4,6..foo"]`,
@@ -2875,8 +2933,10 @@ include::../../test/includes/chapter-a.adoc[]
 								types.AttrLineRanges: `"1;3..4;6..10"`,
 							},
 							Location: types.Location{
-								types.StringElement{
-									Content: "../../test/includes/chapter-a.adoc",
+								Elements: []interface{}{
+									types.StringElement{
+										Content: "../../test/includes/chapter-a.adoc",
+									},
 								},
 							},
 							RawText: source,
@@ -2903,8 +2963,10 @@ include::../../test/includes/chapter-a.adoc[]
 								},
 							},
 							Location: types.Location{
-								types.StringElement{
-									Content: "../../test/includes/tag-include.adoc",
+								Elements: []interface{}{
+									types.StringElement{
+										Content: "../../test/includes/tag-include.adoc",
+									},
 								},
 							},
 							RawText: source,
@@ -2932,8 +2994,10 @@ include::../../test/includes/chapter-a.adoc[]
 								},
 							},
 							Location: types.Location{
-								types.StringElement{
-									Content: "../../test/includes/tag-include.adoc",
+								Elements: []interface{}{
+									types.StringElement{
+										Content: "../../test/includes/tag-include.adoc",
+									},
 								},
 							},
 							RawText: source,
@@ -2942,8 +3006,6 @@ include::../../test/includes/chapter-a.adoc[]
 				}
 				Expect(source).To(BecomeDraftDocument(expected, WithoutPreprocessing()))
 			})
-
 		})
 	})
-
 })

--- a/pkg/parser/footnote_test.go
+++ b/pkg/parser/footnote_test.go
@@ -75,8 +75,10 @@ var _ = Describe("footnotes - draft", func() {
 							},
 						},
 						Location: types.Location{
-							types.StringElement{
-								Content: "https://foo.com",
+							Elements: []interface{}{
+								types.StringElement{
+									Content: "https://foo.com",
+								},
 							},
 						},
 					},
@@ -391,8 +393,10 @@ var _ = Describe("footnotes - document", func() {
 							},
 						},
 						Location: types.Location{
-							types.StringElement{
-								Content: "https://foo.com",
+							Elements: []interface{}{
+								types.StringElement{
+									Content: "https://foo.com",
+								},
 							},
 						},
 					},

--- a/pkg/parser/image_test.go
+++ b/pkg/parser/image_test.go
@@ -12,77 +12,117 @@ var _ = Describe("images", func() {
 
 	Context("block images", func() {
 
-		Context("correct behaviour", func() {
+		Context("draft document", func() {
 
 			It("block image with empty alt", func() {
 				source := "image::images/foo.png[]"
-				expected := types.ImageBlock{
-					Attributes: types.ElementAttributes{
-						types.AttrImageAlt: "foo",
+				expected := types.DraftDocument{
+					Blocks: []interface{}{
+						types.ImageBlock{
+							Attributes: types.ElementAttributes{},
+							Location: types.Location{
+								Elements: []interface{}{
+									types.StringElement{Content: "images/foo.png"},
+								},
+							},
+						},
 					},
-					Path: "images/foo.png",
 				}
-				Expect(source).To(BecomeDocumentBlock(expected))
+				Expect(source).To(BecomeDraftDocument(expected))
 			})
 
 			It("block image with empty alt and trailing spaces", func() {
 				source := "image::images/foo.png[]  \t\t  "
-				expected := types.ImageBlock{
-					Attributes: types.ElementAttributes{
-						types.AttrImageAlt: "foo",
+				expected := types.DraftDocument{
+					Blocks: []interface{}{
+						types.ImageBlock{
+							Attributes: types.ElementAttributes{},
+							Location: types.Location{
+								Elements: []interface{}{
+									types.StringElement{Content: "images/foo.png"},
+								},
+							},
+						},
 					},
-					Path: "images/foo.png",
 				}
-				Expect(source).To(BecomeDocumentBlock(expected))
+				Expect(source).To(BecomeDraftDocument(expected))
 			})
 
 			It("block image with line return", func() {
 				// line return here is not considered as a blank line
 				source := `image::images/foo.png[]
 `
-				expected := types.ImageBlock{
-					Attributes: types.ElementAttributes{
-						types.AttrImageAlt: "foo",
+				expected := types.DraftDocument{
+					Blocks: []interface{}{
+						types.ImageBlock{
+							Attributes: types.ElementAttributes{},
+							Location: types.Location{
+								Elements: []interface{}{
+									types.StringElement{Content: "images/foo.png"},
+								},
+							},
+						},
 					},
-					Path: "images/foo.png",
 				}
-				Expect(source).To(BecomeDocumentBlock(expected))
+				Expect(source).To(BecomeDraftDocument(expected))
 			})
 
 			It("block image with 1 empty blank line", func() {
 				// here, there's a real blank line with some spaces
 				source := `image::images/foo.png[]
   `
-				expected := types.ImageBlock{
-					Attributes: types.ElementAttributes{
-						types.AttrImageAlt: "foo",
+				expected := types.DraftDocument{
+					Blocks: []interface{}{
+						types.ImageBlock{
+							Attributes: types.ElementAttributes{},
+							Location: types.Location{
+								Elements: []interface{}{
+									types.StringElement{Content: "images/foo.png"},
+								},
+							},
+						},
+						types.BlankLine{},
 					},
-					Path: "images/foo.png",
 				}
-				Expect(source).To(BecomeDocumentBlock(expected))
+				Expect(source).To(BecomeDraftDocument(expected))
 			})
 
 			It("block image with 2 blank lines with spaces and tabs", func() {
 				source := `image::images/foo.png[]
 			`
-				expected := types.ImageBlock{
-					Attributes: types.ElementAttributes{
-						types.AttrImageAlt: "foo",
+				expected := types.DraftDocument{
+					Blocks: []interface{}{
+						types.ImageBlock{
+							Attributes: types.ElementAttributes{},
+							Location: types.Location{
+								Elements: []interface{}{
+									types.StringElement{Content: "images/foo.png"},
+								},
+							},
+						},
+						types.BlankLine{},
 					},
-					Path: "images/foo.png",
 				}
-				Expect(source).To(BecomeDocumentBlock(expected))
+				Expect(source).To(BecomeDraftDocument(expected))
 			})
 
 			It("block image with alt", func() {
 				source := `image::images/foo.png[the foo.png image]`
-				expected := types.ImageBlock{
-					Attributes: types.ElementAttributes{
-						types.AttrImageAlt: "the foo.png image",
+				expected := types.DraftDocument{
+					Blocks: []interface{}{
+						types.ImageBlock{
+							Attributes: types.ElementAttributes{
+								types.AttrImageAlt: "the foo.png image",
+							},
+							Location: types.Location{
+								Elements: []interface{}{
+									types.StringElement{Content: "images/foo.png"},
+								},
+							},
+						},
 					},
-					Path: "images/foo.png",
 				}
-				Expect(source).To(BecomeDocumentBlock(expected))
+				Expect(source).To(BecomeDraftDocument(expected))
 			})
 
 			It("block image with dimensions and id link title meta", func() {
@@ -90,41 +130,110 @@ var _ = Describe("images", func() {
 .A title to foobar
 [link=http://foo.bar]
 image::images/foo.png[the foo.png image, 600, 400]`
-				expected := types.ImageBlock{
-					Attributes: types.ElementAttributes{
-						types.AttrID:          "img-foobar",
-						types.AttrCustomID:    true,
-						types.AttrTitle:       "A title to foobar",
-						types.AttrInlineLink:  "http://foo.bar",
-						types.AttrImageAlt:    "the foo.png image",
-						types.AttrImageWidth:  "600",
-						types.AttrImageHeight: "400",
-					},
-					Path: "images/foo.png",
-				}
-				Expect(source).To(BecomeDocumentBlock(expected))
-			})
-
-			It("2 block images", func() {
-				source := `image::app.png[]
-image::appa.png[]`
 				expected := types.DraftDocument{
 					Blocks: []interface{}{
 						types.ImageBlock{
 							Attributes: types.ElementAttributes{
-								types.AttrImageAlt: "app",
+								types.AttrID:          "img-foobar",
+								types.AttrCustomID:    true,
+								types.AttrTitle:       "A title to foobar",
+								types.AttrInlineLink:  "http://foo.bar",
+								types.AttrImageAlt:    "the foo.png image",
+								types.AttrImageWidth:  "600",
+								types.AttrImageHeight: "400",
 							},
-							Path: "app.png",
-						},
-						types.ImageBlock{
-							Attributes: types.ElementAttributes{
-								types.AttrImageAlt: "appa",
+							Location: types.Location{
+								Elements: []interface{}{
+									types.StringElement{Content: "images/foo.png"},
+								},
 							},
-							Path: "appa.png",
 						},
 					},
 				}
 				Expect(source).To(BecomeDraftDocument(expected))
+			})
+
+			It("2 block images", func() {
+				source := `image::images/foo.png[]
+image::images/bar.png[]`
+				expected := types.DraftDocument{
+					Blocks: []interface{}{
+						types.ImageBlock{
+							Attributes: types.ElementAttributes{},
+							Location: types.Location{
+								Elements: []interface{}{
+									types.StringElement{Content: "images/foo.png"},
+								},
+							},
+						},
+						types.ImageBlock{
+							Attributes: types.ElementAttributes{},
+							Location: types.Location{
+								Elements: []interface{}{
+									types.StringElement{Content: "images/bar.png"},
+								},
+							},
+						},
+					},
+				}
+				Expect(source).To(BecomeDraftDocument(expected))
+			})
+		})
+
+		Context("final document", func() {
+
+			It("block image with empty alt", func() {
+				source := "image::images/foo.png[]"
+				expected := types.Document{
+					Attributes:         types.DocumentAttributes{},
+					ElementReferences:  types.ElementReferences{},
+					Footnotes:          types.Footnotes{},
+					FootnoteReferences: types.FootnoteReferences{},
+					Elements: []interface{}{
+						types.ImageBlock{
+							Attributes: types.ElementAttributes{
+								types.AttrImageAlt: "foo",
+							},
+							Location: types.Location{
+								Elements: []interface{}{
+									types.StringElement{Content: "images/foo.png"},
+								},
+								// Resolved: "images/foo.png",
+							},
+						},
+					},
+				}
+				Expect(source).To(BecomeDocument(expected))
+			})
+
+			It("image block with document attribute in URL", func() {
+				source := `:imagesdir: ./path/to/images
+
+image::{imagesdir}/foo.png[]`
+				expected := types.Document{
+					Attributes:         types.DocumentAttributes{},
+					ElementReferences:  types.ElementReferences{},
+					Footnotes:          types.Footnotes{},
+					FootnoteReferences: types.FootnoteReferences{},
+					Elements: []interface{}{
+						types.DocumentAttributeDeclaration{
+							Name:  "imagesdir",
+							Value: "./path/to/images",
+						},
+						types.ImageBlock{
+							Attributes: types.ElementAttributes{
+								types.AttrImageAlt: "foo",
+							},
+							Location: types.Location{
+								Elements: []interface{}{
+									types.StringElement{Content: "./path/to/images/foo.png"},
+								},
+								// Resolved: "./path/to/images/foo.png",
+							},
+						},
+					},
+				}
+				Expect(source).To(BecomeDocument(expected))
 			})
 		})
 
@@ -134,18 +243,22 @@ image::appa.png[]`
 
 				It("block image appending inline content", func() {
 					source := "a paragraph\nimage::images/foo.png[]"
-					expected := types.Paragraph{
-						Attributes: types.ElementAttributes{},
-						Lines: []types.InlineElements{
-							{
-								types.StringElement{Content: "a paragraph"},
-							},
-							{
-								types.StringElement{Content: "image::images/foo.png[]"},
+					expected := types.DraftDocument{
+						Blocks: []interface{}{
+							types.Paragraph{
+								Attributes: types.ElementAttributes{},
+								Lines: []types.InlineElements{
+									{
+										types.StringElement{Content: "a paragraph"},
+									},
+									{
+										types.StringElement{Content: "image::images/foo.png[]"},
+									},
+								},
 							},
 						},
 					}
-					Expect(source).To(BecomeDocumentBlock(expected))
+					Expect(source).To(BecomeDraftDocument(expected))
 				})
 			})
 
@@ -173,270 +286,458 @@ image::appa.png[]`
 
 	Context("inline images", func() {
 
-		Context("correct behaviour", func() {
+		Context("draft document", func() {
 
 			It("inline image with empty alt only", func() {
 				source := "image:images/foo.png[]"
-				expected := types.Paragraph{
-					Attributes: types.ElementAttributes{},
-					Lines: []types.InlineElements{
-						{
-							types.InlineImage{
-								Attributes: types.ElementAttributes{
-									types.AttrImageAlt: "foo",
+				expected := types.DraftDocument{
+					Blocks: []interface{}{
+						types.Paragraph{
+							Attributes: types.ElementAttributes{},
+							Lines: []types.InlineElements{
+								{
+									types.InlineImage{
+										Attributes: types.ElementAttributes{},
+										Location: types.Location{
+											Elements: []interface{}{
+												types.StringElement{Content: "images/foo.png"},
+											},
+										},
+									},
 								},
-								Path: "images/foo.png",
 							},
 						},
 					},
 				}
-				Expect(source).To(BecomeDocumentBlock(expected))
+				Expect(source).To(BecomeDraftDocument(expected))
 			})
 
 			It("inline image with empty alt and trailing spaces", func() {
 				source := "image:images/foo.png[]  \t\t  "
-				expected := types.Paragraph{
-					Attributes: types.ElementAttributes{},
-					Lines: []types.InlineElements{
-						{
-							types.InlineImage{
-								Attributes: types.ElementAttributes{
-									types.AttrImageAlt: "foo",
+				expected := types.DraftDocument{
+					Blocks: []interface{}{
+						types.Paragraph{
+							Attributes: types.ElementAttributes{},
+							Lines: []types.InlineElements{
+								{
+									types.InlineImage{
+										Attributes: types.ElementAttributes{},
+										Location: types.Location{
+											Elements: []interface{}{
+												types.StringElement{Content: "images/foo.png"},
+											},
+										},
+									},
+									types.StringElement{
+										Content: "  \t\t  ",
+									},
 								},
-								Path: "images/foo.png",
-							},
-							types.StringElement{
-								Content: "  \t\t  ",
 							},
 						},
 					},
 				}
-				Expect(source).To(BecomeDocumentBlock(expected))
+				Expect(source).To(BecomeDraftDocument(expected))
 			})
 
 			It("inline image surrounded with test", func() {
 				source := "a foo image:images/foo.png[] bar..."
-				expected := types.Paragraph{
-					Attributes: types.ElementAttributes{},
-					Lines: []types.InlineElements{
-						{
-							types.StringElement{
-								Content: "a foo ",
-							},
-							types.InlineImage{
-								Attributes: types.ElementAttributes{
-									types.AttrImageAlt: "foo",
+				expected := types.DraftDocument{
+					Blocks: []interface{}{
+						types.Paragraph{
+							Attributes: types.ElementAttributes{},
+							Lines: []types.InlineElements{
+								{
+									types.StringElement{
+										Content: "a foo ",
+									},
+									types.InlineImage{
+										Attributes: types.ElementAttributes{},
+										Location: types.Location{
+											Elements: []interface{}{
+												types.StringElement{Content: "images/foo.png"},
+											},
+										},
+									},
+									types.StringElement{
+										Content: " bar...",
+									},
 								},
-								Path: "images/foo.png",
-							},
-							types.StringElement{
-								Content: " bar...",
 							},
 						},
 					},
 				}
-				Expect(source).To(BecomeDocumentBlock(expected))
+				Expect(source).To(BecomeDraftDocument(expected))
 			})
 
 			It("inline image with alt alone", func() {
 				source := "image:images/foo.png[the foo.png image]"
-				expected := types.Paragraph{
-					Attributes: types.ElementAttributes{},
-					Lines: []types.InlineElements{
-						{
-							types.InlineImage{
-								Attributes: types.ElementAttributes{
-									types.AttrImageAlt: "the foo.png image",
+				expected := types.DraftDocument{
+					Blocks: []interface{}{
+						types.Paragraph{
+							Attributes: types.ElementAttributes{},
+							Lines: []types.InlineElements{
+								{
+									types.InlineImage{
+										Attributes: types.ElementAttributes{
+											types.AttrImageAlt: "the foo.png image",
+										},
+										Location: types.Location{
+											Elements: []interface{}{
+												types.StringElement{Content: "images/foo.png"},
+											},
+										},
+									},
 								},
-								Path: "images/foo.png",
 							},
 						},
 					},
 				}
-				Expect(source).To(BecomeDocumentBlock(expected))
+				Expect(source).To(BecomeDraftDocument(expected))
 			})
 
 			It("inline image with alt and width", func() {
 				source := "image:images/foo.png[the foo.png image, 600]"
-				expected := types.Paragraph{
-					Attributes: types.ElementAttributes{},
-					Lines: []types.InlineElements{
-						{
-							types.InlineImage{
-								Attributes: types.ElementAttributes{
-									types.AttrImageAlt:   "the foo.png image",
-									types.AttrImageWidth: "600",
+				expected := types.DraftDocument{
+					Blocks: []interface{}{
+						types.Paragraph{
+							Attributes: types.ElementAttributes{},
+							Lines: []types.InlineElements{
+								{
+									types.InlineImage{
+										Attributes: types.ElementAttributes{
+											types.AttrImageAlt:   "the foo.png image",
+											types.AttrImageWidth: "600",
+										},
+										Location: types.Location{
+											Elements: []interface{}{
+												types.StringElement{Content: "images/foo.png"},
+											},
+										},
+									},
 								},
-								Path: "images/foo.png",
 							},
 						},
 					},
 				}
-				Expect(source).To(BecomeDocumentBlock(expected))
+				Expect(source).To(BecomeDraftDocument(expected))
 			})
 
 			It("inline image with alt, width and height", func() {
 				source := "image:images/foo.png[the foo.png image, 600, 400]"
-				expected := types.Paragraph{
-					Attributes: types.ElementAttributes{},
-					Lines: []types.InlineElements{
-						{
-							types.InlineImage{
-								Attributes: types.ElementAttributes{
-									types.AttrImageAlt:    "the foo.png image",
-									types.AttrImageWidth:  "600",
-									types.AttrImageHeight: "400",
+				expected := types.DraftDocument{
+					Blocks: []interface{}{
+						types.Paragraph{
+							Attributes: types.ElementAttributes{},
+							Lines: []types.InlineElements{
+								{
+									types.InlineImage{
+										Attributes: types.ElementAttributes{
+											types.AttrImageAlt:    "the foo.png image",
+											types.AttrImageWidth:  "600",
+											types.AttrImageHeight: "400",
+										},
+										Location: types.Location{
+											Elements: []interface{}{
+												types.StringElement{Content: "images/foo.png"},
+											},
+										},
+									},
 								},
-								Path: "images/foo.png",
 							},
 						},
 					},
 				}
-				Expect(source).To(BecomeDocumentBlock(expected))
+				Expect(source).To(BecomeDraftDocument(expected))
 			})
 
 			It("inline image with alt, but empty width and height", func() {
 				source := "image:images/foo.png[the foo.png image, , ]"
-				expected := types.Paragraph{
-					Attributes: types.ElementAttributes{},
-					Lines: []types.InlineElements{
-						{
-							types.InlineImage{
-								Attributes: types.ElementAttributes{
-									types.AttrImageAlt: "the foo.png image",
+				expected := types.DraftDocument{
+					Blocks: []interface{}{
+						types.Paragraph{
+							Attributes: types.ElementAttributes{},
+							Lines: []types.InlineElements{
+								{
+									types.InlineImage{
+										Attributes: types.ElementAttributes{
+											types.AttrImageAlt: "the foo.png image",
+										},
+										Location: types.Location{
+											Elements: []interface{}{
+												types.StringElement{Content: "images/foo.png"},
+											},
+										},
+									},
 								},
-								Path: "images/foo.png",
 							},
 						},
 					},
 				}
-				Expect(source).To(BecomeDocumentBlock(expected))
+				Expect(source).To(BecomeDraftDocument(expected))
 			})
 
 			It("inline image with single other attribute only", func() {
 				source := "image:images/foo.png[id=myid]"
-				expected := types.Paragraph{
-					Attributes: types.ElementAttributes{},
-					Lines: []types.InlineElements{
-						{
-							types.InlineImage{
-								Attributes: types.ElementAttributes{
-									types.AttrImageAlt: "foo", // based on filename
-									types.AttrID:       "myid",
-									types.AttrCustomID: true,
+				expected := types.DraftDocument{
+					Blocks: []interface{}{
+						types.Paragraph{
+							Attributes: types.ElementAttributes{},
+							Lines: []types.InlineElements{
+								{
+									types.InlineImage{
+										Attributes: types.ElementAttributes{
+											types.AttrID:       "myid",
+											types.AttrCustomID: true,
+										},
+										Location: types.Location{
+											Elements: []interface{}{
+												types.StringElement{Content: "images/foo.png"},
+											},
+										},
+									},
 								},
-								Path: "images/foo.png",
 							},
 						},
 					},
 				}
-				Expect(source).To(BecomeDocumentBlock(expected))
+				Expect(source).To(BecomeDraftDocument(expected))
 			})
 
 			It("inline image with multiple other attributes only", func() {
 				source := "image:images/foo.png[id=myid, title= mytitle, role = myrole ]"
-				expected := types.Paragraph{
-					Attributes: types.ElementAttributes{},
-					Lines: []types.InlineElements{
-						{
-							types.InlineImage{
-								Attributes: types.ElementAttributes{
-									types.AttrImageAlt: "foo", // based on filename
-									types.AttrID:       "myid",
-									types.AttrCustomID: true,
-									types.AttrTitle:    "mytitle",
-									types.AttrRole:     "myrole",
+				expected := types.DraftDocument{
+					Blocks: []interface{}{
+						types.Paragraph{
+							Attributes: types.ElementAttributes{},
+							Lines: []types.InlineElements{
+								{
+									types.InlineImage{
+										Attributes: types.ElementAttributes{
+											types.AttrID:       "myid",
+											types.AttrCustomID: true,
+											types.AttrTitle:    "mytitle",
+											types.AttrRole:     "myrole",
+										},
+										Location: types.Location{
+											Elements: []interface{}{
+												types.StringElement{Content: "images/foo.png"},
+											},
+										},
+									},
 								},
-								Path: "images/foo.png",
 							},
 						},
 					},
 				}
-				Expect(source).To(BecomeDocumentBlock(expected))
+				Expect(source).To(BecomeDraftDocument(expected))
 			})
 
 			It("inline image with alt, width, height and other attributes", func() {
 				source := "image:images/foo.png[ foo, 600, 400, id=myid, title=mytitle, role=myrole ]"
-				expected := types.Paragraph{
-					Attributes: types.ElementAttributes{},
-					Lines: []types.InlineElements{
-						{
-							types.InlineImage{
-								Attributes: types.ElementAttributes{
-									types.AttrImageAlt:    "foo",
-									types.AttrImageWidth:  "600",
-									types.AttrImageHeight: "400",
-									types.AttrID:          "myid",
-									types.AttrCustomID:    true,
-									types.AttrTitle:       "mytitle",
-									types.AttrRole:        "myrole",
+				expected := types.DraftDocument{
+					Blocks: []interface{}{
+						types.Paragraph{
+							Attributes: types.ElementAttributes{},
+							Lines: []types.InlineElements{
+								{
+									types.InlineImage{
+										Attributes: types.ElementAttributes{
+											types.AttrImageAlt:    "foo",
+											types.AttrImageWidth:  "600",
+											types.AttrImageHeight: "400",
+											types.AttrID:          "myid",
+											types.AttrCustomID:    true,
+											types.AttrTitle:       "mytitle",
+											types.AttrRole:        "myrole",
+										},
+										Location: types.Location{
+											Elements: []interface{}{
+												types.StringElement{Content: "images/foo.png"},
+											},
+										},
+									},
 								},
-								Path: "images/foo.png",
 							},
 						},
 					},
 				}
-				Expect(source).To(BecomeDocumentBlock(expected))
+				Expect(source).To(BecomeDraftDocument(expected))
 			})
 
 			It("inline image in a paragraph with space after colon", func() {
 				source := "this is an image: image:images/foo.png[]"
-				expected := types.Paragraph{
-					Attributes: types.ElementAttributes{},
-					Lines: []types.InlineElements{
-						{
-							types.StringElement{
-								Content: "this is an image: ",
-							},
-							types.InlineImage{
-								Attributes: types.ElementAttributes{
-									types.AttrImageAlt: "foo",
+				expected := types.DraftDocument{
+					Blocks: []interface{}{
+						types.Paragraph{
+							Attributes: types.ElementAttributes{},
+							Lines: []types.InlineElements{
+								{
+									types.StringElement{
+										Content: "this is an image: ",
+									},
+									types.InlineImage{
+										Attributes: types.ElementAttributes{},
+										Location: types.Location{
+											Elements: []interface{}{
+												types.StringElement{Content: "images/foo.png"},
+											},
+										},
+									},
 								},
-								Path: "images/foo.png",
 							},
 						},
 					},
 				}
-				Expect(source).To(BecomeDocumentBlock(expected))
+				Expect(source).To(BecomeDraftDocument(expected))
 			})
 
-			It("inline image in a paragraph without space keyword", func() {
+			It("inline image in a paragraph without space separator", func() {
 				source := "this is an inline.image:images/foo.png[]"
-				expected := types.Paragraph{
-					Attributes: types.ElementAttributes{},
-					Lines: []types.InlineElements{
-						{
-							types.StringElement{
-								Content: "this is an inline.",
-							},
-							types.InlineImage{
-								Attributes: types.ElementAttributes{
-									types.AttrImageAlt: "foo",
+				expected := types.DraftDocument{
+					Blocks: []interface{}{
+						types.Paragraph{
+							Attributes: types.ElementAttributes{},
+							Lines: []types.InlineElements{
+								{
+									types.StringElement{
+										Content: "this is an inline.",
+									},
+									types.InlineImage{
+										Attributes: types.ElementAttributes{},
+										Location: types.Location{
+											Elements: []interface{}{
+												types.StringElement{Content: "images/foo.png"},
+											},
+										},
+									},
 								},
-								Path: "images/foo.png",
 							},
 						},
 					},
 				}
+				Expect(source).To(BecomeDraftDocument(expected))
+			})
 
-				Expect(source).To(BecomeDocumentBlock(expected))
+			It("image block with document attribute in URL", func() {
+				source := `:imagesdir: ./path/to/images
+
+image::{imagesdir}/foo.png[]`
+				expected := types.DraftDocument{
+					Blocks: []interface{}{
+						types.DocumentAttributeDeclaration{
+							Name:  "imagesdir",
+							Value: "./path/to/images",
+						},
+						types.BlankLine{},
+						types.ImageBlock{
+							Attributes: types.ElementAttributes{},
+							Location: types.Location{
+								Elements: []interface{}{
+									types.DocumentAttributeSubstitution{
+										Name: "imagesdir",
+									},
+									types.StringElement{Content: "/foo.png"},
+								},
+							},
+						},
+					},
+				}
+				Expect(source).To(BecomeDraftDocument(expected))
 			})
 		})
+
+		Context("final document", func() {
+
+			It("inline image with empty alt only", func() {
+				source := "image:images/foo.png[]"
+				expected := types.Document{
+					Attributes:         types.DocumentAttributes{},
+					ElementReferences:  types.ElementReferences{},
+					Footnotes:          types.Footnotes{},
+					FootnoteReferences: types.FootnoteReferences{},
+					Elements: []interface{}{
+						types.Paragraph{
+							Attributes: types.ElementAttributes{},
+							Lines: []types.InlineElements{
+								{
+									types.InlineImage{
+										Attributes: types.ElementAttributes{
+											types.AttrImageAlt: "foo",
+										},
+										Location: types.Location{
+											Elements: []interface{}{
+												types.StringElement{Content: "images/foo.png"},
+											},
+											// Resolved: "images/foo.png",
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+				Expect(source).To(BecomeDocument(expected))
+			})
+
+			It("inline image with document attribute in URL", func() {
+				source := `:imagesdir: ./path/to/images
+
+an image:{imagesdir}/foo.png[].`
+				expected := types.Document{
+					Attributes:         types.DocumentAttributes{},
+					ElementReferences:  types.ElementReferences{},
+					Footnotes:          types.Footnotes{},
+					FootnoteReferences: types.FootnoteReferences{},
+					Elements: []interface{}{
+						types.DocumentAttributeDeclaration{
+							Name:  "imagesdir",
+							Value: "./path/to/images",
+						},
+						types.Paragraph{
+							Attributes: types.ElementAttributes{},
+							Lines: []types.InlineElements{
+								{
+									types.StringElement{Content: "an "},
+									types.InlineImage{
+										Attributes: types.ElementAttributes{
+											types.AttrImageAlt: "foo",
+										},
+										Location: types.Location{
+											Elements: []interface{}{
+												types.StringElement{Content: "./path/to/images/foo.png"},
+											},
+											// Resolved: "./path/to/images/foo.png",
+										},
+									},
+									types.StringElement{Content: "."},
+								},
+							},
+						},
+					},
+				}
+				Expect(source).To(BecomeDocument(expected))
+			})
+		})
+
 		Context("errors", func() {
 			It("inline image appending inline content", func() {
 				source := "a paragraph\nimage::images/foo.png[]"
-				expected := types.Paragraph{
-					Attributes: types.ElementAttributes{},
-					Lines: []types.InlineElements{
-						{
-							types.StringElement{Content: "a paragraph"},
-						},
-						{
-							types.StringElement{Content: "image::images/foo.png[]"},
+				expected := types.DraftDocument{
+					Blocks: []interface{}{
+						types.Paragraph{
+							Attributes: types.ElementAttributes{},
+							Lines: []types.InlineElements{
+								{
+									types.StringElement{Content: "a paragraph"},
+								},
+								{
+									types.StringElement{Content: "image::images/foo.png[]"},
+								},
+							},
 						},
 					},
 				}
-				Expect(source).To(BecomeDocumentBlock(expected))
+				Expect(source).To(BecomeDraftDocument(expected))
 			})
 		})
 	})

--- a/pkg/parser/labeled_list_test.go
+++ b/pkg/parser/labeled_list_test.go
@@ -1586,4 +1586,37 @@ level 2::: description 2`
 		}
 		Expect(source).To(BecomeDocument(expected))
 	})
+
+	It("labeled list item with predefined attribute", func() {
+		source := `level 1:: {amp}`
+		expected := types.Document{
+			Attributes:         types.DocumentAttributes{},
+			ElementReferences:  types.ElementReferences{},
+			Footnotes:          types.Footnotes{},
+			FootnoteReferences: types.FootnoteReferences{},
+			Elements: []interface{}{
+				types.LabeledList{
+					Attributes: types.ElementAttributes{},
+					Items: []types.LabeledListItem{
+						{
+							Level:      1,
+							Term:       "level 1",
+							Attributes: types.ElementAttributes{},
+							Elements: []interface{}{
+								types.Paragraph{
+									Attributes: types.ElementAttributes{},
+									Lines: []types.InlineElements{
+										{
+											types.StringElement{Content: "&amp;"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		Expect(source).To(BecomeDocument(expected))
+	})
 })

--- a/pkg/parser/link_test.go
+++ b/pkg/parser/link_test.go
@@ -23,8 +23,10 @@ var _ = Describe("links", func() {
 							types.StringElement{Content: "a link to "},
 							types.InlineLink{
 								Location: types.Location{
-									types.StringElement{
-										Content: "https://foo.bar",
+									Elements: []interface{}{
+										types.StringElement{
+											Content: "https://foo.bar",
+										},
 									},
 								},
 								Attributes: types.ElementAttributes{},
@@ -44,8 +46,10 @@ var _ = Describe("links", func() {
 							types.StringElement{Content: "a link to "},
 							types.InlineLink{
 								Location: types.Location{
-									types.StringElement{
-										Content: "https://foo.bar",
+									Elements: []interface{}{
+										types.StringElement{
+											Content: "https://foo.bar",
+										},
 									},
 								},
 								Attributes: types.ElementAttributes{},
@@ -65,8 +69,10 @@ var _ = Describe("links", func() {
 							types.StringElement{Content: "a link to "},
 							types.InlineLink{
 								Location: types.Location{
-									types.StringElement{
-										Content: "mailto:foo@bar",
+									Elements: []interface{}{
+										types.StringElement{
+											Content: "mailto:foo@bar",
+										},
 									},
 								},
 								Attributes: types.ElementAttributes{
@@ -93,8 +99,10 @@ var _ = Describe("links", func() {
 							types.StringElement{Content: "a link to "},
 							types.InlineLink{
 								Location: types.Location{
-									types.StringElement{
-										Content: "mailto:foo@bar",
+									Elements: []interface{}{
+										types.StringElement{
+											Content: "mailto:foo@bar",
+										},
 									},
 								},
 								Attributes: types.ElementAttributes{
@@ -127,8 +135,10 @@ next lines`
 							types.InlineLink{
 								Attributes: types.ElementAttributes{},
 								Location: types.Location{
-									types.StringElement{
-										Content: "http://website.com",
+									Elements: []interface{}{
+										types.StringElement{
+											Content: "http://website.com",
+										},
 									},
 								},
 							},
@@ -163,8 +173,10 @@ next lines`
 							types.InlineLink{
 								Attributes: types.ElementAttributes{},
 								Location: types.Location{
-									types.StringElement{
-										Content: "http://website.com",
+									Elements: []interface{}{
+										types.StringElement{
+											Content: "http://website.com",
+										},
 									},
 								},
 							},
@@ -193,8 +205,10 @@ next lines`
 							types.StringElement{Content: "a link to "},
 							types.InlineLink{
 								Location: types.Location{
-									types.StringElement{
-										Content: "https://foo.bar",
+									Elements: []interface{}{
+										types.StringElement{
+											Content: "https://foo.bar",
+										},
 									},
 								},
 								Attributes: types.ElementAttributes{},
@@ -217,8 +231,10 @@ next lines`
 								types.StringElement{Content: "a link to "},
 								types.InlineLink{
 									Location: types.Location{
-										types.StringElement{
-											Content: "http://website.com",
+										Elements: []interface{}{
+											types.StringElement{
+												Content: "http://website.com",
+											},
 										},
 									},
 									Attributes: types.ElementAttributes{
@@ -244,8 +260,10 @@ next lines`
 								types.StringElement{Content: "a link to "},
 								types.InlineLink{
 									Location: types.Location{
-										types.StringElement{
-											Content: "http://website.com",
+										Elements: []interface{}{
+											types.StringElement{
+												Content: "http://website.com",
+											},
 										},
 									},
 									Attributes: types.ElementAttributes{
@@ -271,8 +289,10 @@ next lines`
 								types.StringElement{Content: "a link to "},
 								types.InlineLink{
 									Location: types.Location{
-										types.StringElement{
-											Content: "http://website.com",
+										Elements: []interface{}{
+											types.StringElement{
+												Content: "http://website.com",
+											},
 										},
 									},
 									Attributes: types.ElementAttributes{
@@ -299,8 +319,10 @@ next lines`
 								types.StringElement{Content: "a link to "},
 								types.InlineLink{
 									Location: types.Location{
-										types.StringElement{
-											Content: "http://website.com",
+										Elements: []interface{}{
+											types.StringElement{
+												Content: "http://website.com",
+											},
 										},
 									},
 									Attributes: types.ElementAttributes{
@@ -334,8 +356,10 @@ next lines`
 							types.StringElement{Content: "a link to "},
 							types.InlineLink{
 								Location: types.Location{
-									types.StringElement{
-										Content: "foo.adoc",
+									Elements: []interface{}{
+										types.StringElement{
+											Content: "foo.adoc",
+										},
 									},
 								},
 								Attributes: types.ElementAttributes{},
@@ -355,8 +379,10 @@ next lines`
 							types.StringElement{Content: "a link to "},
 							types.InlineLink{
 								Location: types.Location{
-									types.StringElement{
-										Content: "foo.adoc",
+									Elements: []interface{}{
+										types.StringElement{
+											Content: "foo.adoc",
+										},
 									},
 								},
 								Attributes: types.ElementAttributes{
@@ -382,8 +408,10 @@ next lines`
 							types.StringElement{Content: "a link to "},
 							types.InlineLink{
 								Location: types.Location{
-									types.StringElement{
-										Content: "https://foo.bar",
+									Elements: []interface{}{
+										types.StringElement{
+											Content: "https://foo.bar",
+										},
 									},
 								},
 								Attributes: types.ElementAttributes{
@@ -409,8 +437,10 @@ next lines`
 							types.StringElement{Content: "a link to "},
 							types.InlineLink{
 								Location: types.Location{
-									types.StringElement{
-										Content: "https://foo.bar",
+									Elements: []interface{}{
+										types.StringElement{
+											Content: "https://foo.bar",
+										},
 									},
 								},
 								Attributes: types.ElementAttributes{
@@ -437,8 +467,10 @@ next lines`
 							types.StringElement{Content: "a link to "},
 							types.InlineLink{
 								Location: types.Location{
-									types.StringElement{
-										Content: "https://foo.bar",
+									Elements: []interface{}{
+										types.StringElement{
+											Content: "https://foo.bar",
+										},
 									},
 								},
 								Attributes: types.ElementAttributes{
@@ -466,7 +498,7 @@ next lines`
 				Expect(source).To(BecomeDocumentBlock(expected))
 			})
 
-			It("relative link with quoted text", func() {
+			It("relative link with quoted text attribute", func() {
 				source := "link:/[a _a_ b *b* c `c`]"
 				expected := types.Paragraph{
 					Attributes: types.ElementAttributes{},
@@ -474,8 +506,10 @@ next lines`
 						{
 							types.InlineLink{
 								Location: types.Location{
-									types.StringElement{
-										Content: "/",
+									Elements: []interface{}{
+										types.StringElement{
+											Content: "/",
+										},
 									},
 								},
 								Attributes: types.ElementAttributes{
@@ -522,6 +556,33 @@ next lines`
 				Expect(source).To(BecomeDocumentBlock(expected))
 			})
 
+			It("relative link within quoted text", func() {
+				source := "*link:foo[]*"
+				expected := types.Paragraph{
+					Attributes: types.ElementAttributes{},
+					Lines: []types.InlineElements{
+						{
+							types.QuotedText{
+								Kind: types.Bold,
+								Elements: types.InlineElements{
+									types.InlineLink{
+										Location: types.Location{
+											Elements: []interface{}{
+												types.StringElement{
+													Content: "foo",
+												},
+											},
+										},
+										Attributes: types.ElementAttributes{},
+									},
+								},
+							},
+						},
+					},
+				}
+				Expect(source).To(BecomeDocumentBlock(expected))
+			})
+
 			It("relative link with all valid characters", func() {
 				source := `a link to link:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789~:/?#@!$&;=()*+,-_.%[as expected]`
 				expected := types.Paragraph{
@@ -531,8 +592,10 @@ next lines`
 							types.StringElement{Content: "a link to "},
 							types.InlineLink{
 								Location: types.Location{
-									types.StringElement{
-										Content: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789~:/?#@!$&;=()*+,-_.%",
+									Elements: []interface{}{
+										types.StringElement{
+											Content: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789~:/?#@!$&;=()*+,-_.%",
+										},
 									},
 								},
 								Attributes: types.ElementAttributes{
@@ -562,8 +625,10 @@ Test 2: link:/test/a%20b[with encoded space]`
 							types.StringElement{Content: "Test 2: "},
 							types.InlineLink{
 								Location: types.Location{
-									types.StringElement{
-										Content: "/test/a%20b",
+									Elements: []interface{}{
+										types.StringElement{
+											Content: "/test/a%20b",
+										},
 									},
 								},
 								Attributes: types.ElementAttributes{
@@ -591,8 +656,10 @@ Test 2: link:/test/a%20b[with encoded space]`
 								types.StringElement{Content: "a link to "},
 								types.InlineLink{
 									Location: types.Location{
-										types.StringElement{
-											Content: "https://foo.bar",
+										Elements: []interface{}{
+											types.StringElement{
+												Content: "https://foo.bar",
+											},
 										},
 									},
 									Attributes: types.ElementAttributes{
@@ -618,8 +685,10 @@ Test 2: link:/test/a%20b[with encoded space]`
 								types.StringElement{Content: "a link to "},
 								types.InlineLink{
 									Location: types.Location{
-										types.StringElement{
-											Content: "https://foo.bar",
+										Elements: []interface{}{
+											types.StringElement{
+												Content: "https://foo.bar",
+											},
 										},
 									},
 									Attributes: types.ElementAttributes{
@@ -645,8 +714,10 @@ Test 2: link:/test/a%20b[with encoded space]`
 								types.StringElement{Content: "a link to "},
 								types.InlineLink{
 									Location: types.Location{
-										types.StringElement{
-											Content: "https://foo.bar",
+										Elements: []interface{}{
+											types.StringElement{
+												Content: "https://foo.bar",
+											},
 										},
 									},
 									Attributes: types.ElementAttributes{
@@ -673,8 +744,10 @@ Test 2: link:/test/a%20b[with encoded space]`
 								types.StringElement{Content: "a link to "},
 								types.InlineLink{
 									Location: types.Location{
-										types.StringElement{
-											Content: "https://foo.bar",
+										Elements: []interface{}{
+											types.StringElement{
+												Content: "https://foo.bar",
+											},
 										},
 									},
 									Attributes: types.ElementAttributes{
@@ -799,6 +872,42 @@ a link to {scheme}://{path}`
 
 	Context("final document", func() {
 
+		It("relative link within quoted text", func() {
+			source := "*link:foo[]*"
+			expected := types.Document{
+				Attributes:         types.DocumentAttributes{},
+				ElementReferences:  types.ElementReferences{},
+				Footnotes:          types.Footnotes{},
+				FootnoteReferences: types.FootnoteReferences{},
+				Elements: []interface{}{
+					types.Paragraph{
+						Attributes: types.ElementAttributes{},
+						Lines: []types.InlineElements{
+							{
+								types.QuotedText{
+									Kind: types.Bold,
+									Elements: types.InlineElements{
+										types.InlineLink{
+											Location: types.Location{
+												Elements: []interface{}{
+													types.StringElement{
+														Content: "foo",
+													},
+												},
+												// Resolved: "foo",
+											},
+											Attributes: types.ElementAttributes{},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(source).To(BecomeDocument(expected))
+		})
+
 		Context("with document attribute substitutions", func() {
 
 			It("external link with a document attribute substitution for the whole URL", func() {
@@ -829,9 +938,12 @@ a link to {url}`
 									types.StringElement{Content: "a link to "},
 									types.InlineLink{
 										Location: types.Location{
-											types.StringElement{
-												Content: "https://foo2.bar",
+											Elements: []interface{}{
+												types.StringElement{
+													Content: "https://foo2.bar",
+												},
 											},
+											// Resolved: "https://foo2.bar",
 										},
 										Attributes: types.ElementAttributes{},
 									},
@@ -870,9 +982,12 @@ a link to {scheme}://{path} and https://foo.baz`
 									types.StringElement{Content: "a link to "},
 									types.InlineLink{
 										Location: types.Location{
-											types.StringElement{
-												Content: "https://foo.bar",
+											Elements: []interface{}{
+												types.StringElement{
+													Content: "https://foo.bar",
+												},
 											},
+											// Resolved: "https://foo.bar",
 										},
 										Attributes: types.ElementAttributes{},
 									},
@@ -880,9 +995,12 @@ a link to {scheme}://{path} and https://foo.baz`
 									types.InlineLink{
 										Attributes: types.ElementAttributes{},
 										Location: types.Location{
-											types.StringElement{
-												Content: "https://foo.baz",
+											Elements: []interface{}{
+												types.StringElement{
+													Content: "https://foo.baz",
+												},
 											},
+											// Resolved: "https://foo.baz",
 										},
 									},
 								},
@@ -926,25 +1044,147 @@ a link to {scheme}://{path} and https://foo.baz`
 									types.InlineLink{
 										Attributes: types.ElementAttributes{},
 										Location: types.Location{
-											types.StringElement{
-												Content: "https://",
+											Elements: []interface{}{
+												types.StringElement{
+													Content: "https://",
+												},
+												types.DocumentAttributeSubstitution{
+													Name: "path", // no match while applying document attribute substitutions, so parsing gave a new document attribute substitution...
+												},
 											},
-											types.DocumentAttributeSubstitution{
-												Name: "path", // no match while applying document attribute substitutions, so parsing gave a new document attribute substitution...
-											},
+											// Resolved: "https://{path}",
 										},
 									},
 									types.StringElement{Content: " and "},
 									types.InlineLink{
 										Attributes: types.ElementAttributes{},
 										Location: types.Location{
-											types.StringElement{
-												Content: "https://foo.baz",
+											Elements: []interface{}{
+												types.StringElement{
+													Content: "https://foo.baz",
+												},
 											},
+											// Resolved: "https://foo.baz",
 										},
 									},
 								},
 							},
+						},
+					},
+				}
+				Expect(source).To(BecomeDocument(expected))
+			})
+
+			// see https://github.com/bytesparadise/libasciidoc/issues/447
+			// 			It("external link with document attribute in section 0 title", func() {
+			// 				source := `= a title to {scheme}://{path} and https://foo.baz
+			// :scheme: https
+			// :path: foo.bar`
+
+			// 				title := types.InlineElements{
+			// 					types.StringElement{Content: "a title to "},
+			// 					types.InlineLink{
+			// 						Attributes: types.ElementAttributes{},
+			// 						Location: types.Location{
+			// 							Elements: []interface{}{
+			// 								types.StringElement{
+			// 									Content: "https://foo.bar",
+			// 								},
+			// 							},
+			// 							// Resolved: "https://foo.bar",
+			// 						},
+			// 					},
+			// 					types.StringElement{Content: " and "},
+			// 					types.InlineLink{
+			// 						Attributes: types.ElementAttributes{},
+			// 						Location: types.Location{
+			// 							Elements: []interface{}{
+			// 								types.StringElement{
+			// 									Content: "https://foo.baz",
+			// 								},
+			// 							},
+			// 							// Resolved: "https://foo.baz",
+			// 						},
+			// 					},
+			// 				}
+			// 				expected := types.Document{
+			// 					Attributes: types.DocumentAttributes{
+
+			// 					},
+			// 					ElementReferences: types.ElementReferences{
+			// 						"a_title_to_https_foo_bar_and_https_foo_baz": title,
+			// 					},
+			// 					Footnotes:          types.Footnotes{},
+			// 					FootnoteReferences: types.FootnoteReferences{},
+			// 					Elements: []interface{}{
+			// 						types.Section{
+			// 							Level: 0,
+			// 							Attributes: types.ElementAttributes{
+			// 								types.AttrID:       "a_title_to_https_foo_bar_and_https_foo_baz",
+			// 								types.AttrCustomID: false,
+			// 							},
+			// 							Title:    title,
+			// 							Elements: []interface{}{},
+			// 						},
+			// 					},
+			// 				}
+			// 				Expect(source).To(BecomeDocument(expected))
+			// 			})
+
+			It("external link with document attribute in section 1 title", func() {
+				source := `:scheme: https
+:path: foo.bar
+
+== a title to {scheme}://{path} and https://foo.baz`
+
+				title := types.InlineElements{
+					types.StringElement{Content: "a title to "},
+					types.InlineLink{
+						Attributes: types.ElementAttributes{},
+						Location: types.Location{
+							Elements: []interface{}{
+								types.StringElement{
+									Content: "https://foo.bar",
+								},
+							},
+						},
+					},
+					types.StringElement{Content: " and "},
+					types.InlineLink{
+						Attributes: types.ElementAttributes{},
+						Location: types.Location{
+							Elements: []interface{}{
+								types.StringElement{
+									Content: "https://foo.baz",
+								},
+							},
+						},
+					},
+				}
+				expected := types.Document{
+					Attributes: types.DocumentAttributes{},
+					ElementReferences: types.ElementReferences{
+						"a_title_to_https_foo_bar_and_https_foo_baz": title,
+					},
+					Footnotes:          types.Footnotes{},
+					FootnoteReferences: types.FootnoteReferences{},
+					Elements: []interface{}{
+						types.DocumentAttributeDeclaration{
+							Name:  "scheme",
+							Value: "https",
+						},
+						types.DocumentAttributeDeclaration{
+							Name:  "path",
+							Value: "foo.bar",
+						},
+						types.Section{
+							Level: 1,
+							Attributes: types.ElementAttributes{
+								types.AttrID:       "a_title_to_https_foo_bar_and_https_foo_baz",
+								types.AttrCustomID: false,
+							},
+							Title:    title,
+							Elements: []interface{}{},
 						},
 					},
 				}

--- a/pkg/parser/ordered_list_test.go
+++ b/pkg/parser/ordered_list_test.go
@@ -951,6 +951,7 @@ var _ = Describe("ordered lists - document", func() {
 				},
 			},
 		}
+
 		It("ordered list item with implicit numbering style", func() {
 			source := `.. item`
 			expected := types.Document{
@@ -1084,11 +1085,43 @@ var _ = Describe("ordered lists - document", func() {
 						Attributes: types.ElementAttributes{},
 						Items: []types.OrderedListItem{
 							{
-
 								Level:          1,
 								NumberingStyle: types.UpperRoman,
 								Attributes:     map[string]interface{}{},
 								Elements:       elements,
+							},
+						},
+					},
+				},
+			}
+			Expect(source).To(BecomeDocument(expected))
+		})
+
+		It("ordered list item with predefined attribute", func() {
+			source := `. {amp}`
+			expected := types.Document{
+				Attributes:         types.DocumentAttributes{},
+				ElementReferences:  types.ElementReferences{},
+				Footnotes:          types.Footnotes{},
+				FootnoteReferences: types.FootnoteReferences{},
+				Elements: []interface{}{
+					types.OrderedList{
+						Attributes: types.ElementAttributes{},
+						Items: []types.OrderedListItem{
+							{
+								Level:          1,
+								NumberingStyle: types.Arabic,
+								Attributes:     map[string]interface{}{},
+								Elements: []interface{}{
+									types.Paragraph{
+										Attributes: types.ElementAttributes{},
+										Lines: []types.InlineElements{
+											{
+												types.StringElement{Content: "&amp;"},
+											},
+										},
+									},
+								},
 							},
 						},
 					},

--- a/pkg/parser/paragraph_test.go
+++ b/pkg/parser/paragraph_test.go
@@ -613,10 +613,14 @@ a foo image:foo.png[]`
 							Content: "a foo ",
 						},
 						types.InlineImage{
-							Attributes: types.ElementAttributes{
-								types.AttrImageAlt: "foo",
+							Attributes: types.ElementAttributes{},
+							Location: types.Location{
+								Elements: []interface{}{
+									types.StringElement{
+										Content: "foo.png",
+									},
+								},
 							},
-							Path: "foo.png",
 						},
 					},
 				},
@@ -629,15 +633,45 @@ a foo image:foo.png[]`
 image::foo.png[]`
 			expected := types.ImageBlock{
 				Attributes: types.ElementAttributes{
-					types.AttrImageAlt: "foo",
+
 					// quote attributes
 					types.AttrKind:        types.Quote,
 					types.AttrQuoteAuthor: "john doe",
 					types.AttrQuoteTitle:  "quote title",
 				},
-				Path: "foo.png",
+				Location: types.Location{
+					Elements: []interface{}{
+						types.StringElement{
+							Content: "foo.png",
+						},
+					},
+				},
 			}
 			Expect(source).To(BecomeDocumentBlock(expected)) //, parser.Debug(true))
 		})
+	})
+})
+
+var _ = Describe("paragraphs - final document", func() {
+
+	It("paragraph with predefined attribute", func() {
+		source := "hello {plus} world"
+		expected := types.Document{
+			Attributes:         types.DocumentAttributes{},
+			ElementReferences:  types.ElementReferences{},
+			Footnotes:          types.Footnotes{},
+			FootnoteReferences: types.FootnoteReferences{},
+			Elements: []interface{}{
+				types.Paragraph{
+					Attributes: types.ElementAttributes{},
+					Lines: []types.InlineElements{
+						{
+							types.StringElement{Content: "hello &#43; world"},
+						},
+					},
+				},
+			},
+		}
+		Expect(source).To(BecomeDocument(expected))
 	})
 })

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -9143,14 +9143,10 @@ var g = &grammar{
 								},
 								&ruleRefExpr{
 									pos:  position{line: 1154, col: 11, offset: 43187},
-									name: "DocumentAttributeSubstitution",
-								},
-								&ruleRefExpr{
-									pos:  position{line: 1155, col: 11, offset: 43228},
 									name: "OtherWord",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1156, col: 11, offset: 43248},
+									pos:  position{line: 1155, col: 11, offset: 43207},
 									name: "Parenthesis",
 								},
 							},
@@ -9161,47 +9157,56 @@ var g = &grammar{
 		},
 		{
 			name: "ImageBlock",
-			pos:  position{line: 1164, col: 1, offset: 43431},
+			pos:  position{line: 1163, col: 1, offset: 43390},
 			expr: &actionExpr{
-				pos: position{line: 1164, col: 15, offset: 43445},
+				pos: position{line: 1163, col: 15, offset: 43404},
 				run: (*parser).callonImageBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1164, col: 15, offset: 43445},
+					pos: position{line: 1163, col: 15, offset: 43404},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1164, col: 15, offset: 43445},
+							pos:   position{line: 1163, col: 15, offset: 43404},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1164, col: 26, offset: 43456},
+								pos: position{line: 1163, col: 26, offset: 43415},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1164, col: 27, offset: 43457},
+									pos:  position{line: 1163, col: 27, offset: 43416},
 									name: "ElementAttributes",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1164, col: 47, offset: 43477},
+							pos:        position{line: 1163, col: 47, offset: 43436},
 							val:        "image::",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1164, col: 57, offset: 43487},
+							pos:   position{line: 1163, col: 57, offset: 43446},
 							label: "path",
-							expr: &ruleRefExpr{
-								pos:  position{line: 1164, col: 63, offset: 43493},
-								name: "URL",
+							expr: &choiceExpr{
+								pos: position{line: 1163, col: 63, offset: 43452},
+								alternatives: []interface{}{
+									&ruleRefExpr{
+										pos:  position{line: 1163, col: 63, offset: 43452},
+										name: "Location",
+									},
+									&ruleRefExpr{
+										pos:  position{line: 1163, col: 74, offset: 43463},
+										name: "FileLocation",
+									},
+								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1164, col: 68, offset: 43498},
+							pos:   position{line: 1163, col: 88, offset: 43477},
 							label: "inlineAttributes",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1164, col: 86, offset: 43516},
+								pos:  position{line: 1163, col: 106, offset: 43495},
 								name: "ImageAttributes",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1164, col: 103, offset: 43533},
+							pos:  position{line: 1163, col: 123, offset: 43512},
 							name: "EOLS",
 						},
 					},
@@ -9210,39 +9215,48 @@ var g = &grammar{
 		},
 		{
 			name: "InlineImage",
-			pos:  position{line: 1168, col: 1, offset: 43645},
+			pos:  position{line: 1167, col: 1, offset: 43632},
 			expr: &actionExpr{
-				pos: position{line: 1168, col: 16, offset: 43660},
+				pos: position{line: 1167, col: 16, offset: 43647},
 				run: (*parser).callonInlineImage1,
 				expr: &seqExpr{
-					pos: position{line: 1168, col: 16, offset: 43660},
+					pos: position{line: 1167, col: 16, offset: 43647},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1168, col: 16, offset: 43660},
+							pos:        position{line: 1167, col: 16, offset: 43647},
 							val:        "image:",
 							ignoreCase: false,
 						},
 						&notExpr{
-							pos: position{line: 1168, col: 25, offset: 43669},
+							pos: position{line: 1167, col: 25, offset: 43656},
 							expr: &litMatcher{
-								pos:        position{line: 1168, col: 26, offset: 43670},
+								pos:        position{line: 1167, col: 26, offset: 43657},
 								val:        ":",
 								ignoreCase: false,
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1168, col: 30, offset: 43674},
+							pos:   position{line: 1167, col: 30, offset: 43661},
 							label: "path",
-							expr: &ruleRefExpr{
-								pos:  position{line: 1168, col: 36, offset: 43680},
-								name: "URL",
+							expr: &choiceExpr{
+								pos: position{line: 1167, col: 36, offset: 43667},
+								alternatives: []interface{}{
+									&ruleRefExpr{
+										pos:  position{line: 1167, col: 36, offset: 43667},
+										name: "Location",
+									},
+									&ruleRefExpr{
+										pos:  position{line: 1167, col: 47, offset: 43678},
+										name: "FileLocation",
+									},
+								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1168, col: 41, offset: 43685},
+							pos:   position{line: 1167, col: 61, offset: 43692},
 							label: "inlineAttributes",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1168, col: 59, offset: 43703},
+								pos:  position{line: 1167, col: 79, offset: 43710},
 								name: "ImageAttributes",
 							},
 						},
@@ -9252,95 +9266,95 @@ var g = &grammar{
 		},
 		{
 			name: "ImageAttributes",
-			pos:  position{line: 1172, col: 1, offset: 43816},
+			pos:  position{line: 1171, col: 1, offset: 43831},
 			expr: &actionExpr{
-				pos: position{line: 1172, col: 20, offset: 43835},
+				pos: position{line: 1171, col: 20, offset: 43850},
 				run: (*parser).callonImageAttributes1,
 				expr: &seqExpr{
-					pos: position{line: 1172, col: 20, offset: 43835},
+					pos: position{line: 1171, col: 20, offset: 43850},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1172, col: 20, offset: 43835},
+							pos:        position{line: 1171, col: 20, offset: 43850},
 							val:        "[",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1172, col: 24, offset: 43839},
+							pos:   position{line: 1171, col: 24, offset: 43854},
 							label: "alt",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1172, col: 28, offset: 43843},
+								pos: position{line: 1171, col: 28, offset: 43858},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1172, col: 29, offset: 43844},
+									pos:  position{line: 1171, col: 29, offset: 43859},
 									name: "AttributeValue",
 								},
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 1172, col: 46, offset: 43861},
+							pos: position{line: 1171, col: 46, offset: 43876},
 							expr: &litMatcher{
-								pos:        position{line: 1172, col: 46, offset: 43861},
+								pos:        position{line: 1171, col: 46, offset: 43876},
 								val:        ",",
 								ignoreCase: false,
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1172, col: 51, offset: 43866},
+							pos:   position{line: 1171, col: 51, offset: 43881},
 							label: "width",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1172, col: 57, offset: 43872},
+								pos: position{line: 1171, col: 57, offset: 43887},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1172, col: 58, offset: 43873},
+									pos:  position{line: 1171, col: 58, offset: 43888},
 									name: "AttributeValue",
 								},
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 1172, col: 75, offset: 43890},
+							pos: position{line: 1171, col: 75, offset: 43905},
 							expr: &litMatcher{
-								pos:        position{line: 1172, col: 75, offset: 43890},
+								pos:        position{line: 1171, col: 75, offset: 43905},
 								val:        ",",
 								ignoreCase: false,
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1172, col: 80, offset: 43895},
+							pos:   position{line: 1171, col: 80, offset: 43910},
 							label: "height",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1172, col: 87, offset: 43902},
+								pos: position{line: 1171, col: 87, offset: 43917},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1172, col: 88, offset: 43903},
+									pos:  position{line: 1171, col: 88, offset: 43918},
 									name: "AttributeValue",
 								},
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 1172, col: 105, offset: 43920},
+							pos: position{line: 1171, col: 105, offset: 43935},
 							expr: &litMatcher{
-								pos:        position{line: 1172, col: 105, offset: 43920},
+								pos:        position{line: 1171, col: 105, offset: 43935},
 								val:        ",",
 								ignoreCase: false,
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1172, col: 110, offset: 43925},
+							pos: position{line: 1171, col: 110, offset: 43940},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1172, col: 110, offset: 43925},
+								pos:  position{line: 1171, col: 110, offset: 43940},
 								name: "WS",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1172, col: 114, offset: 43929},
+							pos:   position{line: 1171, col: 114, offset: 43944},
 							label: "otherattrs",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1172, col: 125, offset: 43940},
+								pos: position{line: 1171, col: 125, offset: 43955},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1172, col: 126, offset: 43941},
+									pos:  position{line: 1171, col: 126, offset: 43956},
 									name: "GenericAttribute",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1172, col: 145, offset: 43960},
+							pos:        position{line: 1171, col: 145, offset: 43975},
 							val:        "]",
 							ignoreCase: false,
 						},
@@ -9350,31 +9364,31 @@ var g = &grammar{
 		},
 		{
 			name: "InlineFootnote",
-			pos:  position{line: 1179, col: 1, offset: 44250},
+			pos:  position{line: 1178, col: 1, offset: 44265},
 			expr: &choiceExpr{
-				pos: position{line: 1179, col: 19, offset: 44268},
+				pos: position{line: 1178, col: 19, offset: 44283},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1179, col: 19, offset: 44268},
+						pos: position{line: 1178, col: 19, offset: 44283},
 						run: (*parser).callonInlineFootnote2,
 						expr: &seqExpr{
-							pos: position{line: 1179, col: 19, offset: 44268},
+							pos: position{line: 1178, col: 19, offset: 44283},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1179, col: 19, offset: 44268},
+									pos:        position{line: 1178, col: 19, offset: 44283},
 									val:        "footnote:[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1179, col: 32, offset: 44281},
+									pos:   position{line: 1178, col: 32, offset: 44296},
 									label: "content",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1179, col: 41, offset: 44290},
+										pos:  position{line: 1178, col: 41, offset: 44305},
 										name: "FootnoteContent",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1179, col: 58, offset: 44307},
+									pos:        position{line: 1178, col: 58, offset: 44322},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -9382,39 +9396,39 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1181, col: 5, offset: 44382},
+						pos: position{line: 1180, col: 5, offset: 44397},
 						run: (*parser).callonInlineFootnote8,
 						expr: &seqExpr{
-							pos: position{line: 1181, col: 5, offset: 44382},
+							pos: position{line: 1180, col: 5, offset: 44397},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1181, col: 5, offset: 44382},
+									pos:        position{line: 1180, col: 5, offset: 44397},
 									val:        "footnoteref:[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1181, col: 21, offset: 44398},
+									pos:   position{line: 1180, col: 21, offset: 44413},
 									label: "ref",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1181, col: 26, offset: 44403},
+										pos:  position{line: 1180, col: 26, offset: 44418},
 										name: "FootnoteRef",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1181, col: 39, offset: 44416},
+									pos:        position{line: 1180, col: 39, offset: 44431},
 									val:        ",",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1181, col: 43, offset: 44420},
+									pos:   position{line: 1180, col: 43, offset: 44435},
 									label: "content",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1181, col: 52, offset: 44429},
+										pos:  position{line: 1180, col: 52, offset: 44444},
 										name: "FootnoteContent",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1181, col: 69, offset: 44446},
+									pos:        position{line: 1180, col: 69, offset: 44461},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -9422,26 +9436,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1183, col: 5, offset: 44531},
+						pos: position{line: 1182, col: 5, offset: 44546},
 						run: (*parser).callonInlineFootnote17,
 						expr: &seqExpr{
-							pos: position{line: 1183, col: 5, offset: 44531},
+							pos: position{line: 1182, col: 5, offset: 44546},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1183, col: 5, offset: 44531},
+									pos:        position{line: 1182, col: 5, offset: 44546},
 									val:        "footnoteref:[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1183, col: 21, offset: 44547},
+									pos:   position{line: 1182, col: 21, offset: 44562},
 									label: "ref",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1183, col: 26, offset: 44552},
+										pos:  position{line: 1182, col: 26, offset: 44567},
 										name: "FootnoteRef",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1183, col: 39, offset: 44565},
+									pos:        position{line: 1182, col: 39, offset: 44580},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -9453,51 +9467,51 @@ var g = &grammar{
 		},
 		{
 			name: "FootnoteRef",
-			pos:  position{line: 1187, col: 1, offset: 44680},
+			pos:  position{line: 1186, col: 1, offset: 44695},
 			expr: &actionExpr{
-				pos: position{line: 1187, col: 16, offset: 44695},
+				pos: position{line: 1186, col: 16, offset: 44710},
 				run: (*parser).callonFootnoteRef1,
 				expr: &zeroOrMoreExpr{
-					pos: position{line: 1187, col: 16, offset: 44695},
+					pos: position{line: 1186, col: 16, offset: 44710},
 					expr: &choiceExpr{
-						pos: position{line: 1187, col: 17, offset: 44696},
+						pos: position{line: 1186, col: 17, offset: 44711},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 1187, col: 17, offset: 44696},
+								pos:  position{line: 1186, col: 17, offset: 44711},
 								name: "Alphanums",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1187, col: 29, offset: 44708},
+								pos:  position{line: 1186, col: 29, offset: 44723},
 								name: "Spaces",
 							},
 							&seqExpr{
-								pos: position{line: 1187, col: 39, offset: 44718},
+								pos: position{line: 1186, col: 39, offset: 44733},
 								exprs: []interface{}{
 									&notExpr{
-										pos: position{line: 1187, col: 39, offset: 44718},
+										pos: position{line: 1186, col: 39, offset: 44733},
 										expr: &litMatcher{
-											pos:        position{line: 1187, col: 40, offset: 44719},
+											pos:        position{line: 1186, col: 40, offset: 44734},
 											val:        ",",
 											ignoreCase: false,
 										},
 									},
 									&notExpr{
-										pos: position{line: 1187, col: 44, offset: 44723},
+										pos: position{line: 1186, col: 44, offset: 44738},
 										expr: &litMatcher{
-											pos:        position{line: 1187, col: 45, offset: 44724},
+											pos:        position{line: 1186, col: 45, offset: 44739},
 											val:        "]",
 											ignoreCase: false,
 										},
 									},
 									&notExpr{
-										pos: position{line: 1187, col: 49, offset: 44728},
+										pos: position{line: 1186, col: 49, offset: 44743},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1187, col: 50, offset: 44729},
+											pos:  position{line: 1186, col: 50, offset: 44744},
 											name: "EOL",
 										},
 									},
 									&anyMatcher{
-										line: 1187, col: 55, offset: 44734,
+										line: 1186, col: 55, offset: 44749,
 									},
 								},
 							},
@@ -9508,55 +9522,55 @@ var g = &grammar{
 		},
 		{
 			name: "FootnoteContent",
-			pos:  position{line: 1191, col: 1, offset: 44819},
+			pos:  position{line: 1190, col: 1, offset: 44834},
 			expr: &actionExpr{
-				pos: position{line: 1191, col: 20, offset: 44838},
+				pos: position{line: 1190, col: 20, offset: 44853},
 				run: (*parser).callonFootnoteContent1,
 				expr: &labeledExpr{
-					pos:   position{line: 1191, col: 20, offset: 44838},
+					pos:   position{line: 1190, col: 20, offset: 44853},
 					label: "elements",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 1191, col: 29, offset: 44847},
+						pos: position{line: 1190, col: 29, offset: 44862},
 						expr: &seqExpr{
-							pos: position{line: 1191, col: 30, offset: 44848},
+							pos: position{line: 1190, col: 30, offset: 44863},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1191, col: 30, offset: 44848},
+									pos: position{line: 1190, col: 30, offset: 44863},
 									expr: &litMatcher{
-										pos:        position{line: 1191, col: 31, offset: 44849},
+										pos:        position{line: 1190, col: 31, offset: 44864},
 										val:        "]",
 										ignoreCase: false,
 									},
 								},
 								&notExpr{
-									pos: position{line: 1191, col: 35, offset: 44853},
+									pos: position{line: 1190, col: 35, offset: 44868},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1191, col: 36, offset: 44854},
+										pos:  position{line: 1190, col: 36, offset: 44869},
 										name: "EOL",
 									},
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1191, col: 40, offset: 44858},
+									pos: position{line: 1190, col: 40, offset: 44873},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1191, col: 40, offset: 44858},
+										pos:  position{line: 1190, col: 40, offset: 44873},
 										name: "WS",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1191, col: 44, offset: 44862},
+									pos: position{line: 1190, col: 44, offset: 44877},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1191, col: 45, offset: 44863},
+										pos:  position{line: 1190, col: 45, offset: 44878},
 										name: "InlineElementID",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1191, col: 61, offset: 44879},
+									pos:  position{line: 1190, col: 61, offset: 44894},
 									name: "InlineElement",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1191, col: 75, offset: 44893},
+									pos: position{line: 1190, col: 75, offset: 44908},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1191, col: 75, offset: 44893},
+										pos:  position{line: 1190, col: 75, offset: 44908},
 										name: "WS",
 									},
 								},
@@ -9568,60 +9582,60 @@ var g = &grammar{
 		},
 		{
 			name: "DelimitedBlock",
-			pos:  position{line: 1198, col: 1, offset: 45207},
+			pos:  position{line: 1197, col: 1, offset: 45222},
 			expr: &actionExpr{
-				pos: position{line: 1198, col: 19, offset: 45225},
+				pos: position{line: 1197, col: 19, offset: 45240},
 				run: (*parser).callonDelimitedBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1198, col: 19, offset: 45225},
+					pos: position{line: 1197, col: 19, offset: 45240},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1198, col: 19, offset: 45225},
+							pos: position{line: 1197, col: 19, offset: 45240},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1198, col: 20, offset: 45226},
+								pos:  position{line: 1197, col: 20, offset: 45241},
 								name: "Alphanum",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1199, col: 5, offset: 45255},
+							pos:   position{line: 1198, col: 5, offset: 45270},
 							label: "block",
 							expr: &choiceExpr{
-								pos: position{line: 1199, col: 12, offset: 45262},
+								pos: position{line: 1198, col: 12, offset: 45277},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1199, col: 12, offset: 45262},
+										pos:  position{line: 1198, col: 12, offset: 45277},
 										name: "FencedBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1200, col: 11, offset: 45285},
+										pos:  position{line: 1199, col: 11, offset: 45300},
 										name: "ListingBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1201, col: 11, offset: 45309},
+										pos:  position{line: 1200, col: 11, offset: 45324},
 										name: "ExampleBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1202, col: 11, offset: 45333},
+										pos:  position{line: 1201, col: 11, offset: 45348},
 										name: "VerseBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1203, col: 11, offset: 45355},
+										pos:  position{line: 1202, col: 11, offset: 45370},
 										name: "QuoteBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1204, col: 11, offset: 45377},
+										pos:  position{line: 1203, col: 11, offset: 45392},
 										name: "SidebarBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1205, col: 11, offset: 45400},
+										pos:  position{line: 1204, col: 11, offset: 45415},
 										name: "SingleLineComment",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1206, col: 11, offset: 45428},
+										pos:  position{line: 1205, col: 11, offset: 45443},
 										name: "Table",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1207, col: 11, offset: 45444},
+										pos:  position{line: 1206, col: 11, offset: 45459},
 										name: "CommentBlock",
 									},
 								},
@@ -9633,36 +9647,36 @@ var g = &grammar{
 		},
 		{
 			name: "BlockDelimiter",
-			pos:  position{line: 1211, col: 1, offset: 45485},
+			pos:  position{line: 1210, col: 1, offset: 45500},
 			expr: &choiceExpr{
-				pos: position{line: 1211, col: 19, offset: 45503},
+				pos: position{line: 1210, col: 19, offset: 45518},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1211, col: 19, offset: 45503},
+						pos:  position{line: 1210, col: 19, offset: 45518},
 						name: "LiteralBlockDelimiter",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1212, col: 19, offset: 45544},
+						pos:  position{line: 1211, col: 19, offset: 45559},
 						name: "FencedBlockDelimiter",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1213, col: 19, offset: 45584},
+						pos:  position{line: 1212, col: 19, offset: 45599},
 						name: "ListingBlockDelimiter",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1214, col: 19, offset: 45625},
+						pos:  position{line: 1213, col: 19, offset: 45640},
 						name: "ExampleBlockDelimiter",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1215, col: 19, offset: 45666},
+						pos:  position{line: 1214, col: 19, offset: 45681},
 						name: "CommentBlockDelimiter",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1216, col: 19, offset: 45707},
+						pos:  position{line: 1215, col: 19, offset: 45722},
 						name: "QuoteBlockDelimiter",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1217, col: 19, offset: 45745},
+						pos:  position{line: 1216, col: 19, offset: 45760},
 						name: "SidebarBlockDelimiter",
 					},
 				},
@@ -9670,17 +9684,17 @@ var g = &grammar{
 		},
 		{
 			name: "FencedBlockDelimiter",
-			pos:  position{line: 1223, col: 1, offset: 45964},
+			pos:  position{line: 1222, col: 1, offset: 45979},
 			expr: &seqExpr{
-				pos: position{line: 1223, col: 25, offset: 45988},
+				pos: position{line: 1222, col: 25, offset: 46003},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1223, col: 25, offset: 45988},
+						pos:        position{line: 1222, col: 25, offset: 46003},
 						val:        "```",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1223, col: 31, offset: 45994},
+						pos:  position{line: 1222, col: 31, offset: 46009},
 						name: "EOLS",
 					},
 				},
@@ -9688,48 +9702,48 @@ var g = &grammar{
 		},
 		{
 			name: "FencedBlock",
-			pos:  position{line: 1225, col: 1, offset: 46000},
+			pos:  position{line: 1224, col: 1, offset: 46015},
 			expr: &actionExpr{
-				pos: position{line: 1225, col: 16, offset: 46015},
+				pos: position{line: 1224, col: 16, offset: 46030},
 				run: (*parser).callonFencedBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1225, col: 16, offset: 46015},
+					pos: position{line: 1224, col: 16, offset: 46030},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1225, col: 16, offset: 46015},
+							pos:   position{line: 1224, col: 16, offset: 46030},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1225, col: 27, offset: 46026},
+								pos: position{line: 1224, col: 27, offset: 46041},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1225, col: 28, offset: 46027},
+									pos:  position{line: 1224, col: 28, offset: 46042},
 									name: "ElementAttributes",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1225, col: 48, offset: 46047},
+							pos:  position{line: 1224, col: 48, offset: 46062},
 							name: "FencedBlockDelimiter",
 						},
 						&labeledExpr{
-							pos:   position{line: 1225, col: 69, offset: 46068},
+							pos:   position{line: 1224, col: 69, offset: 46083},
 							label: "content",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1225, col: 77, offset: 46076},
+								pos: position{line: 1224, col: 77, offset: 46091},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1225, col: 78, offset: 46077},
+									pos:  position{line: 1224, col: 78, offset: 46092},
 									name: "FencedBlockContent",
 								},
 							},
 						},
 						&choiceExpr{
-							pos: position{line: 1225, col: 100, offset: 46099},
+							pos: position{line: 1224, col: 100, offset: 46114},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 1225, col: 100, offset: 46099},
+									pos:  position{line: 1224, col: 100, offset: 46114},
 									name: "FencedBlockDelimiter",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1225, col: 123, offset: 46122},
+									pos:  position{line: 1224, col: 123, offset: 46137},
 									name: "EOF",
 								},
 							},
@@ -9740,24 +9754,24 @@ var g = &grammar{
 		},
 		{
 			name: "FencedBlockContent",
-			pos:  position{line: 1229, col: 1, offset: 46230},
+			pos:  position{line: 1228, col: 1, offset: 46245},
 			expr: &choiceExpr{
-				pos: position{line: 1229, col: 23, offset: 46252},
+				pos: position{line: 1228, col: 23, offset: 46267},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1229, col: 23, offset: 46252},
+						pos:  position{line: 1228, col: 23, offset: 46267},
 						name: "BlankLine",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1229, col: 35, offset: 46264},
+						pos:  position{line: 1228, col: 35, offset: 46279},
 						name: "FileInclusion",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1229, col: 51, offset: 46280},
+						pos:  position{line: 1228, col: 51, offset: 46295},
 						name: "ListItem",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1229, col: 62, offset: 46291},
+						pos:  position{line: 1228, col: 62, offset: 46306},
 						name: "FencedBlockParagraph",
 					},
 				},
@@ -9765,17 +9779,17 @@ var g = &grammar{
 		},
 		{
 			name: "FencedBlockParagraph",
-			pos:  position{line: 1232, col: 1, offset: 46331},
+			pos:  position{line: 1231, col: 1, offset: 46346},
 			expr: &actionExpr{
-				pos: position{line: 1232, col: 25, offset: 46355},
+				pos: position{line: 1231, col: 25, offset: 46370},
 				run: (*parser).callonFencedBlockParagraph1,
 				expr: &labeledExpr{
-					pos:   position{line: 1232, col: 25, offset: 46355},
+					pos:   position{line: 1231, col: 25, offset: 46370},
 					label: "lines",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 1232, col: 31, offset: 46361},
+						pos: position{line: 1231, col: 31, offset: 46376},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1232, col: 32, offset: 46362},
+							pos:  position{line: 1231, col: 32, offset: 46377},
 							name: "FencedBlockParagraphLine",
 						},
 					},
@@ -9784,32 +9798,32 @@ var g = &grammar{
 		},
 		{
 			name: "FencedBlockParagraphLine",
-			pos:  position{line: 1236, col: 1, offset: 46475},
+			pos:  position{line: 1235, col: 1, offset: 46490},
 			expr: &actionExpr{
-				pos: position{line: 1236, col: 29, offset: 46503},
+				pos: position{line: 1235, col: 29, offset: 46518},
 				run: (*parser).callonFencedBlockParagraphLine1,
 				expr: &seqExpr{
-					pos: position{line: 1236, col: 29, offset: 46503},
+					pos: position{line: 1235, col: 29, offset: 46518},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1236, col: 29, offset: 46503},
+							pos: position{line: 1235, col: 29, offset: 46518},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1236, col: 30, offset: 46504},
+								pos:  position{line: 1235, col: 30, offset: 46519},
 								name: "FencedBlockDelimiter",
 							},
 						},
 						&notExpr{
-							pos: position{line: 1236, col: 51, offset: 46525},
+							pos: position{line: 1235, col: 51, offset: 46540},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1236, col: 52, offset: 46526},
+								pos:  position{line: 1235, col: 52, offset: 46541},
 								name: "BlankLine",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1236, col: 62, offset: 46536},
+							pos:   position{line: 1235, col: 62, offset: 46551},
 							label: "line",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1236, col: 68, offset: 46542},
+								pos:  position{line: 1235, col: 68, offset: 46557},
 								name: "InlineElements",
 							},
 						},
@@ -9819,17 +9833,17 @@ var g = &grammar{
 		},
 		{
 			name: "ListingBlockDelimiter",
-			pos:  position{line: 1243, col: 1, offset: 46780},
+			pos:  position{line: 1242, col: 1, offset: 46795},
 			expr: &seqExpr{
-				pos: position{line: 1243, col: 26, offset: 46805},
+				pos: position{line: 1242, col: 26, offset: 46820},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1243, col: 26, offset: 46805},
+						pos:        position{line: 1242, col: 26, offset: 46820},
 						val:        "----",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1243, col: 33, offset: 46812},
+						pos:  position{line: 1242, col: 33, offset: 46827},
 						name: "EOLS",
 					},
 				},
@@ -9837,48 +9851,48 @@ var g = &grammar{
 		},
 		{
 			name: "ListingBlock",
-			pos:  position{line: 1246, col: 1, offset: 46853},
+			pos:  position{line: 1245, col: 1, offset: 46868},
 			expr: &actionExpr{
-				pos: position{line: 1246, col: 17, offset: 46869},
+				pos: position{line: 1245, col: 17, offset: 46884},
 				run: (*parser).callonListingBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1246, col: 17, offset: 46869},
+					pos: position{line: 1245, col: 17, offset: 46884},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1246, col: 17, offset: 46869},
+							pos:   position{line: 1245, col: 17, offset: 46884},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1246, col: 28, offset: 46880},
+								pos: position{line: 1245, col: 28, offset: 46895},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1246, col: 29, offset: 46881},
+									pos:  position{line: 1245, col: 29, offset: 46896},
 									name: "ElementAttributes",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1246, col: 49, offset: 46901},
+							pos:  position{line: 1245, col: 49, offset: 46916},
 							name: "ListingBlockDelimiter",
 						},
 						&labeledExpr{
-							pos:   position{line: 1246, col: 71, offset: 46923},
+							pos:   position{line: 1245, col: 71, offset: 46938},
 							label: "content",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1246, col: 79, offset: 46931},
+								pos: position{line: 1245, col: 79, offset: 46946},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1246, col: 80, offset: 46932},
+									pos:  position{line: 1245, col: 80, offset: 46947},
 									name: "ListingBlockElement",
 								},
 							},
 						},
 						&choiceExpr{
-							pos: position{line: 1246, col: 103, offset: 46955},
+							pos: position{line: 1245, col: 103, offset: 46970},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 1246, col: 103, offset: 46955},
+									pos:  position{line: 1245, col: 103, offset: 46970},
 									name: "ListingBlockDelimiter",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1246, col: 127, offset: 46979},
+									pos:  position{line: 1245, col: 127, offset: 46994},
 									name: "EOF",
 								},
 							},
@@ -9889,16 +9903,16 @@ var g = &grammar{
 		},
 		{
 			name: "ListingBlockElement",
-			pos:  position{line: 1250, col: 1, offset: 47088},
+			pos:  position{line: 1249, col: 1, offset: 47103},
 			expr: &choiceExpr{
-				pos: position{line: 1250, col: 24, offset: 47111},
+				pos: position{line: 1249, col: 24, offset: 47126},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1250, col: 24, offset: 47111},
+						pos:  position{line: 1249, col: 24, offset: 47126},
 						name: "FileInclusion",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1250, col: 40, offset: 47127},
+						pos:  position{line: 1249, col: 40, offset: 47142},
 						name: "ListingBlockParagraph",
 					},
 				},
@@ -9906,17 +9920,17 @@ var g = &grammar{
 		},
 		{
 			name: "ListingBlockParagraph",
-			pos:  position{line: 1252, col: 1, offset: 47150},
+			pos:  position{line: 1251, col: 1, offset: 47165},
 			expr: &actionExpr{
-				pos: position{line: 1252, col: 26, offset: 47175},
+				pos: position{line: 1251, col: 26, offset: 47190},
 				run: (*parser).callonListingBlockParagraph1,
 				expr: &labeledExpr{
-					pos:   position{line: 1252, col: 26, offset: 47175},
+					pos:   position{line: 1251, col: 26, offset: 47190},
 					label: "lines",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 1252, col: 32, offset: 47181},
+						pos: position{line: 1251, col: 32, offset: 47196},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1252, col: 33, offset: 47182},
+							pos:  position{line: 1251, col: 33, offset: 47197},
 							name: "ListingBlockParagraphLine",
 						},
 					},
@@ -9925,61 +9939,61 @@ var g = &grammar{
 		},
 		{
 			name: "ListingBlockParagraphLine",
-			pos:  position{line: 1256, col: 1, offset: 47301},
+			pos:  position{line: 1255, col: 1, offset: 47316},
 			expr: &actionExpr{
-				pos: position{line: 1256, col: 30, offset: 47330},
+				pos: position{line: 1255, col: 30, offset: 47345},
 				run: (*parser).callonListingBlockParagraphLine1,
 				expr: &seqExpr{
-					pos: position{line: 1256, col: 30, offset: 47330},
+					pos: position{line: 1255, col: 30, offset: 47345},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1256, col: 30, offset: 47330},
+							pos: position{line: 1255, col: 30, offset: 47345},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1256, col: 31, offset: 47331},
+								pos:  position{line: 1255, col: 31, offset: 47346},
 								name: "ListingBlockDelimiter",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1256, col: 53, offset: 47353},
+							pos:   position{line: 1255, col: 53, offset: 47368},
 							label: "line",
 							expr: &actionExpr{
-								pos: position{line: 1256, col: 59, offset: 47359},
+								pos: position{line: 1255, col: 59, offset: 47374},
 								run: (*parser).callonListingBlockParagraphLine6,
 								expr: &seqExpr{
-									pos: position{line: 1256, col: 59, offset: 47359},
+									pos: position{line: 1255, col: 59, offset: 47374},
 									exprs: []interface{}{
 										&notExpr{
-											pos: position{line: 1256, col: 59, offset: 47359},
+											pos: position{line: 1255, col: 59, offset: 47374},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1256, col: 60, offset: 47360},
+												pos:  position{line: 1255, col: 60, offset: 47375},
 												name: "EOF",
 											},
 										},
 										&zeroOrMoreExpr{
-											pos: position{line: 1256, col: 64, offset: 47364},
+											pos: position{line: 1255, col: 64, offset: 47379},
 											expr: &choiceExpr{
-												pos: position{line: 1256, col: 65, offset: 47365},
+												pos: position{line: 1255, col: 65, offset: 47380},
 												alternatives: []interface{}{
 													&ruleRefExpr{
-														pos:  position{line: 1256, col: 65, offset: 47365},
+														pos:  position{line: 1255, col: 65, offset: 47380},
 														name: "Alphanums",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1256, col: 77, offset: 47377},
+														pos:  position{line: 1255, col: 77, offset: 47392},
 														name: "Spaces",
 													},
 													&seqExpr{
-														pos: position{line: 1256, col: 87, offset: 47387},
+														pos: position{line: 1255, col: 87, offset: 47402},
 														exprs: []interface{}{
 															&notExpr{
-																pos: position{line: 1256, col: 87, offset: 47387},
+																pos: position{line: 1255, col: 87, offset: 47402},
 																expr: &ruleRefExpr{
-																	pos:  position{line: 1256, col: 88, offset: 47388},
+																	pos:  position{line: 1255, col: 88, offset: 47403},
 																	name: "EOL",
 																},
 															},
 															&anyMatcher{
-																line: 1256, col: 92, offset: 47392,
+																line: 1255, col: 92, offset: 47407,
 															},
 														},
 													},
@@ -9991,7 +10005,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1256, col: 128, offset: 47428},
+							pos:  position{line: 1255, col: 128, offset: 47443},
 							name: "EOL",
 						},
 					},
@@ -10000,17 +10014,17 @@ var g = &grammar{
 		},
 		{
 			name: "ExampleBlockDelimiter",
-			pos:  position{line: 1263, col: 1, offset: 47754},
+			pos:  position{line: 1262, col: 1, offset: 47769},
 			expr: &seqExpr{
-				pos: position{line: 1263, col: 26, offset: 47779},
+				pos: position{line: 1262, col: 26, offset: 47794},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1263, col: 26, offset: 47779},
+						pos:        position{line: 1262, col: 26, offset: 47794},
 						val:        "====",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1263, col: 33, offset: 47786},
+						pos:  position{line: 1262, col: 33, offset: 47801},
 						name: "EOLS",
 					},
 				},
@@ -10018,50 +10032,50 @@ var g = &grammar{
 		},
 		{
 			name: "ExampleBlock",
-			pos:  position{line: 1265, col: 1, offset: 47792},
+			pos:  position{line: 1264, col: 1, offset: 47807},
 			expr: &actionExpr{
-				pos: position{line: 1265, col: 17, offset: 47808},
+				pos: position{line: 1264, col: 17, offset: 47823},
 				run: (*parser).callonExampleBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1265, col: 17, offset: 47808},
+					pos: position{line: 1264, col: 17, offset: 47823},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1265, col: 17, offset: 47808},
+							pos:   position{line: 1264, col: 17, offset: 47823},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1265, col: 28, offset: 47819},
+								pos: position{line: 1264, col: 28, offset: 47834},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1265, col: 29, offset: 47820},
+									pos:  position{line: 1264, col: 29, offset: 47835},
 									name: "ElementAttributes",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1265, col: 49, offset: 47840},
+							pos:  position{line: 1264, col: 49, offset: 47855},
 							name: "ExampleBlockDelimiter",
 						},
 						&labeledExpr{
-							pos:   position{line: 1265, col: 71, offset: 47862},
+							pos:   position{line: 1264, col: 71, offset: 47877},
 							label: "content",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1265, col: 79, offset: 47870},
+								pos: position{line: 1264, col: 79, offset: 47885},
 								expr: &choiceExpr{
-									pos: position{line: 1265, col: 80, offset: 47871},
+									pos: position{line: 1264, col: 80, offset: 47886},
 									alternatives: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 1265, col: 80, offset: 47871},
+											pos:  position{line: 1264, col: 80, offset: 47886},
 											name: "BlankLine",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1265, col: 92, offset: 47883},
+											pos:  position{line: 1264, col: 92, offset: 47898},
 											name: "FileInclusion",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1265, col: 108, offset: 47899},
+											pos:  position{line: 1264, col: 108, offset: 47914},
 											name: "ListItem",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1265, col: 119, offset: 47910},
+											pos:  position{line: 1264, col: 119, offset: 47925},
 											name: "ExampleBlockParagraph",
 										},
 									},
@@ -10069,14 +10083,14 @@ var g = &grammar{
 							},
 						},
 						&choiceExpr{
-							pos: position{line: 1265, col: 145, offset: 47936},
+							pos: position{line: 1264, col: 145, offset: 47951},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 1265, col: 145, offset: 47936},
+									pos:  position{line: 1264, col: 145, offset: 47951},
 									name: "ExampleBlockDelimiter",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1265, col: 169, offset: 47960},
+									pos:  position{line: 1264, col: 169, offset: 47975},
 									name: "EOF",
 								},
 							},
@@ -10087,17 +10101,17 @@ var g = &grammar{
 		},
 		{
 			name: "ExampleBlockParagraph",
-			pos:  position{line: 1270, col: 1, offset: 48087},
+			pos:  position{line: 1269, col: 1, offset: 48102},
 			expr: &actionExpr{
-				pos: position{line: 1270, col: 26, offset: 48112},
+				pos: position{line: 1269, col: 26, offset: 48127},
 				run: (*parser).callonExampleBlockParagraph1,
 				expr: &labeledExpr{
-					pos:   position{line: 1270, col: 26, offset: 48112},
+					pos:   position{line: 1269, col: 26, offset: 48127},
 					label: "lines",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 1270, col: 32, offset: 48118},
+						pos: position{line: 1269, col: 32, offset: 48133},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1270, col: 33, offset: 48119},
+							pos:  position{line: 1269, col: 33, offset: 48134},
 							name: "ExampleBlockParagraphLine",
 						},
 					},
@@ -10106,32 +10120,32 @@ var g = &grammar{
 		},
 		{
 			name: "ExampleBlockParagraphLine",
-			pos:  position{line: 1274, col: 1, offset: 48233},
+			pos:  position{line: 1273, col: 1, offset: 48248},
 			expr: &actionExpr{
-				pos: position{line: 1274, col: 30, offset: 48262},
+				pos: position{line: 1273, col: 30, offset: 48277},
 				run: (*parser).callonExampleBlockParagraphLine1,
 				expr: &seqExpr{
-					pos: position{line: 1274, col: 30, offset: 48262},
+					pos: position{line: 1273, col: 30, offset: 48277},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1274, col: 30, offset: 48262},
+							pos: position{line: 1273, col: 30, offset: 48277},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1274, col: 31, offset: 48263},
+								pos:  position{line: 1273, col: 31, offset: 48278},
 								name: "ExampleBlockDelimiter",
 							},
 						},
 						&notExpr{
-							pos: position{line: 1274, col: 53, offset: 48285},
+							pos: position{line: 1273, col: 53, offset: 48300},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1274, col: 54, offset: 48286},
+								pos:  position{line: 1273, col: 54, offset: 48301},
 								name: "BlankLine",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1274, col: 64, offset: 48296},
+							pos:   position{line: 1273, col: 64, offset: 48311},
 							label: "line",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1274, col: 70, offset: 48302},
+								pos:  position{line: 1273, col: 70, offset: 48317},
 								name: "InlineElements",
 							},
 						},
@@ -10141,17 +10155,17 @@ var g = &grammar{
 		},
 		{
 			name: "QuoteBlockDelimiter",
-			pos:  position{line: 1281, col: 1, offset: 48538},
+			pos:  position{line: 1280, col: 1, offset: 48553},
 			expr: &seqExpr{
-				pos: position{line: 1281, col: 24, offset: 48561},
+				pos: position{line: 1280, col: 24, offset: 48576},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1281, col: 24, offset: 48561},
+						pos:        position{line: 1280, col: 24, offset: 48576},
 						val:        "____",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1281, col: 31, offset: 48568},
+						pos:  position{line: 1280, col: 31, offset: 48583},
 						name: "EOLS",
 					},
 				},
@@ -10159,48 +10173,48 @@ var g = &grammar{
 		},
 		{
 			name: "QuoteBlock",
-			pos:  position{line: 1283, col: 1, offset: 48599},
+			pos:  position{line: 1282, col: 1, offset: 48614},
 			expr: &actionExpr{
-				pos: position{line: 1283, col: 15, offset: 48613},
+				pos: position{line: 1282, col: 15, offset: 48628},
 				run: (*parser).callonQuoteBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1283, col: 15, offset: 48613},
+					pos: position{line: 1282, col: 15, offset: 48628},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1283, col: 15, offset: 48613},
+							pos:   position{line: 1282, col: 15, offset: 48628},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1283, col: 26, offset: 48624},
+								pos: position{line: 1282, col: 26, offset: 48639},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1283, col: 27, offset: 48625},
+									pos:  position{line: 1282, col: 27, offset: 48640},
 									name: "ElementAttributes",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1283, col: 47, offset: 48645},
+							pos:  position{line: 1282, col: 47, offset: 48660},
 							name: "QuoteBlockDelimiter",
 						},
 						&labeledExpr{
-							pos:   position{line: 1283, col: 67, offset: 48665},
+							pos:   position{line: 1282, col: 67, offset: 48680},
 							label: "content",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1283, col: 75, offset: 48673},
+								pos: position{line: 1282, col: 75, offset: 48688},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1283, col: 76, offset: 48674},
+									pos:  position{line: 1282, col: 76, offset: 48689},
 									name: "QuoteBlockElement",
 								},
 							},
 						},
 						&choiceExpr{
-							pos: position{line: 1283, col: 97, offset: 48695},
+							pos: position{line: 1282, col: 97, offset: 48710},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 1283, col: 97, offset: 48695},
+									pos:  position{line: 1282, col: 97, offset: 48710},
 									name: "QuoteBlockDelimiter",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1283, col: 119, offset: 48717},
+									pos:  position{line: 1282, col: 119, offset: 48732},
 									name: "EOF",
 								},
 							},
@@ -10211,99 +10225,99 @@ var g = &grammar{
 		},
 		{
 			name: "QuoteBlockElement",
-			pos:  position{line: 1287, col: 1, offset: 48824},
+			pos:  position{line: 1286, col: 1, offset: 48839},
 			expr: &actionExpr{
-				pos: position{line: 1288, col: 5, offset: 48850},
+				pos: position{line: 1287, col: 5, offset: 48865},
 				run: (*parser).callonQuoteBlockElement1,
 				expr: &seqExpr{
-					pos: position{line: 1288, col: 5, offset: 48850},
+					pos: position{line: 1287, col: 5, offset: 48865},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1288, col: 5, offset: 48850},
+							pos: position{line: 1287, col: 5, offset: 48865},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1288, col: 6, offset: 48851},
+								pos:  position{line: 1287, col: 6, offset: 48866},
 								name: "QuoteBlockDelimiter",
 							},
 						},
 						&notExpr{
-							pos: position{line: 1288, col: 26, offset: 48871},
+							pos: position{line: 1287, col: 26, offset: 48886},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1288, col: 27, offset: 48872},
+								pos:  position{line: 1287, col: 27, offset: 48887},
 								name: "EOF",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1288, col: 31, offset: 48876},
+							pos:   position{line: 1287, col: 31, offset: 48891},
 							label: "element",
 							expr: &choiceExpr{
-								pos: position{line: 1288, col: 40, offset: 48885},
+								pos: position{line: 1287, col: 40, offset: 48900},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1288, col: 40, offset: 48885},
+										pos:  position{line: 1287, col: 40, offset: 48900},
 										name: "BlankLine",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1289, col: 15, offset: 48910},
+										pos:  position{line: 1288, col: 15, offset: 48925},
 										name: "FileInclusion",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1290, col: 15, offset: 48938},
+										pos:  position{line: 1289, col: 15, offset: 48953},
 										name: "ImageBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1291, col: 15, offset: 48964},
+										pos:  position{line: 1290, col: 15, offset: 48979},
 										name: "ListItem",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1292, col: 15, offset: 48987},
+										pos:  position{line: 1291, col: 15, offset: 49002},
 										name: "FencedBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1293, col: 15, offset: 49013},
+										pos:  position{line: 1292, col: 15, offset: 49028},
 										name: "ListingBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1294, col: 15, offset: 49040},
+										pos:  position{line: 1293, col: 15, offset: 49055},
 										name: "ExampleBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1295, col: 15, offset: 49067},
+										pos:  position{line: 1294, col: 15, offset: 49082},
 										name: "CommentBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1296, col: 15, offset: 49094},
+										pos:  position{line: 1295, col: 15, offset: 49109},
 										name: "SingleLineComment",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1297, col: 15, offset: 49126},
+										pos:  position{line: 1296, col: 15, offset: 49141},
 										name: "QuoteBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1298, col: 15, offset: 49152},
+										pos:  position{line: 1297, col: 15, offset: 49167},
 										name: "SidebarBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1299, col: 15, offset: 49179},
+										pos:  position{line: 1298, col: 15, offset: 49194},
 										name: "Table",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1300, col: 15, offset: 49200},
+										pos:  position{line: 1299, col: 15, offset: 49215},
 										name: "LiteralBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1301, col: 15, offset: 49228},
+										pos:  position{line: 1300, col: 15, offset: 49243},
 										name: "DocumentAttributeDeclaration",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1302, col: 15, offset: 49272},
+										pos:  position{line: 1301, col: 15, offset: 49287},
 										name: "DocumentAttributeReset",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1303, col: 15, offset: 49310},
+										pos:  position{line: 1302, col: 15, offset: 49325},
 										name: "TableOfContentsMacro",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1304, col: 15, offset: 49345},
+										pos:  position{line: 1303, col: 15, offset: 49360},
 										name: "QuoteBlockParagraph",
 									},
 								},
@@ -10315,17 +10329,17 @@ var g = &grammar{
 		},
 		{
 			name: "QuoteBlockParagraph",
-			pos:  position{line: 1308, col: 1, offset: 49404},
+			pos:  position{line: 1307, col: 1, offset: 49419},
 			expr: &actionExpr{
-				pos: position{line: 1308, col: 24, offset: 49427},
+				pos: position{line: 1307, col: 24, offset: 49442},
 				run: (*parser).callonQuoteBlockParagraph1,
 				expr: &labeledExpr{
-					pos:   position{line: 1308, col: 24, offset: 49427},
+					pos:   position{line: 1307, col: 24, offset: 49442},
 					label: "lines",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 1308, col: 30, offset: 49433},
+						pos: position{line: 1307, col: 30, offset: 49448},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1308, col: 31, offset: 49434},
+							pos:  position{line: 1307, col: 31, offset: 49449},
 							name: "InlineElements",
 						},
 					},
@@ -10334,49 +10348,49 @@ var g = &grammar{
 		},
 		{
 			name: "VerseBlock",
-			pos:  position{line: 1317, col: 1, offset: 49780},
+			pos:  position{line: 1316, col: 1, offset: 49795},
 			expr: &actionExpr{
-				pos: position{line: 1317, col: 15, offset: 49794},
+				pos: position{line: 1316, col: 15, offset: 49809},
 				run: (*parser).callonVerseBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1317, col: 15, offset: 49794},
+					pos: position{line: 1316, col: 15, offset: 49809},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1317, col: 15, offset: 49794},
+							pos:   position{line: 1316, col: 15, offset: 49809},
 							label: "attributes",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1317, col: 27, offset: 49806},
+								pos:  position{line: 1316, col: 27, offset: 49821},
 								name: "ElementAttributes",
 							},
 						},
 						&andCodeExpr{
-							pos: position{line: 1318, col: 5, offset: 49830},
+							pos: position{line: 1317, col: 5, offset: 49845},
 							run: (*parser).callonVerseBlock5,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1322, col: 5, offset: 50016},
+							pos:  position{line: 1321, col: 5, offset: 50031},
 							name: "QuoteBlockDelimiter",
 						},
 						&labeledExpr{
-							pos:   position{line: 1322, col: 25, offset: 50036},
+							pos:   position{line: 1321, col: 25, offset: 50051},
 							label: "content",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1322, col: 33, offset: 50044},
+								pos: position{line: 1321, col: 33, offset: 50059},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1322, col: 34, offset: 50045},
+									pos:  position{line: 1321, col: 34, offset: 50060},
 									name: "VerseBlockElement",
 								},
 							},
 						},
 						&choiceExpr{
-							pos: position{line: 1322, col: 55, offset: 50066},
+							pos: position{line: 1321, col: 55, offset: 50081},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 1322, col: 55, offset: 50066},
+									pos:  position{line: 1321, col: 55, offset: 50081},
 									name: "QuoteBlockDelimiter",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1322, col: 77, offset: 50088},
+									pos:  position{line: 1321, col: 77, offset: 50103},
 									name: "EOF",
 								},
 							},
@@ -10387,20 +10401,20 @@ var g = &grammar{
 		},
 		{
 			name: "VerseBlockElement",
-			pos:  position{line: 1326, col: 1, offset: 50203},
+			pos:  position{line: 1325, col: 1, offset: 50218},
 			expr: &choiceExpr{
-				pos: position{line: 1326, col: 22, offset: 50224},
+				pos: position{line: 1325, col: 22, offset: 50239},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1326, col: 22, offset: 50224},
+						pos:  position{line: 1325, col: 22, offset: 50239},
 						name: "VerseFileInclude",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1326, col: 41, offset: 50243},
+						pos:  position{line: 1325, col: 41, offset: 50258},
 						name: "BlankLine",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1326, col: 53, offset: 50255},
+						pos:  position{line: 1325, col: 53, offset: 50270},
 						name: "VerseBlockParagraph",
 					},
 				},
@@ -10408,25 +10422,25 @@ var g = &grammar{
 		},
 		{
 			name: "VerseFileInclude",
-			pos:  position{line: 1328, col: 1, offset: 50276},
+			pos:  position{line: 1327, col: 1, offset: 50291},
 			expr: &actionExpr{
-				pos: position{line: 1328, col: 21, offset: 50296},
+				pos: position{line: 1327, col: 21, offset: 50311},
 				run: (*parser).callonVerseFileInclude1,
 				expr: &seqExpr{
-					pos: position{line: 1328, col: 21, offset: 50296},
+					pos: position{line: 1327, col: 21, offset: 50311},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1328, col: 21, offset: 50296},
+							pos: position{line: 1327, col: 21, offset: 50311},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1328, col: 22, offset: 50297},
+								pos:  position{line: 1327, col: 22, offset: 50312},
 								name: "QuoteBlockDelimiter",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1328, col: 42, offset: 50317},
+							pos:   position{line: 1327, col: 42, offset: 50332},
 							label: "include",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1328, col: 51, offset: 50326},
+								pos:  position{line: 1327, col: 51, offset: 50341},
 								name: "FileInclusion",
 							},
 						},
@@ -10436,17 +10450,17 @@ var g = &grammar{
 		},
 		{
 			name: "VerseBlockParagraph",
-			pos:  position{line: 1333, col: 1, offset: 50388},
+			pos:  position{line: 1332, col: 1, offset: 50403},
 			expr: &actionExpr{
-				pos: position{line: 1333, col: 24, offset: 50411},
+				pos: position{line: 1332, col: 24, offset: 50426},
 				run: (*parser).callonVerseBlockParagraph1,
 				expr: &labeledExpr{
-					pos:   position{line: 1333, col: 24, offset: 50411},
+					pos:   position{line: 1332, col: 24, offset: 50426},
 					label: "lines",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 1333, col: 30, offset: 50417},
+						pos: position{line: 1332, col: 30, offset: 50432},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1333, col: 31, offset: 50418},
+							pos:  position{line: 1332, col: 31, offset: 50433},
 							name: "VerseBlockParagraphLine",
 						},
 					},
@@ -10455,49 +10469,49 @@ var g = &grammar{
 		},
 		{
 			name: "VerseBlockParagraphLine",
-			pos:  position{line: 1337, col: 1, offset: 50508},
+			pos:  position{line: 1336, col: 1, offset: 50523},
 			expr: &actionExpr{
-				pos: position{line: 1337, col: 28, offset: 50535},
+				pos: position{line: 1336, col: 28, offset: 50550},
 				run: (*parser).callonVerseBlockParagraphLine1,
 				expr: &seqExpr{
-					pos: position{line: 1337, col: 28, offset: 50535},
+					pos: position{line: 1336, col: 28, offset: 50550},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1337, col: 28, offset: 50535},
+							pos: position{line: 1336, col: 28, offset: 50550},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1337, col: 29, offset: 50536},
+								pos:  position{line: 1336, col: 29, offset: 50551},
 								name: "QuoteBlockDelimiter",
 							},
 						},
 						&notExpr{
-							pos: position{line: 1337, col: 49, offset: 50556},
+							pos: position{line: 1336, col: 49, offset: 50571},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1337, col: 50, offset: 50557},
+								pos:  position{line: 1336, col: 50, offset: 50572},
 								name: "BlankLine",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1337, col: 60, offset: 50567},
+							pos:   position{line: 1336, col: 60, offset: 50582},
 							label: "line",
 							expr: &actionExpr{
-								pos: position{line: 1337, col: 66, offset: 50573},
+								pos: position{line: 1336, col: 66, offset: 50588},
 								run: (*parser).callonVerseBlockParagraphLine8,
 								expr: &seqExpr{
-									pos: position{line: 1337, col: 66, offset: 50573},
+									pos: position{line: 1336, col: 66, offset: 50588},
 									exprs: []interface{}{
 										&labeledExpr{
-											pos:   position{line: 1337, col: 66, offset: 50573},
+											pos:   position{line: 1336, col: 66, offset: 50588},
 											label: "elements",
 											expr: &oneOrMoreExpr{
-												pos: position{line: 1337, col: 75, offset: 50582},
+												pos: position{line: 1336, col: 75, offset: 50597},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1337, col: 76, offset: 50583},
+													pos:  position{line: 1336, col: 76, offset: 50598},
 													name: "VerseBlockParagraphLineElement",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1337, col: 109, offset: 50616},
+											pos:  position{line: 1336, col: 109, offset: 50631},
 											name: "EOL",
 										},
 									},
@@ -10510,79 +10524,79 @@ var g = &grammar{
 		},
 		{
 			name: "VerseBlockParagraphLineElement",
-			pos:  position{line: 1343, col: 1, offset: 50712},
+			pos:  position{line: 1342, col: 1, offset: 50727},
 			expr: &actionExpr{
-				pos: position{line: 1343, col: 35, offset: 50746},
+				pos: position{line: 1342, col: 35, offset: 50761},
 				run: (*parser).callonVerseBlockParagraphLineElement1,
 				expr: &seqExpr{
-					pos: position{line: 1343, col: 35, offset: 50746},
+					pos: position{line: 1342, col: 35, offset: 50761},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1343, col: 35, offset: 50746},
+							pos: position{line: 1342, col: 35, offset: 50761},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1343, col: 36, offset: 50747},
+								pos:  position{line: 1342, col: 36, offset: 50762},
 								name: "EOL",
 							},
 						},
 						&notExpr{
-							pos: position{line: 1343, col: 40, offset: 50751},
+							pos: position{line: 1342, col: 40, offset: 50766},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1343, col: 41, offset: 50752},
+								pos:  position{line: 1342, col: 41, offset: 50767},
 								name: "LineBreak",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1344, col: 5, offset: 50767},
+							pos:   position{line: 1343, col: 5, offset: 50782},
 							label: "element",
 							expr: &choiceExpr{
-								pos: position{line: 1344, col: 14, offset: 50776},
+								pos: position{line: 1343, col: 14, offset: 50791},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1344, col: 14, offset: 50776},
+										pos:  position{line: 1343, col: 14, offset: 50791},
 										name: "Spaces",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1345, col: 11, offset: 50794},
+										pos:  position{line: 1344, col: 11, offset: 50809},
 										name: "InlineImage",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1346, col: 11, offset: 50817},
+										pos:  position{line: 1345, col: 11, offset: 50832},
 										name: "Link",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1347, col: 11, offset: 50833},
+										pos:  position{line: 1346, col: 11, offset: 50848},
 										name: "Passthrough",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1348, col: 11, offset: 50856},
+										pos:  position{line: 1347, col: 11, offset: 50871},
 										name: "InlineFootnote",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1349, col: 11, offset: 50882},
+										pos:  position{line: 1348, col: 11, offset: 50897},
 										name: "InlineUserMacro",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1350, col: 11, offset: 50909},
+										pos:  position{line: 1349, col: 11, offset: 50924},
 										name: "QuotedText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1351, col: 11, offset: 50931},
+										pos:  position{line: 1350, col: 11, offset: 50946},
 										name: "CrossReference",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1352, col: 11, offset: 50957},
+										pos:  position{line: 1351, col: 11, offset: 50972},
 										name: "DocumentAttributeSubstitution",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1353, col: 11, offset: 50998},
+										pos:  position{line: 1352, col: 11, offset: 51013},
 										name: "InlineElementID",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1354, col: 11, offset: 51025},
+										pos:  position{line: 1353, col: 11, offset: 51040},
 										name: "OtherWord",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1355, col: 11, offset: 51045},
+										pos:  position{line: 1354, col: 11, offset: 51060},
 										name: "Parenthesis",
 									},
 								},
@@ -10594,17 +10608,17 @@ var g = &grammar{
 		},
 		{
 			name: "SidebarBlockDelimiter",
-			pos:  position{line: 1362, col: 1, offset: 51277},
+			pos:  position{line: 1361, col: 1, offset: 51292},
 			expr: &seqExpr{
-				pos: position{line: 1362, col: 26, offset: 51302},
+				pos: position{line: 1361, col: 26, offset: 51317},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1362, col: 26, offset: 51302},
+						pos:        position{line: 1361, col: 26, offset: 51317},
 						val:        "****",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1362, col: 33, offset: 51309},
+						pos:  position{line: 1361, col: 33, offset: 51324},
 						name: "EOLS",
 					},
 				},
@@ -10612,48 +10626,48 @@ var g = &grammar{
 		},
 		{
 			name: "SidebarBlock",
-			pos:  position{line: 1364, col: 1, offset: 51315},
+			pos:  position{line: 1363, col: 1, offset: 51330},
 			expr: &actionExpr{
-				pos: position{line: 1364, col: 17, offset: 51331},
+				pos: position{line: 1363, col: 17, offset: 51346},
 				run: (*parser).callonSidebarBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1364, col: 17, offset: 51331},
+					pos: position{line: 1363, col: 17, offset: 51346},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1364, col: 17, offset: 51331},
+							pos:   position{line: 1363, col: 17, offset: 51346},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1364, col: 28, offset: 51342},
+								pos: position{line: 1363, col: 28, offset: 51357},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1364, col: 29, offset: 51343},
+									pos:  position{line: 1363, col: 29, offset: 51358},
 									name: "ElementAttributes",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1364, col: 49, offset: 51363},
+							pos:  position{line: 1363, col: 49, offset: 51378},
 							name: "SidebarBlockDelimiter",
 						},
 						&labeledExpr{
-							pos:   position{line: 1364, col: 71, offset: 51385},
+							pos:   position{line: 1363, col: 71, offset: 51400},
 							label: "content",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1364, col: 79, offset: 51393},
+								pos: position{line: 1363, col: 79, offset: 51408},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1364, col: 80, offset: 51394},
+									pos:  position{line: 1363, col: 80, offset: 51409},
 									name: "SidebarBlockContent",
 								},
 							},
 						},
 						&choiceExpr{
-							pos: position{line: 1364, col: 104, offset: 51418},
+							pos: position{line: 1363, col: 104, offset: 51433},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 1364, col: 104, offset: 51418},
+									pos:  position{line: 1363, col: 104, offset: 51433},
 									name: "SidebarBlockDelimiter",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1364, col: 128, offset: 51442},
+									pos:  position{line: 1363, col: 128, offset: 51457},
 									name: "EOF",
 								},
 							},
@@ -10664,28 +10678,28 @@ var g = &grammar{
 		},
 		{
 			name: "SidebarBlockContent",
-			pos:  position{line: 1368, col: 1, offset: 51551},
+			pos:  position{line: 1367, col: 1, offset: 51566},
 			expr: &choiceExpr{
-				pos: position{line: 1368, col: 24, offset: 51574},
+				pos: position{line: 1367, col: 24, offset: 51589},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1368, col: 24, offset: 51574},
+						pos:  position{line: 1367, col: 24, offset: 51589},
 						name: "BlankLine",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1368, col: 36, offset: 51586},
+						pos:  position{line: 1367, col: 36, offset: 51601},
 						name: "FileInclusion",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1368, col: 52, offset: 51602},
+						pos:  position{line: 1367, col: 52, offset: 51617},
 						name: "ListItem",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1368, col: 63, offset: 51613},
+						pos:  position{line: 1367, col: 63, offset: 51628},
 						name: "NonSidebarBlock",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1368, col: 81, offset: 51631},
+						pos:  position{line: 1367, col: 81, offset: 51646},
 						name: "SidebarBlockParagraph",
 					},
 				},
@@ -10693,25 +10707,25 @@ var g = &grammar{
 		},
 		{
 			name: "NonSidebarBlock",
-			pos:  position{line: 1370, col: 1, offset: 51654},
+			pos:  position{line: 1369, col: 1, offset: 51669},
 			expr: &actionExpr{
-				pos: position{line: 1370, col: 20, offset: 51673},
+				pos: position{line: 1369, col: 20, offset: 51688},
 				run: (*parser).callonNonSidebarBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1370, col: 20, offset: 51673},
+					pos: position{line: 1369, col: 20, offset: 51688},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1370, col: 20, offset: 51673},
+							pos: position{line: 1369, col: 20, offset: 51688},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1370, col: 21, offset: 51674},
+								pos:  position{line: 1369, col: 21, offset: 51689},
 								name: "SidebarBlock",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1370, col: 34, offset: 51687},
+							pos:   position{line: 1369, col: 34, offset: 51702},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1370, col: 43, offset: 51696},
+								pos:  position{line: 1369, col: 43, offset: 51711},
 								name: "DelimitedBlock",
 							},
 						},
@@ -10721,17 +10735,17 @@ var g = &grammar{
 		},
 		{
 			name: "SidebarBlockParagraph",
-			pos:  position{line: 1375, col: 1, offset: 51759},
+			pos:  position{line: 1374, col: 1, offset: 51774},
 			expr: &actionExpr{
-				pos: position{line: 1375, col: 26, offset: 51784},
+				pos: position{line: 1374, col: 26, offset: 51799},
 				run: (*parser).callonSidebarBlockParagraph1,
 				expr: &labeledExpr{
-					pos:   position{line: 1375, col: 26, offset: 51784},
+					pos:   position{line: 1374, col: 26, offset: 51799},
 					label: "lines",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 1375, col: 32, offset: 51790},
+						pos: position{line: 1374, col: 32, offset: 51805},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1375, col: 33, offset: 51791},
+							pos:  position{line: 1374, col: 33, offset: 51806},
 							name: "SidebarBlockParagraphLine",
 						},
 					},
@@ -10740,32 +10754,32 @@ var g = &grammar{
 		},
 		{
 			name: "SidebarBlockParagraphLine",
-			pos:  position{line: 1379, col: 1, offset: 51905},
+			pos:  position{line: 1378, col: 1, offset: 51920},
 			expr: &actionExpr{
-				pos: position{line: 1379, col: 30, offset: 51934},
+				pos: position{line: 1378, col: 30, offset: 51949},
 				run: (*parser).callonSidebarBlockParagraphLine1,
 				expr: &seqExpr{
-					pos: position{line: 1379, col: 30, offset: 51934},
+					pos: position{line: 1378, col: 30, offset: 51949},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1379, col: 30, offset: 51934},
+							pos: position{line: 1378, col: 30, offset: 51949},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1379, col: 31, offset: 51935},
+								pos:  position{line: 1378, col: 31, offset: 51950},
 								name: "SidebarBlockDelimiter",
 							},
 						},
 						&notExpr{
-							pos: position{line: 1379, col: 53, offset: 51957},
+							pos: position{line: 1378, col: 53, offset: 51972},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1379, col: 54, offset: 51958},
+								pos:  position{line: 1378, col: 54, offset: 51973},
 								name: "BlankLine",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1379, col: 64, offset: 51968},
+							pos:   position{line: 1378, col: 64, offset: 51983},
 							label: "line",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1379, col: 70, offset: 51974},
+								pos:  position{line: 1378, col: 70, offset: 51989},
 								name: "InlineElements",
 							},
 						},
@@ -10775,59 +10789,59 @@ var g = &grammar{
 		},
 		{
 			name: "Table",
-			pos:  position{line: 1387, col: 1, offset: 52205},
+			pos:  position{line: 1386, col: 1, offset: 52220},
 			expr: &actionExpr{
-				pos: position{line: 1387, col: 10, offset: 52214},
+				pos: position{line: 1386, col: 10, offset: 52229},
 				run: (*parser).callonTable1,
 				expr: &seqExpr{
-					pos: position{line: 1387, col: 10, offset: 52214},
+					pos: position{line: 1386, col: 10, offset: 52229},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1387, col: 10, offset: 52214},
+							pos:   position{line: 1386, col: 10, offset: 52229},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1387, col: 21, offset: 52225},
+								pos: position{line: 1386, col: 21, offset: 52240},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1387, col: 22, offset: 52226},
+									pos:  position{line: 1386, col: 22, offset: 52241},
 									name: "ElementAttributes",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1387, col: 42, offset: 52246},
+							pos:  position{line: 1386, col: 42, offset: 52261},
 							name: "TableDelimiter",
 						},
 						&labeledExpr{
-							pos:   position{line: 1388, col: 5, offset: 52265},
+							pos:   position{line: 1387, col: 5, offset: 52280},
 							label: "header",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1388, col: 12, offset: 52272},
+								pos: position{line: 1387, col: 12, offset: 52287},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1388, col: 13, offset: 52273},
+									pos:  position{line: 1387, col: 13, offset: 52288},
 									name: "TableLineHeader",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1389, col: 5, offset: 52295},
+							pos:   position{line: 1388, col: 5, offset: 52310},
 							label: "lines",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1389, col: 11, offset: 52301},
+								pos: position{line: 1388, col: 11, offset: 52316},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1389, col: 12, offset: 52302},
+									pos:  position{line: 1388, col: 12, offset: 52317},
 									name: "TableLine",
 								},
 							},
 						},
 						&choiceExpr{
-							pos: position{line: 1390, col: 6, offset: 52319},
+							pos: position{line: 1389, col: 6, offset: 52334},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 1390, col: 6, offset: 52319},
+									pos:  position{line: 1389, col: 6, offset: 52334},
 									name: "TableDelimiter",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1390, col: 23, offset: 52336},
+									pos:  position{line: 1389, col: 23, offset: 52351},
 									name: "EOF",
 								},
 							},
@@ -10838,19 +10852,19 @@ var g = &grammar{
 		},
 		{
 			name: "TableCellSeparator",
-			pos:  position{line: 1394, col: 1, offset: 52451},
+			pos:  position{line: 1393, col: 1, offset: 52466},
 			expr: &seqExpr{
-				pos: position{line: 1394, col: 23, offset: 52473},
+				pos: position{line: 1393, col: 23, offset: 52488},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1394, col: 23, offset: 52473},
+						pos:        position{line: 1393, col: 23, offset: 52488},
 						val:        "|",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1394, col: 27, offset: 52477},
+						pos: position{line: 1393, col: 27, offset: 52492},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1394, col: 27, offset: 52477},
+							pos:  position{line: 1393, col: 27, offset: 52492},
 							name: "WS",
 						},
 					},
@@ -10859,17 +10873,17 @@ var g = &grammar{
 		},
 		{
 			name: "TableDelimiter",
-			pos:  position{line: 1396, col: 1, offset: 52482},
+			pos:  position{line: 1395, col: 1, offset: 52497},
 			expr: &seqExpr{
-				pos: position{line: 1396, col: 19, offset: 52500},
+				pos: position{line: 1395, col: 19, offset: 52515},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1396, col: 19, offset: 52500},
+						pos:        position{line: 1395, col: 19, offset: 52515},
 						val:        "|===",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1396, col: 26, offset: 52507},
+						pos:  position{line: 1395, col: 26, offset: 52522},
 						name: "EOLS",
 					},
 				},
@@ -10877,37 +10891,37 @@ var g = &grammar{
 		},
 		{
 			name: "TableLineHeader",
-			pos:  position{line: 1399, col: 1, offset: 52576},
+			pos:  position{line: 1398, col: 1, offset: 52591},
 			expr: &actionExpr{
-				pos: position{line: 1399, col: 20, offset: 52595},
+				pos: position{line: 1398, col: 20, offset: 52610},
 				run: (*parser).callonTableLineHeader1,
 				expr: &seqExpr{
-					pos: position{line: 1399, col: 20, offset: 52595},
+					pos: position{line: 1398, col: 20, offset: 52610},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1399, col: 20, offset: 52595},
+							pos: position{line: 1398, col: 20, offset: 52610},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1399, col: 21, offset: 52596},
+								pos:  position{line: 1398, col: 21, offset: 52611},
 								name: "TableDelimiter",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1399, col: 36, offset: 52611},
+							pos:   position{line: 1398, col: 36, offset: 52626},
 							label: "cells",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1399, col: 42, offset: 52617},
+								pos: position{line: 1398, col: 42, offset: 52632},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1399, col: 43, offset: 52618},
+									pos:  position{line: 1398, col: 43, offset: 52633},
 									name: "TableCell",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1399, col: 55, offset: 52630},
+							pos:  position{line: 1398, col: 55, offset: 52645},
 							name: "EOL",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1399, col: 59, offset: 52634},
+							pos:  position{line: 1398, col: 59, offset: 52649},
 							name: "BlankLine",
 						},
 					},
@@ -10916,39 +10930,39 @@ var g = &grammar{
 		},
 		{
 			name: "TableLine",
-			pos:  position{line: 1403, col: 1, offset: 52702},
+			pos:  position{line: 1402, col: 1, offset: 52717},
 			expr: &actionExpr{
-				pos: position{line: 1403, col: 14, offset: 52715},
+				pos: position{line: 1402, col: 14, offset: 52730},
 				run: (*parser).callonTableLine1,
 				expr: &seqExpr{
-					pos: position{line: 1403, col: 14, offset: 52715},
+					pos: position{line: 1402, col: 14, offset: 52730},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1403, col: 14, offset: 52715},
+							pos: position{line: 1402, col: 14, offset: 52730},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1403, col: 15, offset: 52716},
+								pos:  position{line: 1402, col: 15, offset: 52731},
 								name: "TableDelimiter",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1403, col: 30, offset: 52731},
+							pos:   position{line: 1402, col: 30, offset: 52746},
 							label: "cells",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1403, col: 36, offset: 52737},
+								pos: position{line: 1402, col: 36, offset: 52752},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1403, col: 37, offset: 52738},
+									pos:  position{line: 1402, col: 37, offset: 52753},
 									name: "TableCell",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1403, col: 49, offset: 52750},
+							pos:  position{line: 1402, col: 49, offset: 52765},
 							name: "EOL",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1403, col: 53, offset: 52754},
+							pos: position{line: 1402, col: 53, offset: 52769},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1403, col: 53, offset: 52754},
+								pos:  position{line: 1402, col: 53, offset: 52769},
 								name: "BlankLine",
 							},
 						},
@@ -10958,54 +10972,54 @@ var g = &grammar{
 		},
 		{
 			name: "TableCell",
-			pos:  position{line: 1407, col: 1, offset: 52823},
+			pos:  position{line: 1406, col: 1, offset: 52838},
 			expr: &actionExpr{
-				pos: position{line: 1407, col: 14, offset: 52836},
+				pos: position{line: 1406, col: 14, offset: 52851},
 				run: (*parser).callonTableCell1,
 				expr: &seqExpr{
-					pos: position{line: 1407, col: 14, offset: 52836},
+					pos: position{line: 1406, col: 14, offset: 52851},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1407, col: 14, offset: 52836},
+							pos:  position{line: 1406, col: 14, offset: 52851},
 							name: "TableCellSeparator",
 						},
 						&labeledExpr{
-							pos:   position{line: 1407, col: 33, offset: 52855},
+							pos:   position{line: 1406, col: 33, offset: 52870},
 							label: "elements",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1407, col: 42, offset: 52864},
+								pos: position{line: 1406, col: 42, offset: 52879},
 								expr: &seqExpr{
-									pos: position{line: 1407, col: 43, offset: 52865},
+									pos: position{line: 1406, col: 43, offset: 52880},
 									exprs: []interface{}{
 										&notExpr{
-											pos: position{line: 1407, col: 43, offset: 52865},
+											pos: position{line: 1406, col: 43, offset: 52880},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1407, col: 44, offset: 52866},
+												pos:  position{line: 1406, col: 44, offset: 52881},
 												name: "TableCellSeparator",
 											},
 										},
 										&notExpr{
-											pos: position{line: 1407, col: 63, offset: 52885},
+											pos: position{line: 1406, col: 63, offset: 52900},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1407, col: 64, offset: 52886},
+												pos:  position{line: 1406, col: 64, offset: 52901},
 												name: "EOL",
 											},
 										},
 										&zeroOrMoreExpr{
-											pos: position{line: 1407, col: 68, offset: 52890},
+											pos: position{line: 1406, col: 68, offset: 52905},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1407, col: 68, offset: 52890},
+												pos:  position{line: 1406, col: 68, offset: 52905},
 												name: "WS",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1407, col: 72, offset: 52894},
+											pos:  position{line: 1406, col: 72, offset: 52909},
 											name: "InlineElement",
 										},
 										&zeroOrMoreExpr{
-											pos: position{line: 1407, col: 86, offset: 52908},
+											pos: position{line: 1406, col: 86, offset: 52923},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1407, col: 86, offset: 52908},
+												pos:  position{line: 1406, col: 86, offset: 52923},
 												name: "WS",
 											},
 										},
@@ -11019,66 +11033,66 @@ var g = &grammar{
 		},
 		{
 			name: "CommentBlockDelimiter",
-			pos:  position{line: 1414, col: 1, offset: 53154},
+			pos:  position{line: 1413, col: 1, offset: 53169},
 			expr: &litMatcher{
-				pos:        position{line: 1414, col: 26, offset: 53179},
+				pos:        position{line: 1413, col: 26, offset: 53194},
 				val:        "////",
 				ignoreCase: false,
 			},
 		},
 		{
 			name: "CommentBlock",
-			pos:  position{line: 1416, col: 1, offset: 53187},
+			pos:  position{line: 1415, col: 1, offset: 53202},
 			expr: &actionExpr{
-				pos: position{line: 1416, col: 17, offset: 53203},
+				pos: position{line: 1415, col: 17, offset: 53218},
 				run: (*parser).callonCommentBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1416, col: 17, offset: 53203},
+					pos: position{line: 1415, col: 17, offset: 53218},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1416, col: 17, offset: 53203},
+							pos:  position{line: 1415, col: 17, offset: 53218},
 							name: "CommentBlockDelimiter",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1416, col: 39, offset: 53225},
+							pos: position{line: 1415, col: 39, offset: 53240},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1416, col: 39, offset: 53225},
+								pos:  position{line: 1415, col: 39, offset: 53240},
 								name: "WS",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1416, col: 43, offset: 53229},
+							pos:  position{line: 1415, col: 43, offset: 53244},
 							name: "NEWLINE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1416, col: 51, offset: 53237},
+							pos:   position{line: 1415, col: 51, offset: 53252},
 							label: "content",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1416, col: 59, offset: 53245},
+								pos: position{line: 1415, col: 59, offset: 53260},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1416, col: 60, offset: 53246},
+									pos:  position{line: 1415, col: 60, offset: 53261},
 									name: "CommentBlockLine",
 								},
 							},
 						},
 						&choiceExpr{
-							pos: position{line: 1416, col: 81, offset: 53267},
+							pos: position{line: 1415, col: 81, offset: 53282},
 							alternatives: []interface{}{
 								&seqExpr{
-									pos: position{line: 1416, col: 82, offset: 53268},
+									pos: position{line: 1415, col: 82, offset: 53283},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 1416, col: 82, offset: 53268},
+											pos:  position{line: 1415, col: 82, offset: 53283},
 											name: "CommentBlockDelimiter",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1416, col: 104, offset: 53290},
+											pos:  position{line: 1415, col: 104, offset: 53305},
 											name: "EOLS",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1416, col: 112, offset: 53298},
+									pos:  position{line: 1415, col: 112, offset: 53313},
 									name: "EOF",
 								},
 							},
@@ -11089,45 +11103,45 @@ var g = &grammar{
 		},
 		{
 			name: "CommentBlockLine",
-			pos:  position{line: 1420, col: 1, offset: 53404},
+			pos:  position{line: 1419, col: 1, offset: 53419},
 			expr: &actionExpr{
-				pos: position{line: 1420, col: 21, offset: 53424},
+				pos: position{line: 1419, col: 21, offset: 53439},
 				run: (*parser).callonCommentBlockLine1,
 				expr: &seqExpr{
-					pos: position{line: 1420, col: 21, offset: 53424},
+					pos: position{line: 1419, col: 21, offset: 53439},
 					exprs: []interface{}{
 						&zeroOrMoreExpr{
-							pos: position{line: 1420, col: 21, offset: 53424},
+							pos: position{line: 1419, col: 21, offset: 53439},
 							expr: &choiceExpr{
-								pos: position{line: 1420, col: 22, offset: 53425},
+								pos: position{line: 1419, col: 22, offset: 53440},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1420, col: 22, offset: 53425},
+										pos:  position{line: 1419, col: 22, offset: 53440},
 										name: "Alphanums",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1420, col: 34, offset: 53437},
+										pos:  position{line: 1419, col: 34, offset: 53452},
 										name: "Spaces",
 									},
 									&seqExpr{
-										pos: position{line: 1420, col: 44, offset: 53447},
+										pos: position{line: 1419, col: 44, offset: 53462},
 										exprs: []interface{}{
 											&notExpr{
-												pos: position{line: 1420, col: 44, offset: 53447},
+												pos: position{line: 1419, col: 44, offset: 53462},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1420, col: 45, offset: 53448},
+													pos:  position{line: 1419, col: 45, offset: 53463},
 													name: "CommentBlockDelimiter",
 												},
 											},
 											&notExpr{
-												pos: position{line: 1420, col: 67, offset: 53470},
+												pos: position{line: 1419, col: 67, offset: 53485},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1420, col: 68, offset: 53471},
+													pos:  position{line: 1419, col: 68, offset: 53486},
 													name: "EOL",
 												},
 											},
 											&anyMatcher{
-												line: 1420, col: 73, offset: 53476,
+												line: 1419, col: 73, offset: 53491,
 											},
 										},
 									},
@@ -11135,7 +11149,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1420, col: 78, offset: 53481},
+							pos:  position{line: 1419, col: 78, offset: 53496},
 							name: "EOL",
 						},
 					},
@@ -11144,42 +11158,42 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineComment",
-			pos:  position{line: 1424, col: 1, offset: 53521},
+			pos:  position{line: 1423, col: 1, offset: 53536},
 			expr: &actionExpr{
-				pos: position{line: 1424, col: 22, offset: 53542},
+				pos: position{line: 1423, col: 22, offset: 53557},
 				run: (*parser).callonSingleLineComment1,
 				expr: &seqExpr{
-					pos: position{line: 1424, col: 22, offset: 53542},
+					pos: position{line: 1423, col: 22, offset: 53557},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1424, col: 22, offset: 53542},
+							pos: position{line: 1423, col: 22, offset: 53557},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1424, col: 23, offset: 53543},
+								pos:  position{line: 1423, col: 23, offset: 53558},
 								name: "CommentBlockDelimiter",
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1424, col: 45, offset: 53565},
+							pos: position{line: 1423, col: 45, offset: 53580},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1424, col: 45, offset: 53565},
+								pos:  position{line: 1423, col: 45, offset: 53580},
 								name: "WS",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1424, col: 49, offset: 53569},
+							pos:        position{line: 1423, col: 49, offset: 53584},
 							val:        "//",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1424, col: 54, offset: 53574},
+							pos:   position{line: 1423, col: 54, offset: 53589},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1424, col: 63, offset: 53583},
+								pos:  position{line: 1423, col: 63, offset: 53598},
 								name: "SingleLineCommentContent",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1424, col: 89, offset: 53609},
+							pos:  position{line: 1423, col: 89, offset: 53624},
 							name: "EOL",
 						},
 					},
@@ -11188,35 +11202,35 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineCommentContent",
-			pos:  position{line: 1428, col: 1, offset: 53674},
+			pos:  position{line: 1427, col: 1, offset: 53689},
 			expr: &actionExpr{
-				pos: position{line: 1428, col: 29, offset: 53702},
+				pos: position{line: 1427, col: 29, offset: 53717},
 				run: (*parser).callonSingleLineCommentContent1,
 				expr: &zeroOrMoreExpr{
-					pos: position{line: 1428, col: 29, offset: 53702},
+					pos: position{line: 1427, col: 29, offset: 53717},
 					expr: &choiceExpr{
-						pos: position{line: 1428, col: 30, offset: 53703},
+						pos: position{line: 1427, col: 30, offset: 53718},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 1428, col: 30, offset: 53703},
+								pos:  position{line: 1427, col: 30, offset: 53718},
 								name: "Alphanums",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1428, col: 42, offset: 53715},
+								pos:  position{line: 1427, col: 42, offset: 53730},
 								name: "Spaces",
 							},
 							&seqExpr{
-								pos: position{line: 1428, col: 52, offset: 53725},
+								pos: position{line: 1427, col: 52, offset: 53740},
 								exprs: []interface{}{
 									&notExpr{
-										pos: position{line: 1428, col: 52, offset: 53725},
+										pos: position{line: 1427, col: 52, offset: 53740},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1428, col: 53, offset: 53726},
+											pos:  position{line: 1427, col: 53, offset: 53741},
 											name: "EOL",
 										},
 									},
 									&anyMatcher{
-										line: 1428, col: 58, offset: 53731,
+										line: 1427, col: 58, offset: 53746,
 									},
 								},
 							},
@@ -11227,20 +11241,20 @@ var g = &grammar{
 		},
 		{
 			name: "LiteralBlock",
-			pos:  position{line: 1436, col: 1, offset: 54040},
+			pos:  position{line: 1435, col: 1, offset: 54055},
 			expr: &choiceExpr{
-				pos: position{line: 1436, col: 17, offset: 54056},
+				pos: position{line: 1435, col: 17, offset: 54071},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1436, col: 17, offset: 54056},
+						pos:  position{line: 1435, col: 17, offset: 54071},
 						name: "ParagraphWithLiteralAttribute",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1436, col: 49, offset: 54088},
+						pos:  position{line: 1435, col: 49, offset: 54103},
 						name: "ParagraphWithHeadingSpaces",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1436, col: 78, offset: 54117},
+						pos:  position{line: 1435, col: 78, offset: 54132},
 						name: "ParagraphWithLiteralBlockDelimiter",
 					},
 				},
@@ -11248,38 +11262,38 @@ var g = &grammar{
 		},
 		{
 			name: "LiteralBlockDelimiter",
-			pos:  position{line: 1438, col: 1, offset: 54153},
+			pos:  position{line: 1437, col: 1, offset: 54168},
 			expr: &litMatcher{
-				pos:        position{line: 1438, col: 26, offset: 54178},
+				pos:        position{line: 1437, col: 26, offset: 54193},
 				val:        "....",
 				ignoreCase: false,
 			},
 		},
 		{
 			name: "ParagraphWithHeadingSpaces",
-			pos:  position{line: 1441, col: 1, offset: 54250},
+			pos:  position{line: 1440, col: 1, offset: 54265},
 			expr: &actionExpr{
-				pos: position{line: 1441, col: 31, offset: 54280},
+				pos: position{line: 1440, col: 31, offset: 54295},
 				run: (*parser).callonParagraphWithHeadingSpaces1,
 				expr: &seqExpr{
-					pos: position{line: 1441, col: 31, offset: 54280},
+					pos: position{line: 1440, col: 31, offset: 54295},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1441, col: 31, offset: 54280},
+							pos:   position{line: 1440, col: 31, offset: 54295},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1441, col: 42, offset: 54291},
+								pos: position{line: 1440, col: 42, offset: 54306},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1441, col: 43, offset: 54292},
+									pos:  position{line: 1440, col: 43, offset: 54307},
 									name: "ElementAttributes",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1441, col: 63, offset: 54312},
+							pos:   position{line: 1440, col: 63, offset: 54327},
 							label: "lines",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1441, col: 70, offset: 54319},
+								pos:  position{line: 1440, col: 70, offset: 54334},
 								name: "ParagraphWithHeadingSpacesLines",
 							},
 						},
@@ -11289,54 +11303,54 @@ var g = &grammar{
 		},
 		{
 			name: "ParagraphWithHeadingSpacesLines",
-			pos:  position{line: 1446, col: 1, offset: 54549},
+			pos:  position{line: 1445, col: 1, offset: 54564},
 			expr: &actionExpr{
-				pos: position{line: 1447, col: 5, offset: 54589},
+				pos: position{line: 1446, col: 5, offset: 54604},
 				run: (*parser).callonParagraphWithHeadingSpacesLines1,
 				expr: &seqExpr{
-					pos: position{line: 1447, col: 5, offset: 54589},
+					pos: position{line: 1446, col: 5, offset: 54604},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1447, col: 5, offset: 54589},
+							pos:   position{line: 1446, col: 5, offset: 54604},
 							label: "firstLine",
 							expr: &actionExpr{
-								pos: position{line: 1447, col: 16, offset: 54600},
+								pos: position{line: 1446, col: 16, offset: 54615},
 								run: (*parser).callonParagraphWithHeadingSpacesLines4,
 								expr: &seqExpr{
-									pos: position{line: 1447, col: 16, offset: 54600},
+									pos: position{line: 1446, col: 16, offset: 54615},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 1447, col: 16, offset: 54600},
+											pos:  position{line: 1446, col: 16, offset: 54615},
 											name: "WS",
 										},
 										&oneOrMoreExpr{
-											pos: position{line: 1447, col: 19, offset: 54603},
+											pos: position{line: 1446, col: 19, offset: 54618},
 											expr: &choiceExpr{
-												pos: position{line: 1447, col: 20, offset: 54604},
+												pos: position{line: 1446, col: 20, offset: 54619},
 												alternatives: []interface{}{
 													&ruleRefExpr{
-														pos:  position{line: 1447, col: 20, offset: 54604},
+														pos:  position{line: 1446, col: 20, offset: 54619},
 														name: "Alphanums",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1447, col: 32, offset: 54616},
+														pos:  position{line: 1446, col: 32, offset: 54631},
 														name: "Spaces",
 													},
 													&actionExpr{
-														pos: position{line: 1447, col: 41, offset: 54625},
+														pos: position{line: 1446, col: 41, offset: 54640},
 														run: (*parser).callonParagraphWithHeadingSpacesLines11,
 														expr: &seqExpr{
-															pos: position{line: 1447, col: 42, offset: 54626},
+															pos: position{line: 1446, col: 42, offset: 54641},
 															exprs: []interface{}{
 																&notExpr{
-																	pos: position{line: 1447, col: 42, offset: 54626},
+																	pos: position{line: 1446, col: 42, offset: 54641},
 																	expr: &ruleRefExpr{
-																		pos:  position{line: 1447, col: 43, offset: 54627},
+																		pos:  position{line: 1446, col: 43, offset: 54642},
 																		name: "EOL",
 																	},
 																},
 																&anyMatcher{
-																	line: 1447, col: 48, offset: 54632,
+																	line: 1446, col: 48, offset: 54647,
 																},
 															},
 														},
@@ -11349,58 +11363,58 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1451, col: 8, offset: 54723},
+							pos:  position{line: 1450, col: 8, offset: 54738},
 							name: "EOL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1452, col: 5, offset: 54786},
+							pos:   position{line: 1451, col: 5, offset: 54801},
 							label: "otherLines",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1452, col: 16, offset: 54797},
+								pos: position{line: 1451, col: 16, offset: 54812},
 								expr: &actionExpr{
-									pos: position{line: 1453, col: 9, offset: 54807},
+									pos: position{line: 1452, col: 9, offset: 54822},
 									run: (*parser).callonParagraphWithHeadingSpacesLines19,
 									expr: &seqExpr{
-										pos: position{line: 1453, col: 9, offset: 54807},
+										pos: position{line: 1452, col: 9, offset: 54822},
 										exprs: []interface{}{
 											&notExpr{
-												pos: position{line: 1453, col: 9, offset: 54807},
+												pos: position{line: 1452, col: 9, offset: 54822},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1453, col: 10, offset: 54808},
+													pos:  position{line: 1452, col: 10, offset: 54823},
 													name: "BlankLine",
 												},
 											},
 											&labeledExpr{
-												pos:   position{line: 1454, col: 9, offset: 54827},
+												pos:   position{line: 1453, col: 9, offset: 54842},
 												label: "otherLine",
 												expr: &actionExpr{
-													pos: position{line: 1454, col: 20, offset: 54838},
+													pos: position{line: 1453, col: 20, offset: 54853},
 													run: (*parser).callonParagraphWithHeadingSpacesLines24,
 													expr: &oneOrMoreExpr{
-														pos: position{line: 1454, col: 20, offset: 54838},
+														pos: position{line: 1453, col: 20, offset: 54853},
 														expr: &choiceExpr{
-															pos: position{line: 1454, col: 21, offset: 54839},
+															pos: position{line: 1453, col: 21, offset: 54854},
 															alternatives: []interface{}{
 																&ruleRefExpr{
-																	pos:  position{line: 1454, col: 21, offset: 54839},
+																	pos:  position{line: 1453, col: 21, offset: 54854},
 																	name: "Alphanums",
 																},
 																&ruleRefExpr{
-																	pos:  position{line: 1454, col: 33, offset: 54851},
+																	pos:  position{line: 1453, col: 33, offset: 54866},
 																	name: "Spaces",
 																},
 																&seqExpr{
-																	pos: position{line: 1454, col: 43, offset: 54861},
+																	pos: position{line: 1453, col: 43, offset: 54876},
 																	exprs: []interface{}{
 																		&notExpr{
-																			pos: position{line: 1454, col: 43, offset: 54861},
+																			pos: position{line: 1453, col: 43, offset: 54876},
 																			expr: &ruleRefExpr{
-																				pos:  position{line: 1454, col: 44, offset: 54862},
+																				pos:  position{line: 1453, col: 44, offset: 54877},
 																				name: "EOL",
 																			},
 																		},
 																		&anyMatcher{
-																			line: 1454, col: 49, offset: 54867,
+																			line: 1453, col: 49, offset: 54882,
 																		},
 																	},
 																},
@@ -11410,7 +11424,7 @@ var g = &grammar{
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1456, col: 12, offset: 54924},
+												pos:  position{line: 1455, col: 12, offset: 54939},
 												name: "EOL",
 											},
 										},
@@ -11424,65 +11438,65 @@ var g = &grammar{
 		},
 		{
 			name: "ParagraphWithLiteralBlockDelimiter",
-			pos:  position{line: 1463, col: 1, offset: 55154},
+			pos:  position{line: 1462, col: 1, offset: 55169},
 			expr: &actionExpr{
-				pos: position{line: 1463, col: 39, offset: 55192},
+				pos: position{line: 1462, col: 39, offset: 55207},
 				run: (*parser).callonParagraphWithLiteralBlockDelimiter1,
 				expr: &seqExpr{
-					pos: position{line: 1463, col: 39, offset: 55192},
+					pos: position{line: 1462, col: 39, offset: 55207},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1463, col: 39, offset: 55192},
+							pos:   position{line: 1462, col: 39, offset: 55207},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1463, col: 50, offset: 55203},
+								pos: position{line: 1462, col: 50, offset: 55218},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1463, col: 51, offset: 55204},
+									pos:  position{line: 1462, col: 51, offset: 55219},
 									name: "ElementAttributes",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1464, col: 9, offset: 55232},
+							pos:  position{line: 1463, col: 9, offset: 55247},
 							name: "LiteralBlockDelimiter",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1464, col: 31, offset: 55254},
+							pos: position{line: 1463, col: 31, offset: 55269},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1464, col: 31, offset: 55254},
+								pos:  position{line: 1463, col: 31, offset: 55269},
 								name: "WS",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1464, col: 35, offset: 55258},
+							pos:  position{line: 1463, col: 35, offset: 55273},
 							name: "NEWLINE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1464, col: 43, offset: 55266},
+							pos:   position{line: 1463, col: 43, offset: 55281},
 							label: "lines",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1464, col: 50, offset: 55273},
+								pos:  position{line: 1463, col: 50, offset: 55288},
 								name: "ParagraphWithLiteralBlockDelimiterLines",
 							},
 						},
 						&choiceExpr{
-							pos: position{line: 1464, col: 92, offset: 55315},
+							pos: position{line: 1463, col: 92, offset: 55330},
 							alternatives: []interface{}{
 								&seqExpr{
-									pos: position{line: 1464, col: 93, offset: 55316},
+									pos: position{line: 1463, col: 93, offset: 55331},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 1464, col: 93, offset: 55316},
+											pos:  position{line: 1463, col: 93, offset: 55331},
 											name: "LiteralBlockDelimiter",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1464, col: 115, offset: 55338},
+											pos:  position{line: 1463, col: 115, offset: 55353},
 											name: "EOLS",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1464, col: 123, offset: 55346},
+									pos:  position{line: 1463, col: 123, offset: 55361},
 									name: "EOF",
 								},
 							},
@@ -11493,17 +11507,17 @@ var g = &grammar{
 		},
 		{
 			name: "ParagraphWithLiteralBlockDelimiterLines",
-			pos:  position{line: 1469, col: 1, offset: 55505},
+			pos:  position{line: 1468, col: 1, offset: 55520},
 			expr: &actionExpr{
-				pos: position{line: 1469, col: 44, offset: 55548},
+				pos: position{line: 1468, col: 44, offset: 55563},
 				run: (*parser).callonParagraphWithLiteralBlockDelimiterLines1,
 				expr: &labeledExpr{
-					pos:   position{line: 1469, col: 44, offset: 55548},
+					pos:   position{line: 1468, col: 44, offset: 55563},
 					label: "lines",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 1469, col: 50, offset: 55554},
+						pos: position{line: 1468, col: 50, offset: 55569},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1469, col: 51, offset: 55555},
+							pos:  position{line: 1468, col: 51, offset: 55570},
 							name: "ParagraphWithLiteralBlockDelimiterLine",
 						},
 					},
@@ -11512,51 +11526,51 @@ var g = &grammar{
 		},
 		{
 			name: "ParagraphWithLiteralBlockDelimiterLine",
-			pos:  position{line: 1473, col: 1, offset: 55639},
+			pos:  position{line: 1472, col: 1, offset: 55654},
 			expr: &actionExpr{
-				pos: position{line: 1474, col: 5, offset: 55694},
+				pos: position{line: 1473, col: 5, offset: 55709},
 				run: (*parser).callonParagraphWithLiteralBlockDelimiterLine1,
 				expr: &seqExpr{
-					pos: position{line: 1474, col: 5, offset: 55694},
+					pos: position{line: 1473, col: 5, offset: 55709},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1474, col: 5, offset: 55694},
+							pos:   position{line: 1473, col: 5, offset: 55709},
 							label: "line",
 							expr: &actionExpr{
-								pos: position{line: 1474, col: 11, offset: 55700},
+								pos: position{line: 1473, col: 11, offset: 55715},
 								run: (*parser).callonParagraphWithLiteralBlockDelimiterLine4,
 								expr: &zeroOrMoreExpr{
-									pos: position{line: 1474, col: 11, offset: 55700},
+									pos: position{line: 1473, col: 11, offset: 55715},
 									expr: &choiceExpr{
-										pos: position{line: 1474, col: 12, offset: 55701},
+										pos: position{line: 1473, col: 12, offset: 55716},
 										alternatives: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1474, col: 12, offset: 55701},
+												pos:  position{line: 1473, col: 12, offset: 55716},
 												name: "Alphanums",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1474, col: 24, offset: 55713},
+												pos:  position{line: 1473, col: 24, offset: 55728},
 												name: "Spaces",
 											},
 											&seqExpr{
-												pos: position{line: 1474, col: 34, offset: 55723},
+												pos: position{line: 1473, col: 34, offset: 55738},
 												exprs: []interface{}{
 													&notExpr{
-														pos: position{line: 1474, col: 34, offset: 55723},
+														pos: position{line: 1473, col: 34, offset: 55738},
 														expr: &ruleRefExpr{
-															pos:  position{line: 1474, col: 35, offset: 55724},
+															pos:  position{line: 1473, col: 35, offset: 55739},
 															name: "LiteralBlockDelimiter",
 														},
 													},
 													&notExpr{
-														pos: position{line: 1474, col: 57, offset: 55746},
+														pos: position{line: 1473, col: 57, offset: 55761},
 														expr: &ruleRefExpr{
-															pos:  position{line: 1474, col: 58, offset: 55747},
+															pos:  position{line: 1473, col: 58, offset: 55762},
 															name: "EOL",
 														},
 													},
 													&anyMatcher{
-														line: 1474, col: 62, offset: 55751,
+														line: 1473, col: 62, offset: 55766,
 													},
 												},
 											},
@@ -11566,7 +11580,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1476, col: 8, offset: 55800},
+							pos:  position{line: 1475, col: 8, offset: 55815},
 							name: "EOL",
 						},
 					},
@@ -11575,33 +11589,33 @@ var g = &grammar{
 		},
 		{
 			name: "ParagraphWithLiteralAttribute",
-			pos:  position{line: 1481, col: 1, offset: 55926},
+			pos:  position{line: 1480, col: 1, offset: 55941},
 			expr: &actionExpr{
-				pos: position{line: 1482, col: 5, offset: 55964},
+				pos: position{line: 1481, col: 5, offset: 55979},
 				run: (*parser).callonParagraphWithLiteralAttribute1,
 				expr: &seqExpr{
-					pos: position{line: 1482, col: 5, offset: 55964},
+					pos: position{line: 1481, col: 5, offset: 55979},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1482, col: 5, offset: 55964},
+							pos:   position{line: 1481, col: 5, offset: 55979},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1482, col: 16, offset: 55975},
+								pos: position{line: 1481, col: 16, offset: 55990},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1482, col: 17, offset: 55976},
+									pos:  position{line: 1481, col: 17, offset: 55991},
 									name: "ElementAttributes",
 								},
 							},
 						},
 						&andCodeExpr{
-							pos: position{line: 1483, col: 5, offset: 56000},
+							pos: position{line: 1482, col: 5, offset: 56015},
 							run: (*parser).callonParagraphWithLiteralAttribute6,
 						},
 						&labeledExpr{
-							pos:   position{line: 1490, col: 5, offset: 56214},
+							pos:   position{line: 1489, col: 5, offset: 56229},
 							label: "lines",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1490, col: 12, offset: 56221},
+								pos:  position{line: 1489, col: 12, offset: 56236},
 								name: "ParagraphWithLiteralAttributeLines",
 							},
 						},
@@ -11611,12 +11625,12 @@ var g = &grammar{
 		},
 		{
 			name: "LiteralKind",
-			pos:  position{line: 1494, col: 1, offset: 56371},
+			pos:  position{line: 1493, col: 1, offset: 56386},
 			expr: &actionExpr{
-				pos: position{line: 1494, col: 16, offset: 56386},
+				pos: position{line: 1493, col: 16, offset: 56401},
 				run: (*parser).callonLiteralKind1,
 				expr: &litMatcher{
-					pos:        position{line: 1494, col: 16, offset: 56386},
+					pos:        position{line: 1493, col: 16, offset: 56401},
 					val:        "literal",
 					ignoreCase: false,
 				},
@@ -11624,17 +11638,17 @@ var g = &grammar{
 		},
 		{
 			name: "ParagraphWithLiteralAttributeLines",
-			pos:  position{line: 1499, col: 1, offset: 56469},
+			pos:  position{line: 1498, col: 1, offset: 56484},
 			expr: &actionExpr{
-				pos: position{line: 1499, col: 39, offset: 56507},
+				pos: position{line: 1498, col: 39, offset: 56522},
 				run: (*parser).callonParagraphWithLiteralAttributeLines1,
 				expr: &labeledExpr{
-					pos:   position{line: 1499, col: 39, offset: 56507},
+					pos:   position{line: 1498, col: 39, offset: 56522},
 					label: "lines",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 1499, col: 45, offset: 56513},
+						pos: position{line: 1498, col: 45, offset: 56528},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1499, col: 46, offset: 56514},
+							pos:  position{line: 1498, col: 46, offset: 56529},
 							name: "ParagraphWithLiteralAttributeLine",
 						},
 					},
@@ -11643,54 +11657,54 @@ var g = &grammar{
 		},
 		{
 			name: "ParagraphWithLiteralAttributeLine",
-			pos:  position{line: 1503, col: 1, offset: 56594},
+			pos:  position{line: 1502, col: 1, offset: 56609},
 			expr: &actionExpr{
-				pos: position{line: 1503, col: 38, offset: 56631},
+				pos: position{line: 1502, col: 38, offset: 56646},
 				run: (*parser).callonParagraphWithLiteralAttributeLine1,
 				expr: &seqExpr{
-					pos: position{line: 1503, col: 38, offset: 56631},
+					pos: position{line: 1502, col: 38, offset: 56646},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1503, col: 38, offset: 56631},
+							pos:   position{line: 1502, col: 38, offset: 56646},
 							label: "line",
 							expr: &actionExpr{
-								pos: position{line: 1503, col: 44, offset: 56637},
+								pos: position{line: 1502, col: 44, offset: 56652},
 								run: (*parser).callonParagraphWithLiteralAttributeLine4,
 								expr: &seqExpr{
-									pos: position{line: 1503, col: 44, offset: 56637},
+									pos: position{line: 1502, col: 44, offset: 56652},
 									exprs: []interface{}{
 										&notExpr{
-											pos: position{line: 1503, col: 44, offset: 56637},
+											pos: position{line: 1502, col: 44, offset: 56652},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1503, col: 46, offset: 56639},
+												pos:  position{line: 1502, col: 46, offset: 56654},
 												name: "BlankLine",
 											},
 										},
 										&oneOrMoreExpr{
-											pos: position{line: 1503, col: 57, offset: 56650},
+											pos: position{line: 1502, col: 57, offset: 56665},
 											expr: &choiceExpr{
-												pos: position{line: 1503, col: 58, offset: 56651},
+												pos: position{line: 1502, col: 58, offset: 56666},
 												alternatives: []interface{}{
 													&ruleRefExpr{
-														pos:  position{line: 1503, col: 58, offset: 56651},
+														pos:  position{line: 1502, col: 58, offset: 56666},
 														name: "Alphanums",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1503, col: 70, offset: 56663},
+														pos:  position{line: 1502, col: 70, offset: 56678},
 														name: "Spaces",
 													},
 													&seqExpr{
-														pos: position{line: 1503, col: 80, offset: 56673},
+														pos: position{line: 1502, col: 80, offset: 56688},
 														exprs: []interface{}{
 															&notExpr{
-																pos: position{line: 1503, col: 80, offset: 56673},
+																pos: position{line: 1502, col: 80, offset: 56688},
 																expr: &ruleRefExpr{
-																	pos:  position{line: 1503, col: 81, offset: 56674},
+																	pos:  position{line: 1502, col: 81, offset: 56689},
 																	name: "EOL",
 																},
 															},
 															&anyMatcher{
-																line: 1503, col: 86, offset: 56679,
+																line: 1502, col: 86, offset: 56694,
 															},
 														},
 													},
@@ -11702,7 +11716,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1505, col: 4, offset: 56720},
+							pos:  position{line: 1504, col: 4, offset: 56735},
 							name: "EOL",
 						},
 					},
@@ -11711,22 +11725,22 @@ var g = &grammar{
 		},
 		{
 			name: "BlankLine",
-			pos:  position{line: 1512, col: 1, offset: 56892},
+			pos:  position{line: 1511, col: 1, offset: 56907},
 			expr: &actionExpr{
-				pos: position{line: 1512, col: 14, offset: 56905},
+				pos: position{line: 1511, col: 14, offset: 56920},
 				run: (*parser).callonBlankLine1,
 				expr: &seqExpr{
-					pos: position{line: 1512, col: 14, offset: 56905},
+					pos: position{line: 1511, col: 14, offset: 56920},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1512, col: 14, offset: 56905},
+							pos: position{line: 1511, col: 14, offset: 56920},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1512, col: 15, offset: 56906},
+								pos:  position{line: 1511, col: 15, offset: 56921},
 								name: "EOF",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1512, col: 19, offset: 56910},
+							pos:  position{line: 1511, col: 19, offset: 56925},
 							name: "EOLS",
 						},
 					},
@@ -11735,9 +11749,9 @@ var g = &grammar{
 		},
 		{
 			name: "Alphanum",
-			pos:  position{line: 1519, col: 1, offset: 57058},
+			pos:  position{line: 1518, col: 1, offset: 57073},
 			expr: &charClassMatcher{
-				pos:        position{line: 1519, col: 13, offset: 57070},
+				pos:        position{line: 1518, col: 13, offset: 57085},
 				val:        "[\\pL0-9]",
 				ranges:     []rune{'0', '9'},
 				classes:    []*unicode.RangeTable{rangeTable("L")},
@@ -11747,37 +11761,37 @@ var g = &grammar{
 		},
 		{
 			name: "Parenthesis",
-			pos:  position{line: 1521, col: 1, offset: 57080},
+			pos:  position{line: 1520, col: 1, offset: 57095},
 			expr: &choiceExpr{
-				pos: position{line: 1521, col: 16, offset: 57095},
+				pos: position{line: 1520, col: 16, offset: 57110},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1521, col: 16, offset: 57095},
+						pos:        position{line: 1520, col: 16, offset: 57110},
 						val:        "(",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1521, col: 22, offset: 57101},
+						pos:        position{line: 1520, col: 22, offset: 57116},
 						val:        ")",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1521, col: 28, offset: 57107},
+						pos:        position{line: 1520, col: 28, offset: 57122},
 						val:        "[",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1521, col: 34, offset: 57113},
+						pos:        position{line: 1520, col: 34, offset: 57128},
 						val:        "]",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1521, col: 40, offset: 57119},
+						pos:        position{line: 1520, col: 40, offset: 57134},
 						val:        "{",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1521, col: 46, offset: 57125},
+						pos:        position{line: 1520, col: 46, offset: 57140},
 						val:        "}",
 						ignoreCase: false,
 					},
@@ -11786,14 +11800,14 @@ var g = &grammar{
 		},
 		{
 			name: "Alphanums",
-			pos:  position{line: 1523, col: 1, offset: 57131},
+			pos:  position{line: 1522, col: 1, offset: 57146},
 			expr: &actionExpr{
-				pos: position{line: 1523, col: 14, offset: 57144},
+				pos: position{line: 1522, col: 14, offset: 57159},
 				run: (*parser).callonAlphanums1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1523, col: 14, offset: 57144},
+					pos: position{line: 1522, col: 14, offset: 57159},
 					expr: &charClassMatcher{
-						pos:        position{line: 1523, col: 14, offset: 57144},
+						pos:        position{line: 1522, col: 14, offset: 57159},
 						val:        "[\\pL0-9]",
 						ranges:     []rune{'0', '9'},
 						classes:    []*unicode.RangeTable{rangeTable("L")},
@@ -11805,37 +11819,37 @@ var g = &grammar{
 		},
 		{
 			name: "Dot",
-			pos:  position{line: 1527, col: 1, offset: 57190},
+			pos:  position{line: 1526, col: 1, offset: 57205},
 			expr: &litMatcher{
-				pos:        position{line: 1527, col: 8, offset: 57197},
+				pos:        position{line: 1526, col: 8, offset: 57212},
 				val:        ".",
 				ignoreCase: false,
 			},
 		},
 		{
 			name: "SimpleWord",
-			pos:  position{line: 1529, col: 1, offset: 57202},
+			pos:  position{line: 1528, col: 1, offset: 57217},
 			expr: &actionExpr{
-				pos: position{line: 1529, col: 15, offset: 57216},
+				pos: position{line: 1528, col: 15, offset: 57231},
 				run: (*parser).callonSimpleWord1,
 				expr: &seqExpr{
-					pos: position{line: 1529, col: 15, offset: 57216},
+					pos: position{line: 1528, col: 15, offset: 57231},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1529, col: 15, offset: 57216},
+							pos:  position{line: 1528, col: 15, offset: 57231},
 							name: "Alphanums",
 						},
 						&andExpr{
-							pos: position{line: 1529, col: 25, offset: 57226},
+							pos: position{line: 1528, col: 25, offset: 57241},
 							expr: &choiceExpr{
-								pos: position{line: 1529, col: 27, offset: 57228},
+								pos: position{line: 1528, col: 27, offset: 57243},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1529, col: 27, offset: 57228},
+										pos:  position{line: 1528, col: 27, offset: 57243},
 										name: "WS",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1529, col: 32, offset: 57233},
+										pos:  position{line: 1528, col: 32, offset: 57248},
 										name: "EOL",
 									},
 								},
@@ -11847,76 +11861,76 @@ var g = &grammar{
 		},
 		{
 			name: "OtherWord",
-			pos:  position{line: 1534, col: 1, offset: 57498},
+			pos:  position{line: 1533, col: 1, offset: 57513},
 			expr: &actionExpr{
-				pos: position{line: 1534, col: 14, offset: 57511},
+				pos: position{line: 1533, col: 14, offset: 57526},
 				run: (*parser).callonOtherWord1,
 				expr: &choiceExpr{
-					pos: position{line: 1534, col: 15, offset: 57512},
+					pos: position{line: 1533, col: 15, offset: 57527},
 					alternatives: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1534, col: 15, offset: 57512},
+							pos:  position{line: 1533, col: 15, offset: 57527},
 							name: "Alphanums",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1534, col: 27, offset: 57524},
+							pos:  position{line: 1533, col: 27, offset: 57539},
 							name: "QuotedTextPrefix",
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 1534, col: 46, offset: 57543},
+							pos: position{line: 1533, col: 46, offset: 57558},
 							expr: &actionExpr{
-								pos: position{line: 1534, col: 47, offset: 57544},
+								pos: position{line: 1533, col: 47, offset: 57559},
 								run: (*parser).callonOtherWord6,
 								expr: &seqExpr{
-									pos: position{line: 1534, col: 47, offset: 57544},
+									pos: position{line: 1533, col: 47, offset: 57559},
 									exprs: []interface{}{
 										&seqExpr{
-											pos: position{line: 1534, col: 48, offset: 57545},
+											pos: position{line: 1533, col: 48, offset: 57560},
 											exprs: []interface{}{
 												&notExpr{
-													pos: position{line: 1534, col: 48, offset: 57545},
+													pos: position{line: 1533, col: 48, offset: 57560},
 													expr: &ruleRefExpr{
-														pos:  position{line: 1534, col: 49, offset: 57546},
+														pos:  position{line: 1533, col: 49, offset: 57561},
 														name: "NEWLINE",
 													},
 												},
 												&notExpr{
-													pos: position{line: 1534, col: 57, offset: 57554},
+													pos: position{line: 1533, col: 57, offset: 57569},
 													expr: &ruleRefExpr{
-														pos:  position{line: 1534, col: 58, offset: 57555},
+														pos:  position{line: 1533, col: 58, offset: 57570},
 														name: "WS",
 													},
 												},
 												&notExpr{
-													pos: position{line: 1534, col: 61, offset: 57558},
+													pos: position{line: 1533, col: 61, offset: 57573},
 													expr: &ruleRefExpr{
-														pos:  position{line: 1534, col: 62, offset: 57559},
+														pos:  position{line: 1533, col: 62, offset: 57574},
 														name: "Dot",
 													},
 												},
 												&notExpr{
-													pos: position{line: 1534, col: 66, offset: 57563},
+													pos: position{line: 1533, col: 66, offset: 57578},
 													expr: &ruleRefExpr{
-														pos:  position{line: 1534, col: 67, offset: 57564},
+														pos:  position{line: 1533, col: 67, offset: 57579},
 														name: "QuotedTextPrefix",
 													},
 												},
 												&notExpr{
-													pos: position{line: 1534, col: 84, offset: 57581},
+													pos: position{line: 1533, col: 84, offset: 57596},
 													expr: &ruleRefExpr{
-														pos:  position{line: 1534, col: 85, offset: 57582},
+														pos:  position{line: 1533, col: 85, offset: 57597},
 														name: "Parenthesis",
 													},
 												},
 												&anyMatcher{
-													line: 1534, col: 97, offset: 57594,
+													line: 1533, col: 97, offset: 57609,
 												},
 											},
 										},
 										&zeroOrOneExpr{
-											pos: position{line: 1534, col: 100, offset: 57597},
+											pos: position{line: 1533, col: 100, offset: 57612},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1534, col: 100, offset: 57597},
+												pos:  position{line: 1533, col: 100, offset: 57612},
 												name: "Dot",
 											},
 										},
@@ -11925,9 +11939,9 @@ var g = &grammar{
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 1536, col: 7, offset: 57706},
+							pos: position{line: 1535, col: 7, offset: 57721},
 							expr: &litMatcher{
-								pos:        position{line: 1536, col: 7, offset: 57706},
+								pos:        position{line: 1535, col: 7, offset: 57721},
 								val:        ".",
 								ignoreCase: false,
 							},
@@ -11938,35 +11952,35 @@ var g = &grammar{
 		},
 		{
 			name: "Spaces",
-			pos:  position{line: 1540, col: 1, offset: 57887},
+			pos:  position{line: 1539, col: 1, offset: 57902},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 1540, col: 11, offset: 57897},
+				pos: position{line: 1539, col: 11, offset: 57912},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1540, col: 11, offset: 57897},
+					pos:  position{line: 1539, col: 11, offset: 57912},
 					name: "WS",
 				},
 			},
 		},
 		{
 			name: "FileLocation",
-			pos:  position{line: 1542, col: 1, offset: 57903},
+			pos:  position{line: 1541, col: 1, offset: 57918},
 			expr: &actionExpr{
-				pos: position{line: 1542, col: 17, offset: 57919},
+				pos: position{line: 1541, col: 17, offset: 57934},
 				run: (*parser).callonFileLocation1,
 				expr: &labeledExpr{
-					pos:   position{line: 1542, col: 17, offset: 57919},
+					pos:   position{line: 1541, col: 17, offset: 57934},
 					label: "elements",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 1542, col: 26, offset: 57928},
+						pos: position{line: 1541, col: 26, offset: 57943},
 						expr: &choiceExpr{
-							pos: position{line: 1542, col: 27, offset: 57929},
+							pos: position{line: 1541, col: 27, offset: 57944},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 1542, col: 27, offset: 57929},
+									pos:  position{line: 1541, col: 27, offset: 57944},
 									name: "FILENAME",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1542, col: 38, offset: 57940},
+									pos:  position{line: 1541, col: 38, offset: 57955},
 									name: "DocumentAttributeSubstitution",
 								},
 							},
@@ -11977,60 +11991,60 @@ var g = &grammar{
 		},
 		{
 			name: "Location",
-			pos:  position{line: 1546, col: 1, offset: 58032},
+			pos:  position{line: 1545, col: 1, offset: 58047},
 			expr: &actionExpr{
-				pos: position{line: 1546, col: 13, offset: 58044},
+				pos: position{line: 1545, col: 13, offset: 58059},
 				run: (*parser).callonLocation1,
 				expr: &labeledExpr{
-					pos:   position{line: 1546, col: 13, offset: 58044},
+					pos:   position{line: 1545, col: 13, offset: 58059},
 					label: "elements",
 					expr: &seqExpr{
-						pos: position{line: 1546, col: 23, offset: 58054},
+						pos: position{line: 1545, col: 23, offset: 58069},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 1546, col: 23, offset: 58054},
+								pos:  position{line: 1545, col: 23, offset: 58069},
 								name: "URL_SCHEME",
 							},
 							&oneOrMoreExpr{
-								pos: position{line: 1546, col: 34, offset: 58065},
+								pos: position{line: 1545, col: 34, offset: 58080},
 								expr: &choiceExpr{
-									pos: position{line: 1546, col: 35, offset: 58066},
+									pos: position{line: 1545, col: 35, offset: 58081},
 									alternatives: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 1546, col: 35, offset: 58066},
+											pos:  position{line: 1545, col: 35, offset: 58081},
 											name: "FILENAME",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1546, col: 46, offset: 58077},
+											pos:  position{line: 1545, col: 46, offset: 58092},
 											name: "DocumentAttributeSubstitution",
 										},
 										&seqExpr{
-											pos: position{line: 1546, col: 78, offset: 58109},
+											pos: position{line: 1545, col: 78, offset: 58124},
 											exprs: []interface{}{
 												&notExpr{
-													pos: position{line: 1546, col: 78, offset: 58109},
+													pos: position{line: 1545, col: 78, offset: 58124},
 													expr: &ruleRefExpr{
-														pos:  position{line: 1546, col: 79, offset: 58110},
+														pos:  position{line: 1545, col: 79, offset: 58125},
 														name: "EOL",
 													},
 												},
 												&notExpr{
-													pos: position{line: 1546, col: 83, offset: 58114},
+													pos: position{line: 1545, col: 83, offset: 58129},
 													expr: &ruleRefExpr{
-														pos:  position{line: 1546, col: 84, offset: 58115},
+														pos:  position{line: 1545, col: 84, offset: 58130},
 														name: "WS",
 													},
 												},
 												&notExpr{
-													pos: position{line: 1546, col: 87, offset: 58118},
+													pos: position{line: 1545, col: 87, offset: 58133},
 													expr: &litMatcher{
-														pos:        position{line: 1546, col: 88, offset: 58119},
+														pos:        position{line: 1545, col: 88, offset: 58134},
 														val:        "[",
 														ignoreCase: false,
 													},
 												},
 												&anyMatcher{
-													line: 1546, col: 92, offset: 58123,
+													line: 1545, col: 92, offset: 58138,
 												},
 											},
 										},
@@ -12044,26 +12058,26 @@ var g = &grammar{
 		},
 		{
 			name: "FILENAME",
-			pos:  position{line: 1550, col: 1, offset: 58188},
+			pos:  position{line: 1549, col: 1, offset: 58203},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 1550, col: 13, offset: 58200},
+				pos: position{line: 1549, col: 13, offset: 58215},
 				expr: &choiceExpr{
-					pos: position{line: 1550, col: 14, offset: 58201},
+					pos: position{line: 1549, col: 14, offset: 58216},
 					alternatives: []interface{}{
 						&charClassMatcher{
-							pos:        position{line: 1550, col: 14, offset: 58201},
+							pos:        position{line: 1549, col: 14, offset: 58216},
 							val:        "[ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789~:/?#@!$&;=()*+,_%]",
 							chars:      []rune{'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '~', ':', '/', '?', '#', '@', '!', '$', '&', ';', '=', '(', ')', '*', '+', ',', '_', '%'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 1550, col: 99, offset: 58286},
+							pos:        position{line: 1549, col: 99, offset: 58301},
 							val:        "-",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1550, col: 105, offset: 58292},
+							pos:        position{line: 1549, col: 105, offset: 58307},
 							val:        ".",
 							ignoreCase: false,
 						},
@@ -12073,54 +12087,54 @@ var g = &grammar{
 		},
 		{
 			name: "URL",
-			pos:  position{line: 1552, col: 1, offset: 58333},
+			pos:  position{line: 1551, col: 1, offset: 58348},
 			expr: &actionExpr{
-				pos: position{line: 1552, col: 8, offset: 58340},
+				pos: position{line: 1551, col: 8, offset: 58355},
 				run: (*parser).callonURL1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1552, col: 8, offset: 58340},
+					pos: position{line: 1551, col: 8, offset: 58355},
 					expr: &choiceExpr{
-						pos: position{line: 1552, col: 9, offset: 58341},
+						pos: position{line: 1551, col: 9, offset: 58356},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 1552, col: 9, offset: 58341},
+								pos:  position{line: 1551, col: 9, offset: 58356},
 								name: "Alphanums",
 							},
 							&seqExpr{
-								pos: position{line: 1552, col: 22, offset: 58354},
+								pos: position{line: 1551, col: 22, offset: 58369},
 								exprs: []interface{}{
 									&notExpr{
-										pos: position{line: 1552, col: 22, offset: 58354},
+										pos: position{line: 1551, col: 22, offset: 58369},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1552, col: 23, offset: 58355},
+											pos:  position{line: 1551, col: 23, offset: 58370},
 											name: "NEWLINE",
 										},
 									},
 									&notExpr{
-										pos: position{line: 1552, col: 31, offset: 58363},
+										pos: position{line: 1551, col: 31, offset: 58378},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1552, col: 32, offset: 58364},
+											pos:  position{line: 1551, col: 32, offset: 58379},
 											name: "WS",
 										},
 									},
 									&notExpr{
-										pos: position{line: 1552, col: 35, offset: 58367},
+										pos: position{line: 1551, col: 35, offset: 58382},
 										expr: &litMatcher{
-											pos:        position{line: 1552, col: 36, offset: 58368},
+											pos:        position{line: 1551, col: 36, offset: 58383},
 											val:        "[",
 											ignoreCase: false,
 										},
 									},
 									&notExpr{
-										pos: position{line: 1552, col: 40, offset: 58372},
+										pos: position{line: 1551, col: 40, offset: 58387},
 										expr: &litMatcher{
-											pos:        position{line: 1552, col: 41, offset: 58373},
+											pos:        position{line: 1551, col: 41, offset: 58388},
 											val:        "]",
 											ignoreCase: false,
 										},
 									},
 									&anyMatcher{
-										line: 1552, col: 46, offset: 58378,
+										line: 1551, col: 46, offset: 58393,
 									},
 								},
 							},
@@ -12131,32 +12145,32 @@ var g = &grammar{
 		},
 		{
 			name: "URL_SCHEME",
-			pos:  position{line: 1556, col: 1, offset: 58419},
+			pos:  position{line: 1555, col: 1, offset: 58434},
 			expr: &choiceExpr{
-				pos: position{line: 1556, col: 15, offset: 58433},
+				pos: position{line: 1555, col: 15, offset: 58448},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1556, col: 15, offset: 58433},
+						pos:        position{line: 1555, col: 15, offset: 58448},
 						val:        "http://",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1556, col: 27, offset: 58445},
+						pos:        position{line: 1555, col: 27, offset: 58460},
 						val:        "https://",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1556, col: 40, offset: 58458},
+						pos:        position{line: 1555, col: 40, offset: 58473},
 						val:        "ftp://",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1556, col: 51, offset: 58469},
+						pos:        position{line: 1555, col: 51, offset: 58484},
 						val:        "irc://",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1556, col: 62, offset: 58480},
+						pos:        position{line: 1555, col: 62, offset: 58495},
 						val:        "mailto:",
 						ignoreCase: false,
 					},
@@ -12165,78 +12179,78 @@ var g = &grammar{
 		},
 		{
 			name: "ID",
-			pos:  position{line: 1558, col: 1, offset: 58491},
+			pos:  position{line: 1557, col: 1, offset: 58506},
 			expr: &actionExpr{
-				pos: position{line: 1558, col: 7, offset: 58497},
+				pos: position{line: 1557, col: 7, offset: 58512},
 				run: (*parser).callonID1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1558, col: 7, offset: 58497},
+					pos: position{line: 1557, col: 7, offset: 58512},
 					expr: &choiceExpr{
-						pos: position{line: 1558, col: 8, offset: 58498},
+						pos: position{line: 1557, col: 8, offset: 58513},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 1558, col: 8, offset: 58498},
+								pos:  position{line: 1557, col: 8, offset: 58513},
 								name: "Alphanums",
 							},
 							&seqExpr{
-								pos: position{line: 1558, col: 21, offset: 58511},
+								pos: position{line: 1557, col: 21, offset: 58526},
 								exprs: []interface{}{
 									&notExpr{
-										pos: position{line: 1558, col: 21, offset: 58511},
+										pos: position{line: 1557, col: 21, offset: 58526},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1558, col: 22, offset: 58512},
+											pos:  position{line: 1557, col: 22, offset: 58527},
 											name: "NEWLINE",
 										},
 									},
 									&notExpr{
-										pos: position{line: 1558, col: 30, offset: 58520},
+										pos: position{line: 1557, col: 30, offset: 58535},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1558, col: 31, offset: 58521},
+											pos:  position{line: 1557, col: 31, offset: 58536},
 											name: "WS",
 										},
 									},
 									&notExpr{
-										pos: position{line: 1558, col: 34, offset: 58524},
+										pos: position{line: 1557, col: 34, offset: 58539},
 										expr: &litMatcher{
-											pos:        position{line: 1558, col: 35, offset: 58525},
+											pos:        position{line: 1557, col: 35, offset: 58540},
 											val:        "[",
 											ignoreCase: false,
 										},
 									},
 									&notExpr{
-										pos: position{line: 1558, col: 39, offset: 58529},
+										pos: position{line: 1557, col: 39, offset: 58544},
 										expr: &litMatcher{
-											pos:        position{line: 1558, col: 40, offset: 58530},
+											pos:        position{line: 1557, col: 40, offset: 58545},
 											val:        "]",
 											ignoreCase: false,
 										},
 									},
 									&notExpr{
-										pos: position{line: 1558, col: 44, offset: 58534},
+										pos: position{line: 1557, col: 44, offset: 58549},
 										expr: &litMatcher{
-											pos:        position{line: 1558, col: 45, offset: 58535},
+											pos:        position{line: 1557, col: 45, offset: 58550},
 											val:        "<<",
 											ignoreCase: false,
 										},
 									},
 									&notExpr{
-										pos: position{line: 1558, col: 50, offset: 58540},
+										pos: position{line: 1557, col: 50, offset: 58555},
 										expr: &litMatcher{
-											pos:        position{line: 1558, col: 51, offset: 58541},
+											pos:        position{line: 1557, col: 51, offset: 58556},
 											val:        ">>",
 											ignoreCase: false,
 										},
 									},
 									&notExpr{
-										pos: position{line: 1558, col: 56, offset: 58546},
+										pos: position{line: 1557, col: 56, offset: 58561},
 										expr: &litMatcher{
-											pos:        position{line: 1558, col: 57, offset: 58547},
+											pos:        position{line: 1557, col: 57, offset: 58562},
 											val:        ",",
 											ignoreCase: false,
 										},
 									},
 									&anyMatcher{
-										line: 1558, col: 62, offset: 58552,
+										line: 1557, col: 62, offset: 58567,
 									},
 								},
 							},
@@ -12247,12 +12261,12 @@ var g = &grammar{
 		},
 		{
 			name: "DIGIT",
-			pos:  position{line: 1562, col: 1, offset: 58593},
+			pos:  position{line: 1561, col: 1, offset: 58608},
 			expr: &actionExpr{
-				pos: position{line: 1562, col: 10, offset: 58602},
+				pos: position{line: 1561, col: 10, offset: 58617},
 				run: (*parser).callonDIGIT1,
 				expr: &charClassMatcher{
-					pos:        position{line: 1562, col: 10, offset: 58602},
+					pos:        position{line: 1561, col: 10, offset: 58617},
 					val:        "[0-9]",
 					ranges:     []rune{'0', '9'},
 					ignoreCase: false,
@@ -12262,25 +12276,25 @@ var g = &grammar{
 		},
 		{
 			name: "NUMBER",
-			pos:  position{line: 1566, col: 1, offset: 58644},
+			pos:  position{line: 1565, col: 1, offset: 58659},
 			expr: &actionExpr{
-				pos: position{line: 1566, col: 11, offset: 58654},
+				pos: position{line: 1565, col: 11, offset: 58669},
 				run: (*parser).callonNUMBER1,
 				expr: &seqExpr{
-					pos: position{line: 1566, col: 11, offset: 58654},
+					pos: position{line: 1565, col: 11, offset: 58669},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 1566, col: 11, offset: 58654},
+							pos: position{line: 1565, col: 11, offset: 58669},
 							expr: &litMatcher{
-								pos:        position{line: 1566, col: 11, offset: 58654},
+								pos:        position{line: 1565, col: 11, offset: 58669},
 								val:        "-",
 								ignoreCase: false,
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 1566, col: 16, offset: 58659},
+							pos: position{line: 1565, col: 16, offset: 58674},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1566, col: 16, offset: 58659},
+								pos:  position{line: 1565, col: 16, offset: 58674},
 								name: "DIGIT",
 							},
 						},
@@ -12290,20 +12304,20 @@ var g = &grammar{
 		},
 		{
 			name: "WS",
-			pos:  position{line: 1570, col: 1, offset: 58711},
+			pos:  position{line: 1569, col: 1, offset: 58726},
 			expr: &choiceExpr{
-				pos: position{line: 1570, col: 7, offset: 58717},
+				pos: position{line: 1569, col: 7, offset: 58732},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1570, col: 7, offset: 58717},
+						pos:        position{line: 1569, col: 7, offset: 58732},
 						val:        " ",
 						ignoreCase: false,
 					},
 					&actionExpr{
-						pos: position{line: 1570, col: 13, offset: 58723},
+						pos: position{line: 1569, col: 13, offset: 58738},
 						run: (*parser).callonWS3,
 						expr: &litMatcher{
-							pos:        position{line: 1570, col: 13, offset: 58723},
+							pos:        position{line: 1569, col: 13, offset: 58738},
 							val:        "\t",
 							ignoreCase: false,
 						},
@@ -12313,22 +12327,22 @@ var g = &grammar{
 		},
 		{
 			name: "NEWLINE",
-			pos:  position{line: 1574, col: 1, offset: 58764},
+			pos:  position{line: 1573, col: 1, offset: 58779},
 			expr: &choiceExpr{
-				pos: position{line: 1574, col: 12, offset: 58775},
+				pos: position{line: 1573, col: 12, offset: 58790},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1574, col: 12, offset: 58775},
+						pos:        position{line: 1573, col: 12, offset: 58790},
 						val:        "\r\n",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1574, col: 21, offset: 58784},
+						pos:        position{line: 1573, col: 21, offset: 58799},
 						val:        "\r",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1574, col: 28, offset: 58791},
+						pos:        position{line: 1573, col: 28, offset: 58806},
 						val:        "\n",
 						ignoreCase: false,
 					},
@@ -12337,26 +12351,26 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 1576, col: 1, offset: 58797},
+			pos:  position{line: 1575, col: 1, offset: 58812},
 			expr: &notExpr{
-				pos: position{line: 1576, col: 8, offset: 58804},
+				pos: position{line: 1575, col: 8, offset: 58819},
 				expr: &anyMatcher{
-					line: 1576, col: 9, offset: 58805,
+					line: 1575, col: 9, offset: 58820,
 				},
 			},
 		},
 		{
 			name: "EOL",
-			pos:  position{line: 1578, col: 1, offset: 58808},
+			pos:  position{line: 1577, col: 1, offset: 58823},
 			expr: &choiceExpr{
-				pos: position{line: 1578, col: 8, offset: 58815},
+				pos: position{line: 1577, col: 8, offset: 58830},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1578, col: 8, offset: 58815},
+						pos:  position{line: 1577, col: 8, offset: 58830},
 						name: "NEWLINE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1578, col: 18, offset: 58825},
+						pos:  position{line: 1577, col: 18, offset: 58840},
 						name: "EOF",
 					},
 				},
@@ -12364,19 +12378,19 @@ var g = &grammar{
 		},
 		{
 			name: "EOLS",
-			pos:  position{line: 1580, col: 1, offset: 58830},
+			pos:  position{line: 1579, col: 1, offset: 58845},
 			expr: &seqExpr{
-				pos: position{line: 1580, col: 9, offset: 58838},
+				pos: position{line: 1579, col: 9, offset: 58853},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1580, col: 9, offset: 58838},
+						pos: position{line: 1579, col: 9, offset: 58853},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1580, col: 9, offset: 58838},
+							pos:  position{line: 1579, col: 9, offset: 58853},
 							name: "WS",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1580, col: 13, offset: 58842},
+						pos:  position{line: 1579, col: 13, offset: 58857},
 						name: "EOL",
 					},
 				},
@@ -14833,7 +14847,7 @@ func (p *parser) callonInlineLinks1() (interface{}, error) {
 }
 
 func (c *current) onImageBlock1(attributes, path, inlineAttributes interface{}) (interface{}, error) {
-	return types.NewImageBlock(path.(string), inlineAttributes.(types.ElementAttributes), attributes)
+	return types.NewImageBlock(path.(types.Location), inlineAttributes.(types.ElementAttributes), attributes)
 }
 
 func (p *parser) callonImageBlock1() (interface{}, error) {
@@ -14843,7 +14857,7 @@ func (p *parser) callonImageBlock1() (interface{}, error) {
 }
 
 func (c *current) onInlineImage1(path, inlineAttributes interface{}) (interface{}, error) {
-	return types.NewInlineImage(path.(string), inlineAttributes.(types.ElementAttributes))
+	return types.NewInlineImage(path.(types.Location), inlineAttributes.(types.ElementAttributes))
 }
 
 func (p *parser) callonInlineImage1() (interface{}, error) {

--- a/pkg/parser/parser.peg
+++ b/pkg/parser/parser.peg
@@ -1151,7 +1151,6 @@ InlineLinks <-
     elements:(SimpleWord
         / Spaces 
         / Link 
-        / DocumentAttributeSubstitution 
         / OtherWord
         / Parenthesis)+ {
     return types.NewInlineElements(elements.([]interface{}))
@@ -1161,12 +1160,12 @@ InlineLinks <-
 // ------------------------------------------
 // Images
 // ------------------------------------------
-ImageBlock <- attributes:(ElementAttributes)? "image::" path:(URL) inlineAttributes:(ImageAttributes) EOLS {
-    return types.NewImageBlock(path.(string), inlineAttributes.(types.ElementAttributes), attributes)
+ImageBlock <- attributes:(ElementAttributes)? "image::" path:(Location / FileLocation) inlineAttributes:(ImageAttributes) EOLS {
+    return types.NewImageBlock(path.(types.Location), inlineAttributes.(types.ElementAttributes), attributes)
 }
 
-InlineImage <- "image:" !":" path:(URL) inlineAttributes:(ImageAttributes) {
-    return types.NewInlineImage(path.(string), inlineAttributes.(types.ElementAttributes))
+InlineImage <- "image:" !":" path:(Location / FileLocation) inlineAttributes:(ImageAttributes) {
+    return types.NewInlineImage(path.(types.Location), inlineAttributes.(types.ElementAttributes))
 }
 
 ImageAttributes <- "[" alt:(AttributeValue)? ","? width:(AttributeValue)? ","? height:(AttributeValue)? ","? WS* otherattrs:(GenericAttribute)* "]" {

--- a/pkg/parser/predefined_attributes.go
+++ b/pkg/parser/predefined_attributes.go
@@ -1,13 +1,14 @@
-package html5
+package parser
 
 import (
 	"github.com/bytesparadise/libasciidoc/pkg/types"
 )
 
-var predefined types.DocumentAttributes
+// Predefined the predefined document attributes, mainly for special characters
+var Predefined types.DocumentAttributes
 
 func init() {
-	predefined = types.DocumentAttributes{
+	Predefined = types.DocumentAttributes{
 		"sp":             " ",
 		"blank":          "",
 		"empty":          "",

--- a/pkg/parser/predefined_attributes_test.go
+++ b/pkg/parser/predefined_attributes_test.go
@@ -1,6 +1,8 @@
-package html5
+package parser_test
 
 import (
+	"github.com/bytesparadise/libasciidoc/pkg/parser"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -10,7 +12,7 @@ var _ = Describe("document with attributes", func() {
 
 	DescribeTable("predefined attributes",
 		func(code, rendered string) {
-			Expect(predefined[code]).To(Equal(rendered))
+			Expect(parser.Predefined[code]).To(Equal(rendered))
 		},
 		Entry("sp", "sp", " "),
 		Entry("blank", "blank", ""),

--- a/pkg/parser/quoted_text_test.go
+++ b/pkg/parser/quoted_text_test.go
@@ -1145,8 +1145,10 @@ var _ = Describe("quoted texts - draft", func() {
 										},
 									},
 									Location: types.Location{
-										types.StringElement{
-											Content: "/",
+										Elements: []interface{}{
+											types.StringElement{
+												Content: "/",
+											},
 										},
 									},
 								},
@@ -1169,10 +1171,14 @@ var _ = Describe("quoted texts - draft", func() {
 							Elements: types.InlineElements{
 								types.StringElement{Content: "a "},
 								types.InlineImage{
-									Attributes: types.ElementAttributes{
-										types.AttrImageAlt: "foo",
+									Attributes: types.ElementAttributes{},
+									Location: types.Location{
+										Elements: []interface{}{
+											types.StringElement{
+												Content: "foo.png",
+											},
+										},
 									},
-									Path: "foo.png",
 								},
 							},
 						},
@@ -1249,8 +1255,10 @@ var _ = Describe("quoted texts - draft", func() {
 										},
 									},
 									Location: types.Location{
-										types.StringElement{
-											Content: "/",
+										Elements: []interface{}{
+											types.StringElement{
+												Content: "/",
+											},
 										},
 									},
 								},
@@ -1273,10 +1281,14 @@ var _ = Describe("quoted texts - draft", func() {
 							Elements: types.InlineElements{
 								types.StringElement{Content: "a "},
 								types.InlineImage{
-									Attributes: types.ElementAttributes{
-										types.AttrImageAlt: "foo",
+									Attributes: types.ElementAttributes{},
+									Location: types.Location{
+										Elements: []interface{}{
+											types.StringElement{
+												Content: "foo.png",
+											},
+										},
 									},
-									Path: "foo.png",
 								},
 							},
 						},
@@ -1353,8 +1365,10 @@ var _ = Describe("quoted texts - draft", func() {
 										},
 									},
 									Location: types.Location{
-										types.StringElement{
-											Content: "/",
+										Elements: []interface{}{
+											types.StringElement{
+												Content: "/",
+											},
 										},
 									},
 								},
@@ -1377,10 +1391,14 @@ var _ = Describe("quoted texts - draft", func() {
 							Elements: types.InlineElements{
 								types.StringElement{Content: "a "},
 								types.InlineImage{
-									Attributes: types.ElementAttributes{
-										types.AttrImageAlt: "foo",
+									Attributes: types.ElementAttributes{},
+									Location: types.Location{
+										Elements: []interface{}{
+											types.StringElement{
+												Content: "foo.png",
+											},
+										},
 									},
-									Path: "foo.png",
 								},
 							},
 						},
@@ -2198,5 +2216,122 @@ var _ = Describe("quoted texts - draft", func() {
 				})
 			})
 		})
+	})
+})
+
+var _ = Describe("quoted texts - final document", func() {
+
+	It("image in bold", func() {
+		source := "*a image:foo.png[]*"
+		expected := types.Document{
+			Attributes:         types.DocumentAttributes{},
+			ElementReferences:  types.ElementReferences{},
+			Footnotes:          types.Footnotes{},
+			FootnoteReferences: types.FootnoteReferences{},
+			Elements: []interface{}{
+				types.Paragraph{
+					Attributes: types.ElementAttributes{},
+					Lines: []types.InlineElements{
+						{
+							types.QuotedText{
+								Kind: types.Bold,
+								Elements: types.InlineElements{
+									types.StringElement{Content: "a "},
+									types.InlineImage{
+										Attributes: types.ElementAttributes{
+											types.AttrImageAlt: "foo",
+										},
+										Location: types.Location{
+											Elements: []interface{}{
+												types.StringElement{
+													Content: "foo.png",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		Expect(source).To(BecomeDocument(expected))
+	})
+
+	It("image in italic", func() {
+		source := "_a image:foo.png[]_"
+		expected := types.Document{
+			Attributes:         types.DocumentAttributes{},
+			ElementReferences:  types.ElementReferences{},
+			Footnotes:          types.Footnotes{},
+			FootnoteReferences: types.FootnoteReferences{},
+			Elements: []interface{}{
+				types.Paragraph{
+					Attributes: types.ElementAttributes{},
+					Lines: []types.InlineElements{
+						{
+							types.QuotedText{
+								Kind: types.Italic,
+								Elements: types.InlineElements{
+									types.StringElement{Content: "a "},
+									types.InlineImage{
+										Attributes: types.ElementAttributes{
+											types.AttrImageAlt: "foo",
+										},
+										Location: types.Location{
+											Elements: []interface{}{
+												types.StringElement{
+													Content: "foo.png",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		Expect(source).To(BecomeDocument(expected))
+	})
+
+	It("image in monospace", func() {
+		source := "`a image:foo.png[]`"
+		expected := types.Document{
+			Attributes:         types.DocumentAttributes{},
+			ElementReferences:  types.ElementReferences{},
+			Footnotes:          types.Footnotes{},
+			FootnoteReferences: types.FootnoteReferences{},
+			Elements: []interface{}{
+				types.Paragraph{
+					Attributes: types.ElementAttributes{},
+					Lines: []types.InlineElements{
+						{
+							types.QuotedText{
+								Kind: types.Monospace,
+								Elements: types.InlineElements{
+									types.StringElement{Content: "a "},
+									types.InlineImage{
+										Attributes: types.ElementAttributes{
+											types.AttrImageAlt: "foo",
+										},
+										Location: types.Location{
+											Elements: []interface{}{
+												types.StringElement{
+													Content: "foo.png",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		Expect(source).To(BecomeDocument(expected))
 	})
 })

--- a/pkg/parser/section_test.go
+++ b/pkg/parser/section_test.go
@@ -543,6 +543,99 @@ a paragraph`
 			}
 			Expect(source).To(BecomeDraftDocument(expected))
 		})
+
+		It("section with link in title", func() {
+			source := `== link to https://foo.bar
+`
+			section1aTitle := types.InlineElements{
+				types.StringElement{Content: "link to "},
+				types.InlineLink{
+					Attributes: types.ElementAttributes{},
+					Location: types.Location{
+						Elements: []interface{}{
+							types.StringElement{Content: "https://foo.bar"},
+						},
+					},
+				},
+			}
+			expected := types.DraftDocument{
+				Blocks: []interface{}{
+					types.Section{
+						Attributes: types.ElementAttributes{
+							types.AttrID:       "link_to_https_foo_bar",
+							types.AttrCustomID: false,
+						},
+						Level:    1,
+						Title:    section1aTitle,
+						Elements: []interface{}{},
+					},
+				},
+			}
+			Expect(source).To(BecomeDraftDocument(expected))
+		})
+
+		It("section 0, 1 and paragraph with bold quote", func() {
+
+			source := `= a header
+				
+== section 1
+
+a paragraph with *bold content*`
+
+			title := types.InlineElements{
+				types.StringElement{Content: "a header"},
+			}
+			section1Title := types.InlineElements{
+				types.StringElement{Content: "section 1"},
+			}
+			expected := types.Document{
+				Attributes: types.DocumentAttributes{},
+				ElementReferences: types.ElementReferences{
+					"a_header":  title,
+					"section_1": section1Title,
+				},
+				Footnotes:          types.Footnotes{},
+				FootnoteReferences: types.FootnoteReferences{},
+				Elements: []interface{}{
+					types.Section{
+						Level: 0,
+						Attributes: types.ElementAttributes{
+							types.AttrID:       "a_header",
+							types.AttrCustomID: false,
+						},
+						Title: title,
+						Elements: []interface{}{
+							types.Section{
+								Level: 1,
+								Title: section1Title,
+								Attributes: types.ElementAttributes{
+									types.AttrID:       "section_1",
+									types.AttrCustomID: false,
+								},
+								Elements: []interface{}{
+									types.Paragraph{
+										Attributes: types.ElementAttributes{},
+										Lines: []types.InlineElements{
+											{
+												types.StringElement{Content: "a paragraph with "},
+												types.QuotedText{
+													Kind: types.Bold,
+													Elements: types.InlineElements{
+														types.StringElement{Content: "bold content"},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(source).To(BecomeDocument(expected))
+		})
+
 	})
 
 	Context("invalid sections", func() {

--- a/pkg/parser/unordered_list_test.go
+++ b/pkg/parser/unordered_list_test.go
@@ -2726,6 +2726,40 @@ on 2 lines, too.`
 			}
 			Expect(source).To(BecomeDocument(expected))
 		})
+
+		It("unordered list item with predefined attribute", func() {
+			source := `* {amp}`
+			expected := types.Document{
+				Attributes:         types.DocumentAttributes{},
+				ElementReferences:  types.ElementReferences{},
+				Footnotes:          types.Footnotes{},
+				FootnoteReferences: types.FootnoteReferences{},
+				Elements: []interface{}{
+					types.UnorderedList{
+						Attributes: types.ElementAttributes{},
+						Items: []types.UnorderedListItem{
+							{
+								Level:       1,
+								BulletStyle: types.OneAsterisk,
+								CheckStyle:  types.NoCheck,
+								Attributes:  map[string]interface{}{},
+								Elements: []interface{}{
+									types.Paragraph{
+										Attributes: types.ElementAttributes{},
+										Lines: []types.InlineElements{
+											{
+												types.StringElement{Content: "&amp;"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(source).To(BecomeDocument(expected))
+		})
 	})
 
 	Context("invalid content", func() {
@@ -3036,13 +3070,7 @@ The {plus} symbol is on a new line.
 																			},
 																			{
 																				types.StringElement{
-																					Content: "This is a new line inside an unordered list using ",
-																				},
-																				types.DocumentAttributeSubstitution{
-																					Name: "plus",
-																				},
-																				types.StringElement{
-																					Content: " symbol.",
+																					Content: "This is a new line inside an unordered list using &#43; symbol.",
 																				},
 																			},
 																			{
@@ -3083,13 +3111,7 @@ The {plus} symbol is on a new line.
 																						Lines: []types.InlineElements{
 																							{
 																								types.StringElement{
-																									Content: "The ",
-																								},
-																								types.DocumentAttributeSubstitution{
-																									Name: "plus",
-																								},
-																								types.StringElement{
-																									Content: " symbol is on a new line.",
+																									Content: "The &#43; symbol is on a new line.",
 																								},
 																							},
 																						},

--- a/pkg/renderer/html5/delimited_block.go
+++ b/pkg/renderer/html5/delimited_block.go
@@ -2,7 +2,6 @@ package html5
 
 import (
 	"bytes"
-	"html"
 	"strconv"
 	texttemplate "text/template"
 
@@ -31,7 +30,7 @@ func init() {
 </div>{{ end }}`,
 		texttemplate.FuncMap{
 			"renderPlainString": renderPlainString,
-			"escape":            html.EscapeString,
+			"escape":            EscapeString,
 		})
 
 	listingBlockTmpl = newTextTemplate("listing block", `{{ $ctx := .Context }}{{ with .Data }}<div {{ if .ID }}id="{{ .ID }}" {{ end }}class="listingblock">{{ if .Title }}
@@ -42,7 +41,7 @@ func init() {
 </div>{{ end }}`,
 		texttemplate.FuncMap{
 			"renderPlainString": renderPlainString,
-			"escape":            html.EscapeString,
+			"escape":            EscapeString,
 		})
 
 	sourceBlockTmpl = newTextTemplate("source block",
@@ -54,7 +53,7 @@ func init() {
 </div>{{ end }}`,
 		texttemplate.FuncMap{
 			"renderPlainString": renderPlainString,
-			"escape":            html.EscapeString,
+			"escape":            EscapeString,
 		})
 
 	exampleBlockTmpl = newTextTemplate("example block", `{{ $ctx := .Context }}{{ with .Data }}<div {{ if .ID }}id="{{ .ID }}" {{ end }}class="exampleblock">{{ if .Title }}
@@ -65,7 +64,7 @@ func init() {
 </div>{{ end }}`,
 		texttemplate.FuncMap{
 			"renderElements": renderElements,
-			"escape":         html.EscapeString,
+			"escape":         EscapeString,
 		})
 
 	quoteBlockTmpl = newTextTemplate("quote block", `{{ $ctx := .Context }}{{ with .Data }}<div {{ if .ID }}id="{{ .ID }}" {{ end }}class="quoteblock">{{ if .Title }}
@@ -80,7 +79,7 @@ func init() {
 </div>{{ end }}`,
 		texttemplate.FuncMap{
 			"renderElements": renderElements,
-			"escape":         html.EscapeString,
+			"escape":         EscapeString,
 		})
 
 	verseBlockTmpl = newTextTemplate("verse block", `{{ $ctx := .Context }}{{ with .Data }}<div {{ if .ID }}id="{{ .ID }}" {{ end }}class="verseblock">{{ if .Title }}
@@ -93,7 +92,7 @@ func init() {
 </div>{{ end }}`,
 		texttemplate.FuncMap{
 			"renderElements": renderElements,
-			"escape":         html.EscapeString,
+			"escape":         EscapeString,
 		})
 
 	admonitionBlockTmpl = newTextTemplate("admonition block", `{{ $ctx := .Context }}{{ with .Data }}<div {{ if .ID }}id="{{ .ID}}" {{ end }}class="admonitionblock {{ .Class }}">
@@ -111,7 +110,7 @@ func init() {
 </div>{{ end }}`,
 		texttemplate.FuncMap{
 			"renderElements": renderElements,
-			"escape":         html.EscapeString,
+			"escape":         EscapeString,
 		})
 
 	sidebarBlockTmpl = newTextTemplate("sidebar block", `{{ $ctx := .Context }}{{ with .Data }}<div {{ if .ID }}id="{{ .ID }}" {{ end }}class="sidebarblock">
@@ -122,7 +121,7 @@ func init() {
 </div>{{ end }}`,
 		texttemplate.FuncMap{
 			"renderElements": renderElements,
-			"escape":         html.EscapeString,
+			"escape":         EscapeString,
 		})
 }
 

--- a/pkg/renderer/html5/document.go
+++ b/pkg/renderer/html5/document.go
@@ -2,7 +2,6 @@ package html5
 
 import (
 	"bytes"
-	"html"
 	htmltemplate "html/template"
 	"io"
 	texttemplate "text/template"
@@ -44,7 +43,7 @@ Last updated {{ .LastUpdated }}
 </body>
 </html>`,
 		texttemplate.FuncMap{
-			"escape": html.EscapeString,
+			"escape": EscapeString,
 		})
 
 }

--- a/pkg/renderer/html5/document_attribute_substitution.go
+++ b/pkg/renderer/html5/document_attribute_substitution.go
@@ -1,8 +1,6 @@
 package html5
 
 import (
-	"bytes"
-
 	"github.com/bytesparadise/libasciidoc/pkg/renderer"
 	"github.com/bytesparadise/libasciidoc/pkg/types"
 )
@@ -15,14 +13,4 @@ func processAttributeDeclaration(ctx *renderer.Context, attr types.DocumentAttri
 func processAttributeReset(ctx *renderer.Context, attr types.DocumentAttributeReset) []byte {
 	ctx.Document.Attributes.Reset(attr)
 	return []byte{}
-}
-
-func renderAttributeSubstitution(ctx *renderer.Context, attr types.DocumentAttributeSubstitution) []byte {
-	result := bytes.NewBuffer(nil)
-	if value, found := ctx.Document.Attributes.GetAsString(attr.Name); found {
-		result.WriteString(value)
-	} else {
-		result.WriteString("{" + attr.Name + "}")
-	}
-	return result.Bytes()
 }

--- a/pkg/renderer/html5/document_attribute_substitution.go
+++ b/pkg/renderer/html5/document_attribute_substitution.go
@@ -21,8 +21,6 @@ func renderAttributeSubstitution(ctx *renderer.Context, attr types.DocumentAttri
 	result := bytes.NewBuffer(nil)
 	if value, found := ctx.Document.Attributes.GetAsString(attr.Name); found {
 		result.WriteString(value)
-	} else if value, found := predefined.GetAsString(attr.Name); found {
-		result.WriteString(value)
 	} else {
 		result.WriteString("{" + attr.Name + "}")
 	}

--- a/pkg/renderer/html5/file_inclusion_test.go
+++ b/pkg/renderer/html5/file_inclusion_test.go
@@ -912,7 +912,7 @@ last line of grandchild</pre>
 
 				source := `include::../../../test/includes/unknown.adoc[leveloffset=+1]`
 				expected := `<div class="paragraph">
-<p>Unresolved directive in test.adoc - include::../../../test/includes/unknown.adoc[leveloffset=&#43;1]</p>
+<p>Unresolved directive in test.adoc - include::../../../test/includes/unknown.adoc[leveloffset=+1]</p>
 </div>`
 				Expect(source).To(RenderHTML5Body(expected))
 				// verify error in logs
@@ -930,7 +930,7 @@ last line of grandchild</pre>
 
 				source := `include::{includedir}/unknown.adoc[leveloffset=+1]`
 				expected := `<div class="paragraph">
-<p>Unresolved directive in test.adoc - include::{includedir}/unknown.adoc[leveloffset=&#43;1]</p>
+<p>Unresolved directive in test.adoc - include::{includedir}/unknown.adoc[leveloffset=+1]</p>
 </div>`
 				Expect(source).To(RenderHTML5Body(expected))
 				// verify error in logs

--- a/pkg/renderer/html5/html5.go
+++ b/pkg/renderer/html5/html5.go
@@ -156,7 +156,7 @@ func renderPlainString(ctx *renderer.Context, element interface{}) ([]byte, erro
 		if alt, ok := element.Attributes[types.AttrInlineLinkText].(types.InlineElements); ok {
 			return renderPlainString(ctx, alt)
 		}
-		return []byte(element.Location.Resolve(ctx.Document.Attributes)), nil
+		return []byte(element.Location.String()), nil
 	case types.BlankLine:
 		return []byte("\n\n"), nil
 	case types.StringElement:

--- a/pkg/renderer/html5/html5.go
+++ b/pkg/renderer/html5/html5.go
@@ -131,8 +131,6 @@ func renderElement(ctx *renderer.Context, element interface{}) ([]byte, error) {
 		return processAttributeDeclaration(ctx, e), nil
 	case types.DocumentAttributeReset:
 		return processAttributeReset(ctx, e), nil
-	case types.DocumentAttributeSubstitution:
-		return renderAttributeSubstitution(ctx, e), nil
 	case types.LineBreak:
 		return renderLineBreak()
 	case types.UserMacro:

--- a/pkg/renderer/html5/html_escape.go
+++ b/pkg/renderer/html5/html_escape.go
@@ -1,0 +1,24 @@
+package html5
+
+import (
+	"strings"
+)
+
+// EscapeString uses the stdlib html5.Escape func except but bypasses
+// a few replacements which
+func EscapeString(s string) string {
+	return htmlEscaper.Replace(s)
+}
+
+var htmlEscaper = strings.NewReplacer(
+	`&lt;`, "&lt;", // keep as-is (we do not want `&amp;lt;`)
+	`&gt;`, "&gt;", // keep `&lgt;` as-is (we do not want `&amp;gt;`)
+	`&amp;`, "&amp;", // keep `&amps` as-is (we do not want `&amp;amp;`)
+	`&#`, "&#", // assume this is for an character entity and this keep as-is
+	// standard escape combinations
+	`&`, "&amp;",
+	`'`, "&#39;", // "&#39;" is shorter than "&apos;" and apos was not in HTML until HTML5.
+	`<`, "&lt;",
+	`>`, "&gt;",
+	`"`, "&#34;", // "&#34;" is shorter than "&quot;".
+)

--- a/pkg/renderer/html5/image.go
+++ b/pkg/renderer/html5/image.go
@@ -3,7 +3,6 @@ package html5
 import (
 	"bytes"
 	"fmt"
-	"html"
 	"net/url"
 	"path/filepath"
 	texttemplate "text/template"
@@ -26,11 +25,11 @@ func init() {
 {{ else }}
 {{ end }}</div>`,
 		texttemplate.FuncMap{
-			"escape": html.EscapeString,
+			"escape": EscapeString,
 		})
 	inlineImageTmpl = newTextTemplate("inline image", `<span class="image{{ if .Role }} {{ .Role }}{{ end }}"><img src="{{ .Path }}" alt="{{ .Alt }}"{{ if .Width }} width="{{ .Width }}"{{ end }}{{ if .Height }} height="{{ .Height }}"{{ end }}{{ if .Title }} title="{{ escape .Title }}"{{ end }}></span>`,
 		texttemplate.FuncMap{
-			"escape": html.EscapeString,
+			"escape": EscapeString,
 		})
 }
 
@@ -38,7 +37,7 @@ func renderImageBlock(ctx *renderer.Context, img types.ImageBlock) ([]byte, erro
 	result := bytes.NewBuffer(nil)
 	title := ""
 	if t := img.Attributes.GetAsString(types.AttrTitle); t != "" {
-		title = fmt.Sprintf("Figure %d. %s", ctx.GetAndIncrementImageCounter(), html.EscapeString(t))
+		title = fmt.Sprintf("Figure %d. %s", ctx.GetAndIncrementImageCounter(), EscapeString(t))
 	}
 	err := blockImageTmpl.Execute(result, struct {
 		ID     string
@@ -57,7 +56,7 @@ func renderImageBlock(ctx *renderer.Context, img types.ImageBlock) ([]byte, erro
 		Alt:    img.Attributes.GetAsString(types.AttrImageAlt),
 		Width:  img.Attributes.GetAsString(types.AttrImageWidth),
 		Height: img.Attributes.GetAsString(types.AttrImageHeight),
-		Path:   getImageHref(ctx, img.Path),
+		Path:   getImageHref(ctx, img.Location.String()),
 	})
 
 	if err != nil {
@@ -83,7 +82,7 @@ func renderInlineImage(ctx *renderer.Context, img types.InlineImage) ([]byte, er
 		Alt:    img.Attributes.GetAsString(types.AttrImageAlt),
 		Width:  img.Attributes.GetAsString(types.AttrImageWidth),
 		Height: img.Attributes.GetAsString(types.AttrImageHeight),
-		Path:   getImageHref(ctx, img.Path),
+		Path:   getImageHref(ctx, img.Location.String()),
 	})
 
 	if err != nil {

--- a/pkg/renderer/html5/labeled_list.go
+++ b/pkg/renderer/html5/labeled_list.go
@@ -2,7 +2,6 @@ package html5
 
 import (
 	"bytes"
-	"html"
 	texttemplate "text/template"
 
 	"github.com/bytesparadise/libasciidoc/pkg/renderer"
@@ -28,7 +27,7 @@ func init() {
 </div>{{ end }}`,
 		texttemplate.FuncMap{
 			"renderElements": renderListElements,
-			"escape":         html.EscapeString,
+			"escape":         EscapeString,
 		})
 
 	horizontalLabeledListTmpl = newTextTemplate("labeled list with horizontal layout",
@@ -51,7 +50,7 @@ func init() {
 		texttemplate.FuncMap{
 			"renderElements": renderListElements,
 			"includeNewline": includeNewline,
-			"escape":         html.EscapeString,
+			"escape":         EscapeString,
 		})
 
 	qandaLabeledListTmpl = newTextTemplate("qanda labeled list",
@@ -66,7 +65,7 @@ func init() {
 </div>{{ end }}`,
 		texttemplate.FuncMap{
 			"renderElements": renderListElements,
-			"escape":         html.EscapeString,
+			"escape":         EscapeString,
 		})
 
 }

--- a/pkg/renderer/html5/link.go
+++ b/pkg/renderer/html5/link.go
@@ -19,7 +19,7 @@ func init() {
 
 func renderLink(ctx *renderer.Context, l types.InlineLink) ([]byte, error) { //nolint: unparam
 	result := bytes.NewBuffer(nil)
-	location := l.Location.Resolve(ctx.Document.Attributes)
+	location := l.Location.String()
 	var text []byte
 	class := ""
 	var err error

--- a/pkg/renderer/html5/literal_blocks.go
+++ b/pkg/renderer/html5/literal_blocks.go
@@ -2,7 +2,6 @@ package html5
 
 import (
 	"bytes"
-	"html"
 	"math"
 	"strings"
 	texttemplate "text/template"
@@ -24,7 +23,7 @@ func init() {
 </div>
 </div>{{ end }}`, texttemplate.FuncMap{
 		"includeNewline": includeNewline,
-		"escape":         html.EscapeString,
+		"escape":         EscapeString,
 	})
 }
 

--- a/pkg/renderer/html5/ordered_list.go
+++ b/pkg/renderer/html5/ordered_list.go
@@ -2,7 +2,6 @@ package html5
 
 import (
 	"bytes"
-	"html"
 	texttemplate "text/template"
 
 	"github.com/bytesparadise/libasciidoc/pkg/renderer"
@@ -26,7 +25,7 @@ func init() {
 		texttemplate.FuncMap{
 			"renderElements": renderListElements,
 			"style":          numberingType,
-			"escape":         html.EscapeString,
+			"escape":         EscapeString,
 		})
 
 }

--- a/pkg/renderer/html5/paragraph.go
+++ b/pkg/renderer/html5/paragraph.go
@@ -2,7 +2,6 @@ package html5
 
 import (
 	"bytes"
-	"html"
 	"strings"
 	texttemplate "text/template"
 
@@ -28,7 +27,7 @@ func init() {
 </div>{{ end }}{{ end }}`,
 		texttemplate.FuncMap{
 			"renderLines": renderLinesAsString,
-			"escape":      html.EscapeString,
+			"escape":      EscapeString,
 		})
 
 	admonitionParagraphTmpl = newTextTemplate("admonition paragraph",
@@ -47,7 +46,7 @@ func init() {
 </div>{{ end }}{{ end }}`,
 		texttemplate.FuncMap{
 			"renderLines": renderLinesAsString,
-			"escape":      html.EscapeString,
+			"escape":      EscapeString,
 		})
 
 	listParagraphTmpl = newTextTemplate("list paragraph",
@@ -64,7 +63,7 @@ func init() {
 </div>{{ end }}`,
 		texttemplate.FuncMap{
 			"renderLines": renderPlainString,
-			"escape":      html.EscapeString,
+			"escape":      EscapeString,
 		})
 
 	verseParagraphTmpl = newTextTemplate("verse block", `{{ $ctx := .Context }}{{ with .Data }}<div {{ if .ID }}id="{{ .ID }}" {{ end }}class="verseblock">{{ if .Title }}
@@ -77,7 +76,7 @@ func init() {
 </div>{{ end }}`,
 		texttemplate.FuncMap{
 			"renderElements": renderPlainString,
-			"escape":         html.EscapeString,
+			"escape":         EscapeString,
 		})
 	quoteParagraphTmpl = newTextTemplate("quote paragraph", `{{ $ctx := .Context }}{{ with .Data }}<div {{ if .ID }}id="{{ .ID }}" {{ end }}class="quoteblock">{{ if .Title }}
 <div class="title">{{ escape .Title }}</div>{{ end }}
@@ -91,7 +90,7 @@ func init() {
 </div>{{ end }}`,
 		texttemplate.FuncMap{
 			"renderElements": renderLinesAsString,
-			"escape":         html.EscapeString,
+			"escape":         EscapeString,
 		})
 }
 

--- a/pkg/renderer/html5/paragraph_test.go
+++ b/pkg/renderer/html5/paragraph_test.go
@@ -107,6 +107,18 @@ baz</p>
 </div>`
 			Expect(source).To(RenderHTML5Body(expected))
 		})
+
+		It("paragraph with document attribute resets", func() {
+			source := `:author: Xavier
+						
+:!author1:
+:author2!:
+a paragraph written by {author}.`
+			expected := `<div class="paragraph">
+<p>a paragraph written by Xavier.</p>
+</div>`
+			Expect(source).To(RenderHTML5Body(expected))
+		})
 	})
 
 	Context("admonition paragraphs", func() {

--- a/pkg/renderer/html5/passthrough_test.go
+++ b/pkg/renderer/html5/passthrough_test.go
@@ -47,7 +47,7 @@ var _ = Describe("passthroughs", func() {
 		It("an empty standalone singleplus passthrough", func() {
 			source := `++`
 			expected := `<div class="paragraph">
-<p>&#43;&#43;</p>
+<p>++</p>
 </div>`
 			Expect(source).To(RenderHTML5Body(expected))
 		})
@@ -55,7 +55,7 @@ var _ = Describe("passthroughs", func() {
 		It("an empty singleplus passthrough in a paragraph", func() {
 			source := `++ with more content afterwards...`
 			expected := `<div class="paragraph">
-<p>&#43;&#43; with more content afterwards&#8230;&#8203;</p>
+<p>++ with more content afterwards&#8230;&#8203;</p>
 </div>`
 			Expect(source).To(RenderHTML5Body(expected))
 		})
@@ -79,7 +79,7 @@ var _ = Describe("passthroughs", func() {
 		It("invalid singleplus passthrough in paragraph", func() {
 			source := `The text + *hello*, world + is not passed through.`
 			expected := `<div class="paragraph">
-<p>The text &#43; <strong>hello</strong>, world &#43; is not passed through.</p>
+<p>The text + <strong>hello</strong>, world + is not passed through.</p>
 </div>`
 			Expect(source).To(RenderHTML5Body(expected))
 		})

--- a/pkg/renderer/html5/string.go
+++ b/pkg/renderer/html5/string.go
@@ -3,13 +3,17 @@ package html5
 import (
 	"bytes"
 	"strings"
+	texttemplate "text/template"
 
 	"github.com/bytesparadise/libasciidoc/pkg/renderer"
 	"github.com/bytesparadise/libasciidoc/pkg/types"
 	"github.com/pkg/errors"
 )
 
-var stringTmpl = newHTMLTemplate("string element", "{{ . }}")
+var stringTmpl = newTextTemplate("string element", "{{ escape . }}",
+	texttemplate.FuncMap{
+		"escape": EscapeString,
+	})
 
 func renderStringElement(ctx *renderer.Context, str types.StringElement) ([]byte, error) { //nolint: unparam
 	buf := bytes.NewBuffer(nil)

--- a/pkg/renderer/html5/table.go
+++ b/pkg/renderer/html5/table.go
@@ -3,7 +3,6 @@ package html5
 import (
 	"bytes"
 	"fmt"
-	"html"
 	"math"
 	"strconv"
 	texttemplate "text/template"
@@ -36,7 +35,7 @@ func init() {
 		texttemplate.FuncMap{
 			"renderElement":  renderElement,
 			"includeNewline": includeNewline,
-			"escape":         html.EscapeString,
+			"escape":         EscapeString,
 		})
 }
 
@@ -62,7 +61,7 @@ func renderTable(ctx *renderer.Context, t types.Table) ([]byte, error) {
 	}
 	var title string
 	if titleAttr, ok := t.Attributes[types.AttrTitle].(string); ok {
-		title = fmt.Sprintf("Table %d. %s", ctx.GetAndIncrementTableCounter(), html.EscapeString(titleAttr))
+		title = fmt.Sprintf("Table %d. %s", ctx.GetAndIncrementTableCounter(), EscapeString(titleAttr))
 	}
 	err := tableTmpl.Execute(result, ContextualPipeline{
 		Context: ctx,

--- a/pkg/renderer/html5/template_utils.go
+++ b/pkg/renderer/html5/template_utils.go
@@ -1,23 +1,10 @@
 package html5
 
 import (
-	htmltemplate "html/template"
 	texttemplate "text/template"
 
 	log "github.com/sirupsen/logrus"
 )
-
-func newHTMLTemplate(name, src string, funcs ...htmltemplate.FuncMap) htmltemplate.Template {
-	t := htmltemplate.New(name)
-	for _, f := range funcs {
-		t.Funcs(f)
-	}
-	t, err := t.Parse(src)
-	if err != nil {
-		log.Fatalf("failed to initialize '%s' template: %s", name, err.Error())
-	}
-	return *t
-}
 
 func newTextTemplate(name, src string, funcs ...texttemplate.FuncMap) texttemplate.Template {
 	t := texttemplate.New(name)

--- a/pkg/renderer/html5/unordered_list.go
+++ b/pkg/renderer/html5/unordered_list.go
@@ -2,7 +2,6 @@ package html5
 
 import (
 	"bytes"
-	"html"
 	texttemplate "text/template"
 
 	"github.com/bytesparadise/libasciidoc/pkg/renderer"
@@ -25,7 +24,7 @@ func init() {
 </div>{{ end }}`,
 		texttemplate.FuncMap{
 			"renderElements": renderListElements,
-			"escape":         html.EscapeString,
+			"escape":         EscapeString,
 		})
 }
 

--- a/pkg/renderer/html5/user_macro_test.go
+++ b/pkg/renderer/html5/user_macro_test.go
@@ -1,10 +1,10 @@
 package html5_test
 
 import (
-	"html"
 	texttemplate "text/template"
 
 	"github.com/bytesparadise/libasciidoc/pkg/renderer"
+	"github.com/bytesparadise/libasciidoc/pkg/renderer/html5"
 	. "github.com/bytesparadise/libasciidoc/testsupport"
 
 	. "github.com/onsi/ginkgo"
@@ -121,7 +121,7 @@ var _ = Describe("user macros", func() {
 func init() {
 	t := texttemplate.New("hello")
 	t.Funcs(texttemplate.FuncMap{
-		"escape": html.EscapeString,
+		"escape": html5.EscapeString,
 	})
 	helloMacroTmpl = texttemplate.Must(t.Parse(`{{- if eq .Kind "block" -}}
 <div class="helloblock">

--- a/pkg/types/non_alphanumeric_replacement_test.go
+++ b/pkg/types/non_alphanumeric_replacement_test.go
@@ -58,4 +58,22 @@ var _ = Describe("normalizing string", func() {
 		}
 		Expect(source).To(EqualWithoutNonAlphanumeric("a_section_title_with_bold_content"))
 	})
+
+	It("content with link", func() {
+		// == a section title, with *bold content*
+		source := types.InlineElements{
+			types.StringElement{Content: "link to "},
+			types.InlineLink{
+				Attributes: types.ElementAttributes{},
+				Location: types.Location{
+					Elements: []interface{}{
+						types.StringElement{
+							Content: "https://foo.bar",
+						},
+					},
+				},
+			},
+		}
+		Expect(source).To(EqualWithoutNonAlphanumeric("link_to_https_foo_bar")) // asciidoctor will return `_link_to_https_foo_bar`
+	})
 })

--- a/pkg/types/types_test.go
+++ b/pkg/types/types_test.go
@@ -468,141 +468,87 @@ var _ = Describe("tag ranges", func() {
 
 })
 
-var _ = Describe("Location resolution", func() {
+var _ = Describe("location resolution", func() {
 
-	attrs := types.DocumentAttributes{
+	attrs := map[string]string{
 		"includedir": "includes",
 		"foo":        "bar",
 	}
 	DescribeTable("resolve URL",
-		func(location types.Location, expectation string) {
-			f := types.FileInclusion{
-				Location: location,
-			}
-			Expect(f.Location.Resolve(attrs)).To(Equal(expectation))
+		func(actual types.Location, expectation types.Location) {
+			actual.Resolve(attrs)
+			Expect(actual).To(Equal(expectation))
 		},
-		Entry("includes/file.ext", types.Location{
-			types.StringElement{Content: "includes/file.ext"},
-		}, "includes/file.ext"),
-		Entry("./{includedir}/file.ext", types.Location{
-			types.StringElement{Content: "./"},
-			types.DocumentAttributeSubstitution{Name: "includedir"},
-			types.StringElement{Content: "/file.ext"},
-		}, "./includes/file.ext"),
-		Entry("./{unknown}/file.ext", types.Location{
-			types.StringElement{Content: "./"},
-			types.DocumentAttributeSubstitution{Name: "unknown"},
-			types.StringElement{Content: "/file.ext"},
-		}, "./{unknown}/file.ext"),
+		Entry("includes/file.ext",
+			types.Location{
+				Elements: []interface{}{
+					types.StringElement{
+						Content: "includes/file.ext",
+					},
+				},
+			},
+			types.Location{
+				Elements: []interface{}{
+					types.StringElement{
+						Content: "includes/file.ext",
+					},
+				},
+			}),
+		Entry("./{includedir}/file.ext",
+			types.Location{
+				Elements: []interface{}{
+					types.StringElement{
+						Content: "./",
+					},
+					types.DocumentAttributeSubstitution{
+						Name: "includedir",
+					},
+					types.StringElement{
+						Content: "/file.ext",
+					},
+				},
+			},
+			types.Location{
+				Elements: []interface{}{
+					types.StringElement{
+						Content: "./",
+					},
+					types.DocumentAttributeSubstitution{
+						Name: "includedir",
+					},
+					types.StringElement{
+						Content: "/file.ext",
+					},
+				},
+			},
+		),
+		Entry("./{unknown}/file.ext",
+			types.Location{
+				Elements: []interface{}{
+					types.StringElement{
+						Content: "./",
+					},
+					types.DocumentAttributeSubstitution{
+						Name: "unknown",
+					},
+					types.StringElement{
+						Content: "/file.ext",
+					},
+				},
+			},
+			types.Location{
+				Elements: []interface{}{
+					types.StringElement{
+						Content: "./",
+					},
+					types.DocumentAttributeSubstitution{
+						Name: "unknown",
+					},
+					types.StringElement{
+						Content: "/file.ext",
+					},
+				},
+			},
+		),
 	)
-})
-
-var _ = Describe("InlineElements", func() {
-
-	Context("attribute subsititutions", func() {
-
-		It("should replace with new StringElement on first position", func() {
-			// given
-			e := types.InlineElements{
-				types.DocumentAttributeSubstitution{
-					Name: "foo",
-				},
-				types.StringElement{
-					Content: " and more content.",
-				},
-			}
-			// when
-			result, found := e.ApplyDocumentAttributeSubstitutions(map[string]string{
-				"foo": "bar",
-			})
-			// then
-			Expect(result).To(Equal(types.InlineElements{
-				types.StringElement{
-					Content: "bar and more content.",
-				},
-			}))
-			Expect(found).To(BeTrue())
-		})
-
-		It("should replace with new StringElement on middle position", func() {
-			// given
-			e := types.InlineElements{
-				types.StringElement{
-					Content: "baz, ",
-				},
-				types.DocumentAttributeSubstitution{
-					Name: "foo",
-				},
-				types.StringElement{
-					Content: " and more content.",
-				},
-			}
-			// when
-			result, found := e.ApplyDocumentAttributeSubstitutions(map[string]string{
-				"foo": "bar",
-			})
-			// then
-			Expect(result).To(Equal(types.InlineElements{
-				types.StringElement{
-					Content: "baz, bar and more content.",
-				},
-			}))
-			Expect(found).To(BeTrue())
-		})
-
-		It("should replace with undefined attribute", func() {
-			// given
-			e := types.InlineElements{
-				types.StringElement{
-					Content: "baz, ",
-				},
-				types.DocumentAttributeSubstitution{
-					Name: "foo",
-				},
-				types.StringElement{
-					Content: " and more content.",
-				},
-			}
-			// when
-			result, found := e.ApplyDocumentAttributeSubstitutions(map[string]string{})
-			// then
-			Expect(result).To(Equal(types.InlineElements{
-				types.StringElement{
-					Content: "baz, {foo} and more content.",
-				},
-			}))
-			Expect(found).To(BeTrue())
-		})
-
-		It("should remain unchanged without substitution", func() {
-			// given
-			e := types.InlineElements{
-				types.StringElement{
-					Content: "baz, ",
-				},
-				types.StringElement{
-					Content: "foo",
-				},
-				types.StringElement{
-					Content: " and more content.",
-				},
-			}
-			// when
-			result, found := e.ApplyDocumentAttributeSubstitutions(map[string]string{})
-			// then
-			Expect(result).To(Equal(types.InlineElements{
-				types.StringElement{
-					Content: "baz, ",
-				},
-				types.StringElement{
-					Content: "foo",
-				},
-				types.StringElement{
-					Content: " and more content.",
-				},
-			}))
-			Expect(found).To(BeFalse())
-		})
-
-	})
 })

--- a/pkg/types/types_utils.go
+++ b/pkg/types/types_utils.go
@@ -68,10 +68,8 @@ func NilSafe(elements []interface{}) []interface{} {
 	return make([]interface{}, 0)
 }
 
-// removeEmptyTrailingStringElement removes the last
-// func removeEmptyTrailingStringElement([]interface{}) []interface{}
-
-func mergeElements(elements ...interface{}) InlineElements {
+// MergeStringElements merge string elements together
+func MergeStringElements(elements ...interface{}) InlineElements {
 	result := make([]interface{}, 0)
 	buff := bytes.NewBuffer(nil)
 	for _, element := range elements {
@@ -93,9 +91,9 @@ func mergeElements(elements ...interface{}) InlineElements {
 			buff.WriteString(content)
 		case []interface{}:
 			if len(element) > 0 {
-				f := mergeElements(element...)
+				f := MergeStringElements(element...)
 				result, buff = appendBuffer(result, buff)
-				result = mergeElements(append(result, f...)...)
+				result = MergeStringElements(append(result, f...)...)
 			}
 		default:
 			// log.Debugf("Merging with 'default' case an element of type %[1]T", element)

--- a/pkg/types/types_utils_test.go
+++ b/pkg/types/types_utils_test.go
@@ -16,7 +16,7 @@ var _ = Describe("convert to inline elements", func() {
 			StringElement{Content: "helloworld"},
 		}
 		// when
-		result := mergeElements(source...)
+		result := MergeStringElements(source...)
 		// then
 		Expect(result).To(Equal(expected))
 	})
@@ -29,7 +29,7 @@ var _ = Describe("convert to inline elements", func() {
 			StringElement{Content: "hello, world   "},
 		}
 		// when
-		result := mergeElements(source...)
+		result := MergeStringElements(source...)
 		// then
 		Expect(result).To(Equal(expected))
 	})

--- a/testsupport/draft_document_matcher.go
+++ b/testsupport/draft_document_matcher.go
@@ -5,13 +5,14 @@ import (
 	"strings"
 
 	"github.com/bytesparadise/libasciidoc/pkg/parser"
+	"github.com/bytesparadise/libasciidoc/pkg/types"
 
-	"github.com/onsi/gomega/types"
+	gomegatypes "github.com/onsi/gomega/types"
 	"github.com/pkg/errors"
 )
 
 // BecomeDraftDocument a custom matcher to verify that a draft document matches the expectation
-func BecomeDraftDocument(expected interface{}, options ...interface{}) types.GomegaMatcher {
+func BecomeDraftDocument(expected types.DraftDocument, options ...interface{}) gomegatypes.GomegaMatcher {
 	m := &draftDocumentMatcher{
 		expected:      expected,
 		preprocessing: true,

--- a/testsupport/draft_document_matcher_test.go
+++ b/testsupport/draft_document_matcher_test.go
@@ -68,15 +68,6 @@ var _ = Describe("draft document assertions", func() {
 			Expect(matcher.NegatedFailureMessage(actual)).To(Equal(fmt.Sprintf("expected draft documents not to match:\n%s", compare(obtained, expected))))
 		})
 
-		It("should return error when invalid type is input", func() {
-			// given
-			matcher := testsupport.BecomeDraftDocument("", testsupport.WithoutPreprocessing())
-			// when
-			_, err := matcher.Match(1) // not a string
-			// then
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("BecomeDocumentBlock matcher expects a string (actual: int)"))
-		})
 	})
 
 	Context("without preprocessing", func() {


### PR DESCRIPTION
refactored the code to process the document attributes
while building the final document, so there should be
no more document attribute substitution during the
rendering. The 'DocumentAttributeSubstitution' (and siblings)
still exist in the `DraftDocument`, though.

also, renamed some `Path` to `Location` fields

fixes #350

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>