### PR TITLE
fix(parser/renderer): skip trailing empty lines in delimited blocks

### DIFF
--- a/pkg/parser/delimited_block_test.go
+++ b/pkg/parser/delimited_block_test.go
@@ -336,7 +336,13 @@ in the middle
 									Content: "with an empty line",
 								},
 							},
-							{},
+						},
+					},
+					types.BlankLine{},
+					types.Paragraph{
+						Attributes: types.ElementAttributes{},
+						Lines: [][]interface{}{
+
 							{
 								types.StringElement{
 									Content: "in the middle",
@@ -411,7 +417,13 @@ then a normal paragraph.`
 											Content: "with an empty line",
 										},
 									},
-									{},
+								},
+							},
+							types.BlankLine{},
+							types.Paragraph{
+								Attributes: types.ElementAttributes{},
+								Lines: [][]interface{}{
+
 									{
 										types.StringElement{
 											Content: "in the middle",
@@ -717,7 +729,13 @@ paragraphs
 											Content: "multiple",
 										},
 									},
-									{},
+								},
+							},
+							types.BlankLine{},
+							types.Paragraph{
+								Attributes: types.ElementAttributes{},
+								Lines: [][]interface{}{
+
 									{
 										types.StringElement{
 											Content: "paragraphs",
@@ -1335,7 +1353,13 @@ end
 									Content: "require 'sinatra'",
 								},
 							},
-							{},
+						},
+					},
+					types.BlankLine{},
+					types.Paragraph{
+						Attributes: types.ElementAttributes{},
+						Lines: [][]interface{}{
+
 							{
 								types.StringElement{
 									Content: "get '/hi' do",
@@ -1384,7 +1408,13 @@ end
 									Content: "require 'sinatra'",
 								},
 							},
-							{},
+						},
+					},
+					types.BlankLine{},
+					types.Paragraph{
+						Attributes: types.ElementAttributes{},
+						Lines: [][]interface{}{
+
 							{
 								types.StringElement{
 									Content: "get '/hi' do",
@@ -1436,7 +1466,12 @@ end
 									Content: "require 'sinatra'",
 								},
 							},
-							{},
+						},
+					},
+					types.BlankLine{},
+					types.Paragraph{
+						Attributes: types.ElementAttributes{},
+						Lines: [][]interface{}{
 							{
 								types.StringElement{
 									Content: "get '/hi' do",
@@ -1914,7 +1949,12 @@ in the middle
 											Content: "with an empty line",
 										},
 									},
-									{},
+								},
+							},
+							types.BlankLine{},
+							types.Paragraph{
+								Attributes: types.ElementAttributes{},
+								Lines: [][]interface{}{
 									{
 										types.StringElement{
 											Content: "in the middle",
@@ -2003,7 +2043,13 @@ then a normal paragraph.`
 											Content: "with an empty line",
 										},
 									},
-									{},
+								},
+							},
+							types.BlankLine{},
+							types.Paragraph{
+								Attributes: types.ElementAttributes{},
+								Lines: [][]interface{}{
+
 									{
 										types.StringElement{
 											Content: "in the middle",
@@ -2386,7 +2432,13 @@ paragraphs
 											Content: "multiple",
 										},
 									},
-									{},
+								},
+							},
+							types.BlankLine{},
+							types.Paragraph{
+								Attributes: types.ElementAttributes{},
+								Lines: [][]interface{}{
+
 									{
 										types.StringElement{
 											Content: "paragraphs",
@@ -3138,7 +3190,13 @@ end
 											Content: "require 'sinatra'",
 										},
 									},
-									{},
+								},
+							},
+							types.BlankLine{},
+							types.Paragraph{
+								Attributes: types.ElementAttributes{},
+								Lines: [][]interface{}{
+
 									{
 										types.StringElement{
 											Content: "get '/hi' do",
@@ -3195,7 +3253,13 @@ end
 											Content: "require 'sinatra'",
 										},
 									},
-									{},
+								},
+							},
+							types.BlankLine{},
+							types.Paragraph{
+								Attributes: types.ElementAttributes{},
+								Lines: [][]interface{}{
+
 									{
 										types.StringElement{
 											Content: "get '/hi' do",
@@ -3255,7 +3319,13 @@ end
 											Content: "require 'sinatra'",
 										},
 									},
-									{},
+								},
+							},
+							types.BlankLine{},
+							types.Paragraph{
+								Attributes: types.ElementAttributes{},
+								Lines: [][]interface{}{
+
 									{
 										types.StringElement{
 											Content: "get '/hi' do",

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -10252,22 +10252,26 @@ var g = &grammar{
 						pos:  position{line: 1293, col: 40, offset: 49023},
 						name: "ListingBlockParagraph",
 					},
+					&ruleRefExpr{
+						pos:  position{line: 1293, col: 64, offset: 49047},
+						name: "BlankLine",
+					},
 				},
 			},
 		},
 		{
 			name: "ListingBlockParagraph",
-			pos:  position{line: 1295, col: 1, offset: 49046},
+			pos:  position{line: 1295, col: 1, offset: 49058},
 			expr: &actionExpr{
-				pos: position{line: 1295, col: 26, offset: 49071},
+				pos: position{line: 1295, col: 26, offset: 49083},
 				run: (*parser).callonListingBlockParagraph1,
 				expr: &labeledExpr{
-					pos:   position{line: 1295, col: 26, offset: 49071},
+					pos:   position{line: 1295, col: 26, offset: 49083},
 					label: "lines",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 1295, col: 32, offset: 49077},
+						pos: position{line: 1295, col: 32, offset: 49089},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1295, col: 33, offset: 49078},
+							pos:  position{line: 1295, col: 33, offset: 49090},
 							name: "ListingBlockParagraphLine",
 						},
 					},
@@ -10276,61 +10280,61 @@ var g = &grammar{
 		},
 		{
 			name: "ListingBlockParagraphLine",
-			pos:  position{line: 1299, col: 1, offset: 49197},
+			pos:  position{line: 1299, col: 1, offset: 49209},
 			expr: &actionExpr{
-				pos: position{line: 1299, col: 30, offset: 49226},
+				pos: position{line: 1299, col: 30, offset: 49238},
 				run: (*parser).callonListingBlockParagraphLine1,
 				expr: &seqExpr{
-					pos: position{line: 1299, col: 30, offset: 49226},
+					pos: position{line: 1299, col: 30, offset: 49238},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1299, col: 30, offset: 49226},
+							pos: position{line: 1299, col: 30, offset: 49238},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1299, col: 31, offset: 49227},
+								pos:  position{line: 1299, col: 31, offset: 49239},
 								name: "ListingBlockDelimiter",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1299, col: 53, offset: 49249},
+							pos:   position{line: 1299, col: 53, offset: 49261},
 							label: "line",
 							expr: &actionExpr{
-								pos: position{line: 1299, col: 59, offset: 49255},
+								pos: position{line: 1299, col: 59, offset: 49267},
 								run: (*parser).callonListingBlockParagraphLine6,
 								expr: &seqExpr{
-									pos: position{line: 1299, col: 59, offset: 49255},
+									pos: position{line: 1299, col: 59, offset: 49267},
 									exprs: []interface{}{
 										&notExpr{
-											pos: position{line: 1299, col: 59, offset: 49255},
+											pos: position{line: 1299, col: 59, offset: 49267},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1299, col: 60, offset: 49256},
+												pos:  position{line: 1299, col: 60, offset: 49268},
 												name: "EOF",
 											},
 										},
-										&zeroOrMoreExpr{
-											pos: position{line: 1299, col: 64, offset: 49260},
+										&oneOrMoreExpr{
+											pos: position{line: 1299, col: 64, offset: 49272},
 											expr: &choiceExpr{
-												pos: position{line: 1299, col: 65, offset: 49261},
+												pos: position{line: 1299, col: 65, offset: 49273},
 												alternatives: []interface{}{
 													&ruleRefExpr{
-														pos:  position{line: 1299, col: 65, offset: 49261},
+														pos:  position{line: 1299, col: 65, offset: 49273},
 														name: "Alphanums",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1299, col: 77, offset: 49273},
+														pos:  position{line: 1299, col: 77, offset: 49285},
 														name: "Spaces",
 													},
 													&seqExpr{
-														pos: position{line: 1299, col: 87, offset: 49283},
+														pos: position{line: 1299, col: 87, offset: 49295},
 														exprs: []interface{}{
 															&notExpr{
-																pos: position{line: 1299, col: 87, offset: 49283},
+																pos: position{line: 1299, col: 87, offset: 49295},
 																expr: &ruleRefExpr{
-																	pos:  position{line: 1299, col: 88, offset: 49284},
+																	pos:  position{line: 1299, col: 88, offset: 49296},
 																	name: "EOL",
 																},
 															},
 															&anyMatcher{
-																line: 1299, col: 92, offset: 49288,
+																line: 1299, col: 92, offset: 49300,
 															},
 														},
 													},
@@ -10342,7 +10346,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1299, col: 128, offset: 49324},
+							pos:  position{line: 1299, col: 128, offset: 49336},
 							name: "EOL",
 						},
 					},
@@ -10351,17 +10355,17 @@ var g = &grammar{
 		},
 		{
 			name: "ExampleBlockDelimiter",
-			pos:  position{line: 1306, col: 1, offset: 49650},
+			pos:  position{line: 1306, col: 1, offset: 49662},
 			expr: &seqExpr{
-				pos: position{line: 1306, col: 26, offset: 49675},
+				pos: position{line: 1306, col: 26, offset: 49687},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1306, col: 26, offset: 49675},
+						pos:        position{line: 1306, col: 26, offset: 49687},
 						val:        "====",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1306, col: 33, offset: 49682},
+						pos:  position{line: 1306, col: 33, offset: 49694},
 						name: "EOLS",
 					},
 				},
@@ -10369,50 +10373,50 @@ var g = &grammar{
 		},
 		{
 			name: "ExampleBlock",
-			pos:  position{line: 1308, col: 1, offset: 49688},
+			pos:  position{line: 1308, col: 1, offset: 49700},
 			expr: &actionExpr{
-				pos: position{line: 1308, col: 17, offset: 49704},
+				pos: position{line: 1308, col: 17, offset: 49716},
 				run: (*parser).callonExampleBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1308, col: 17, offset: 49704},
+					pos: position{line: 1308, col: 17, offset: 49716},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1308, col: 17, offset: 49704},
+							pos:   position{line: 1308, col: 17, offset: 49716},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1308, col: 28, offset: 49715},
+								pos: position{line: 1308, col: 28, offset: 49727},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1308, col: 29, offset: 49716},
+									pos:  position{line: 1308, col: 29, offset: 49728},
 									name: "ElementAttributes",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1308, col: 49, offset: 49736},
+							pos:  position{line: 1308, col: 49, offset: 49748},
 							name: "ExampleBlockDelimiter",
 						},
 						&labeledExpr{
-							pos:   position{line: 1308, col: 71, offset: 49758},
+							pos:   position{line: 1308, col: 71, offset: 49770},
 							label: "content",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1308, col: 79, offset: 49766},
+								pos: position{line: 1308, col: 79, offset: 49778},
 								expr: &choiceExpr{
-									pos: position{line: 1308, col: 80, offset: 49767},
+									pos: position{line: 1308, col: 80, offset: 49779},
 									alternatives: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 1308, col: 80, offset: 49767},
+											pos:  position{line: 1308, col: 80, offset: 49779},
 											name: "BlankLine",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1308, col: 92, offset: 49779},
+											pos:  position{line: 1308, col: 92, offset: 49791},
 											name: "FileInclusion",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1308, col: 108, offset: 49795},
+											pos:  position{line: 1308, col: 108, offset: 49807},
 											name: "ListItem",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1308, col: 119, offset: 49806},
+											pos:  position{line: 1308, col: 119, offset: 49818},
 											name: "ExampleBlockParagraph",
 										},
 									},
@@ -10420,14 +10424,14 @@ var g = &grammar{
 							},
 						},
 						&choiceExpr{
-							pos: position{line: 1308, col: 145, offset: 49832},
+							pos: position{line: 1308, col: 145, offset: 49844},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 1308, col: 145, offset: 49832},
+									pos:  position{line: 1308, col: 145, offset: 49844},
 									name: "ExampleBlockDelimiter",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1308, col: 169, offset: 49856},
+									pos:  position{line: 1308, col: 169, offset: 49868},
 									name: "EOF",
 								},
 							},
@@ -10438,17 +10442,17 @@ var g = &grammar{
 		},
 		{
 			name: "ExampleBlockParagraph",
-			pos:  position{line: 1313, col: 1, offset: 49983},
+			pos:  position{line: 1313, col: 1, offset: 49995},
 			expr: &actionExpr{
-				pos: position{line: 1313, col: 26, offset: 50008},
+				pos: position{line: 1313, col: 26, offset: 50020},
 				run: (*parser).callonExampleBlockParagraph1,
 				expr: &labeledExpr{
-					pos:   position{line: 1313, col: 26, offset: 50008},
+					pos:   position{line: 1313, col: 26, offset: 50020},
 					label: "lines",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 1313, col: 32, offset: 50014},
+						pos: position{line: 1313, col: 32, offset: 50026},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1313, col: 33, offset: 50015},
+							pos:  position{line: 1313, col: 33, offset: 50027},
 							name: "ExampleBlockParagraphLine",
 						},
 					},
@@ -10457,32 +10461,32 @@ var g = &grammar{
 		},
 		{
 			name: "ExampleBlockParagraphLine",
-			pos:  position{line: 1317, col: 1, offset: 50129},
+			pos:  position{line: 1317, col: 1, offset: 50141},
 			expr: &actionExpr{
-				pos: position{line: 1317, col: 30, offset: 50158},
+				pos: position{line: 1317, col: 30, offset: 50170},
 				run: (*parser).callonExampleBlockParagraphLine1,
 				expr: &seqExpr{
-					pos: position{line: 1317, col: 30, offset: 50158},
+					pos: position{line: 1317, col: 30, offset: 50170},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1317, col: 30, offset: 50158},
+							pos: position{line: 1317, col: 30, offset: 50170},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1317, col: 31, offset: 50159},
+								pos:  position{line: 1317, col: 31, offset: 50171},
 								name: "ExampleBlockDelimiter",
 							},
 						},
 						&notExpr{
-							pos: position{line: 1317, col: 53, offset: 50181},
+							pos: position{line: 1317, col: 53, offset: 50193},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1317, col: 54, offset: 50182},
+								pos:  position{line: 1317, col: 54, offset: 50194},
 								name: "BlankLine",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1317, col: 64, offset: 50192},
+							pos:   position{line: 1317, col: 64, offset: 50204},
 							label: "line",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1317, col: 70, offset: 50198},
+								pos:  position{line: 1317, col: 70, offset: 50210},
 								name: "InlineElements",
 							},
 						},
@@ -10492,17 +10496,17 @@ var g = &grammar{
 		},
 		{
 			name: "QuoteBlockDelimiter",
-			pos:  position{line: 1324, col: 1, offset: 50434},
+			pos:  position{line: 1324, col: 1, offset: 50446},
 			expr: &seqExpr{
-				pos: position{line: 1324, col: 24, offset: 50457},
+				pos: position{line: 1324, col: 24, offset: 50469},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1324, col: 24, offset: 50457},
+						pos:        position{line: 1324, col: 24, offset: 50469},
 						val:        "____",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1324, col: 31, offset: 50464},
+						pos:  position{line: 1324, col: 31, offset: 50476},
 						name: "EOLS",
 					},
 				},
@@ -10510,48 +10514,48 @@ var g = &grammar{
 		},
 		{
 			name: "QuoteBlock",
-			pos:  position{line: 1326, col: 1, offset: 50495},
+			pos:  position{line: 1326, col: 1, offset: 50507},
 			expr: &actionExpr{
-				pos: position{line: 1326, col: 15, offset: 50509},
+				pos: position{line: 1326, col: 15, offset: 50521},
 				run: (*parser).callonQuoteBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1326, col: 15, offset: 50509},
+					pos: position{line: 1326, col: 15, offset: 50521},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1326, col: 15, offset: 50509},
+							pos:   position{line: 1326, col: 15, offset: 50521},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1326, col: 26, offset: 50520},
+								pos: position{line: 1326, col: 26, offset: 50532},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1326, col: 27, offset: 50521},
+									pos:  position{line: 1326, col: 27, offset: 50533},
 									name: "ElementAttributes",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1326, col: 47, offset: 50541},
+							pos:  position{line: 1326, col: 47, offset: 50553},
 							name: "QuoteBlockDelimiter",
 						},
 						&labeledExpr{
-							pos:   position{line: 1326, col: 67, offset: 50561},
+							pos:   position{line: 1326, col: 67, offset: 50573},
 							label: "content",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1326, col: 75, offset: 50569},
+								pos: position{line: 1326, col: 75, offset: 50581},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1326, col: 76, offset: 50570},
+									pos:  position{line: 1326, col: 76, offset: 50582},
 									name: "QuoteBlockElement",
 								},
 							},
 						},
 						&choiceExpr{
-							pos: position{line: 1326, col: 97, offset: 50591},
+							pos: position{line: 1326, col: 97, offset: 50603},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 1326, col: 97, offset: 50591},
+									pos:  position{line: 1326, col: 97, offset: 50603},
 									name: "QuoteBlockDelimiter",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1326, col: 119, offset: 50613},
+									pos:  position{line: 1326, col: 119, offset: 50625},
 									name: "EOF",
 								},
 							},
@@ -10562,99 +10566,99 @@ var g = &grammar{
 		},
 		{
 			name: "QuoteBlockElement",
-			pos:  position{line: 1330, col: 1, offset: 50720},
+			pos:  position{line: 1330, col: 1, offset: 50732},
 			expr: &actionExpr{
-				pos: position{line: 1331, col: 5, offset: 50746},
+				pos: position{line: 1331, col: 5, offset: 50758},
 				run: (*parser).callonQuoteBlockElement1,
 				expr: &seqExpr{
-					pos: position{line: 1331, col: 5, offset: 50746},
+					pos: position{line: 1331, col: 5, offset: 50758},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1331, col: 5, offset: 50746},
+							pos: position{line: 1331, col: 5, offset: 50758},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1331, col: 6, offset: 50747},
+								pos:  position{line: 1331, col: 6, offset: 50759},
 								name: "QuoteBlockDelimiter",
 							},
 						},
 						&notExpr{
-							pos: position{line: 1331, col: 26, offset: 50767},
+							pos: position{line: 1331, col: 26, offset: 50779},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1331, col: 27, offset: 50768},
+								pos:  position{line: 1331, col: 27, offset: 50780},
 								name: "EOF",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1331, col: 31, offset: 50772},
+							pos:   position{line: 1331, col: 31, offset: 50784},
 							label: "element",
 							expr: &choiceExpr{
-								pos: position{line: 1331, col: 40, offset: 50781},
+								pos: position{line: 1331, col: 40, offset: 50793},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1331, col: 40, offset: 50781},
+										pos:  position{line: 1331, col: 40, offset: 50793},
 										name: "BlankLine",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1332, col: 15, offset: 50806},
+										pos:  position{line: 1332, col: 15, offset: 50818},
 										name: "FileInclusion",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1333, col: 15, offset: 50834},
+										pos:  position{line: 1333, col: 15, offset: 50846},
 										name: "ImageBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1334, col: 15, offset: 50860},
+										pos:  position{line: 1334, col: 15, offset: 50872},
 										name: "ListItem",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1335, col: 15, offset: 50883},
+										pos:  position{line: 1335, col: 15, offset: 50895},
 										name: "FencedBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1336, col: 15, offset: 50909},
+										pos:  position{line: 1336, col: 15, offset: 50921},
 										name: "ListingBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1337, col: 15, offset: 50936},
+										pos:  position{line: 1337, col: 15, offset: 50948},
 										name: "ExampleBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1338, col: 15, offset: 50963},
+										pos:  position{line: 1338, col: 15, offset: 50975},
 										name: "CommentBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1339, col: 15, offset: 50990},
+										pos:  position{line: 1339, col: 15, offset: 51002},
 										name: "SingleLineComment",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1340, col: 15, offset: 51022},
+										pos:  position{line: 1340, col: 15, offset: 51034},
 										name: "QuoteBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1341, col: 15, offset: 51048},
+										pos:  position{line: 1341, col: 15, offset: 51060},
 										name: "SidebarBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1342, col: 15, offset: 51075},
+										pos:  position{line: 1342, col: 15, offset: 51087},
 										name: "Table",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1343, col: 15, offset: 51096},
+										pos:  position{line: 1343, col: 15, offset: 51108},
 										name: "LiteralBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1344, col: 15, offset: 51124},
+										pos:  position{line: 1344, col: 15, offset: 51136},
 										name: "DocumentAttributeDeclaration",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1345, col: 15, offset: 51168},
+										pos:  position{line: 1345, col: 15, offset: 51180},
 										name: "DocumentAttributeReset",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1346, col: 15, offset: 51206},
+										pos:  position{line: 1346, col: 15, offset: 51218},
 										name: "TableOfContentsMacro",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1347, col: 15, offset: 51241},
+										pos:  position{line: 1347, col: 15, offset: 51253},
 										name: "QuoteBlockParagraph",
 									},
 								},
@@ -10666,17 +10670,17 @@ var g = &grammar{
 		},
 		{
 			name: "QuoteBlockParagraph",
-			pos:  position{line: 1351, col: 1, offset: 51300},
+			pos:  position{line: 1351, col: 1, offset: 51312},
 			expr: &actionExpr{
-				pos: position{line: 1351, col: 24, offset: 51323},
+				pos: position{line: 1351, col: 24, offset: 51335},
 				run: (*parser).callonQuoteBlockParagraph1,
 				expr: &labeledExpr{
-					pos:   position{line: 1351, col: 24, offset: 51323},
+					pos:   position{line: 1351, col: 24, offset: 51335},
 					label: "lines",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 1351, col: 30, offset: 51329},
+						pos: position{line: 1351, col: 30, offset: 51341},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1351, col: 31, offset: 51330},
+							pos:  position{line: 1351, col: 31, offset: 51342},
 							name: "InlineElements",
 						},
 					},
@@ -10685,49 +10689,49 @@ var g = &grammar{
 		},
 		{
 			name: "VerseBlock",
-			pos:  position{line: 1360, col: 1, offset: 51676},
+			pos:  position{line: 1360, col: 1, offset: 51688},
 			expr: &actionExpr{
-				pos: position{line: 1360, col: 15, offset: 51690},
+				pos: position{line: 1360, col: 15, offset: 51702},
 				run: (*parser).callonVerseBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1360, col: 15, offset: 51690},
+					pos: position{line: 1360, col: 15, offset: 51702},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1360, col: 15, offset: 51690},
+							pos:   position{line: 1360, col: 15, offset: 51702},
 							label: "attributes",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1360, col: 27, offset: 51702},
+								pos:  position{line: 1360, col: 27, offset: 51714},
 								name: "ElementAttributes",
 							},
 						},
 						&andCodeExpr{
-							pos: position{line: 1361, col: 5, offset: 51726},
+							pos: position{line: 1361, col: 5, offset: 51738},
 							run: (*parser).callonVerseBlock5,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1365, col: 5, offset: 51912},
+							pos:  position{line: 1365, col: 5, offset: 51924},
 							name: "QuoteBlockDelimiter",
 						},
 						&labeledExpr{
-							pos:   position{line: 1365, col: 25, offset: 51932},
+							pos:   position{line: 1365, col: 25, offset: 51944},
 							label: "content",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1365, col: 33, offset: 51940},
+								pos: position{line: 1365, col: 33, offset: 51952},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1365, col: 34, offset: 51941},
+									pos:  position{line: 1365, col: 34, offset: 51953},
 									name: "VerseBlockElement",
 								},
 							},
 						},
 						&choiceExpr{
-							pos: position{line: 1365, col: 55, offset: 51962},
+							pos: position{line: 1365, col: 55, offset: 51974},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 1365, col: 55, offset: 51962},
+									pos:  position{line: 1365, col: 55, offset: 51974},
 									name: "QuoteBlockDelimiter",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1365, col: 77, offset: 51984},
+									pos:  position{line: 1365, col: 77, offset: 51996},
 									name: "EOF",
 								},
 							},
@@ -10738,20 +10742,20 @@ var g = &grammar{
 		},
 		{
 			name: "VerseBlockElement",
-			pos:  position{line: 1369, col: 1, offset: 52099},
+			pos:  position{line: 1369, col: 1, offset: 52111},
 			expr: &choiceExpr{
-				pos: position{line: 1369, col: 22, offset: 52120},
+				pos: position{line: 1369, col: 22, offset: 52132},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1369, col: 22, offset: 52120},
+						pos:  position{line: 1369, col: 22, offset: 52132},
 						name: "VerseFileInclude",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1369, col: 41, offset: 52139},
+						pos:  position{line: 1369, col: 41, offset: 52151},
 						name: "BlankLine",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1369, col: 53, offset: 52151},
+						pos:  position{line: 1369, col: 53, offset: 52163},
 						name: "VerseBlockParagraph",
 					},
 				},
@@ -10759,25 +10763,25 @@ var g = &grammar{
 		},
 		{
 			name: "VerseFileInclude",
-			pos:  position{line: 1371, col: 1, offset: 52172},
+			pos:  position{line: 1371, col: 1, offset: 52184},
 			expr: &actionExpr{
-				pos: position{line: 1371, col: 21, offset: 52192},
+				pos: position{line: 1371, col: 21, offset: 52204},
 				run: (*parser).callonVerseFileInclude1,
 				expr: &seqExpr{
-					pos: position{line: 1371, col: 21, offset: 52192},
+					pos: position{line: 1371, col: 21, offset: 52204},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1371, col: 21, offset: 52192},
+							pos: position{line: 1371, col: 21, offset: 52204},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1371, col: 22, offset: 52193},
+								pos:  position{line: 1371, col: 22, offset: 52205},
 								name: "QuoteBlockDelimiter",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1371, col: 42, offset: 52213},
+							pos:   position{line: 1371, col: 42, offset: 52225},
 							label: "include",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1371, col: 51, offset: 52222},
+								pos:  position{line: 1371, col: 51, offset: 52234},
 								name: "FileInclusion",
 							},
 						},
@@ -10787,17 +10791,17 @@ var g = &grammar{
 		},
 		{
 			name: "VerseBlockParagraph",
-			pos:  position{line: 1376, col: 1, offset: 52284},
+			pos:  position{line: 1376, col: 1, offset: 52296},
 			expr: &actionExpr{
-				pos: position{line: 1376, col: 24, offset: 52307},
+				pos: position{line: 1376, col: 24, offset: 52319},
 				run: (*parser).callonVerseBlockParagraph1,
 				expr: &labeledExpr{
-					pos:   position{line: 1376, col: 24, offset: 52307},
+					pos:   position{line: 1376, col: 24, offset: 52319},
 					label: "lines",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 1376, col: 30, offset: 52313},
+						pos: position{line: 1376, col: 30, offset: 52325},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1376, col: 31, offset: 52314},
+							pos:  position{line: 1376, col: 31, offset: 52326},
 							name: "VerseBlockParagraphLine",
 						},
 					},
@@ -10806,49 +10810,49 @@ var g = &grammar{
 		},
 		{
 			name: "VerseBlockParagraphLine",
-			pos:  position{line: 1380, col: 1, offset: 52404},
+			pos:  position{line: 1380, col: 1, offset: 52416},
 			expr: &actionExpr{
-				pos: position{line: 1380, col: 28, offset: 52431},
+				pos: position{line: 1380, col: 28, offset: 52443},
 				run: (*parser).callonVerseBlockParagraphLine1,
 				expr: &seqExpr{
-					pos: position{line: 1380, col: 28, offset: 52431},
+					pos: position{line: 1380, col: 28, offset: 52443},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1380, col: 28, offset: 52431},
+							pos: position{line: 1380, col: 28, offset: 52443},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1380, col: 29, offset: 52432},
+								pos:  position{line: 1380, col: 29, offset: 52444},
 								name: "QuoteBlockDelimiter",
 							},
 						},
 						&notExpr{
-							pos: position{line: 1380, col: 49, offset: 52452},
+							pos: position{line: 1380, col: 49, offset: 52464},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1380, col: 50, offset: 52453},
+								pos:  position{line: 1380, col: 50, offset: 52465},
 								name: "BlankLine",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1380, col: 60, offset: 52463},
+							pos:   position{line: 1380, col: 60, offset: 52475},
 							label: "line",
 							expr: &actionExpr{
-								pos: position{line: 1380, col: 66, offset: 52469},
+								pos: position{line: 1380, col: 66, offset: 52481},
 								run: (*parser).callonVerseBlockParagraphLine8,
 								expr: &seqExpr{
-									pos: position{line: 1380, col: 66, offset: 52469},
+									pos: position{line: 1380, col: 66, offset: 52481},
 									exprs: []interface{}{
 										&labeledExpr{
-											pos:   position{line: 1380, col: 66, offset: 52469},
+											pos:   position{line: 1380, col: 66, offset: 52481},
 											label: "elements",
 											expr: &oneOrMoreExpr{
-												pos: position{line: 1380, col: 75, offset: 52478},
+												pos: position{line: 1380, col: 75, offset: 52490},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1380, col: 76, offset: 52479},
+													pos:  position{line: 1380, col: 76, offset: 52491},
 													name: "VerseBlockParagraphLineElement",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1380, col: 109, offset: 52512},
+											pos:  position{line: 1380, col: 109, offset: 52524},
 											name: "EOL",
 										},
 									},
@@ -10861,79 +10865,79 @@ var g = &grammar{
 		},
 		{
 			name: "VerseBlockParagraphLineElement",
-			pos:  position{line: 1386, col: 1, offset: 52608},
+			pos:  position{line: 1386, col: 1, offset: 52620},
 			expr: &actionExpr{
-				pos: position{line: 1386, col: 35, offset: 52642},
+				pos: position{line: 1386, col: 35, offset: 52654},
 				run: (*parser).callonVerseBlockParagraphLineElement1,
 				expr: &seqExpr{
-					pos: position{line: 1386, col: 35, offset: 52642},
+					pos: position{line: 1386, col: 35, offset: 52654},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1386, col: 35, offset: 52642},
+							pos: position{line: 1386, col: 35, offset: 52654},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1386, col: 36, offset: 52643},
+								pos:  position{line: 1386, col: 36, offset: 52655},
 								name: "EOL",
 							},
 						},
 						&notExpr{
-							pos: position{line: 1386, col: 40, offset: 52647},
+							pos: position{line: 1386, col: 40, offset: 52659},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1386, col: 41, offset: 52648},
+								pos:  position{line: 1386, col: 41, offset: 52660},
 								name: "LineBreak",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1387, col: 5, offset: 52663},
+							pos:   position{line: 1387, col: 5, offset: 52675},
 							label: "element",
 							expr: &choiceExpr{
-								pos: position{line: 1387, col: 14, offset: 52672},
+								pos: position{line: 1387, col: 14, offset: 52684},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1387, col: 14, offset: 52672},
+										pos:  position{line: 1387, col: 14, offset: 52684},
 										name: "Spaces",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1388, col: 11, offset: 52690},
+										pos:  position{line: 1388, col: 11, offset: 52702},
 										name: "InlineImage",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1389, col: 11, offset: 52713},
+										pos:  position{line: 1389, col: 11, offset: 52725},
 										name: "Link",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1390, col: 11, offset: 52729},
+										pos:  position{line: 1390, col: 11, offset: 52741},
 										name: "Passthrough",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1391, col: 11, offset: 52752},
+										pos:  position{line: 1391, col: 11, offset: 52764},
 										name: "InlineFootnote",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1392, col: 11, offset: 52778},
+										pos:  position{line: 1392, col: 11, offset: 52790},
 										name: "QuotedText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1393, col: 11, offset: 52800},
+										pos:  position{line: 1393, col: 11, offset: 52812},
 										name: "CrossReference",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1394, col: 11, offset: 52826},
+										pos:  position{line: 1394, col: 11, offset: 52838},
 										name: "InlineUserMacro",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1395, col: 11, offset: 52853},
+										pos:  position{line: 1395, col: 11, offset: 52865},
 										name: "DocumentAttributeSubstitution",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1396, col: 11, offset: 52894},
+										pos:  position{line: 1396, col: 11, offset: 52906},
 										name: "InlineElementID",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1397, col: 11, offset: 52921},
+										pos:  position{line: 1397, col: 11, offset: 52933},
 										name: "OtherWord",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1398, col: 11, offset: 52941},
+										pos:  position{line: 1398, col: 11, offset: 52953},
 										name: "Parenthesis",
 									},
 								},
@@ -10945,17 +10949,17 @@ var g = &grammar{
 		},
 		{
 			name: "SidebarBlockDelimiter",
-			pos:  position{line: 1405, col: 1, offset: 53173},
+			pos:  position{line: 1405, col: 1, offset: 53185},
 			expr: &seqExpr{
-				pos: position{line: 1405, col: 26, offset: 53198},
+				pos: position{line: 1405, col: 26, offset: 53210},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1405, col: 26, offset: 53198},
+						pos:        position{line: 1405, col: 26, offset: 53210},
 						val:        "****",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1405, col: 33, offset: 53205},
+						pos:  position{line: 1405, col: 33, offset: 53217},
 						name: "EOLS",
 					},
 				},
@@ -10963,48 +10967,48 @@ var g = &grammar{
 		},
 		{
 			name: "SidebarBlock",
-			pos:  position{line: 1407, col: 1, offset: 53211},
+			pos:  position{line: 1407, col: 1, offset: 53223},
 			expr: &actionExpr{
-				pos: position{line: 1407, col: 17, offset: 53227},
+				pos: position{line: 1407, col: 17, offset: 53239},
 				run: (*parser).callonSidebarBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1407, col: 17, offset: 53227},
+					pos: position{line: 1407, col: 17, offset: 53239},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1407, col: 17, offset: 53227},
+							pos:   position{line: 1407, col: 17, offset: 53239},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1407, col: 28, offset: 53238},
+								pos: position{line: 1407, col: 28, offset: 53250},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1407, col: 29, offset: 53239},
+									pos:  position{line: 1407, col: 29, offset: 53251},
 									name: "ElementAttributes",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1407, col: 49, offset: 53259},
+							pos:  position{line: 1407, col: 49, offset: 53271},
 							name: "SidebarBlockDelimiter",
 						},
 						&labeledExpr{
-							pos:   position{line: 1407, col: 71, offset: 53281},
+							pos:   position{line: 1407, col: 71, offset: 53293},
 							label: "content",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1407, col: 79, offset: 53289},
+								pos: position{line: 1407, col: 79, offset: 53301},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1407, col: 80, offset: 53290},
+									pos:  position{line: 1407, col: 80, offset: 53302},
 									name: "SidebarBlockContent",
 								},
 							},
 						},
 						&choiceExpr{
-							pos: position{line: 1407, col: 104, offset: 53314},
+							pos: position{line: 1407, col: 104, offset: 53326},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 1407, col: 104, offset: 53314},
+									pos:  position{line: 1407, col: 104, offset: 53326},
 									name: "SidebarBlockDelimiter",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1407, col: 128, offset: 53338},
+									pos:  position{line: 1407, col: 128, offset: 53350},
 									name: "EOF",
 								},
 							},
@@ -11015,28 +11019,28 @@ var g = &grammar{
 		},
 		{
 			name: "SidebarBlockContent",
-			pos:  position{line: 1411, col: 1, offset: 53447},
+			pos:  position{line: 1411, col: 1, offset: 53459},
 			expr: &choiceExpr{
-				pos: position{line: 1411, col: 24, offset: 53470},
+				pos: position{line: 1411, col: 24, offset: 53482},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1411, col: 24, offset: 53470},
+						pos:  position{line: 1411, col: 24, offset: 53482},
 						name: "BlankLine",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1411, col: 36, offset: 53482},
+						pos:  position{line: 1411, col: 36, offset: 53494},
 						name: "FileInclusion",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1411, col: 52, offset: 53498},
+						pos:  position{line: 1411, col: 52, offset: 53510},
 						name: "ListItem",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1411, col: 63, offset: 53509},
+						pos:  position{line: 1411, col: 63, offset: 53521},
 						name: "NonSidebarBlock",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1411, col: 81, offset: 53527},
+						pos:  position{line: 1411, col: 81, offset: 53539},
 						name: "SidebarBlockParagraph",
 					},
 				},
@@ -11044,25 +11048,25 @@ var g = &grammar{
 		},
 		{
 			name: "NonSidebarBlock",
-			pos:  position{line: 1413, col: 1, offset: 53550},
+			pos:  position{line: 1413, col: 1, offset: 53562},
 			expr: &actionExpr{
-				pos: position{line: 1413, col: 20, offset: 53569},
+				pos: position{line: 1413, col: 20, offset: 53581},
 				run: (*parser).callonNonSidebarBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1413, col: 20, offset: 53569},
+					pos: position{line: 1413, col: 20, offset: 53581},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1413, col: 20, offset: 53569},
+							pos: position{line: 1413, col: 20, offset: 53581},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1413, col: 21, offset: 53570},
+								pos:  position{line: 1413, col: 21, offset: 53582},
 								name: "SidebarBlock",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1413, col: 34, offset: 53583},
+							pos:   position{line: 1413, col: 34, offset: 53595},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1413, col: 43, offset: 53592},
+								pos:  position{line: 1413, col: 43, offset: 53604},
 								name: "DelimitedBlock",
 							},
 						},
@@ -11072,17 +11076,17 @@ var g = &grammar{
 		},
 		{
 			name: "SidebarBlockParagraph",
-			pos:  position{line: 1418, col: 1, offset: 53655},
+			pos:  position{line: 1418, col: 1, offset: 53667},
 			expr: &actionExpr{
-				pos: position{line: 1418, col: 26, offset: 53680},
+				pos: position{line: 1418, col: 26, offset: 53692},
 				run: (*parser).callonSidebarBlockParagraph1,
 				expr: &labeledExpr{
-					pos:   position{line: 1418, col: 26, offset: 53680},
+					pos:   position{line: 1418, col: 26, offset: 53692},
 					label: "lines",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 1418, col: 32, offset: 53686},
+						pos: position{line: 1418, col: 32, offset: 53698},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1418, col: 33, offset: 53687},
+							pos:  position{line: 1418, col: 33, offset: 53699},
 							name: "SidebarBlockParagraphLine",
 						},
 					},
@@ -11091,32 +11095,32 @@ var g = &grammar{
 		},
 		{
 			name: "SidebarBlockParagraphLine",
-			pos:  position{line: 1422, col: 1, offset: 53801},
+			pos:  position{line: 1422, col: 1, offset: 53813},
 			expr: &actionExpr{
-				pos: position{line: 1422, col: 30, offset: 53830},
+				pos: position{line: 1422, col: 30, offset: 53842},
 				run: (*parser).callonSidebarBlockParagraphLine1,
 				expr: &seqExpr{
-					pos: position{line: 1422, col: 30, offset: 53830},
+					pos: position{line: 1422, col: 30, offset: 53842},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1422, col: 30, offset: 53830},
+							pos: position{line: 1422, col: 30, offset: 53842},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1422, col: 31, offset: 53831},
+								pos:  position{line: 1422, col: 31, offset: 53843},
 								name: "SidebarBlockDelimiter",
 							},
 						},
 						&notExpr{
-							pos: position{line: 1422, col: 53, offset: 53853},
+							pos: position{line: 1422, col: 53, offset: 53865},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1422, col: 54, offset: 53854},
+								pos:  position{line: 1422, col: 54, offset: 53866},
 								name: "BlankLine",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1422, col: 64, offset: 53864},
+							pos:   position{line: 1422, col: 64, offset: 53876},
 							label: "line",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1422, col: 70, offset: 53870},
+								pos:  position{line: 1422, col: 70, offset: 53882},
 								name: "InlineElements",
 							},
 						},
@@ -11126,59 +11130,59 @@ var g = &grammar{
 		},
 		{
 			name: "Table",
-			pos:  position{line: 1430, col: 1, offset: 54101},
+			pos:  position{line: 1430, col: 1, offset: 54113},
 			expr: &actionExpr{
-				pos: position{line: 1430, col: 10, offset: 54110},
+				pos: position{line: 1430, col: 10, offset: 54122},
 				run: (*parser).callonTable1,
 				expr: &seqExpr{
-					pos: position{line: 1430, col: 10, offset: 54110},
+					pos: position{line: 1430, col: 10, offset: 54122},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1430, col: 10, offset: 54110},
+							pos:   position{line: 1430, col: 10, offset: 54122},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1430, col: 21, offset: 54121},
+								pos: position{line: 1430, col: 21, offset: 54133},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1430, col: 22, offset: 54122},
+									pos:  position{line: 1430, col: 22, offset: 54134},
 									name: "ElementAttributes",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1430, col: 42, offset: 54142},
+							pos:  position{line: 1430, col: 42, offset: 54154},
 							name: "TableDelimiter",
 						},
 						&labeledExpr{
-							pos:   position{line: 1431, col: 5, offset: 54161},
+							pos:   position{line: 1431, col: 5, offset: 54173},
 							label: "header",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1431, col: 12, offset: 54168},
+								pos: position{line: 1431, col: 12, offset: 54180},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1431, col: 13, offset: 54169},
+									pos:  position{line: 1431, col: 13, offset: 54181},
 									name: "TableLineHeader",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1432, col: 5, offset: 54191},
+							pos:   position{line: 1432, col: 5, offset: 54203},
 							label: "lines",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1432, col: 11, offset: 54197},
+								pos: position{line: 1432, col: 11, offset: 54209},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1432, col: 12, offset: 54198},
+									pos:  position{line: 1432, col: 12, offset: 54210},
 									name: "TableLine",
 								},
 							},
 						},
 						&choiceExpr{
-							pos: position{line: 1433, col: 6, offset: 54215},
+							pos: position{line: 1433, col: 6, offset: 54227},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 1433, col: 6, offset: 54215},
+									pos:  position{line: 1433, col: 6, offset: 54227},
 									name: "TableDelimiter",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1433, col: 23, offset: 54232},
+									pos:  position{line: 1433, col: 23, offset: 54244},
 									name: "EOF",
 								},
 							},
@@ -11189,19 +11193,19 @@ var g = &grammar{
 		},
 		{
 			name: "TableCellSeparator",
-			pos:  position{line: 1437, col: 1, offset: 54347},
+			pos:  position{line: 1437, col: 1, offset: 54359},
 			expr: &seqExpr{
-				pos: position{line: 1437, col: 23, offset: 54369},
+				pos: position{line: 1437, col: 23, offset: 54381},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1437, col: 23, offset: 54369},
+						pos:        position{line: 1437, col: 23, offset: 54381},
 						val:        "|",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1437, col: 27, offset: 54373},
+						pos: position{line: 1437, col: 27, offset: 54385},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1437, col: 27, offset: 54373},
+							pos:  position{line: 1437, col: 27, offset: 54385},
 							name: "WS",
 						},
 					},
@@ -11210,17 +11214,17 @@ var g = &grammar{
 		},
 		{
 			name: "TableDelimiter",
-			pos:  position{line: 1439, col: 1, offset: 54378},
+			pos:  position{line: 1439, col: 1, offset: 54390},
 			expr: &seqExpr{
-				pos: position{line: 1439, col: 19, offset: 54396},
+				pos: position{line: 1439, col: 19, offset: 54408},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1439, col: 19, offset: 54396},
+						pos:        position{line: 1439, col: 19, offset: 54408},
 						val:        "|===",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1439, col: 26, offset: 54403},
+						pos:  position{line: 1439, col: 26, offset: 54415},
 						name: "EOLS",
 					},
 				},
@@ -11228,37 +11232,37 @@ var g = &grammar{
 		},
 		{
 			name: "TableLineHeader",
-			pos:  position{line: 1442, col: 1, offset: 54472},
+			pos:  position{line: 1442, col: 1, offset: 54484},
 			expr: &actionExpr{
-				pos: position{line: 1442, col: 20, offset: 54491},
+				pos: position{line: 1442, col: 20, offset: 54503},
 				run: (*parser).callonTableLineHeader1,
 				expr: &seqExpr{
-					pos: position{line: 1442, col: 20, offset: 54491},
+					pos: position{line: 1442, col: 20, offset: 54503},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1442, col: 20, offset: 54491},
+							pos: position{line: 1442, col: 20, offset: 54503},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1442, col: 21, offset: 54492},
+								pos:  position{line: 1442, col: 21, offset: 54504},
 								name: "TableDelimiter",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1442, col: 36, offset: 54507},
+							pos:   position{line: 1442, col: 36, offset: 54519},
 							label: "cells",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1442, col: 42, offset: 54513},
+								pos: position{line: 1442, col: 42, offset: 54525},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1442, col: 43, offset: 54514},
+									pos:  position{line: 1442, col: 43, offset: 54526},
 									name: "TableCell",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1442, col: 55, offset: 54526},
+							pos:  position{line: 1442, col: 55, offset: 54538},
 							name: "EOL",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1442, col: 59, offset: 54530},
+							pos:  position{line: 1442, col: 59, offset: 54542},
 							name: "BlankLine",
 						},
 					},
@@ -11267,39 +11271,39 @@ var g = &grammar{
 		},
 		{
 			name: "TableLine",
-			pos:  position{line: 1446, col: 1, offset: 54598},
+			pos:  position{line: 1446, col: 1, offset: 54610},
 			expr: &actionExpr{
-				pos: position{line: 1446, col: 14, offset: 54611},
+				pos: position{line: 1446, col: 14, offset: 54623},
 				run: (*parser).callonTableLine1,
 				expr: &seqExpr{
-					pos: position{line: 1446, col: 14, offset: 54611},
+					pos: position{line: 1446, col: 14, offset: 54623},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1446, col: 14, offset: 54611},
+							pos: position{line: 1446, col: 14, offset: 54623},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1446, col: 15, offset: 54612},
+								pos:  position{line: 1446, col: 15, offset: 54624},
 								name: "TableDelimiter",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1446, col: 30, offset: 54627},
+							pos:   position{line: 1446, col: 30, offset: 54639},
 							label: "cells",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1446, col: 36, offset: 54633},
+								pos: position{line: 1446, col: 36, offset: 54645},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1446, col: 37, offset: 54634},
+									pos:  position{line: 1446, col: 37, offset: 54646},
 									name: "TableCell",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1446, col: 49, offset: 54646},
+							pos:  position{line: 1446, col: 49, offset: 54658},
 							name: "EOL",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1446, col: 53, offset: 54650},
+							pos: position{line: 1446, col: 53, offset: 54662},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1446, col: 53, offset: 54650},
+								pos:  position{line: 1446, col: 53, offset: 54662},
 								name: "BlankLine",
 							},
 						},
@@ -11309,54 +11313,54 @@ var g = &grammar{
 		},
 		{
 			name: "TableCell",
-			pos:  position{line: 1450, col: 1, offset: 54719},
+			pos:  position{line: 1450, col: 1, offset: 54731},
 			expr: &actionExpr{
-				pos: position{line: 1450, col: 14, offset: 54732},
+				pos: position{line: 1450, col: 14, offset: 54744},
 				run: (*parser).callonTableCell1,
 				expr: &seqExpr{
-					pos: position{line: 1450, col: 14, offset: 54732},
+					pos: position{line: 1450, col: 14, offset: 54744},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1450, col: 14, offset: 54732},
+							pos:  position{line: 1450, col: 14, offset: 54744},
 							name: "TableCellSeparator",
 						},
 						&labeledExpr{
-							pos:   position{line: 1450, col: 33, offset: 54751},
+							pos:   position{line: 1450, col: 33, offset: 54763},
 							label: "elements",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1450, col: 42, offset: 54760},
+								pos: position{line: 1450, col: 42, offset: 54772},
 								expr: &seqExpr{
-									pos: position{line: 1450, col: 43, offset: 54761},
+									pos: position{line: 1450, col: 43, offset: 54773},
 									exprs: []interface{}{
 										&notExpr{
-											pos: position{line: 1450, col: 43, offset: 54761},
+											pos: position{line: 1450, col: 43, offset: 54773},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1450, col: 44, offset: 54762},
+												pos:  position{line: 1450, col: 44, offset: 54774},
 												name: "TableCellSeparator",
 											},
 										},
 										&notExpr{
-											pos: position{line: 1450, col: 63, offset: 54781},
+											pos: position{line: 1450, col: 63, offset: 54793},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1450, col: 64, offset: 54782},
+												pos:  position{line: 1450, col: 64, offset: 54794},
 												name: "EOL",
 											},
 										},
 										&zeroOrMoreExpr{
-											pos: position{line: 1450, col: 68, offset: 54786},
+											pos: position{line: 1450, col: 68, offset: 54798},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1450, col: 68, offset: 54786},
+												pos:  position{line: 1450, col: 68, offset: 54798},
 												name: "WS",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1450, col: 72, offset: 54790},
+											pos:  position{line: 1450, col: 72, offset: 54802},
 											name: "InlineElement",
 										},
 										&zeroOrMoreExpr{
-											pos: position{line: 1450, col: 86, offset: 54804},
+											pos: position{line: 1450, col: 86, offset: 54816},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1450, col: 86, offset: 54804},
+												pos:  position{line: 1450, col: 86, offset: 54816},
 												name: "WS",
 											},
 										},
@@ -11370,66 +11374,66 @@ var g = &grammar{
 		},
 		{
 			name: "CommentBlockDelimiter",
-			pos:  position{line: 1457, col: 1, offset: 55050},
+			pos:  position{line: 1457, col: 1, offset: 55062},
 			expr: &litMatcher{
-				pos:        position{line: 1457, col: 26, offset: 55075},
+				pos:        position{line: 1457, col: 26, offset: 55087},
 				val:        "////",
 				ignoreCase: false,
 			},
 		},
 		{
 			name: "CommentBlock",
-			pos:  position{line: 1459, col: 1, offset: 55083},
+			pos:  position{line: 1459, col: 1, offset: 55095},
 			expr: &actionExpr{
-				pos: position{line: 1459, col: 17, offset: 55099},
+				pos: position{line: 1459, col: 17, offset: 55111},
 				run: (*parser).callonCommentBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1459, col: 17, offset: 55099},
+					pos: position{line: 1459, col: 17, offset: 55111},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1459, col: 17, offset: 55099},
+							pos:  position{line: 1459, col: 17, offset: 55111},
 							name: "CommentBlockDelimiter",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1459, col: 39, offset: 55121},
+							pos: position{line: 1459, col: 39, offset: 55133},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1459, col: 39, offset: 55121},
+								pos:  position{line: 1459, col: 39, offset: 55133},
 								name: "WS",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1459, col: 43, offset: 55125},
+							pos:  position{line: 1459, col: 43, offset: 55137},
 							name: "NEWLINE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1459, col: 51, offset: 55133},
+							pos:   position{line: 1459, col: 51, offset: 55145},
 							label: "content",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1459, col: 59, offset: 55141},
+								pos: position{line: 1459, col: 59, offset: 55153},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1459, col: 60, offset: 55142},
+									pos:  position{line: 1459, col: 60, offset: 55154},
 									name: "CommentBlockLine",
 								},
 							},
 						},
 						&choiceExpr{
-							pos: position{line: 1459, col: 81, offset: 55163},
+							pos: position{line: 1459, col: 81, offset: 55175},
 							alternatives: []interface{}{
 								&seqExpr{
-									pos: position{line: 1459, col: 82, offset: 55164},
+									pos: position{line: 1459, col: 82, offset: 55176},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 1459, col: 82, offset: 55164},
+											pos:  position{line: 1459, col: 82, offset: 55176},
 											name: "CommentBlockDelimiter",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1459, col: 104, offset: 55186},
+											pos:  position{line: 1459, col: 104, offset: 55198},
 											name: "EOLS",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1459, col: 112, offset: 55194},
+									pos:  position{line: 1459, col: 112, offset: 55206},
 									name: "EOF",
 								},
 							},
@@ -11440,45 +11444,45 @@ var g = &grammar{
 		},
 		{
 			name: "CommentBlockLine",
-			pos:  position{line: 1463, col: 1, offset: 55300},
+			pos:  position{line: 1463, col: 1, offset: 55312},
 			expr: &actionExpr{
-				pos: position{line: 1463, col: 21, offset: 55320},
+				pos: position{line: 1463, col: 21, offset: 55332},
 				run: (*parser).callonCommentBlockLine1,
 				expr: &seqExpr{
-					pos: position{line: 1463, col: 21, offset: 55320},
+					pos: position{line: 1463, col: 21, offset: 55332},
 					exprs: []interface{}{
 						&zeroOrMoreExpr{
-							pos: position{line: 1463, col: 21, offset: 55320},
+							pos: position{line: 1463, col: 21, offset: 55332},
 							expr: &choiceExpr{
-								pos: position{line: 1463, col: 22, offset: 55321},
+								pos: position{line: 1463, col: 22, offset: 55333},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1463, col: 22, offset: 55321},
+										pos:  position{line: 1463, col: 22, offset: 55333},
 										name: "Alphanums",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1463, col: 34, offset: 55333},
+										pos:  position{line: 1463, col: 34, offset: 55345},
 										name: "Spaces",
 									},
 									&seqExpr{
-										pos: position{line: 1463, col: 44, offset: 55343},
+										pos: position{line: 1463, col: 44, offset: 55355},
 										exprs: []interface{}{
 											&notExpr{
-												pos: position{line: 1463, col: 44, offset: 55343},
+												pos: position{line: 1463, col: 44, offset: 55355},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1463, col: 45, offset: 55344},
+													pos:  position{line: 1463, col: 45, offset: 55356},
 													name: "CommentBlockDelimiter",
 												},
 											},
 											&notExpr{
-												pos: position{line: 1463, col: 67, offset: 55366},
+												pos: position{line: 1463, col: 67, offset: 55378},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1463, col: 68, offset: 55367},
+													pos:  position{line: 1463, col: 68, offset: 55379},
 													name: "EOL",
 												},
 											},
 											&anyMatcher{
-												line: 1463, col: 72, offset: 55371,
+												line: 1463, col: 72, offset: 55383,
 											},
 										},
 									},
@@ -11486,7 +11490,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1463, col: 77, offset: 55376},
+							pos:  position{line: 1463, col: 77, offset: 55388},
 							name: "EOL",
 						},
 					},
@@ -11495,42 +11499,42 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineComment",
-			pos:  position{line: 1467, col: 1, offset: 55416},
+			pos:  position{line: 1467, col: 1, offset: 55428},
 			expr: &actionExpr{
-				pos: position{line: 1467, col: 22, offset: 55437},
+				pos: position{line: 1467, col: 22, offset: 55449},
 				run: (*parser).callonSingleLineComment1,
 				expr: &seqExpr{
-					pos: position{line: 1467, col: 22, offset: 55437},
+					pos: position{line: 1467, col: 22, offset: 55449},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1467, col: 22, offset: 55437},
+							pos: position{line: 1467, col: 22, offset: 55449},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1467, col: 23, offset: 55438},
+								pos:  position{line: 1467, col: 23, offset: 55450},
 								name: "CommentBlockDelimiter",
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1467, col: 45, offset: 55460},
+							pos: position{line: 1467, col: 45, offset: 55472},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1467, col: 45, offset: 55460},
+								pos:  position{line: 1467, col: 45, offset: 55472},
 								name: "WS",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1467, col: 49, offset: 55464},
+							pos:        position{line: 1467, col: 49, offset: 55476},
 							val:        "//",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1467, col: 54, offset: 55469},
+							pos:   position{line: 1467, col: 54, offset: 55481},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1467, col: 63, offset: 55478},
+								pos:  position{line: 1467, col: 63, offset: 55490},
 								name: "SingleLineCommentContent",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1467, col: 89, offset: 55504},
+							pos:  position{line: 1467, col: 89, offset: 55516},
 							name: "EOL",
 						},
 					},
@@ -11539,35 +11543,35 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineCommentContent",
-			pos:  position{line: 1471, col: 1, offset: 55569},
+			pos:  position{line: 1471, col: 1, offset: 55581},
 			expr: &actionExpr{
-				pos: position{line: 1471, col: 29, offset: 55597},
+				pos: position{line: 1471, col: 29, offset: 55609},
 				run: (*parser).callonSingleLineCommentContent1,
 				expr: &zeroOrMoreExpr{
-					pos: position{line: 1471, col: 29, offset: 55597},
+					pos: position{line: 1471, col: 29, offset: 55609},
 					expr: &choiceExpr{
-						pos: position{line: 1471, col: 30, offset: 55598},
+						pos: position{line: 1471, col: 30, offset: 55610},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 1471, col: 30, offset: 55598},
+								pos:  position{line: 1471, col: 30, offset: 55610},
 								name: "Alphanums",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1471, col: 42, offset: 55610},
+								pos:  position{line: 1471, col: 42, offset: 55622},
 								name: "Spaces",
 							},
 							&seqExpr{
-								pos: position{line: 1471, col: 52, offset: 55620},
+								pos: position{line: 1471, col: 52, offset: 55632},
 								exprs: []interface{}{
 									&notExpr{
-										pos: position{line: 1471, col: 52, offset: 55620},
+										pos: position{line: 1471, col: 52, offset: 55632},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1471, col: 53, offset: 55621},
+											pos:  position{line: 1471, col: 53, offset: 55633},
 											name: "EOL",
 										},
 									},
 									&anyMatcher{
-										line: 1471, col: 58, offset: 55626,
+										line: 1471, col: 58, offset: 55638,
 									},
 								},
 							},
@@ -11578,20 +11582,20 @@ var g = &grammar{
 		},
 		{
 			name: "LiteralBlock",
-			pos:  position{line: 1479, col: 1, offset: 55935},
+			pos:  position{line: 1479, col: 1, offset: 55947},
 			expr: &choiceExpr{
-				pos: position{line: 1479, col: 17, offset: 55951},
+				pos: position{line: 1479, col: 17, offset: 55963},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1479, col: 17, offset: 55951},
+						pos:  position{line: 1479, col: 17, offset: 55963},
 						name: "ParagraphWithLiteralAttribute",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1479, col: 49, offset: 55983},
+						pos:  position{line: 1479, col: 49, offset: 55995},
 						name: "ParagraphWithHeadingSpaces",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1479, col: 78, offset: 56012},
+						pos:  position{line: 1479, col: 78, offset: 56024},
 						name: "ParagraphWithLiteralBlockDelimiter",
 					},
 				},
@@ -11599,38 +11603,38 @@ var g = &grammar{
 		},
 		{
 			name: "LiteralBlockDelimiter",
-			pos:  position{line: 1481, col: 1, offset: 56048},
+			pos:  position{line: 1481, col: 1, offset: 56060},
 			expr: &litMatcher{
-				pos:        position{line: 1481, col: 26, offset: 56073},
+				pos:        position{line: 1481, col: 26, offset: 56085},
 				val:        "....",
 				ignoreCase: false,
 			},
 		},
 		{
 			name: "ParagraphWithHeadingSpaces",
-			pos:  position{line: 1484, col: 1, offset: 56145},
+			pos:  position{line: 1484, col: 1, offset: 56157},
 			expr: &actionExpr{
-				pos: position{line: 1484, col: 31, offset: 56175},
+				pos: position{line: 1484, col: 31, offset: 56187},
 				run: (*parser).callonParagraphWithHeadingSpaces1,
 				expr: &seqExpr{
-					pos: position{line: 1484, col: 31, offset: 56175},
+					pos: position{line: 1484, col: 31, offset: 56187},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1484, col: 31, offset: 56175},
+							pos:   position{line: 1484, col: 31, offset: 56187},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1484, col: 42, offset: 56186},
+								pos: position{line: 1484, col: 42, offset: 56198},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1484, col: 43, offset: 56187},
+									pos:  position{line: 1484, col: 43, offset: 56199},
 									name: "ElementAttributes",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1484, col: 63, offset: 56207},
+							pos:   position{line: 1484, col: 63, offset: 56219},
 							label: "lines",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1484, col: 70, offset: 56214},
+								pos:  position{line: 1484, col: 70, offset: 56226},
 								name: "ParagraphWithHeadingSpacesLines",
 							},
 						},
@@ -11640,54 +11644,54 @@ var g = &grammar{
 		},
 		{
 			name: "ParagraphWithHeadingSpacesLines",
-			pos:  position{line: 1489, col: 1, offset: 56444},
+			pos:  position{line: 1489, col: 1, offset: 56456},
 			expr: &actionExpr{
-				pos: position{line: 1490, col: 5, offset: 56484},
+				pos: position{line: 1490, col: 5, offset: 56496},
 				run: (*parser).callonParagraphWithHeadingSpacesLines1,
 				expr: &seqExpr{
-					pos: position{line: 1490, col: 5, offset: 56484},
+					pos: position{line: 1490, col: 5, offset: 56496},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1490, col: 5, offset: 56484},
+							pos:   position{line: 1490, col: 5, offset: 56496},
 							label: "firstLine",
 							expr: &actionExpr{
-								pos: position{line: 1490, col: 16, offset: 56495},
+								pos: position{line: 1490, col: 16, offset: 56507},
 								run: (*parser).callonParagraphWithHeadingSpacesLines4,
 								expr: &seqExpr{
-									pos: position{line: 1490, col: 16, offset: 56495},
+									pos: position{line: 1490, col: 16, offset: 56507},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 1490, col: 16, offset: 56495},
+											pos:  position{line: 1490, col: 16, offset: 56507},
 											name: "WS",
 										},
 										&oneOrMoreExpr{
-											pos: position{line: 1490, col: 19, offset: 56498},
+											pos: position{line: 1490, col: 19, offset: 56510},
 											expr: &choiceExpr{
-												pos: position{line: 1490, col: 20, offset: 56499},
+												pos: position{line: 1490, col: 20, offset: 56511},
 												alternatives: []interface{}{
 													&ruleRefExpr{
-														pos:  position{line: 1490, col: 20, offset: 56499},
+														pos:  position{line: 1490, col: 20, offset: 56511},
 														name: "Alphanums",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1490, col: 32, offset: 56511},
+														pos:  position{line: 1490, col: 32, offset: 56523},
 														name: "Spaces",
 													},
 													&actionExpr{
-														pos: position{line: 1490, col: 41, offset: 56520},
+														pos: position{line: 1490, col: 41, offset: 56532},
 														run: (*parser).callonParagraphWithHeadingSpacesLines11,
 														expr: &seqExpr{
-															pos: position{line: 1490, col: 42, offset: 56521},
+															pos: position{line: 1490, col: 42, offset: 56533},
 															exprs: []interface{}{
 																&notExpr{
-																	pos: position{line: 1490, col: 42, offset: 56521},
+																	pos: position{line: 1490, col: 42, offset: 56533},
 																	expr: &ruleRefExpr{
-																		pos:  position{line: 1490, col: 43, offset: 56522},
+																		pos:  position{line: 1490, col: 43, offset: 56534},
 																		name: "EOL",
 																	},
 																},
 																&anyMatcher{
-																	line: 1490, col: 48, offset: 56527,
+																	line: 1490, col: 48, offset: 56539,
 																},
 															},
 														},
@@ -11700,58 +11704,58 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1494, col: 8, offset: 56618},
+							pos:  position{line: 1494, col: 8, offset: 56630},
 							name: "EOL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1495, col: 5, offset: 56681},
+							pos:   position{line: 1495, col: 5, offset: 56693},
 							label: "otherLines",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1495, col: 16, offset: 56692},
+								pos: position{line: 1495, col: 16, offset: 56704},
 								expr: &actionExpr{
-									pos: position{line: 1496, col: 9, offset: 56702},
+									pos: position{line: 1496, col: 9, offset: 56714},
 									run: (*parser).callonParagraphWithHeadingSpacesLines19,
 									expr: &seqExpr{
-										pos: position{line: 1496, col: 9, offset: 56702},
+										pos: position{line: 1496, col: 9, offset: 56714},
 										exprs: []interface{}{
 											&notExpr{
-												pos: position{line: 1496, col: 9, offset: 56702},
+												pos: position{line: 1496, col: 9, offset: 56714},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1496, col: 10, offset: 56703},
+													pos:  position{line: 1496, col: 10, offset: 56715},
 													name: "BlankLine",
 												},
 											},
 											&labeledExpr{
-												pos:   position{line: 1497, col: 9, offset: 56722},
+												pos:   position{line: 1497, col: 9, offset: 56734},
 												label: "otherLine",
 												expr: &actionExpr{
-													pos: position{line: 1497, col: 20, offset: 56733},
+													pos: position{line: 1497, col: 20, offset: 56745},
 													run: (*parser).callonParagraphWithHeadingSpacesLines24,
 													expr: &oneOrMoreExpr{
-														pos: position{line: 1497, col: 20, offset: 56733},
+														pos: position{line: 1497, col: 20, offset: 56745},
 														expr: &choiceExpr{
-															pos: position{line: 1497, col: 21, offset: 56734},
+															pos: position{line: 1497, col: 21, offset: 56746},
 															alternatives: []interface{}{
 																&ruleRefExpr{
-																	pos:  position{line: 1497, col: 21, offset: 56734},
+																	pos:  position{line: 1497, col: 21, offset: 56746},
 																	name: "Alphanums",
 																},
 																&ruleRefExpr{
-																	pos:  position{line: 1497, col: 33, offset: 56746},
+																	pos:  position{line: 1497, col: 33, offset: 56758},
 																	name: "Spaces",
 																},
 																&seqExpr{
-																	pos: position{line: 1497, col: 43, offset: 56756},
+																	pos: position{line: 1497, col: 43, offset: 56768},
 																	exprs: []interface{}{
 																		&notExpr{
-																			pos: position{line: 1497, col: 43, offset: 56756},
+																			pos: position{line: 1497, col: 43, offset: 56768},
 																			expr: &ruleRefExpr{
-																				pos:  position{line: 1497, col: 44, offset: 56757},
+																				pos:  position{line: 1497, col: 44, offset: 56769},
 																				name: "EOL",
 																			},
 																		},
 																		&anyMatcher{
-																			line: 1497, col: 49, offset: 56762,
+																			line: 1497, col: 49, offset: 56774,
 																		},
 																	},
 																},
@@ -11761,7 +11765,7 @@ var g = &grammar{
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1499, col: 12, offset: 56819},
+												pos:  position{line: 1499, col: 12, offset: 56831},
 												name: "EOL",
 											},
 										},
@@ -11775,65 +11779,65 @@ var g = &grammar{
 		},
 		{
 			name: "ParagraphWithLiteralBlockDelimiter",
-			pos:  position{line: 1506, col: 1, offset: 57049},
+			pos:  position{line: 1506, col: 1, offset: 57061},
 			expr: &actionExpr{
-				pos: position{line: 1506, col: 39, offset: 57087},
+				pos: position{line: 1506, col: 39, offset: 57099},
 				run: (*parser).callonParagraphWithLiteralBlockDelimiter1,
 				expr: &seqExpr{
-					pos: position{line: 1506, col: 39, offset: 57087},
+					pos: position{line: 1506, col: 39, offset: 57099},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1506, col: 39, offset: 57087},
+							pos:   position{line: 1506, col: 39, offset: 57099},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1506, col: 50, offset: 57098},
+								pos: position{line: 1506, col: 50, offset: 57110},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1506, col: 51, offset: 57099},
+									pos:  position{line: 1506, col: 51, offset: 57111},
 									name: "ElementAttributes",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1507, col: 9, offset: 57127},
+							pos:  position{line: 1507, col: 9, offset: 57139},
 							name: "LiteralBlockDelimiter",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1507, col: 31, offset: 57149},
+							pos: position{line: 1507, col: 31, offset: 57161},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1507, col: 31, offset: 57149},
+								pos:  position{line: 1507, col: 31, offset: 57161},
 								name: "WS",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1507, col: 35, offset: 57153},
+							pos:  position{line: 1507, col: 35, offset: 57165},
 							name: "NEWLINE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1507, col: 43, offset: 57161},
+							pos:   position{line: 1507, col: 43, offset: 57173},
 							label: "lines",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1507, col: 50, offset: 57168},
+								pos:  position{line: 1507, col: 50, offset: 57180},
 								name: "ParagraphWithLiteralBlockDelimiterLines",
 							},
 						},
 						&choiceExpr{
-							pos: position{line: 1507, col: 92, offset: 57210},
+							pos: position{line: 1507, col: 92, offset: 57222},
 							alternatives: []interface{}{
 								&seqExpr{
-									pos: position{line: 1507, col: 93, offset: 57211},
+									pos: position{line: 1507, col: 93, offset: 57223},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 1507, col: 93, offset: 57211},
+											pos:  position{line: 1507, col: 93, offset: 57223},
 											name: "LiteralBlockDelimiter",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1507, col: 115, offset: 57233},
+											pos:  position{line: 1507, col: 115, offset: 57245},
 											name: "EOLS",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1507, col: 123, offset: 57241},
+									pos:  position{line: 1507, col: 123, offset: 57253},
 									name: "EOF",
 								},
 							},
@@ -11844,17 +11848,17 @@ var g = &grammar{
 		},
 		{
 			name: "ParagraphWithLiteralBlockDelimiterLines",
-			pos:  position{line: 1512, col: 1, offset: 57400},
+			pos:  position{line: 1512, col: 1, offset: 57412},
 			expr: &actionExpr{
-				pos: position{line: 1512, col: 44, offset: 57443},
+				pos: position{line: 1512, col: 44, offset: 57455},
 				run: (*parser).callonParagraphWithLiteralBlockDelimiterLines1,
 				expr: &labeledExpr{
-					pos:   position{line: 1512, col: 44, offset: 57443},
+					pos:   position{line: 1512, col: 44, offset: 57455},
 					label: "lines",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 1512, col: 50, offset: 57449},
+						pos: position{line: 1512, col: 50, offset: 57461},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1512, col: 51, offset: 57450},
+							pos:  position{line: 1512, col: 51, offset: 57462},
 							name: "ParagraphWithLiteralBlockDelimiterLine",
 						},
 					},
@@ -11863,51 +11867,51 @@ var g = &grammar{
 		},
 		{
 			name: "ParagraphWithLiteralBlockDelimiterLine",
-			pos:  position{line: 1516, col: 1, offset: 57534},
+			pos:  position{line: 1516, col: 1, offset: 57546},
 			expr: &actionExpr{
-				pos: position{line: 1517, col: 5, offset: 57589},
+				pos: position{line: 1517, col: 5, offset: 57601},
 				run: (*parser).callonParagraphWithLiteralBlockDelimiterLine1,
 				expr: &seqExpr{
-					pos: position{line: 1517, col: 5, offset: 57589},
+					pos: position{line: 1517, col: 5, offset: 57601},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1517, col: 5, offset: 57589},
+							pos:   position{line: 1517, col: 5, offset: 57601},
 							label: "line",
 							expr: &actionExpr{
-								pos: position{line: 1517, col: 11, offset: 57595},
+								pos: position{line: 1517, col: 11, offset: 57607},
 								run: (*parser).callonParagraphWithLiteralBlockDelimiterLine4,
 								expr: &zeroOrMoreExpr{
-									pos: position{line: 1517, col: 11, offset: 57595},
+									pos: position{line: 1517, col: 11, offset: 57607},
 									expr: &choiceExpr{
-										pos: position{line: 1517, col: 12, offset: 57596},
+										pos: position{line: 1517, col: 12, offset: 57608},
 										alternatives: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1517, col: 12, offset: 57596},
+												pos:  position{line: 1517, col: 12, offset: 57608},
 												name: "Alphanums",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1517, col: 24, offset: 57608},
+												pos:  position{line: 1517, col: 24, offset: 57620},
 												name: "Spaces",
 											},
 											&seqExpr{
-												pos: position{line: 1517, col: 34, offset: 57618},
+												pos: position{line: 1517, col: 34, offset: 57630},
 												exprs: []interface{}{
 													&notExpr{
-														pos: position{line: 1517, col: 34, offset: 57618},
+														pos: position{line: 1517, col: 34, offset: 57630},
 														expr: &ruleRefExpr{
-															pos:  position{line: 1517, col: 35, offset: 57619},
+															pos:  position{line: 1517, col: 35, offset: 57631},
 															name: "LiteralBlockDelimiter",
 														},
 													},
 													&notExpr{
-														pos: position{line: 1517, col: 57, offset: 57641},
+														pos: position{line: 1517, col: 57, offset: 57653},
 														expr: &ruleRefExpr{
-															pos:  position{line: 1517, col: 58, offset: 57642},
+															pos:  position{line: 1517, col: 58, offset: 57654},
 															name: "EOL",
 														},
 													},
 													&anyMatcher{
-														line: 1517, col: 62, offset: 57646,
+														line: 1517, col: 62, offset: 57658,
 													},
 												},
 											},
@@ -11917,7 +11921,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1519, col: 8, offset: 57695},
+							pos:  position{line: 1519, col: 8, offset: 57707},
 							name: "EOL",
 						},
 					},
@@ -11926,33 +11930,33 @@ var g = &grammar{
 		},
 		{
 			name: "ParagraphWithLiteralAttribute",
-			pos:  position{line: 1524, col: 1, offset: 57821},
+			pos:  position{line: 1524, col: 1, offset: 57833},
 			expr: &actionExpr{
-				pos: position{line: 1525, col: 5, offset: 57859},
+				pos: position{line: 1525, col: 5, offset: 57871},
 				run: (*parser).callonParagraphWithLiteralAttribute1,
 				expr: &seqExpr{
-					pos: position{line: 1525, col: 5, offset: 57859},
+					pos: position{line: 1525, col: 5, offset: 57871},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1525, col: 5, offset: 57859},
+							pos:   position{line: 1525, col: 5, offset: 57871},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1525, col: 16, offset: 57870},
+								pos: position{line: 1525, col: 16, offset: 57882},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1525, col: 17, offset: 57871},
+									pos:  position{line: 1525, col: 17, offset: 57883},
 									name: "ElementAttributes",
 								},
 							},
 						},
 						&andCodeExpr{
-							pos: position{line: 1526, col: 5, offset: 57895},
+							pos: position{line: 1526, col: 5, offset: 57907},
 							run: (*parser).callonParagraphWithLiteralAttribute6,
 						},
 						&labeledExpr{
-							pos:   position{line: 1533, col: 5, offset: 58109},
+							pos:   position{line: 1533, col: 5, offset: 58121},
 							label: "lines",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1533, col: 12, offset: 58116},
+								pos:  position{line: 1533, col: 12, offset: 58128},
 								name: "ParagraphWithLiteralAttributeLines",
 							},
 						},
@@ -11962,12 +11966,12 @@ var g = &grammar{
 		},
 		{
 			name: "LiteralKind",
-			pos:  position{line: 1537, col: 1, offset: 58266},
+			pos:  position{line: 1537, col: 1, offset: 58278},
 			expr: &actionExpr{
-				pos: position{line: 1537, col: 16, offset: 58281},
+				pos: position{line: 1537, col: 16, offset: 58293},
 				run: (*parser).callonLiteralKind1,
 				expr: &litMatcher{
-					pos:        position{line: 1537, col: 16, offset: 58281},
+					pos:        position{line: 1537, col: 16, offset: 58293},
 					val:        "literal",
 					ignoreCase: false,
 				},
@@ -11975,17 +11979,17 @@ var g = &grammar{
 		},
 		{
 			name: "ParagraphWithLiteralAttributeLines",
-			pos:  position{line: 1542, col: 1, offset: 58364},
+			pos:  position{line: 1542, col: 1, offset: 58376},
 			expr: &actionExpr{
-				pos: position{line: 1542, col: 39, offset: 58402},
+				pos: position{line: 1542, col: 39, offset: 58414},
 				run: (*parser).callonParagraphWithLiteralAttributeLines1,
 				expr: &labeledExpr{
-					pos:   position{line: 1542, col: 39, offset: 58402},
+					pos:   position{line: 1542, col: 39, offset: 58414},
 					label: "lines",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 1542, col: 45, offset: 58408},
+						pos: position{line: 1542, col: 45, offset: 58420},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1542, col: 46, offset: 58409},
+							pos:  position{line: 1542, col: 46, offset: 58421},
 							name: "ParagraphWithLiteralAttributeLine",
 						},
 					},
@@ -11994,54 +11998,54 @@ var g = &grammar{
 		},
 		{
 			name: "ParagraphWithLiteralAttributeLine",
-			pos:  position{line: 1546, col: 1, offset: 58489},
+			pos:  position{line: 1546, col: 1, offset: 58501},
 			expr: &actionExpr{
-				pos: position{line: 1546, col: 38, offset: 58526},
+				pos: position{line: 1546, col: 38, offset: 58538},
 				run: (*parser).callonParagraphWithLiteralAttributeLine1,
 				expr: &seqExpr{
-					pos: position{line: 1546, col: 38, offset: 58526},
+					pos: position{line: 1546, col: 38, offset: 58538},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1546, col: 38, offset: 58526},
+							pos:   position{line: 1546, col: 38, offset: 58538},
 							label: "line",
 							expr: &actionExpr{
-								pos: position{line: 1546, col: 44, offset: 58532},
+								pos: position{line: 1546, col: 44, offset: 58544},
 								run: (*parser).callonParagraphWithLiteralAttributeLine4,
 								expr: &seqExpr{
-									pos: position{line: 1546, col: 44, offset: 58532},
+									pos: position{line: 1546, col: 44, offset: 58544},
 									exprs: []interface{}{
 										&notExpr{
-											pos: position{line: 1546, col: 44, offset: 58532},
+											pos: position{line: 1546, col: 44, offset: 58544},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1546, col: 46, offset: 58534},
+												pos:  position{line: 1546, col: 46, offset: 58546},
 												name: "BlankLine",
 											},
 										},
 										&oneOrMoreExpr{
-											pos: position{line: 1546, col: 57, offset: 58545},
+											pos: position{line: 1546, col: 57, offset: 58557},
 											expr: &choiceExpr{
-												pos: position{line: 1546, col: 58, offset: 58546},
+												pos: position{line: 1546, col: 58, offset: 58558},
 												alternatives: []interface{}{
 													&ruleRefExpr{
-														pos:  position{line: 1546, col: 58, offset: 58546},
+														pos:  position{line: 1546, col: 58, offset: 58558},
 														name: "Alphanums",
 													},
 													&ruleRefExpr{
-														pos:  position{line: 1546, col: 70, offset: 58558},
+														pos:  position{line: 1546, col: 70, offset: 58570},
 														name: "Spaces",
 													},
 													&seqExpr{
-														pos: position{line: 1546, col: 80, offset: 58568},
+														pos: position{line: 1546, col: 80, offset: 58580},
 														exprs: []interface{}{
 															&notExpr{
-																pos: position{line: 1546, col: 80, offset: 58568},
+																pos: position{line: 1546, col: 80, offset: 58580},
 																expr: &ruleRefExpr{
-																	pos:  position{line: 1546, col: 81, offset: 58569},
+																	pos:  position{line: 1546, col: 81, offset: 58581},
 																	name: "EOL",
 																},
 															},
 															&anyMatcher{
-																line: 1546, col: 86, offset: 58574,
+																line: 1546, col: 86, offset: 58586,
 															},
 														},
 													},
@@ -12053,7 +12057,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1548, col: 4, offset: 58615},
+							pos:  position{line: 1548, col: 4, offset: 58627},
 							name: "EOL",
 						},
 					},
@@ -12062,22 +12066,22 @@ var g = &grammar{
 		},
 		{
 			name: "BlankLine",
-			pos:  position{line: 1555, col: 1, offset: 58787},
+			pos:  position{line: 1555, col: 1, offset: 58799},
 			expr: &actionExpr{
-				pos: position{line: 1555, col: 14, offset: 58800},
+				pos: position{line: 1555, col: 14, offset: 58812},
 				run: (*parser).callonBlankLine1,
 				expr: &seqExpr{
-					pos: position{line: 1555, col: 14, offset: 58800},
+					pos: position{line: 1555, col: 14, offset: 58812},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1555, col: 14, offset: 58800},
+							pos: position{line: 1555, col: 14, offset: 58812},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1555, col: 15, offset: 58801},
+								pos:  position{line: 1555, col: 15, offset: 58813},
 								name: "EOF",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1555, col: 19, offset: 58805},
+							pos:  position{line: 1555, col: 19, offset: 58817},
 							name: "EOLS",
 						},
 					},
@@ -12086,9 +12090,9 @@ var g = &grammar{
 		},
 		{
 			name: "Alphanum",
-			pos:  position{line: 1562, col: 1, offset: 58953},
+			pos:  position{line: 1562, col: 1, offset: 58965},
 			expr: &charClassMatcher{
-				pos:        position{line: 1562, col: 13, offset: 58965},
+				pos:        position{line: 1562, col: 13, offset: 58977},
 				val:        "[\\pL0-9]",
 				ranges:     []rune{'0', '9'},
 				classes:    []*unicode.RangeTable{rangeTable("L")},
@@ -12098,37 +12102,37 @@ var g = &grammar{
 		},
 		{
 			name: "Parenthesis",
-			pos:  position{line: 1564, col: 1, offset: 58975},
+			pos:  position{line: 1564, col: 1, offset: 58987},
 			expr: &choiceExpr{
-				pos: position{line: 1564, col: 16, offset: 58990},
+				pos: position{line: 1564, col: 16, offset: 59002},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1564, col: 16, offset: 58990},
+						pos:        position{line: 1564, col: 16, offset: 59002},
 						val:        "(",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1564, col: 22, offset: 58996},
+						pos:        position{line: 1564, col: 22, offset: 59008},
 						val:        ")",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1564, col: 28, offset: 59002},
+						pos:        position{line: 1564, col: 28, offset: 59014},
 						val:        "[",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1564, col: 34, offset: 59008},
+						pos:        position{line: 1564, col: 34, offset: 59020},
 						val:        "]",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1564, col: 40, offset: 59014},
+						pos:        position{line: 1564, col: 40, offset: 59026},
 						val:        "{",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1564, col: 46, offset: 59020},
+						pos:        position{line: 1564, col: 46, offset: 59032},
 						val:        "}",
 						ignoreCase: false,
 					},
@@ -12137,14 +12141,14 @@ var g = &grammar{
 		},
 		{
 			name: "Alphanums",
-			pos:  position{line: 1566, col: 1, offset: 59026},
+			pos:  position{line: 1566, col: 1, offset: 59038},
 			expr: &actionExpr{
-				pos: position{line: 1566, col: 14, offset: 59039},
+				pos: position{line: 1566, col: 14, offset: 59051},
 				run: (*parser).callonAlphanums1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1566, col: 14, offset: 59039},
+					pos: position{line: 1566, col: 14, offset: 59051},
 					expr: &charClassMatcher{
-						pos:        position{line: 1566, col: 14, offset: 59039},
+						pos:        position{line: 1566, col: 14, offset: 59051},
 						val:        "[\\pL0-9]",
 						ranges:     []rune{'0', '9'},
 						classes:    []*unicode.RangeTable{rangeTable("L")},
@@ -12156,37 +12160,37 @@ var g = &grammar{
 		},
 		{
 			name: "Dot",
-			pos:  position{line: 1570, col: 1, offset: 59085},
+			pos:  position{line: 1570, col: 1, offset: 59097},
 			expr: &litMatcher{
-				pos:        position{line: 1570, col: 8, offset: 59092},
+				pos:        position{line: 1570, col: 8, offset: 59104},
 				val:        ".",
 				ignoreCase: false,
 			},
 		},
 		{
 			name: "SimpleWord",
-			pos:  position{line: 1572, col: 1, offset: 59097},
+			pos:  position{line: 1572, col: 1, offset: 59109},
 			expr: &actionExpr{
-				pos: position{line: 1572, col: 15, offset: 59111},
+				pos: position{line: 1572, col: 15, offset: 59123},
 				run: (*parser).callonSimpleWord1,
 				expr: &seqExpr{
-					pos: position{line: 1572, col: 15, offset: 59111},
+					pos: position{line: 1572, col: 15, offset: 59123},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1572, col: 15, offset: 59111},
+							pos:  position{line: 1572, col: 15, offset: 59123},
 							name: "Alphanums",
 						},
 						&andExpr{
-							pos: position{line: 1572, col: 25, offset: 59121},
+							pos: position{line: 1572, col: 25, offset: 59133},
 							expr: &choiceExpr{
-								pos: position{line: 1572, col: 27, offset: 59123},
+								pos: position{line: 1572, col: 27, offset: 59135},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1572, col: 27, offset: 59123},
+										pos:  position{line: 1572, col: 27, offset: 59135},
 										name: "WS",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1572, col: 32, offset: 59128},
+										pos:  position{line: 1572, col: 32, offset: 59140},
 										name: "EOL",
 									},
 								},
@@ -12198,83 +12202,83 @@ var g = &grammar{
 		},
 		{
 			name: "OtherWord",
-			pos:  position{line: 1577, col: 1, offset: 59393},
+			pos:  position{line: 1577, col: 1, offset: 59405},
 			expr: &actionExpr{
-				pos: position{line: 1577, col: 14, offset: 59406},
+				pos: position{line: 1577, col: 14, offset: 59418},
 				run: (*parser).callonOtherWord1,
 				expr: &choiceExpr{
-					pos: position{line: 1577, col: 15, offset: 59407},
+					pos: position{line: 1577, col: 15, offset: 59419},
 					alternatives: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1577, col: 15, offset: 59407},
+							pos:  position{line: 1577, col: 15, offset: 59419},
 							name: "Alphanums",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1577, col: 27, offset: 59419},
+							pos:  position{line: 1577, col: 27, offset: 59431},
 							name: "QuotedTextPrefix",
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 1577, col: 46, offset: 59438},
+							pos: position{line: 1577, col: 46, offset: 59450},
 							expr: &actionExpr{
-								pos: position{line: 1577, col: 47, offset: 59439},
+								pos: position{line: 1577, col: 47, offset: 59451},
 								run: (*parser).callonOtherWord6,
 								expr: &seqExpr{
-									pos: position{line: 1577, col: 47, offset: 59439},
+									pos: position{line: 1577, col: 47, offset: 59451},
 									exprs: []interface{}{
 										&seqExpr{
-											pos: position{line: 1577, col: 48, offset: 59440},
+											pos: position{line: 1577, col: 48, offset: 59452},
 											exprs: []interface{}{
 												&notExpr{
-													pos: position{line: 1577, col: 48, offset: 59440},
+													pos: position{line: 1577, col: 48, offset: 59452},
 													expr: &ruleRefExpr{
-														pos:  position{line: 1577, col: 49, offset: 59441},
+														pos:  position{line: 1577, col: 49, offset: 59453},
 														name: "NEWLINE",
 													},
 												},
 												&notExpr{
-													pos: position{line: 1577, col: 57, offset: 59449},
+													pos: position{line: 1577, col: 57, offset: 59461},
 													expr: &ruleRefExpr{
-														pos:  position{line: 1577, col: 58, offset: 59450},
+														pos:  position{line: 1577, col: 58, offset: 59462},
 														name: "WS",
 													},
 												},
 												&notExpr{
-													pos: position{line: 1577, col: 61, offset: 59453},
+													pos: position{line: 1577, col: 61, offset: 59465},
 													expr: &ruleRefExpr{
-														pos:  position{line: 1577, col: 62, offset: 59454},
+														pos:  position{line: 1577, col: 62, offset: 59466},
 														name: "Dot",
 													},
 												},
 												&notExpr{
-													pos: position{line: 1577, col: 66, offset: 59458},
+													pos: position{line: 1577, col: 66, offset: 59470},
 													expr: &ruleRefExpr{
-														pos:  position{line: 1577, col: 67, offset: 59459},
+														pos:  position{line: 1577, col: 67, offset: 59471},
 														name: "QuotedTextPrefix",
 													},
 												},
 												&notExpr{
-													pos: position{line: 1577, col: 84, offset: 59476},
+													pos: position{line: 1577, col: 84, offset: 59488},
 													expr: &ruleRefExpr{
-														pos:  position{line: 1577, col: 85, offset: 59477},
+														pos:  position{line: 1577, col: 85, offset: 59489},
 														name: "LabeledListItemSeparator",
 													},
 												},
 												&notExpr{
-													pos: position{line: 1577, col: 110, offset: 59502},
+													pos: position{line: 1577, col: 110, offset: 59514},
 													expr: &ruleRefExpr{
-														pos:  position{line: 1577, col: 111, offset: 59503},
+														pos:  position{line: 1577, col: 111, offset: 59515},
 														name: "Parenthesis",
 													},
 												},
 												&anyMatcher{
-													line: 1577, col: 123, offset: 59515,
+													line: 1577, col: 123, offset: 59527,
 												},
 											},
 										},
 										&zeroOrOneExpr{
-											pos: position{line: 1577, col: 126, offset: 59518},
+											pos: position{line: 1577, col: 126, offset: 59530},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1577, col: 126, offset: 59518},
+												pos:  position{line: 1577, col: 126, offset: 59530},
 												name: "Dot",
 											},
 										},
@@ -12283,9 +12287,9 @@ var g = &grammar{
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 1579, col: 7, offset: 59627},
+							pos: position{line: 1579, col: 7, offset: 59639},
 							expr: &litMatcher{
-								pos:        position{line: 1579, col: 7, offset: 59627},
+								pos:        position{line: 1579, col: 7, offset: 59639},
 								val:        ".",
 								ignoreCase: false,
 							},
@@ -12296,35 +12300,35 @@ var g = &grammar{
 		},
 		{
 			name: "Spaces",
-			pos:  position{line: 1583, col: 1, offset: 59808},
+			pos:  position{line: 1583, col: 1, offset: 59820},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 1583, col: 11, offset: 59818},
+				pos: position{line: 1583, col: 11, offset: 59830},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1583, col: 11, offset: 59818},
+					pos:  position{line: 1583, col: 11, offset: 59830},
 					name: "WS",
 				},
 			},
 		},
 		{
 			name: "FileLocation",
-			pos:  position{line: 1585, col: 1, offset: 59824},
+			pos:  position{line: 1585, col: 1, offset: 59836},
 			expr: &actionExpr{
-				pos: position{line: 1585, col: 17, offset: 59840},
+				pos: position{line: 1585, col: 17, offset: 59852},
 				run: (*parser).callonFileLocation1,
 				expr: &labeledExpr{
-					pos:   position{line: 1585, col: 17, offset: 59840},
+					pos:   position{line: 1585, col: 17, offset: 59852},
 					label: "elements",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 1585, col: 26, offset: 59849},
+						pos: position{line: 1585, col: 26, offset: 59861},
 						expr: &choiceExpr{
-							pos: position{line: 1585, col: 27, offset: 59850},
+							pos: position{line: 1585, col: 27, offset: 59862},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 1585, col: 27, offset: 59850},
+									pos:  position{line: 1585, col: 27, offset: 59862},
 									name: "FILENAME",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1585, col: 38, offset: 59861},
+									pos:  position{line: 1585, col: 38, offset: 59873},
 									name: "DocumentAttributeSubstitution",
 								},
 							},
@@ -12335,42 +12339,42 @@ var g = &grammar{
 		},
 		{
 			name: "ResolvedFileLocation",
-			pos:  position{line: 1589, col: 1, offset: 59953},
+			pos:  position{line: 1589, col: 1, offset: 59965},
 			expr: &actionExpr{
-				pos: position{line: 1589, col: 25, offset: 59977},
+				pos: position{line: 1589, col: 25, offset: 59989},
 				run: (*parser).callonResolvedFileLocation1,
 				expr: &labeledExpr{
-					pos:   position{line: 1589, col: 25, offset: 59977},
+					pos:   position{line: 1589, col: 25, offset: 59989},
 					label: "elements",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 1589, col: 34, offset: 59986},
+						pos: position{line: 1589, col: 34, offset: 59998},
 						expr: &seqExpr{
-							pos: position{line: 1589, col: 35, offset: 59987},
+							pos: position{line: 1589, col: 35, offset: 59999},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1589, col: 35, offset: 59987},
+									pos: position{line: 1589, col: 35, offset: 59999},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1589, col: 36, offset: 59988},
+										pos:  position{line: 1589, col: 36, offset: 60000},
 										name: "EOL",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1589, col: 40, offset: 59992},
+									pos: position{line: 1589, col: 40, offset: 60004},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1589, col: 41, offset: 59993},
+										pos:  position{line: 1589, col: 41, offset: 60005},
 										name: "WS",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1589, col: 44, offset: 59996},
+									pos: position{line: 1589, col: 44, offset: 60008},
 									expr: &litMatcher{
-										pos:        position{line: 1589, col: 45, offset: 59997},
+										pos:        position{line: 1589, col: 45, offset: 60009},
 										val:        "[",
 										ignoreCase: false,
 									},
 								},
 								&anyMatcher{
-									line: 1589, col: 49, offset: 60001,
+									line: 1589, col: 49, offset: 60013,
 								},
 							},
 						},
@@ -12380,31 +12384,31 @@ var g = &grammar{
 		},
 		{
 			name: "Location",
-			pos:  position{line: 1593, col: 1, offset: 60065},
+			pos:  position{line: 1593, col: 1, offset: 60077},
 			expr: &actionExpr{
-				pos: position{line: 1593, col: 13, offset: 60077},
+				pos: position{line: 1593, col: 13, offset: 60089},
 				run: (*parser).callonLocation1,
 				expr: &labeledExpr{
-					pos:   position{line: 1593, col: 13, offset: 60077},
+					pos:   position{line: 1593, col: 13, offset: 60089},
 					label: "elements",
 					expr: &seqExpr{
-						pos: position{line: 1593, col: 23, offset: 60087},
+						pos: position{line: 1593, col: 23, offset: 60099},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 1593, col: 23, offset: 60087},
+								pos:  position{line: 1593, col: 23, offset: 60099},
 								name: "URL_SCHEME",
 							},
 							&oneOrMoreExpr{
-								pos: position{line: 1593, col: 34, offset: 60098},
+								pos: position{line: 1593, col: 34, offset: 60110},
 								expr: &choiceExpr{
-									pos: position{line: 1593, col: 35, offset: 60099},
+									pos: position{line: 1593, col: 35, offset: 60111},
 									alternatives: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 1593, col: 35, offset: 60099},
+											pos:  position{line: 1593, col: 35, offset: 60111},
 											name: "FILENAME",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1593, col: 46, offset: 60110},
+											pos:  position{line: 1593, col: 46, offset: 60122},
 											name: "DocumentAttributeSubstitution",
 										},
 									},
@@ -12417,26 +12421,26 @@ var g = &grammar{
 		},
 		{
 			name: "FILENAME",
-			pos:  position{line: 1597, col: 1, offset: 60203},
+			pos:  position{line: 1597, col: 1, offset: 60215},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 1597, col: 13, offset: 60215},
+				pos: position{line: 1597, col: 13, offset: 60227},
 				expr: &choiceExpr{
-					pos: position{line: 1597, col: 14, offset: 60216},
+					pos: position{line: 1597, col: 14, offset: 60228},
 					alternatives: []interface{}{
 						&charClassMatcher{
-							pos:        position{line: 1597, col: 14, offset: 60216},
+							pos:        position{line: 1597, col: 14, offset: 60228},
 							val:        "[ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789~:/?#@!$&;=()*+,_%]",
 							chars:      []rune{'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '~', ':', '/', '?', '#', '@', '!', '$', '&', ';', '=', '(', ')', '*', '+', ',', '_', '%'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 1597, col: 99, offset: 60301},
+							pos:        position{line: 1597, col: 99, offset: 60313},
 							val:        "-",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1597, col: 105, offset: 60307},
+							pos:        position{line: 1597, col: 105, offset: 60319},
 							val:        ".",
 							ignoreCase: false,
 						},
@@ -12446,22 +12450,22 @@ var g = &grammar{
 		},
 		{
 			name: "ResolvedLocation",
-			pos:  position{line: 1599, col: 1, offset: 60428},
+			pos:  position{line: 1599, col: 1, offset: 60440},
 			expr: &actionExpr{
-				pos: position{line: 1599, col: 21, offset: 60448},
+				pos: position{line: 1599, col: 21, offset: 60460},
 				run: (*parser).callonResolvedLocation1,
 				expr: &labeledExpr{
-					pos:   position{line: 1599, col: 21, offset: 60448},
+					pos:   position{line: 1599, col: 21, offset: 60460},
 					label: "elements",
 					expr: &seqExpr{
-						pos: position{line: 1599, col: 31, offset: 60458},
+						pos: position{line: 1599, col: 31, offset: 60470},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 1599, col: 31, offset: 60458},
+								pos:  position{line: 1599, col: 31, offset: 60470},
 								name: "URL_SCHEME",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1599, col: 42, offset: 60469},
+								pos:  position{line: 1599, col: 42, offset: 60481},
 								name: "RESOLVED_FILENAME",
 							},
 						},
@@ -12471,26 +12475,26 @@ var g = &grammar{
 		},
 		{
 			name: "RESOLVED_FILENAME",
-			pos:  position{line: 1603, col: 1, offset: 60548},
+			pos:  position{line: 1603, col: 1, offset: 60560},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 1603, col: 22, offset: 60569},
+				pos: position{line: 1603, col: 22, offset: 60581},
 				expr: &choiceExpr{
-					pos: position{line: 1603, col: 23, offset: 60570},
+					pos: position{line: 1603, col: 23, offset: 60582},
 					alternatives: []interface{}{
 						&charClassMatcher{
-							pos:        position{line: 1603, col: 23, offset: 60570},
+							pos:        position{line: 1603, col: 23, offset: 60582},
 							val:        "[ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789~:/?#@!$&;=()*+_,%{}]",
 							chars:      []rune{'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '~', ':', '/', '?', '#', '@', '!', '$', '&', ';', '=', '(', ')', '*', '+', '_', ',', '%', '{', '}'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 1603, col: 110, offset: 60657},
+							pos:        position{line: 1603, col: 110, offset: 60669},
 							val:        "-",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 1603, col: 116, offset: 60663},
+							pos:        position{line: 1603, col: 116, offset: 60675},
 							val:        ".",
 							ignoreCase: false,
 						},
@@ -12500,54 +12504,54 @@ var g = &grammar{
 		},
 		{
 			name: "URL",
-			pos:  position{line: 1605, col: 1, offset: 60712},
+			pos:  position{line: 1605, col: 1, offset: 60724},
 			expr: &actionExpr{
-				pos: position{line: 1605, col: 8, offset: 60719},
+				pos: position{line: 1605, col: 8, offset: 60731},
 				run: (*parser).callonURL1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1605, col: 8, offset: 60719},
+					pos: position{line: 1605, col: 8, offset: 60731},
 					expr: &choiceExpr{
-						pos: position{line: 1605, col: 9, offset: 60720},
+						pos: position{line: 1605, col: 9, offset: 60732},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 1605, col: 9, offset: 60720},
+								pos:  position{line: 1605, col: 9, offset: 60732},
 								name: "Alphanums",
 							},
 							&seqExpr{
-								pos: position{line: 1605, col: 22, offset: 60733},
+								pos: position{line: 1605, col: 22, offset: 60745},
 								exprs: []interface{}{
 									&notExpr{
-										pos: position{line: 1605, col: 22, offset: 60733},
+										pos: position{line: 1605, col: 22, offset: 60745},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1605, col: 23, offset: 60734},
+											pos:  position{line: 1605, col: 23, offset: 60746},
 											name: "NEWLINE",
 										},
 									},
 									&notExpr{
-										pos: position{line: 1605, col: 31, offset: 60742},
+										pos: position{line: 1605, col: 31, offset: 60754},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1605, col: 32, offset: 60743},
+											pos:  position{line: 1605, col: 32, offset: 60755},
 											name: "WS",
 										},
 									},
 									&notExpr{
-										pos: position{line: 1605, col: 35, offset: 60746},
+										pos: position{line: 1605, col: 35, offset: 60758},
 										expr: &litMatcher{
-											pos:        position{line: 1605, col: 36, offset: 60747},
+											pos:        position{line: 1605, col: 36, offset: 60759},
 											val:        "[",
 											ignoreCase: false,
 										},
 									},
 									&notExpr{
-										pos: position{line: 1605, col: 40, offset: 60751},
+										pos: position{line: 1605, col: 40, offset: 60763},
 										expr: &litMatcher{
-											pos:        position{line: 1605, col: 41, offset: 60752},
+											pos:        position{line: 1605, col: 41, offset: 60764},
 											val:        "]",
 											ignoreCase: false,
 										},
 									},
 									&anyMatcher{
-										line: 1605, col: 46, offset: 60757,
+										line: 1605, col: 46, offset: 60769,
 									},
 								},
 							},
@@ -12558,32 +12562,32 @@ var g = &grammar{
 		},
 		{
 			name: "URL_SCHEME",
-			pos:  position{line: 1609, col: 1, offset: 60798},
+			pos:  position{line: 1609, col: 1, offset: 60810},
 			expr: &choiceExpr{
-				pos: position{line: 1609, col: 15, offset: 60812},
+				pos: position{line: 1609, col: 15, offset: 60824},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1609, col: 15, offset: 60812},
+						pos:        position{line: 1609, col: 15, offset: 60824},
 						val:        "http://",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1609, col: 27, offset: 60824},
+						pos:        position{line: 1609, col: 27, offset: 60836},
 						val:        "https://",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1609, col: 40, offset: 60837},
+						pos:        position{line: 1609, col: 40, offset: 60849},
 						val:        "ftp://",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1609, col: 51, offset: 60848},
+						pos:        position{line: 1609, col: 51, offset: 60860},
 						val:        "irc://",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1609, col: 62, offset: 60859},
+						pos:        position{line: 1609, col: 62, offset: 60871},
 						val:        "mailto:",
 						ignoreCase: false,
 					},
@@ -12592,78 +12596,78 @@ var g = &grammar{
 		},
 		{
 			name: "ID",
-			pos:  position{line: 1611, col: 1, offset: 60870},
+			pos:  position{line: 1611, col: 1, offset: 60882},
 			expr: &actionExpr{
-				pos: position{line: 1611, col: 7, offset: 60876},
+				pos: position{line: 1611, col: 7, offset: 60888},
 				run: (*parser).callonID1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1611, col: 7, offset: 60876},
+					pos: position{line: 1611, col: 7, offset: 60888},
 					expr: &choiceExpr{
-						pos: position{line: 1611, col: 8, offset: 60877},
+						pos: position{line: 1611, col: 8, offset: 60889},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 1611, col: 8, offset: 60877},
+								pos:  position{line: 1611, col: 8, offset: 60889},
 								name: "Alphanums",
 							},
 							&seqExpr{
-								pos: position{line: 1611, col: 21, offset: 60890},
+								pos: position{line: 1611, col: 21, offset: 60902},
 								exprs: []interface{}{
 									&notExpr{
-										pos: position{line: 1611, col: 21, offset: 60890},
+										pos: position{line: 1611, col: 21, offset: 60902},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1611, col: 22, offset: 60891},
+											pos:  position{line: 1611, col: 22, offset: 60903},
 											name: "NEWLINE",
 										},
 									},
 									&notExpr{
-										pos: position{line: 1611, col: 30, offset: 60899},
+										pos: position{line: 1611, col: 30, offset: 60911},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1611, col: 31, offset: 60900},
+											pos:  position{line: 1611, col: 31, offset: 60912},
 											name: "WS",
 										},
 									},
 									&notExpr{
-										pos: position{line: 1611, col: 34, offset: 60903},
+										pos: position{line: 1611, col: 34, offset: 60915},
 										expr: &litMatcher{
-											pos:        position{line: 1611, col: 35, offset: 60904},
+											pos:        position{line: 1611, col: 35, offset: 60916},
 											val:        "[",
 											ignoreCase: false,
 										},
 									},
 									&notExpr{
-										pos: position{line: 1611, col: 39, offset: 60908},
+										pos: position{line: 1611, col: 39, offset: 60920},
 										expr: &litMatcher{
-											pos:        position{line: 1611, col: 40, offset: 60909},
+											pos:        position{line: 1611, col: 40, offset: 60921},
 											val:        "]",
 											ignoreCase: false,
 										},
 									},
 									&notExpr{
-										pos: position{line: 1611, col: 44, offset: 60913},
+										pos: position{line: 1611, col: 44, offset: 60925},
 										expr: &litMatcher{
-											pos:        position{line: 1611, col: 45, offset: 60914},
+											pos:        position{line: 1611, col: 45, offset: 60926},
 											val:        "<<",
 											ignoreCase: false,
 										},
 									},
 									&notExpr{
-										pos: position{line: 1611, col: 50, offset: 60919},
+										pos: position{line: 1611, col: 50, offset: 60931},
 										expr: &litMatcher{
-											pos:        position{line: 1611, col: 51, offset: 60920},
+											pos:        position{line: 1611, col: 51, offset: 60932},
 											val:        ">>",
 											ignoreCase: false,
 										},
 									},
 									&notExpr{
-										pos: position{line: 1611, col: 56, offset: 60925},
+										pos: position{line: 1611, col: 56, offset: 60937},
 										expr: &litMatcher{
-											pos:        position{line: 1611, col: 57, offset: 60926},
+											pos:        position{line: 1611, col: 57, offset: 60938},
 											val:        ",",
 											ignoreCase: false,
 										},
 									},
 									&anyMatcher{
-										line: 1611, col: 62, offset: 60931,
+										line: 1611, col: 62, offset: 60943,
 									},
 								},
 							},
@@ -12674,12 +12678,12 @@ var g = &grammar{
 		},
 		{
 			name: "DIGIT",
-			pos:  position{line: 1615, col: 1, offset: 60972},
+			pos:  position{line: 1615, col: 1, offset: 60984},
 			expr: &actionExpr{
-				pos: position{line: 1615, col: 10, offset: 60981},
+				pos: position{line: 1615, col: 10, offset: 60993},
 				run: (*parser).callonDIGIT1,
 				expr: &charClassMatcher{
-					pos:        position{line: 1615, col: 10, offset: 60981},
+					pos:        position{line: 1615, col: 10, offset: 60993},
 					val:        "[0-9]",
 					ranges:     []rune{'0', '9'},
 					ignoreCase: false,
@@ -12689,25 +12693,25 @@ var g = &grammar{
 		},
 		{
 			name: "NUMBER",
-			pos:  position{line: 1619, col: 1, offset: 61023},
+			pos:  position{line: 1619, col: 1, offset: 61035},
 			expr: &actionExpr{
-				pos: position{line: 1619, col: 11, offset: 61033},
+				pos: position{line: 1619, col: 11, offset: 61045},
 				run: (*parser).callonNUMBER1,
 				expr: &seqExpr{
-					pos: position{line: 1619, col: 11, offset: 61033},
+					pos: position{line: 1619, col: 11, offset: 61045},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 1619, col: 11, offset: 61033},
+							pos: position{line: 1619, col: 11, offset: 61045},
 							expr: &litMatcher{
-								pos:        position{line: 1619, col: 11, offset: 61033},
+								pos:        position{line: 1619, col: 11, offset: 61045},
 								val:        "-",
 								ignoreCase: false,
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 1619, col: 16, offset: 61038},
+							pos: position{line: 1619, col: 16, offset: 61050},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1619, col: 16, offset: 61038},
+								pos:  position{line: 1619, col: 16, offset: 61050},
 								name: "DIGIT",
 							},
 						},
@@ -12717,20 +12721,20 @@ var g = &grammar{
 		},
 		{
 			name: "WS",
-			pos:  position{line: 1623, col: 1, offset: 61090},
+			pos:  position{line: 1623, col: 1, offset: 61102},
 			expr: &choiceExpr{
-				pos: position{line: 1623, col: 7, offset: 61096},
+				pos: position{line: 1623, col: 7, offset: 61108},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1623, col: 7, offset: 61096},
+						pos:        position{line: 1623, col: 7, offset: 61108},
 						val:        " ",
 						ignoreCase: false,
 					},
 					&actionExpr{
-						pos: position{line: 1623, col: 13, offset: 61102},
+						pos: position{line: 1623, col: 13, offset: 61114},
 						run: (*parser).callonWS3,
 						expr: &litMatcher{
-							pos:        position{line: 1623, col: 13, offset: 61102},
+							pos:        position{line: 1623, col: 13, offset: 61114},
 							val:        "\t",
 							ignoreCase: false,
 						},
@@ -12740,22 +12744,22 @@ var g = &grammar{
 		},
 		{
 			name: "NEWLINE",
-			pos:  position{line: 1627, col: 1, offset: 61143},
+			pos:  position{line: 1627, col: 1, offset: 61155},
 			expr: &choiceExpr{
-				pos: position{line: 1627, col: 12, offset: 61154},
+				pos: position{line: 1627, col: 12, offset: 61166},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1627, col: 12, offset: 61154},
+						pos:        position{line: 1627, col: 12, offset: 61166},
 						val:        "\r\n",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1627, col: 21, offset: 61163},
+						pos:        position{line: 1627, col: 21, offset: 61175},
 						val:        "\r",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1627, col: 28, offset: 61170},
+						pos:        position{line: 1627, col: 28, offset: 61182},
 						val:        "\n",
 						ignoreCase: false,
 					},
@@ -12764,26 +12768,26 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 1629, col: 1, offset: 61176},
+			pos:  position{line: 1629, col: 1, offset: 61188},
 			expr: &notExpr{
-				pos: position{line: 1629, col: 8, offset: 61183},
+				pos: position{line: 1629, col: 8, offset: 61195},
 				expr: &anyMatcher{
-					line: 1629, col: 9, offset: 61184,
+					line: 1629, col: 9, offset: 61196,
 				},
 			},
 		},
 		{
 			name: "EOL",
-			pos:  position{line: 1631, col: 1, offset: 61187},
+			pos:  position{line: 1631, col: 1, offset: 61199},
 			expr: &choiceExpr{
-				pos: position{line: 1631, col: 8, offset: 61194},
+				pos: position{line: 1631, col: 8, offset: 61206},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1631, col: 8, offset: 61194},
+						pos:  position{line: 1631, col: 8, offset: 61206},
 						name: "NEWLINE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1631, col: 18, offset: 61204},
+						pos:  position{line: 1631, col: 18, offset: 61216},
 						name: "EOF",
 					},
 				},
@@ -12791,19 +12795,19 @@ var g = &grammar{
 		},
 		{
 			name: "EOLS",
-			pos:  position{line: 1633, col: 1, offset: 61209},
+			pos:  position{line: 1633, col: 1, offset: 61221},
 			expr: &seqExpr{
-				pos: position{line: 1633, col: 9, offset: 61217},
+				pos: position{line: 1633, col: 9, offset: 61229},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1633, col: 9, offset: 61217},
+						pos: position{line: 1633, col: 9, offset: 61229},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1633, col: 9, offset: 61217},
+							pos:  position{line: 1633, col: 9, offset: 61229},
 							name: "WS",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1633, col: 13, offset: 61221},
+						pos:  position{line: 1633, col: 13, offset: 61233},
 						name: "EOL",
 					},
 				},

--- a/pkg/parser/parser.peg
+++ b/pkg/parser/parser.peg
@@ -1290,13 +1290,13 @@ ListingBlock <- attributes:(ElementAttributes)? ListingBlockDelimiter content:(L
     return types.NewDelimitedBlock(types.Listing, content.([]interface{}), types.None, attributes)
 }
 
-ListingBlockElement <- FileInclusion / ListingBlockParagraph
+ListingBlockElement <- FileInclusion / ListingBlockParagraph / BlankLine
 
 ListingBlockParagraph <- lines:(ListingBlockParagraphLine)+ { 
     return types.NewParagraph(lines.([]interface{}), nil) // no attributes supported
 }
 
-ListingBlockParagraphLine <- !ListingBlockDelimiter line:(!EOF (Alphanums / Spaces / (!EOL .))* {return string(c.text), nil }) EOL { // skip EOL in line content, and stop when quote block delimiter is encountered
+ListingBlockParagraphLine <- !ListingBlockDelimiter line:(!EOF (Alphanums / Spaces / (!EOL .))+ {return string(c.text), nil }) EOL { // skip EOL in line content, and stop when quote block delimiter is encountered
     return types.NewInlineElements(line)
 }
 

--- a/pkg/renderer/html5/delimited_block.go
+++ b/pkg/renderer/html5/delimited_block.go
@@ -303,7 +303,7 @@ func renderVerseBlock(ctx *renderer.Context, b types.DelimitedBlock) ([]byte, er
 			ID:          renderElementID(b.Attributes),
 			Title:       renderTitle(b.Attributes),
 			Attribution: NewDelimitedBlockAttribution(b),
-			Elements:    b.Elements,
+			Elements:    discardTrailingBlankLines(b.Elements),
 		},
 	})
 	return result.Bytes(), err
@@ -354,7 +354,8 @@ func renderSidebarBlock(ctx *renderer.Context, b types.DelimitedBlock) ([]byte, 
 }
 
 func discardTrailingBlankLines(elements []interface{}) []interface{} {
-	// discard blank lines at the end
+	// discard blank elements at the end
+	log.Debugf("discarding trailing blank lines on %d elements...", len(elements))
 	filteredElements := make([]interface{}, len(elements))
 	copy(filteredElements, elements)
 	for {
@@ -369,5 +370,6 @@ func discardTrailingBlankLines(elements []interface{}) []interface{} {
 			break
 		}
 	}
+	log.Debugf("returning %d elements", len(filteredElements))
 	return filteredElements
 }

--- a/pkg/renderer/html5/delimited_block_test.go
+++ b/pkg/renderer/html5/delimited_block_test.go
@@ -40,7 +40,7 @@ here</code></pre>
 			source := "```" + "\n" +
 				"a http://website.com" + "\n" +
 				"and more text on the" + "\n" +
-				"next lines" + "\n" +
+				"next lines" + "\n\n" +
 				"```"
 			expected := `<div class="listingblock">
 <div class="content">
@@ -60,6 +60,7 @@ next lines</code></pre>
 some source code
 
 here
+
 ----`
 			expected := `<div class="listingblock">
 <div class="content">
@@ -76,6 +77,22 @@ here</pre>
 .listing block title
 ----
 some source code
+----`
+			expected := `<div id="id-for-listing-block" class="listingblock">
+<div class="title">listing block title</div>
+<div class="content">
+<pre>some source code</pre>
+</div>
+</div>`
+			Expect(source).To(RenderHTML5Body(expected))
+		})
+
+		It("listing block with ID and title and empty trailing line", func() {
+			source := `[#id-for-listing-block]
+.listing block title
+----
+some source code
+
 ----`
 			expected := `<div id="id-for-listing-block" class="listingblock">
 <div class="title">listing block title</div>
@@ -120,6 +137,31 @@ require 'sinatra'
 get '/hi' do
   "Hello World!"
 end
+
+----`
+			expected := `<div class="listingblock">
+<div class="title">Source block title</div>
+<div class="content">
+<pre class="highlight"><code class="language-ruby" data-lang="ruby">require &#39;sinatra&#39;
+
+get &#39;/hi&#39; do
+  &#34;Hello World!&#34;
+end</code></pre>
+</div>
+</div>`
+			Expect(source).To(RenderHTML5Body(expected))
+		})
+
+		It("with title, source and languages attributes and empty trailing line", func() {
+			source := `[source,ruby]
+.Source block title
+----
+require 'sinatra'
+
+get '/hi' do
+  "Hello World!"
+end
+
 ----`
 			expected := `<div class="listingblock">
 <div class="title">Source block title</div>
@@ -191,6 +233,7 @@ some listing code
 with *bold content*
 
 * and a list item
+
 ====`
 			expected := `<div class="exampleblock">
 <div class="content">
@@ -253,6 +296,7 @@ and "more" content
 .example block title
 ====
 foo
+
 ====`
 			expected := `<div id="id-for-example-block" class="exampleblock">
 <div class="title">Example 1. example block title</div>
@@ -275,6 +319,7 @@ some listing code
 with *bold content*
 
 * and a list item
+
 ====`
 			expected := `<div class="admonitionblock note">
 <table>
@@ -347,6 +392,7 @@ some listing code
 with *bold content*
 
 * and a list item
+
 ====`
 			expected := `<div id="id-for-admonition-block" class="admonitionblock note">
 <table>
@@ -445,7 +491,8 @@ an admonition text on
 
 [#id-for-admonition-block]
 .title for the admonition block
-TIP: an admonition text on 1 line.`
+TIP: an admonition text on 1 line.
+`
 			expected := `<div id="id-for-admonition-block" class="admonitionblock tip">
 <table>
 <tr>
@@ -469,6 +516,7 @@ an admonition text on 1 line.
 			source := `[quote, john doe, quote title]
 ____
 some *quote* content
+
 ____`
 			expected := `<div class="quoteblock">
 <blockquote>
@@ -509,9 +557,11 @@ ____`
 		It("multi-line quote with author and title", func() {
 			source := `[quote, john doe, quote title]
 ____
+
 - some 
 - quote 
 - content
+
 ____`
 			expected := `<div class="quoteblock">
 <blockquote>
@@ -599,6 +649,7 @@ ____
 lines 
 	and tabs 
 are preserved, but not trailing spaces   
+
 ____`
 
 			expected := `<div class="quoteblock">
@@ -634,6 +685,7 @@ ____`
 			source := `[verse, john doe, verse title]
 ____
 some *verse* content
+
 ____`
 			expected := `<div class="verseblock">
 <pre class="content">some <strong>verse</strong> content</pre>
@@ -671,6 +723,7 @@ ____
 - content
 
 and more!
+
 ____`
 			expected := `<div class="verseblock">
 <pre class="content">- some
@@ -720,6 +773,7 @@ ____
 lines 
 	and tabs 
 are preserved
+
 ____`
 
 			expected := `<div class="verseblock">
@@ -747,6 +801,7 @@ ____`
 		It("sidebar block with paragraph", func() {
 			source := `****
 some *verse* content
+
 ****`
 			expected := `<div class="sidebarblock">
 <div class="content">


### PR DESCRIPTION
change the parser rules to identify the blank lines and skip them
during rendering when there is nothing else afterwards

fixes #470

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>