### PR TITLE
feat(cli): add 'css' arg to specify the stylesheet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
 
 install:
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then git config --global core.autocrlf true ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then choco install make --version 4.3; fi
+  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then choco install make; fi
   - make install-devtools
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
 
 install:
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then git config --global core.autocrlf true ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then choco install make; fi
+  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then choco install make --version 4.3; fi
   - make install-devtools
 
 script:

--- a/cmd/libasciidoc/root_cmd.go
+++ b/cmd/libasciidoc/root_cmd.go
@@ -22,6 +22,7 @@ func NewRootCmd() *cobra.Command {
 	var noHeaderFooter bool
 	var outputName string
 	var logLevel string
+	var css string
 
 	rootCmd := &cobra.Command{
 		Use:   "libasciidoc [flags] FILE",
@@ -48,7 +49,7 @@ func NewRootCmd() *cobra.Command {
 					defer close()
 					path, _ := filepath.Abs(source)
 					log.Debugf("Starting to process file %v", path)
-					_, err := libasciidoc.ConvertFileToHTML(source, out, renderer.IncludeHeaderFooter(!noHeaderFooter))
+					_, err := libasciidoc.ConvertFileToHTML(source, out, renderer.IncludeHeaderFooter(!noHeaderFooter), renderer.IncludeCSS(css))
 					if err != nil {
 						return err
 					}
@@ -60,7 +61,8 @@ func NewRootCmd() *cobra.Command {
 	flags := rootCmd.Flags()
 	flags.BoolVarP(&noHeaderFooter, "no-header-footer", "s", false, "do not render header/footer (default: false)")
 	flags.StringVarP(&outputName, "out-file", "o", "", "output file (default: based on path of input file); use - to output to STDOUT")
-	rootCmd.PersistentFlags().StringVar(&logLevel, "log", "warning", "log level to set [debug|info|warning|error|fatal|panic]")
+	flags.StringVar(&logLevel, "log", "warning", "log level to set [debug|info|warning|error|fatal|panic]")
+	flags.StringVar(&css, "css", "", "the path to the CSS file to link to the document")
 	return rootCmd
 }
 

--- a/libasciidoc_test.go
+++ b/libasciidoc_test.go
@@ -1,6 +1,7 @@
 package libasciidoc_test
 
 import (
+	"github.com/bytesparadise/libasciidoc/pkg/renderer"
 	. "github.com/bytesparadise/libasciidoc/testsupport"
 
 	. "github.com/onsi/ginkgo"
@@ -191,6 +192,7 @@ a paragraph with _italic content_`
 <!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="generator" content="libasciidoc">
+<link type="text/css" rel="stylesheet" href="path/to/style.css">
 <title>Chapter A</title>
 </head>
 <body class="article">
@@ -209,7 +211,7 @@ Last updated {{.LastUpdated}}
 </div>
 </body>
 </html>`
-			Expect("test/includes/chapter-a.adoc").To(RenderHTML5Document(expectedContent))
+			Expect("test/includes/chapter-a.adoc").To(RenderHTML5Document(expectedContent, renderer.IncludeCSS("path/to/style.css")))
 		})
 
 	})

--- a/pkg/renderer/html5/document.go
+++ b/pkg/renderer/html5/document.go
@@ -23,7 +23,8 @@ func init() {
 <meta charset="UTF-8">
 <!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
 <meta name="viewport" content="width=device-width, initial-scale=1.0">{{ if .Generator }}
-<meta name="generator" content="{{ .Generator }}">{{ end }}
+<meta name="generator" content="{{ .Generator }}">{{ end }}{{ if .CSS}}
+<link type="text/css" rel="stylesheet" href="{{ .CSS }}">{{ end }}
 <title>{{ escape .Title }}</title>
 </head>
 <body class="article">
@@ -78,6 +79,7 @@ func renderDocument(ctx renderer.Context, output io.Writer) (map[string]interfac
 			Content     htmltemplate.HTML
 			RevNumber   string
 			LastUpdated string
+			CSS         string
 			Details     *htmltemplate.HTML
 		}{
 			Generator:   "libasciidoc", // TODO: externalize this value and include the lib version ?
@@ -86,6 +88,7 @@ func renderDocument(ctx renderer.Context, output io.Writer) (map[string]interfac
 			Content:     htmltemplate.HTML(string(renderedElements)), //nolint: gosec
 			RevNumber:   revNumber,
 			LastUpdated: ctx.LastUpdated(),
+			CSS:         ctx.CSS(),
 			Details:     documentDetails,
 		})
 		if err != nil {

--- a/pkg/renderer/html5/document_test.go
+++ b/pkg/renderer/html5/document_test.go
@@ -23,6 +23,7 @@ var _ = Describe("document header", func() {
 <!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="generator" content="libasciidoc">
+<link type="text/css" rel="stylesheet" href="/path/to/style.css">
 <title>The Dangerous and Thrilling Documentation Chronicles</title>
 </head>
 <body class="article">
@@ -39,7 +40,7 @@ Last updated {{.LastUpdated}}
 </div>
 </body>
 </html>`
-			Expect(source).To(RenderHTML5Body(expected, renderer.IncludeHeaderFooter(true), renderer.LastUpdated(time.Now())))
+			Expect(source).To(RenderHTML5Body(expected, renderer.IncludeHeaderFooter(true), renderer.IncludeCSS("/path/to/style.css"), renderer.LastUpdated(time.Now())))
 		})
 	})
 

--- a/pkg/renderer/options.go
+++ b/pkg/renderer/options.go
@@ -13,11 +13,13 @@ const (
 	// keyLastUpdated the key to specify the last update of the document to render.
 	// Can be a string or a time, which will be formatted using the 2006/01/02 15:04:05 MST` pattern
 	keyLastUpdated string = types.AttrLastUpdated
-	// keyIncludeHeaderFooter a bool value to indicate if the header and footer should be rendered
+	// keyIncludeHeaderFooter key to a bool value to indicate if the header and footer should be rendered
 	keyIncludeHeaderFooter string = "IncludeHeaderFooter"
-	// keyEntrypoint a bool value to indicate if the entrypoint to start with when parsing the document
+	// keyCSS key to the options CSS to add in the document head. Default is empty ("")
+	keyCSS string = "CSS"
+	// keyEntrypoint key to the entrypoint to start with when parsing the document
 	keyEntrypoint string = "Entrypoint"
-	// LastUpdatedFormat the time format for the `last updated` document attribute
+	// LastUpdatedFormat key to the time format for the `last updated` document attribute
 	LastUpdatedFormat string = "2006-01-02 15:04:05 -0700"
 )
 
@@ -32,6 +34,13 @@ func LastUpdated(value time.Time) Option {
 func IncludeHeaderFooter(value bool) Option {
 	return func(ctx *Context) {
 		ctx.options[keyIncludeHeaderFooter] = value
+	}
+}
+
+// IncludeCSS function to set the `css` option in the renderer context
+func IncludeCSS(href string) Option {
+	return func(ctx *Context) {
+		ctx.options[keyCSS] = href
 	}
 }
 
@@ -52,10 +61,8 @@ func DefineMacro(name string, t MacroTemplate) Option {
 // LastUpdated returns the value of the 'LastUpdated' Option if it was present,
 // otherwise it returns the current time using the `2006/01/02 15:04:05 MST` format
 func (ctx *Context) LastUpdated() string {
-	if lastUpdated, found := ctx.options[keyLastUpdated]; found {
-		if lastUpdated, typeMatch := lastUpdated.(time.Time); typeMatch {
-			return lastUpdated.Format(LastUpdatedFormat)
-		}
+	if lastUpdated, ok := ctx.options[keyLastUpdated].(time.Time); ok {
+		return lastUpdated.Format(LastUpdatedFormat)
 	}
 	return time.Now().Format(LastUpdatedFormat)
 }
@@ -63,10 +70,17 @@ func (ctx *Context) LastUpdated() string {
 // IncludeHeaderFooter returns the value of the 'IncludeHeaderFooter' Option if it was present,
 // otherwise it returns `false`
 func (ctx *Context) IncludeHeaderFooter() bool {
-	if includeHeaderFooter, found := ctx.options[keyIncludeHeaderFooter]; found {
-		if includeHeaderFooter, typeMatch := includeHeaderFooter.(bool); typeMatch {
-			return includeHeaderFooter
-		}
+	if includeHeaderFooter, ok := ctx.options[keyIncludeHeaderFooter].(bool); ok {
+		return includeHeaderFooter
 	}
 	return false
+}
+
+// CSS returns the value of the 'CSS' Option if it was present,
+// otherwise it returns an empty string
+func (ctx *Context) CSS() string {
+	if css, ok := ctx.options[keyCSS].(string); ok {
+		return css
+	}
+	return ""
 }

--- a/testsupport/html5_rendering_matcher.go
+++ b/testsupport/html5_rendering_matcher.go
@@ -145,14 +145,16 @@ func (m *html5TitleMatcher) NegatedFailureMessage(_ interface{}) (message string
 // ---------------------
 
 // RenderHTML5Document a custom matcher to verify that a block renders as the expectation
-func RenderHTML5Document(expected string, options ...interface{}) gomegatypes.GomegaMatcher {
+func RenderHTML5Document(expected string, options ...renderer.Option) gomegatypes.GomegaMatcher {
 	m := &html5DocumentMatcher{
 		expected: expected,
+		options:  options,
 	}
 	return m
 }
 
 type html5DocumentMatcher struct {
+	options  []renderer.Option
 	expected string
 	actual   string
 }
@@ -163,7 +165,8 @@ func (m *html5DocumentMatcher) Match(actual interface{}) (success bool, err erro
 		return false, errors.Errorf("RenderHTML5Body matcher expects a string (actual: %T)", actual)
 	}
 	resultWriter := bytes.NewBuffer(nil)
-	_, err = libasciidoc.ConvertFileToHTML(filename, resultWriter, renderer.IncludeHeaderFooter(true))
+	m.options = append(m.options, renderer.IncludeHeaderFooter(true))
+	_, err = libasciidoc.ConvertFileToHTML(filename, resultWriter, m.options...)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
when the `--css=...` argument is used, the generated HTML
document contains a `<link type="text/html" rel="stylesheet" href="...">`
element with the given `--css` value.

Fixes #482

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>