### PR TITLE
fix(renderer): use file mtime as 'Last updated'

### DIFF
--- a/libasciidoc_test.go
+++ b/libasciidoc_test.go
@@ -183,12 +183,7 @@ a paragraph with _italic content_`
 
 	Context("complete Document ", func() {
 
-		It("section levels 0 and 5", func() {
-			source := `= a document title
-
-====== Section A
-
-a paragraph with *bold content*`
+		It("using existing file", func() {
 			expectedContent := `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -196,18 +191,15 @@ a paragraph with *bold content*`
 <!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="generator" content="libasciidoc">
-<title>a document title</title>
+<title>Chapter A</title>
 </head>
 <body class="article">
 <div id="header">
-<h1>a document title</h1>
+<h1>Chapter A</h1>
 </div>
 <div id="content">
-<div class="sect5">
-<h6 id="_section_a">Section A</h6>
 <div class="paragraph">
-<p>a paragraph with <strong>bold content</strong></p>
-</div>
+<p>content</p>
 </div>
 </div>
 <div id="footer">
@@ -217,8 +209,9 @@ Last updated {{.LastUpdated}}
 </div>
 </body>
 </html>`
-			Expect(source).To(RenderHTML5Document(expectedContent))
+			Expect("test/includes/chapter-a.adoc").To(RenderHTML5Document(expectedContent))
 		})
+
 	})
 
 })

--- a/pkg/renderer/options.go
+++ b/pkg/renderer/options.go
@@ -18,7 +18,7 @@ const (
 	// keyEntrypoint a bool value to indicate if the entrypoint to start with when parsing the document
 	keyEntrypoint string = "Entrypoint"
 	// LastUpdatedFormat the time format for the `last updated` document attribute
-	LastUpdatedFormat string = "2006/01/02 15:04:05 MST"
+	LastUpdatedFormat string = "2006-01-02 15:04:05 -0700"
 )
 
 // LastUpdated function to set the `last updated` option in the renderer context (default is `time.Now()`)


### PR DESCRIPTION
use file's mtime instead of `time.Now()`

Fixes #461

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>