### PR TITLE
feat(parser): include document attribute when processing section 0

### DIFF
--- a/pkg/parser/document_preprocessing.go
+++ b/pkg/parser/document_preprocessing.go
@@ -4,6 +4,7 @@ import (
 	"io"
 
 	"github.com/bytesparadise/libasciidoc/pkg/types"
+	"github.com/davecgh/go-spew/spew"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -32,6 +33,10 @@ func parseDraftDocument(filename string, r io.Reader, levelOffsets []levelOffset
 		return types.DraftDocument{}, err
 	}
 	doc.Blocks = blocks
+	if log.IsLevelEnabled(log.DebugLevel) {
+		log.Debug("draf document:")
+		spew.Dump(doc)
+	}
 	return doc, nil
 }
 

--- a/pkg/parser/document_processing.go
+++ b/pkg/parser/document_processing.go
@@ -26,12 +26,21 @@ func ParseDocument(filename string, r io.Reader, opts ...Option) (types.Document
 		}
 	}
 
-	// also, add all front-matter values
+	// also, add all front-matter key/values
 	for k, v := range draftDoc.FrontMatter.Content {
 		if v, ok := v.(string); ok {
 			attrs[k] = v
 		}
 	}
+
+	// also, add all DocumentAttributeDeclaration at the top of the document
+	documentAttributes := draftDoc.DocumentAttributes()
+	for k, v := range documentAttributes {
+		if v, ok := v.(string); ok {
+			attrs[k] = v
+		}
+	}
+
 	// apply document attribute substitutions and re-parse paragraphs that were affected
 	blocks, err := ApplyDocumentAttributeSubstitutions(draftDoc.Blocks, attrs)
 	if err != nil {

--- a/pkg/parser/file_inclusion_test.go
+++ b/pkg/parser/file_inclusion_test.go
@@ -14,99 +14,93 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var _ = Describe("file location", func() {
-
-	DescribeTable("'FileLocation' pattern",
-		func(filename string, expected interface{}) {
-			reader := strings.NewReader(filename)
-			actual, err := parser.ParseReader(filename, reader, parser.Entrypoint("FileLocation"))
-			Expect(err).ToNot(HaveOccurred())
-			GinkgoT().Log("actual result: %s", spew.Sdump(actual))
-			GinkgoT().Log("expected result: %s", spew.Sdump(expected))
-			Expect(actual).To(Equal(expected))
+var _ = DescribeTable("'FileLocation' pattern",
+	func(filename string, expected interface{}) {
+		reader := strings.NewReader(filename)
+		actual, err := parser.ParseReader(filename, reader, parser.Entrypoint("FileLocation"))
+		Expect(err).ToNot(HaveOccurred())
+		GinkgoT().Log("actual result: %s", spew.Sdump(actual))
+		GinkgoT().Log("expected result: %s", spew.Sdump(expected))
+		Expect(actual).To(Equal(expected))
+	},
+	Entry("'chapter'", "chapter", types.Location{
+		Elements: []interface{}{
+			types.StringElement{
+				Content: "chapter",
+			},
 		},
-		Entry("'chapter'", "chapter", types.Location{
-			Elements: []interface{}{
-				types.StringElement{
-					Content: "chapter",
-				},
+	}),
+	Entry("'chapter.adoc'", "chapter.adoc", types.Location{
+		Elements: []interface{}{
+			types.StringElement{
+				Content: "chapter.adoc",
 			},
-		}),
-		Entry("'chapter.adoc'", "chapter.adoc", types.Location{
-			Elements: []interface{}{
-				types.StringElement{
-					Content: "chapter.adoc",
-				},
-			},
-		}),
-		Entry("'chapter-a.adoc'", "chapter-a.adoc", types.Location{
-			Elements: []interface{}{
-				types.StringElement{
-					Content: "chapter-a.adoc",
-				},
-			},
-		}),
-		Entry("'chapter_a.adoc'", "chapter_a.adoc", types.Location{
-			Elements: []interface{}{
-				types.StringElement{
-					Content: "chapter_a.adoc",
-				},
-			},
-		}),
-		Entry("'../../test/includes/chapter_a.adoc'", "../../test/includes/chapter_a.adoc", types.Location{
-			Elements: []interface{}{
-				types.StringElement{
-					Content: "../../test/includes/chapter_a.adoc",
-				},
-			},
-		}),
-		Entry("'chapter-{foo}.adoc'", "chapter-{foo}.adoc", types.Location{
-			Elements: []interface{}{
-				types.StringElement{
-					Content: "chapter-",
-				},
-				types.DocumentAttributeSubstitution{
-					Name: "foo",
-				},
-				types.StringElement{
-					Content: ".adoc",
-				},
-			},
-		}),
-		Entry("'{includedir}/chapter-{foo}.adoc'", "{includedir}/chapter-{foo}.adoc", types.Location{
-			Elements: []interface{}{
-				types.DocumentAttributeSubstitution{
-					Name: "includedir",
-				},
-				types.StringElement{
-					Content: "/chapter-",
-				},
-				types.DocumentAttributeSubstitution{
-					Name: "foo",
-				},
-				types.StringElement{
-					Content: ".adoc",
-				},
-			},
-		}),
-	)
-})
-
-var _ = Describe("file inclusions", func() {
-
-	DescribeTable("check asciidoc file",
-		func(path string, expectation bool) {
-			Expect(parser.IsAsciidoc(path)).To(Equal(expectation))
 		},
-		Entry("foo.adoc", "foo.adoc", true),
-		Entry("foo.asc", "foo.asc", true),
-		Entry("foo.ad", "foo.ad", true),
-		Entry("foo.asciidoc", "foo.asciidoc", true),
-		Entry("foo.txt", "foo.txt", true),
-		Entry("foo.csv", "foo.csv", false),
-		Entry("foo.go", "foo.go", false),
-	)
-})
+	}),
+	Entry("'chapter-a.adoc'", "chapter-a.adoc", types.Location{
+		Elements: []interface{}{
+			types.StringElement{
+				Content: "chapter-a.adoc",
+			},
+		},
+	}),
+	Entry("'chapter_a.adoc'", "chapter_a.adoc", types.Location{
+		Elements: []interface{}{
+			types.StringElement{
+				Content: "chapter_a.adoc",
+			},
+		},
+	}),
+	Entry("'../../test/includes/chapter_a.adoc'", "../../test/includes/chapter_a.adoc", types.Location{
+		Elements: []interface{}{
+			types.StringElement{
+				Content: "../../test/includes/chapter_a.adoc",
+			},
+		},
+	}),
+	Entry("'chapter-{foo}.adoc'", "chapter-{foo}.adoc", types.Location{
+		Elements: []interface{}{
+			types.StringElement{
+				Content: "chapter-",
+			},
+			types.DocumentAttributeSubstitution{
+				Name: "foo",
+			},
+			types.StringElement{
+				Content: ".adoc",
+			},
+		},
+	}),
+	Entry("'{includedir}/chapter-{foo}.adoc'", "{includedir}/chapter-{foo}.adoc", types.Location{
+		Elements: []interface{}{
+			types.DocumentAttributeSubstitution{
+				Name: "includedir",
+			},
+			types.StringElement{
+				Content: "/chapter-",
+			},
+			types.DocumentAttributeSubstitution{
+				Name: "foo",
+			},
+			types.StringElement{
+				Content: ".adoc",
+			},
+		},
+	}),
+)
+
+var _ = DescribeTable("check asciidoc file",
+	func(path string, expectation bool) {
+		Expect(parser.IsAsciidoc(path)).To(Equal(expectation))
+	},
+	Entry("foo.adoc", "foo.adoc", true),
+	Entry("foo.asc", "foo.asc", true),
+	Entry("foo.ad", "foo.ad", true),
+	Entry("foo.asciidoc", "foo.asciidoc", true),
+	Entry("foo.txt", "foo.txt", true),
+	Entry("foo.csv", "foo.csv", false),
+	Entry("foo.go", "foo.go", false),
+)
 
 var _ = Describe("file inclusions - draft with preprocessing", func() {
 

--- a/pkg/parser/image_test.go
+++ b/pkg/parser/image_test.go
@@ -198,7 +198,6 @@ image::images/bar.png[]`
 								Elements: []interface{}{
 									types.StringElement{Content: "images/foo.png"},
 								},
-								// Resolved: "images/foo.png",
 							},
 						},
 					},
@@ -228,7 +227,6 @@ image::{imagesdir}/foo.png[]`
 								Elements: []interface{}{
 									types.StringElement{Content: "./path/to/images/foo.png"},
 								},
-								// Resolved: "./path/to/images/foo.png",
 							},
 						},
 					},
@@ -668,7 +666,6 @@ image::{imagesdir}/foo.png[]`
 											Elements: []interface{}{
 												types.StringElement{Content: "images/foo.png"},
 											},
-											// Resolved: "images/foo.png",
 										},
 									},
 								},
@@ -706,7 +703,6 @@ an image:{imagesdir}/foo.png[].`
 											Elements: []interface{}{
 												types.StringElement{Content: "./path/to/images/foo.png"},
 											},
-											// Resolved: "./path/to/images/foo.png",
 										},
 									},
 									types.StringElement{Content: "."},

--- a/pkg/parser/link_test.go
+++ b/pkg/parser/link_test.go
@@ -894,7 +894,6 @@ a link to {scheme}://{path}`
 														Content: "foo",
 													},
 												},
-												// Resolved: "foo",
 											},
 											Attributes: types.ElementAttributes{},
 										},
@@ -943,7 +942,6 @@ a link to {url}`
 													Content: "https://foo2.bar",
 												},
 											},
-											// Resolved: "https://foo2.bar",
 										},
 										Attributes: types.ElementAttributes{},
 									},
@@ -987,7 +985,6 @@ a link to {scheme}://{path} and https://foo.baz`
 													Content: "https://foo.bar",
 												},
 											},
-											// Resolved: "https://foo.bar",
 										},
 										Attributes: types.ElementAttributes{},
 									},
@@ -1000,7 +997,6 @@ a link to {scheme}://{path} and https://foo.baz`
 													Content: "https://foo.baz",
 												},
 											},
-											// Resolved: "https://foo.baz",
 										},
 									},
 								},
@@ -1052,7 +1048,6 @@ a link to {scheme}://{path} and https://foo.baz`
 													Name: "path", // no match while applying document attribute substitutions, so parsing gave a new document attribute substitution...
 												},
 											},
-											// Resolved: "https://{path}",
 										},
 									},
 									types.StringElement{Content: " and "},
@@ -1064,7 +1059,6 @@ a link to {scheme}://{path} and https://foo.baz`
 													Content: "https://foo.baz",
 												},
 											},
-											// Resolved: "https://foo.baz",
 										},
 									},
 								},
@@ -1075,61 +1069,65 @@ a link to {scheme}://{path} and https://foo.baz`
 				Expect(source).To(BecomeDocument(expected))
 			})
 
-			// see https://github.com/bytesparadise/libasciidoc/issues/447
-			// 			It("external link with document attribute in section 0 title", func() {
-			// 				source := `= a title to {scheme}://{path} and https://foo.baz
-			// :scheme: https
-			// :path: foo.bar`
+			It("external link with document attribute in section 0 title", func() {
+				source := `= a title to {scheme}://{path} and https://foo.baz
+:scheme: https
+:path: foo.bar`
 
-			// 				title := types.InlineElements{
-			// 					types.StringElement{Content: "a title to "},
-			// 					types.InlineLink{
-			// 						Attributes: types.ElementAttributes{},
-			// 						Location: types.Location{
-			// 							Elements: []interface{}{
-			// 								types.StringElement{
-			// 									Content: "https://foo.bar",
-			// 								},
-			// 							},
-			// 							// Resolved: "https://foo.bar",
-			// 						},
-			// 					},
-			// 					types.StringElement{Content: " and "},
-			// 					types.InlineLink{
-			// 						Attributes: types.ElementAttributes{},
-			// 						Location: types.Location{
-			// 							Elements: []interface{}{
-			// 								types.StringElement{
-			// 									Content: "https://foo.baz",
-			// 								},
-			// 							},
-			// 							// Resolved: "https://foo.baz",
-			// 						},
-			// 					},
-			// 				}
-			// 				expected := types.Document{
-			// 					Attributes: types.DocumentAttributes{
-
-			// 					},
-			// 					ElementReferences: types.ElementReferences{
-			// 						"a_title_to_https_foo_bar_and_https_foo_baz": title,
-			// 					},
-			// 					Footnotes:          types.Footnotes{},
-			// 					FootnoteReferences: types.FootnoteReferences{},
-			// 					Elements: []interface{}{
-			// 						types.Section{
-			// 							Level: 0,
-			// 							Attributes: types.ElementAttributes{
-			// 								types.AttrID:       "a_title_to_https_foo_bar_and_https_foo_baz",
-			// 								types.AttrCustomID: false,
-			// 							},
-			// 							Title:    title,
-			// 							Elements: []interface{}{},
-			// 						},
-			// 					},
-			// 				}
-			// 				Expect(source).To(BecomeDocument(expected))
-			// 			})
+				title := types.InlineElements{
+					types.StringElement{Content: "a title to "},
+					types.InlineLink{
+						Attributes: types.ElementAttributes{},
+						Location: types.Location{
+							Elements: []interface{}{
+								types.StringElement{
+									Content: "https://foo.bar",
+								},
+							},
+						},
+					},
+					types.StringElement{Content: " and "},
+					types.InlineLink{
+						Attributes: types.ElementAttributes{},
+						Location: types.Location{
+							Elements: []interface{}{
+								types.StringElement{
+									Content: "https://foo.baz",
+								},
+							},
+						},
+					},
+				}
+				expected := types.Document{
+					Attributes: types.DocumentAttributes{},
+					ElementReferences: types.ElementReferences{
+						"a_title_to_https_foo_bar_and_https_foo_baz": title,
+					},
+					Footnotes:          types.Footnotes{},
+					FootnoteReferences: types.FootnoteReferences{},
+					Elements: []interface{}{
+						types.Section{
+							Level: 0,
+							Attributes: types.ElementAttributes{
+								types.AttrID:       "a_title_to_https_foo_bar_and_https_foo_baz",
+								types.AttrCustomID: false,
+							},
+							Title: title,
+							Elements: []interface{}{
+								types.DocumentAttributeDeclaration{
+									Name:  "scheme",
+									Value: "https",
+								},
+								types.DocumentAttributeDeclaration{
+									Name:  "path",
+									Value: "foo.bar",
+								},
+							},
+						},
+					},
+				}
+				Expect(source).To(BecomeDocument(expected))
+			})
 
 			It("external link with document attribute in section 1 title", func() {
 				source := `:scheme: https

--- a/pkg/parser/predefined_attributes_test.go
+++ b/pkg/parser/predefined_attributes_test.go
@@ -3,45 +3,41 @@ package parser_test
 import (
 	"github.com/bytesparadise/libasciidoc/pkg/parser"
 
-	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("document with attributes", func() {
-
-	DescribeTable("predefined attributes",
-		func(code, rendered string) {
-			Expect(parser.Predefined[code]).To(Equal(rendered))
-		},
-		Entry("sp", "sp", " "),
-		Entry("blank", "blank", ""),
-		Entry("empty", "empty", ""),
-		Entry("nbsp", "nbsp", "&#160;"),
-		Entry("zwsp", "zwsp", "&#8203;"),
-		Entry("wj", "wj", "&#8288;"),
-		Entry("apos", "apos", "&#39;"),
-		Entry("quot", "quot", "&#34;"),
-		Entry("lsquo", "lsquo", "&#8216;"),
-		Entry("rsquo", "rsquo", "&#8217;"),
-		Entry("ldquo", "ldquo", "&#8220;"),
-		Entry("rdquo", "rdquo", "&#8221;"),
-		Entry("deg", "deg", "&#176;"),
-		Entry("plus", "plus", "&#43;"),
-		Entry("brvbar", "brvbar", "&#166;"),
-		Entry("vbar", "vbar", "|"),
-		Entry("amp", "amp", "&amp;"),
-		Entry("lt", "lt", "&lt;"),
-		Entry("gt", "gt", "&gt;"),
-		Entry("startsb", "startsb", "["),
-		Entry("endsb", "endsb", "]"),
-		Entry("caret", "caret", "^"),
-		Entry("asterisk", "asterisk", "*"),
-		Entry("tilde", "tilde", "~"),
-		Entry("backslash", "backslash", `\`),
-		Entry("backtick", "backtick", "`"),
-		Entry("two-colons", "two-colons", "::"),
-		Entry("two-semicolons", "two-semicolons", ";"),
-		Entry("cpp", "cpp", "C++"),
-	)
-})
+var _ = DescribeTable("predefined attributes",
+	func(code, rendered string) {
+		Expect(parser.Predefined[code]).To(Equal(rendered))
+	},
+	Entry("sp", "sp", " "),
+	Entry("blank", "blank", ""),
+	Entry("empty", "empty", ""),
+	Entry("nbsp", "nbsp", "&#160;"),
+	Entry("zwsp", "zwsp", "&#8203;"),
+	Entry("wj", "wj", "&#8288;"),
+	Entry("apos", "apos", "&#39;"),
+	Entry("quot", "quot", "&#34;"),
+	Entry("lsquo", "lsquo", "&#8216;"),
+	Entry("rsquo", "rsquo", "&#8217;"),
+	Entry("ldquo", "ldquo", "&#8220;"),
+	Entry("rdquo", "rdquo", "&#8221;"),
+	Entry("deg", "deg", "&#176;"),
+	Entry("plus", "plus", "&#43;"),
+	Entry("brvbar", "brvbar", "&#166;"),
+	Entry("vbar", "vbar", "|"),
+	Entry("amp", "amp", "&amp;"),
+	Entry("lt", "lt", "&lt;"),
+	Entry("gt", "gt", "&gt;"),
+	Entry("startsb", "startsb", "["),
+	Entry("endsb", "endsb", "]"),
+	Entry("caret", "caret", "^"),
+	Entry("asterisk", "asterisk", "*"),
+	Entry("tilde", "tilde", "~"),
+	Entry("backslash", "backslash", `\`),
+	Entry("backtick", "backtick", "`"),
+	Entry("two-colons", "two-colons", "::"),
+	Entry("two-semicolons", "two-semicolons", ";"),
+	Entry("cpp", "cpp", "C++"),
+)

--- a/pkg/renderer/html5/link_test.go
+++ b/pkg/renderer/html5/link_test.go
@@ -40,7 +40,6 @@ var _ = Describe("links", func() {
 			source := `a http://website.com
 and more text on the
 next lines`
-
 			expected := `<div class="paragraph">
 <p>a <a href="http://website.com" class="bare">http://website.com</a>
 and more text on the
@@ -109,7 +108,6 @@ next lines</p>
 :url: https://foo2.bar
 
 a link to {url}`
-
 			expected := `<div class="paragraph">
 <p>a link to <a href="https://foo2.bar" class="bare">https://foo2.bar</a></p>
 </div>`
@@ -121,7 +119,6 @@ a link to {url}`
 :path: foo.bar
 
 a link to {scheme}://{path}`
-
 			expected := `<div class="paragraph">
 <p>a link to <a href="https://foo.bar" class="bare">https://foo.bar</a></p>
 </div>`
@@ -135,11 +132,30 @@ a link to {scheme}://{path}`
 :!path:
 
 a link to {scheme}://{path}`
-
 			expected := `<div class="paragraph">
 <p>a link to <a href="https://{path}" class="bare">https://{path}</a></p>
 </div>`
+			Expect(source).To(RenderHTML5Body(expected))
+		})
 
+		It("external link with document attribute in section 0 title", func() {
+			source := `= a title to {scheme}://{path} and https://foo.baz
+:scheme: https
+:path: foo.bar`
+			expected := `a title to https://foo.bar and https://foo.baz`
+			Expect(source).To(RenderHTML5Title(expected))
+		})
+
+		It("external link with document attribute in section 1 title", func() {
+			source := `:scheme: https
+:path: foo.bar
+
+== a title to {scheme}://{path} and https://foo.baz`
+			expected := `<div class="sect1">
+<h2 id="_a_title_to_https_foo_bar_and_https_foo_baz">a title to <a href="https://foo.bar" class="bare">https://foo.bar</a> and <a href="https://foo.baz" class="bare">https://foo.baz</a></h2>
+<div class="sectionbody">
+</div>
+</div>`
 			Expect(source).To(RenderHTML5Body(expected))
 		})
 	})

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -62,6 +62,26 @@ func NewDraftDocument(frontMatter interface{}, blocks []interface{}) (DraftDocum
 	return result, nil
 }
 
+// DocumentAttributes returns
+func (d DraftDocument) DocumentAttributes() DocumentAttributes {
+	result := DocumentAttributes{}
+blocks:
+	for _, b := range d.Blocks {
+		switch b := b.(type) {
+		case Section:
+			if b.Level == 0 {
+				continue // allow to continue if the section is level 0
+			}
+			break blocks // otherwise, just stop
+		case DocumentAttributeDeclaration:
+			result[b.Name] = b.Value
+		default:
+			break blocks
+		}
+	}
+	return result
+}
+
 // ------------------------------------------
 // Document
 // ------------------------------------------
@@ -2077,7 +2097,6 @@ func (l Location) String() string { // (attrs map[string]string) string {
 	for _, e := range l.Elements {
 		result.WriteString(fmt.Sprintf("%s", e))
 	}
-	// l.Resolved = result.String()
 	return result.String()
 }
 

--- a/pkg/types/types_test.go
+++ b/pkg/types/types_test.go
@@ -552,3 +552,82 @@ var _ = Describe("location resolution", func() {
 		),
 	)
 })
+
+var _ = DescribeTable("draft document attributes",
+	func(draftDoc types.DraftDocument, expectation types.DocumentAttributes) {
+		Expect(draftDoc.DocumentAttributes()).To(Equal(expectation))
+	},
+
+	Entry("should use attribute declarations at top of document only",
+		types.DraftDocument{
+			Blocks: []interface{}{
+				types.DocumentAttributeDeclaration{
+					Name:  "foo1",
+					Value: "bar1",
+				},
+				types.DocumentAttributeDeclaration{
+					Name:  "foo2",
+					Value: "bar2",
+				},
+				types.BlankLine{},
+				types.DocumentAttributeDeclaration{
+					Name:  "foo3",
+					Value: "bar3",
+				},
+			},
+		},
+		types.DocumentAttributes{
+			"foo1": "bar1",
+			"foo2": "bar2",
+		},
+	),
+	Entry("should use attribute declarations right after section 0 only",
+		types.DraftDocument{
+			Blocks: []interface{}{
+				types.Section{
+					Level: 0,
+				},
+				types.DocumentAttributeDeclaration{
+					Name:  "foo1",
+					Value: "bar1",
+				},
+				types.DocumentAttributeDeclaration{
+					Name:  "foo2",
+					Value: "bar2",
+				},
+				types.BlankLine{},
+				types.DocumentAttributeDeclaration{
+					Name:  "foo3",
+					Value: "bar3",
+				},
+			},
+		},
+		types.DocumentAttributes{
+			"foo1": "bar1",
+			"foo2": "bar2",
+		},
+	),
+	Entry("should ignore attribute declarations elsewhere",
+		types.DraftDocument{
+			Blocks: []interface{}{
+				types.Section{
+					Level: 1,
+				},
+				types.DocumentAttributeDeclaration{
+					Name:  "foo1",
+					Value: "bar1",
+				},
+				types.DocumentAttributeDeclaration{
+					Name:  "foo2",
+					Value: "bar2",
+				},
+				types.BlankLine{},
+				types.DocumentAttributeDeclaration{
+					Name:  "foo3",
+					Value: "bar3",
+				},
+			},
+		},
+		types.DocumentAttributes{},
+	),
+)


### PR DESCRIPTION
get the "document attributes" by reading the beginning of the
first blocks of the draft document, and use them while processing
the section 0 title.

Fixes #447

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>