### PR TITLE
fix(parser/renderer): support concelead index terms in labeled lists

### DIFF
--- a/cmd/libasciidoc/root_cmd.go
+++ b/cmd/libasciidoc/root_cmd.go
@@ -65,6 +65,7 @@ func NewRootCmd() *cobra.Command {
 			return nil
 		},
 	}
+	rootCmd.SilenceUsage = true
 	flags := rootCmd.Flags()
 	flags.BoolVarP(&noHeaderFooter, "no-header-footer", "s", false, "do not render header/footer (default: false)")
 	flags.StringVarP(&outputName, "out-file", "o", "", "output file (default: based on path of input file); use - to output to STDOUT")

--- a/pkg/parser/document_processing_filter_blocks.go
+++ b/pkg/parser/document_processing_filter_blocks.go
@@ -70,7 +70,7 @@ elements:
 }
 
 // AllMatchers all the matchers needed to remove the unneeded blocks/elements from the final document
-var allMatchers = []filterMatcher{blankLineMatcher, emptyPreambleMatcher, documentAttributeMatcher, singleLineCommentMatcher, commentBlockMatcher, concealedIndexTermMatcher}
+var allMatchers = []filterMatcher{emptyPreambleMatcher, documentAttributeMatcher, singleLineCommentMatcher, commentBlockMatcher}
 
 // filterMatcher returns true if the given element is to be filtered out
 type filterMatcher func(element interface{}) bool
@@ -83,12 +83,6 @@ var emptyPreambleMatcher filterMatcher = func(element interface{}) bool {
 	}
 	// log.Debugf(" element of type '%T' is an empty preamble: %t", element, result)
 	return result
-}
-
-// blankLineMatcher filters the element if it is a blank line
-var blankLineMatcher filterMatcher = func(element interface{}) bool {
-	_, ok := element.(types.BlankLine)
-	return ok
 }
 
 // documentAttributeMatcher filters the element if it is a DocumentAttributeDeclaration,
@@ -116,10 +110,4 @@ var commentBlockMatcher filterMatcher = func(element interface{}) bool {
 	default:
 		return false
 	}
-}
-
-// concealedIndexTermMatcher filters the element if it is a ConcealedIndexTerm
-var concealedIndexTermMatcher filterMatcher = func(element interface{}) bool {
-	_, ok := element.(types.ConcealedIndexTerm)
-	return ok
 }

--- a/pkg/parser/document_processing_filter_blocks_test.go
+++ b/pkg/parser/document_processing_filter_blocks_test.go
@@ -9,29 +9,6 @@ import (
 
 var _ = Describe("block filters", func() {
 
-	It("should remove blank line", func() {
-		actual := []interface{}{
-			types.BlankLine{},
-			types.Paragraph{
-				Lines: [][]interface{}{
-					{
-						types.StringElement{},
-					},
-				},
-			},
-		}
-		expected := []interface{}{
-			types.Paragraph{
-				Lines: [][]interface{}{
-					{
-						types.StringElement{},
-					},
-				},
-			},
-		}
-		Expect(filter(actual, allMatchers...)).To(Equal(expected))
-	})
-
 	It("should retain blank line in a delimited block", func() {
 		actual := []interface{}{
 			types.DelimitedBlock{

--- a/pkg/parser/index_terms_test.go
+++ b/pkg/parser/index_terms_test.go
@@ -227,6 +227,11 @@ a paragraph with an index term.`
 								types.StringElement{
 									Content: "a paragraph with an index term ",
 								},
+								types.ConcealedIndexTerm{
+									Term1: "index",
+									Term2: "term",
+									Term3: "here",
+								},
 								types.StringElement{
 									Content: ".",
 								},
@@ -250,6 +255,12 @@ a paragraph with an index term.`
 					types.Paragraph{
 						Attributes: types.ElementAttributes{},
 						Lines: [][]interface{}{
+							{
+								types.ConcealedIndexTerm{
+									Term1: "index",
+									Term2: "term",
+								},
+							},
 							{
 								types.StringElement{
 									Content: "a paragraph with an index term.",

--- a/pkg/renderer/html5/elements.go
+++ b/pkg/renderer/html5/elements.go
@@ -126,6 +126,8 @@ func renderElement(ctx renderer.Context, element interface{}) ([]byte, error) {
 		return renderUserMacro(ctx, e)
 	case types.IndexTerm:
 		return renderIndexTerm(ctx, e)
+	case types.ConcealedIndexTerm:
+		return renderConcealedIndexTerm(ctx, e)
 	default:
 		return nil, errors.Errorf("unsupported type of element: %T", element)
 	}

--- a/pkg/renderer/html5/index_term.go
+++ b/pkg/renderer/html5/index_term.go
@@ -8,3 +8,7 @@ import (
 func renderIndexTerm(ctx renderer.Context, t types.IndexTerm) ([]byte, error) {
 	return renderInlineElements(ctx, t.Term)
 }
+
+func renderConcealedIndexTerm(ctx renderer.Context, t types.ConcealedIndexTerm) ([]byte, error) {
+	return []byte{}, nil // do not render
+}

--- a/pkg/renderer/html5/index_terms_test.go
+++ b/pkg/renderer/html5/index_terms_test.go
@@ -30,7 +30,7 @@ a paragraph with an index term.</p>
 
 var _ = Describe("concealed index terms", func() {
 
-	It("index term in existing paragraph line", func() {
+	It("concealed index term in existing paragraph line", func() {
 		source := `a paragraph with an index term (((index, term, here))).`
 		expected := `<div class="paragraph">
 <p>a paragraph with an index term .</p>
@@ -38,11 +38,46 @@ var _ = Describe("concealed index terms", func() {
 		Expect(RenderHTML5Body(source)).To(Equal(expected))
 	})
 
-	It("index term in single paragraph line", func() {
+	It("concealed index term in single paragraph line", func() {
 		source := `(((index, term)))
 a paragraph with an index term.`
 		expected := `<div class="paragraph">
 <p>a paragraph with an index term.</p>
+</div>`
+		Expect(RenderHTML5Body(source)).To(Equal(expected))
+	})
+
+	It("concealed index term in single paragraph line", func() {
+		source := `(((index, term)))
+a paragraph with an index term.`
+		expected := `<div class="paragraph">
+<p>a paragraph with an index term.</p>
+</div>`
+		Expect(RenderHTML5Body(source)).To(Equal(expected))
+	})
+
+	It("concealed index term in labeled list term", func() {
+		source := `((NNG_OPT_SUB_SUBSCRIBE))(((subscribe)))::
+
+This option registers a topic that the subscriber is interested in.
+The option is write-only, and takes an array of bytes, of arbitrary size.
+Each incoming message is checked against the list of subscribed topics.
+If the body begins with the entire set of bytes in the topic, then the
+message is accepted.  If no topic matches, then the message is
+discarded.
+`
+		expected := `<div class="dlist">
+<dl>
+<dt class="hdlist1">NNG_OPT_SUB_SUBSCRIBE</dt>
+<dd>
+<p>This option registers a topic that the subscriber is interested in.
+The option is write-only, and takes an array of bytes, of arbitrary size.
+Each incoming message is checked against the list of subscribed topics.
+If the body begins with the entire set of bytes in the topic, then the
+message is accepted.  If no topic matches, then the message is
+discarded.</p>
+</dd>
+</dl>
 </div>`
 		Expect(RenderHTML5Body(source)).To(Equal(expected))
 	})

--- a/pkg/renderer/html5/inline_elements.go
+++ b/pkg/renderer/html5/inline_elements.go
@@ -10,30 +10,30 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-type renderLinesConfig struct {
+type linesRenderer struct {
 	render renderFunc
 }
 
-type renderLinesOption func(config *renderLinesConfig)
+type renderLinesOption func(config *linesRenderer)
 
 func verbatim() renderLinesOption {
-	return func(config *renderLinesConfig) {
+	return func(config *linesRenderer) {
 		config.render = renderPlainText
 	}
 }
 
 func renderInlineElements(ctx renderer.Context, elements []interface{}, options ...renderLinesOption) ([]byte, error) {
 	log.Debugf("rendering line with %d element(s)...", len(elements))
-	linesRenderer := renderLinesConfig{
+	r := linesRenderer{
 		render: renderElement,
 	}
 	for _, apply := range options {
-		apply(&linesRenderer)
+		apply(&r)
 	}
 	// first pass or rendering, using the provided `renderElementFunc`:
 	buf := bytes.NewBuffer(nil)
 	for i, element := range elements {
-		renderedElement, err := linesRenderer.render(ctx, element)
+		renderedElement, err := r.render(ctx, element)
 		if err != nil {
 			return nil, errors.Wrapf(err, "unable to render line")
 		}

--- a/pkg/renderer/html5/section.go
+++ b/pkg/renderer/html5/section.go
@@ -39,7 +39,7 @@ func init() {
 		texttemplate.FuncMap{
 			"renderElements": renderElements,
 		})
-	otherSectionContentTmpl = newTextTemplate("other section",
+	otherSectionContentTmpl = newTextTemplate("section 2-6",
 		`{{ $ctx := .Context }}{{ with .Data }}<div class="{{ .Class }}">
 {{ .SectionTitle }}{{ $elements := renderElements $ctx .Elements | printf "%s" }}{{ if $elements }}
 {{ $elements }}{{ end }}
@@ -47,7 +47,7 @@ func init() {
 		texttemplate.FuncMap{
 			"renderElements": renderElements,
 		})
-	sectionHeaderTmpl = newTextTemplate("other sectionTitle",
+	sectionHeaderTmpl = newTextTemplate("section 2-6 title",
 		`<h{{ .Level }} id="{{ .ID }}">{{ .Content }}</h{{ .Level }}>`)
 }
 


### PR DESCRIPTION
do not exclude ConceledIndexTerms (and Blanklines)
in final document, but silently ignore them in the  HTML rendering phase.

also, do not print help when an error occurs when running from CLI

Fixes #502

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>