### PR TITLE
refactor(test): rename RenderHTML5Body matcher

### DIFF
--- a/libasciidoc_test.go
+++ b/libasciidoc_test.go
@@ -36,7 +36,7 @@ var _ = Describe("documents", func() {
 			// main title alone is not rendered in the body
 			source := ""
 			expectedContent := ""
-			Expect(RenderHTML5Body(source)).To(Equal(expectedContent))
+			Expect(RenderHTML(source)).To(Equal(expectedContent))
 			Expect(RenderHTML5Title(source)).To(Equal(""))
 		})
 
@@ -45,7 +45,7 @@ var _ = Describe("documents", func() {
 			source := "= a document title"
 			expectedTitle := "a document title"
 			expectedContent := ""
-			Expect(RenderHTML5Body(source)).To(Equal(expectedContent))
+			Expect(RenderHTML(source)).To(Equal(expectedContent))
 			Expect(RenderHTML5Title(source)).To(Equal(expectedTitle))
 		})
 
@@ -64,7 +64,7 @@ a paragraph with *bold content*`
 </div>
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expectedContent))
+			Expect(RenderHTML(source)).To(Equal(expectedContent))
 			Expect(RenderHTML5Title(source)).To(Equal(expectedTitle))
 		})
 
@@ -80,7 +80,7 @@ a paragraph with *bold content*`
 </div>
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expectedContent))
+			Expect(RenderHTML(source)).To(Equal(expectedContent))
 			Expect(RenderHTML5Title(source)).To(Equal(""))
 		})
 
@@ -109,7 +109,7 @@ a paragraph`
 </div>
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expectedContent))
+			Expect(RenderHTML(source)).To(Equal(expectedContent))
 			Expect(RenderHTML5Title(source)).To(Equal(expectedTitle))
 			Expect(DocumentMetadata(source, lastUpdated)).To(Equal(types.Metadata{
 				Title:       "a document title",
@@ -171,7 +171,7 @@ a paragraph with _italic content_`
 </div>
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expectedContent))
+			Expect(RenderHTML(source)).To(Equal(expectedContent))
 			Expect(RenderHTML5Title(source)).To(Equal(expectedTitle))
 			Expect(DocumentMetadata(source, lastUpdated)).To(Equal(types.Metadata{
 				Title:       "a document title",
@@ -215,7 +215,7 @@ a paragraph with _italic content_`
 </div>
 </div>
 </div>`
-			Expect(RenderHTML5Body(source, configuration.WithFilename("test.adoc"), configuration.WithLastUpdated(lastUpdated))).To(Equal(expected))
+			Expect(RenderHTML(source, configuration.WithFilename("test.adoc"), configuration.WithLastUpdated(lastUpdated))).To(Equal(expected))
 			Expect(DocumentMetadata(source, lastUpdated)).To(Equal(types.Metadata{
 				Title:       "",
 				LastUpdated: lastUpdated.Format(configuration.LastUpdatedFormat),
@@ -245,7 +245,7 @@ a paragraph with _italic content_`
 </div>
 </div>
 </div>`
-			Expect(RenderHTML5Body(source, configuration.WithFilename("tmp/foo.adoc"))).To(Equal(expectedContent))
+			Expect(RenderHTML(source, configuration.WithFilename("tmp/foo.adoc"))).To(Equal(expectedContent))
 		})
 
 		It("document with custom icon attributes", func() {
@@ -277,7 +277,7 @@ a note
 </tr>
 </table>
 </div>`
-			Expect(RenderHTML5Body(source, configuration.WithAttributes(attrs))).To(Equal(expected))
+			Expect(RenderHTML(source, configuration.WithAttributes(attrs))).To(Equal(expected))
 		})
 
 		It("document without custom icon attributes", func() {
@@ -306,7 +306,7 @@ a note
 </tr>
 </table>
 </div>`
-			Expect(RenderHTML5Body(source, configuration.WithAttributes(attrs))).To(Equal(expected))
+			Expect(RenderHTML(source, configuration.WithAttributes(attrs))).To(Equal(expected))
 		})
 	})
 

--- a/pkg/renderer/html5/blank_line_test.go
+++ b/pkg/renderer/html5/blank_line_test.go
@@ -19,7 +19,7 @@ second paragraph`
 <div class="paragraph">
 <p>second paragraph</p>
 </div>`
-		Expect(RenderHTML5Body(source)).To(Equal(expected))
+		Expect(RenderHTML(source)).To(Equal(expected))
 	})
 
 	It("blank line with spaces and tabs between 2 paragraphs", func() {
@@ -32,7 +32,7 @@ second paragraph`
 <div class="paragraph">
 <p>second paragraph</p>
 </div>`
-		Expect(RenderHTML5Body(source)).To(Equal(expected))
+		Expect(RenderHTML(source)).To(Equal(expected))
 	})
 
 	It("blank lines (tabs) at end of document", func() {
@@ -43,7 +43,7 @@ second paragraph`
 		expected := `<div class="paragraph">
 <p>first paragraph</p>
 </div>`
-		Expect(RenderHTML5Body(source)).To(Equal(expected))
+		Expect(RenderHTML(source)).To(Equal(expected))
 	})
 
 	It("blank lines (spaces) at end of document", func() {
@@ -54,6 +54,6 @@ second paragraph`
 		expected := `<div class="paragraph">
 <p>first paragraph</p>
 </div>`
-		Expect(RenderHTML5Body(source)).To(Equal(expected))
+		Expect(RenderHTML(source)).To(Equal(expected))
 	})
 })

--- a/pkg/renderer/html5/comment_test.go
+++ b/pkg/renderer/html5/comment_test.go
@@ -14,7 +14,7 @@ var _ = Describe("comments", func() {
 		It("single line comment alone", func() {
 			source := `// A single-line comment.`
 			expected := ""
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("single line comment at end of line", func() {
@@ -22,7 +22,7 @@ var _ = Describe("comments", func() {
 			expected := `<div class="paragraph">
 <p>foo // A single-line comment.</p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("single line comment within a paragraph", func() {
@@ -33,7 +33,7 @@ another line`
 <p>a first line
 another line</p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 	})
 
@@ -45,7 +45,7 @@ a *comment* block
 with multiple lines
 ////`
 			expected := ""
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("comment block with paragraphs around", func() {
@@ -61,7 +61,7 @@ a second paragraph`
 <div class="paragraph">
 <p>a second paragraph</p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 	})
 

--- a/pkg/renderer/html5/cross_reference_test.go
+++ b/pkg/renderer/html5/cross_reference_test.go
@@ -25,7 +25,7 @@ with some content linked to <<thetitle>>!`
 </div>
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("cross reference with custom id and label", func() {
@@ -41,7 +41,7 @@ with some content linked to <<thetitle,a label to the title>>!`
 </div>
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("invalid section reference", func() {
@@ -58,7 +58,7 @@ with some content linked to <<thewrongtitle>>!`
 </div>
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 	})
 
@@ -69,7 +69,7 @@ with some content linked to <<thewrongtitle>>!`
 			expected := `<div class="paragraph">
 <p>some content linked to <a href="another-doc.html"><strong>another doc</strong></a>!</p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("external cross reference to other doc with document attribute in location and label with special chars", func() {
@@ -78,7 +78,7 @@ some content linked to xref:{foo}.adoc[another_doc()]!`
 			expected := `<div class="paragraph">
 <p>some content linked to <a href="foo-doc.html">another_doc()</a>!</p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 	})
 })

--- a/pkg/renderer/html5/delimited_block_test.go
+++ b/pkg/renderer/html5/delimited_block_test.go
@@ -20,7 +20,7 @@ var _ = Describe("delimited blocks", func() {
 here</code></pre>
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("fenced block with id and title", func() {
@@ -33,7 +33,7 @@ here</code></pre>
 here</code></pre>
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("fenced block with external link inside", func() {
@@ -49,7 +49,7 @@ and more text on the
 next lines</code></pre>
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 	})
 
@@ -69,7 +69,7 @@ here
 here</pre>
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("listing block with ID and title", func() {
@@ -84,7 +84,7 @@ some source code
 <pre>some source code</pre>
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("listing block with ID and title and empty trailing line", func() {
@@ -100,7 +100,7 @@ some source code
 <pre>some source code</pre>
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 	})
@@ -125,7 +125,7 @@ get &#39;/hi&#39; do
 end</code></pre>
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("with title, source and languages attributes", func() {
@@ -149,7 +149,7 @@ get &#39;/hi&#39; do
 end</code></pre>
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("with title, source and languages attributes and empty trailing line", func() {
@@ -173,7 +173,7 @@ get &#39;/hi&#39; do
 end</code></pre>
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("with id, title, source and languages attributes", func() {
@@ -197,7 +197,7 @@ get &#39;/hi&#39; do
 end</code></pre>
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("with html content", func() {
@@ -209,7 +209,7 @@ end</code></pre>
 <pre>&lt;a&gt;link&lt;/a&gt;</pre>
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("with other content", func() {
@@ -221,7 +221,7 @@ end</code></pre>
 <pre>  a&lt;&lt;b</pre>
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 	})
 
@@ -250,7 +250,7 @@ with <strong>bold content</strong></p>
 </div>
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("example block with multiple elements - case 2", func() {
@@ -269,7 +269,7 @@ and more content
 </div>
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("example block with multiple elements - case 3", func() {
@@ -288,7 +288,7 @@ and "more" content
 </div>
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("example block with ID and title", func() {
@@ -306,7 +306,7 @@ foo
 </div>
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 	})
 
@@ -343,7 +343,7 @@ with <strong>bold content</strong></p>
 </tr>
 </table>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("admonition block with ID and title", func() {
@@ -379,7 +379,7 @@ with <strong>bold content</strong></p>
 </tr>
 </table>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 		It("admonition block with ID, title and icon", func() {
 			source := `:icons: font
@@ -417,7 +417,7 @@ with <strong>bold content</strong></p>
 </tr>
 </table>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("admonition paragraph and admonition block with multiple elements", func() {
@@ -462,7 +462,7 @@ this is an admonition paragraph.
 </tr>
 </table>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("admonition paragraph with an icon", func() {
@@ -483,7 +483,7 @@ an admonition text on
 </tr>
 </table>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("admonition paragraph with ID, title and icon", func() {
@@ -506,7 +506,7 @@ an admonition text on 1 line.
 </tr>
 </table>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 	})
 
@@ -529,7 +529,7 @@ ____`
 <cite>quote title</cite>
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("single-line quote with author and title, and ID and title ", func() {
@@ -551,7 +551,7 @@ ____`
 <cite>quote title</cite>
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("multi-line quote with author and title", func() {
@@ -584,7 +584,7 @@ ____`
 <cite>quote title</cite>
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("multi-line quote with author only and nested listing", func() {
@@ -622,7 +622,7 @@ ____`
 &#8212; john doe
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("single-line quote with title only", func() {
@@ -640,7 +640,7 @@ ____`
 &#8212; quote title
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("multi-line quote without author and title", func() {
@@ -661,7 +661,7 @@ are preserved, but not trailing spaces</p>
 </div>
 </blockquote>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("empty quote without author and title", func() {
@@ -674,7 +674,7 @@ ____`
 
 </blockquote>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 
 		})
 	})
@@ -694,7 +694,7 @@ ____`
 <cite>verse title</cite>
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("single-line verse with author, id and title ", func() {
@@ -712,7 +712,7 @@ ____`
 <cite>verse title</cite>
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("multi-line verse with author and title", func() {
@@ -736,7 +736,7 @@ and more!</pre>
 <cite>verse title</cite>
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("single-line verse with author only", func() {
@@ -750,7 +750,7 @@ ____`
 &#8212; john doe
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("single-line verse with title only", func() {
@@ -764,7 +764,7 @@ ____`
 &#8212; verse title
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("multi-line verse without author and title", func() {
@@ -781,7 +781,7 @@ ____`
 	and tabs
 are preserved</pre>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("empty verse without author and title", func() {
@@ -791,7 +791,7 @@ ____`
 			expected := `<div class="verseblock">
 <pre class="content"></pre>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 
 		})
 	})
@@ -810,7 +810,7 @@ some *verse* content
 </div>
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("sidebar block with id, title, paragraph and sourcecode block", func() {
@@ -837,7 +837,7 @@ bar</pre>
 </div>
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 	})
 
@@ -859,7 +859,7 @@ type Foo struct{
 <span class="tok-p">}</span></code></pre>
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("should render source block without highlighter when language is not set", func() {
@@ -878,7 +878,7 @@ type Foo struct{
 }</code></pre>
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("should render source block without highlighter when language is not set", func() {
@@ -897,7 +897,7 @@ type Foo struct{
 }</code></pre>
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("should render source block with go syntax and custom style", func() {
@@ -917,7 +917,7 @@ type Foo struct{
 <span class="tok-p">}</span></code></pre>
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("should render source block with go syntax, custom style and line numbers", func() {
@@ -938,7 +938,7 @@ type Foo struct{
 <span class="tok-ln">3</span><span class="tok-p">}</span></code></pre>
 </div>
 </div>` // the pygment.py sets the line number class to `tok-ln` but here we expect `tok-ln`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("should render source block with go syntax, custom style, inline css and line numbers", func() {
@@ -960,7 +960,7 @@ type Foo struct{
 <span style="margin-right:0.4em;padding:0 0.4em 0 0.4em;color:#7f7f7f">3</span>}</code></pre>
 </div>
 </div>` // the pygment.py sets the line number class to `tok-ln` but here we expect `tok-ln`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 	})
 })

--- a/pkg/renderer/html5/distinct_lists_test.go
+++ b/pkg/renderer/html5/distinct_lists_test.go
@@ -33,7 +33,7 @@ var _ = Describe("lists of items", func() {
 </li>
 </ol>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("same list with attribute on middle item", func() {
@@ -59,7 +59,7 @@ var _ = Describe("lists of items", func() {
 </li>
 </ol>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("distinct lists separated by blankline and item attribute - case 1", func() {
@@ -90,7 +90,7 @@ var _ = Describe("lists of items", func() {
 </li>
 </ol>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("distinct lists separated by blankline and item attribute - case 2", func() {
@@ -124,7 +124,7 @@ var _ = Describe("lists of items", func() {
 </li>
 </ol>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 	})
 
@@ -142,7 +142,7 @@ var _ = Describe("lists of items", func() {
 </li>
 </ol>
 </div>`
-		Expect(RenderHTML5Body(source)).To(Equal(expected))
+		Expect(RenderHTML(source)).To(Equal(expected))
 	})
 
 	It("same list with multiple comment lines inside", func() {
@@ -161,7 +161,7 @@ var _ = Describe("lists of items", func() {
 </li>
 </ol>
 </div>`
-		Expect(RenderHTML5Body(source)).To(Equal(expected))
+		Expect(RenderHTML(source)).To(Equal(expected))
 	})
 
 	It("distinct lists separated by single comment line", func() {
@@ -183,7 +183,7 @@ var _ = Describe("lists of items", func() {
 </li>
 </ol>
 </div>`
-		Expect(RenderHTML5Body(source)).To(Equal(expected))
+		Expect(RenderHTML(source)).To(Equal(expected))
 	})
 
 	It("distinct lists separated by multiple comment lines", func() {
@@ -207,6 +207,6 @@ var _ = Describe("lists of items", func() {
 </li>
 </ol>
 </div>`
-		Expect(RenderHTML5Body(source)).To(Equal(expected))
+		Expect(RenderHTML(source)).To(Equal(expected))
 	})
 })

--- a/pkg/renderer/html5/document_details_test.go
+++ b/pkg/renderer/html5/document_details_test.go
@@ -56,7 +56,7 @@ Last updated {{.LastUpdated}}
 </body>
 </html>`
 			now := time.Now()
-			Expect(RenderHTML5Body(source, configuration.WithHeaderFooter(true), configuration.WithLastUpdated(now))).To(MatchHTML5Template(expected, now))
+			Expect(RenderHTML(source, configuration.WithHeaderFooter(true), configuration.WithLastUpdated(now))).To(MatchHTML5Template(expected, now))
 		})
 
 		It("header with 2 authors and no revision", func() {
@@ -94,7 +94,7 @@ Last updated {{.LastUpdated}}
 </body>
 </html>`
 			now := time.Now()
-			Expect(RenderHTML5Body(source, configuration.WithHeaderFooter(true), configuration.WithLastUpdated(now))).
+			Expect(RenderHTML(source, configuration.WithHeaderFooter(true), configuration.WithLastUpdated(now))).
 				To(MatchHTML5Template(expected, now))
 		})
 	})
@@ -132,7 +132,7 @@ Last updated {{.LastUpdated}}
 </div>
 </body>
 </html>`
-			Expect(RenderHTML5Body(source,
+			Expect(RenderHTML(source,
 				configuration.WithHeaderFooter(true),
 				configuration.WithLastUpdated(now),
 				configuration.WithAttributes(map[string]string{}),
@@ -163,7 +163,7 @@ a paragraph`
 </div>
 </body>
 </html>`
-			Expect(RenderHTML5Body(source,
+			Expect(RenderHTML(source,
 				configuration.WithHeaderFooter(true),
 				configuration.WithLastUpdated(now),
 				configuration.WithAttributes(map[string]string{
@@ -198,7 +198,7 @@ Last updated {{.LastUpdated}}
 </div>
 </body>
 </html>`
-			Expect(RenderHTML5Body(source,
+			Expect(RenderHTML(source,
 				configuration.WithHeaderFooter(true),
 				configuration.WithLastUpdated(now),
 				configuration.WithAttributes(map[string]string{
@@ -228,7 +228,7 @@ a paragraph`
 </div>
 </body>
 </html>`
-			Expect(RenderHTML5Body(source,
+			Expect(RenderHTML(source,
 				configuration.WithHeaderFooter(true),
 				configuration.WithLastUpdated(now),
 				configuration.WithAttributes(map[string]string{

--- a/pkg/renderer/html5/file_inclusion_test.go
+++ b/pkg/renderer/html5/file_inclusion_test.go
@@ -30,7 +30,7 @@ var _ = Describe("file inclusions", func() {
 </div>
 </div>
 </div>`
-		Expect(RenderHTML5Body(source, configuration.WithFilename("test.adoc"), configuration.WithLastUpdated(lastUpdated))).To(Equal(expected))
+		Expect(RenderHTML(source, configuration.WithFilename("test.adoc"), configuration.WithLastUpdated(lastUpdated))).To(Equal(expected))
 		Expect(DocumentMetadata(source, lastUpdated)).To(Equal(types.Metadata{
 			Title:       "",
 			LastUpdated: lastUpdated.Format(configuration.LastUpdatedFormat),
@@ -64,7 +64,7 @@ var _ = Describe("file inclusions", func() {
 </div>
 </div>
 </div>`
-		Expect(RenderHTML5Body(source, configuration.WithFilename("tmp/foo.adoc"))).To(Equal(expected))
+		Expect(RenderHTML(source, configuration.WithFilename("tmp/foo.adoc"))).To(Equal(expected))
 		// verify no error/warning in logs
 		Expect(console).ToNot(ContainAnyMessageWithLevels(log.ErrorLevel, log.WarnLevel))
 	})
@@ -80,7 +80,7 @@ var _ = Describe("file inclusions", func() {
 <p>last line of grandchild</p>
 </div>
 </div>`
-		Expect(RenderHTML5Body(source, configuration.WithFilename("test.adoc"))).To(Equal(expected))
+		Expect(RenderHTML(source, configuration.WithFilename("test.adoc"))).To(Equal(expected))
 	})
 
 	It("should include grandchild content with absolute offset", func() {
@@ -96,7 +96,7 @@ var _ = Describe("file inclusions", func() {
 </div>
 </div>
 </div>`
-		Expect(RenderHTML5Body(source, configuration.WithFilename("test.adoc"))).To(Equal(expected))
+		Expect(RenderHTML(source, configuration.WithFilename("test.adoc"))).To(Equal(expected))
 	})
 
 	It("should include child and grandchild content with relative level offset", func() {
@@ -136,7 +136,7 @@ var _ = Describe("file inclusions", func() {
 </div>
 </div>
 </div>`
-		Expect(RenderHTML5Body(source, configuration.WithFilename("test.adoc"))).To(Equal(expected))
+		Expect(RenderHTML(source, configuration.WithFilename("test.adoc"))).To(Equal(expected))
 	})
 
 	It("should include child and grandchild content with relative then absolute level offset", func() {
@@ -176,7 +176,7 @@ var _ = Describe("file inclusions", func() {
 </div>
 </div>
 </div>`
-		Expect(RenderHTML5Body(source, configuration.WithFilename("test.adoc"))).To(Equal(expected))
+		Expect(RenderHTML(source, configuration.WithFilename("test.adoc"))).To(Equal(expected))
 	})
 
 	It("include adoc file with leveloffset attribute", func() {
@@ -200,7 +200,7 @@ include::../../../test/includes/chapter-a.adoc[leveloffset=+1]`
 </div>
 </div>
 </div>`
-		Expect(RenderHTML5Body(source)).To(Equal(expected))
+		Expect(RenderHTML(source)).To(Equal(expected))
 	})
 
 	It("should not include section 0 by default", func() {
@@ -208,7 +208,7 @@ include::../../../test/includes/chapter-a.adoc[leveloffset=+1]`
 		expected := `<div class="paragraph">
 <p>content</p>
 </div>`
-		Expect(RenderHTML5Body(source)).To(Equal(expected))
+		Expect(RenderHTML(source)).To(Equal(expected))
 	})
 
 	It("should not include section 0 when attribute exists", func() {
@@ -218,7 +218,7 @@ include::{includedir}/chapter-a.adoc[]`
 		expected := `<div class="paragraph">
 <p>content</p>
 </div>`
-		Expect(RenderHTML5Body(source)).To(Equal(expected))
+		Expect(RenderHTML(source)).To(Equal(expected))
 	})
 
 	It("include non adoc file", func() {
@@ -241,7 +241,7 @@ include::../../../test/includes/hello_world.go.txt[]`
 	fmt.Println(&#34;hello, world!&#34;)
 }</p>
 </div>`
-		Expect(RenderHTML5Body(source)).To(Equal(expected))
+		Expect(RenderHTML(source)).To(Equal(expected))
 	})
 
 	It("should not further process with non-asciidoc files", func() {
@@ -254,7 +254,7 @@ include::{includedir}/include.foo[]`
 <div class="paragraph">
 <p>include::hello_world.go.txt[]</p>
 </div>`
-		Expect(RenderHTML5Body(source)).To(Equal(expected))
+		Expect(RenderHTML(source)).To(Equal(expected))
 	})
 
 	It("include 2 files", func() {
@@ -294,7 +294,7 @@ include::../../../test/includes/hello_world.go.txt[]`
 </div>
 </div>
 </div>`
-		Expect(RenderHTML5Body(source)).To(Equal(expected))
+		Expect(RenderHTML(source)).To(Equal(expected))
 	})
 
 	It("include file and append following elements in included section", func() {
@@ -322,7 +322,7 @@ a third paragraph`
 </div>
 </div>
 </div>`
-		Expect(RenderHTML5Body(source)).To(Equal(expected))
+		Expect(RenderHTML(source)).To(Equal(expected))
 	})
 
 	Context("file inclusion in delimited blocks", func() {
@@ -347,7 +347,7 @@ include::../../../test/includes/chapter-a.adoc[]
 content</pre>
 </div>
 </div>`
-				Expect(RenderHTML5Body(source)).To(Equal(expected))
+				Expect(RenderHTML(source)).To(Equal(expected))
 			})
 
 			It("should include adoc file within fenced block", func() {
@@ -361,7 +361,7 @@ content</pre>
 content</code></pre>
 </div>
 </div>`
-				Expect(RenderHTML5Body(source)).To(Equal(expected))
+				Expect(RenderHTML(source)).To(Equal(expected))
 			})
 
 			It("should include adoc file within example block", func() {
@@ -378,7 +378,7 @@ include::../../../test/includes/chapter-a.adoc[]
 </div>
 </div>
 </div>`
-				Expect(RenderHTML5Body(source)).To(Equal(expected))
+				Expect(RenderHTML(source)).To(Equal(expected))
 			})
 
 			It("should include adoc file within quote block", func() {
@@ -395,7 +395,7 @@ ____`
 </div>
 </blockquote>
 </div>`
-				Expect(RenderHTML5Body(source)).To(Equal(expected))
+				Expect(RenderHTML(source)).To(Equal(expected))
 			})
 
 			It("should include adoc file within verse block", func() {
@@ -408,7 +408,7 @@ ____`
 
 content</pre>
 </div>`
-				Expect(RenderHTML5Body(source)).To(Equal(expected))
+				Expect(RenderHTML(source)).To(Equal(expected))
 			})
 
 			It("should include adoc file within sidebar block", func() {
@@ -425,7 +425,7 @@ include::../../../test/includes/chapter-a.adoc[]
 </div>
 </div>
 </div>`
-				Expect(RenderHTML5Body(source)).To(Equal(expected))
+				Expect(RenderHTML(source)).To(Equal(expected))
 			})
 
 			It("should include adoc file within passthrough block", func() {
@@ -434,7 +434,7 @@ include::../../../test/includes/chapter-a.adoc[]
 include::../../../test/includes/chapter-a.adoc[]
 ++++`
 				expected := ``
-				Expect(RenderHTML5Body(source)).To(Equal(expected))
+				Expect(RenderHTML(source)).To(Equal(expected))
 			})
 		})
 
@@ -462,7 +462,7 @@ func helloworld() {
 }</pre>
 </div>
 </div>`
-				Expect(RenderHTML5Body(source)).To(Equal(expected))
+				Expect(RenderHTML(source)).To(Equal(expected))
 			})
 
 			It("should include go file within fenced block", func() {
@@ -480,7 +480,7 @@ func helloworld() {
 }</code></pre>
 </div>
 </div>`
-				Expect(RenderHTML5Body(source)).To(Equal(expected))
+				Expect(RenderHTML(source)).To(Equal(expected))
 			})
 
 			It("should include go file within example block", func() {
@@ -502,7 +502,7 @@ include::../../../test/includes/hello_world.go.txt[]
 </div>
 </div>
 </div>`
-				Expect(RenderHTML5Body(source)).To(Equal(expected))
+				Expect(RenderHTML(source)).To(Equal(expected))
 			})
 
 			It("should include go file within quote block", func() {
@@ -524,7 +524,7 @@ ____`
 </div>
 </blockquote>
 </div>`
-				Expect(RenderHTML5Body(source)).To(Equal(expected))
+				Expect(RenderHTML(source)).To(Equal(expected))
 			})
 
 			It("should include go file within verse block", func() {
@@ -541,7 +541,7 @@ func helloworld() {
 	fmt.Println(&#34;hello, world!&#34;)
 }</pre>
 </div>`
-				Expect(RenderHTML5Body(source)).To(Equal(expected))
+				Expect(RenderHTML(source)).To(Equal(expected))
 			})
 
 			It("should include go file within sidebar block", func() {
@@ -563,7 +563,7 @@ include::../../../test/includes/hello_world.go.txt[]
 </div>
 </div>
 </div>`
-				Expect(RenderHTML5Body(source)).To(Equal(expected))
+				Expect(RenderHTML(source)).To(Equal(expected))
 			})
 		})
 	})
@@ -577,7 +577,7 @@ include::../../../test/includes/hello_world.go.txt[]
 				expected := `<div class="paragraph">
 <p>package includes</p>
 </div>`
-				Expect(RenderHTML5Body(source)).To(Equal(expected))
+				Expect(RenderHTML(source)).To(Equal(expected))
 			})
 
 			It("should include multiple lines as paragraph", func() {
@@ -587,7 +587,7 @@ include::../../../test/includes/hello_world.go.txt[]
 	fmt.Println(&#34;hello, world!&#34;)
 }</p>
 </div>`
-				Expect(RenderHTML5Body(source)).To(Equal(expected))
+				Expect(RenderHTML(source)).To(Equal(expected))
 			})
 
 			It("should include multiple ranges as paragraph", func() {
@@ -600,7 +600,7 @@ include::../../../test/includes/hello_world.go.txt[]
 	fmt.Println(&#34;hello, world!&#34;)
 }</p>
 </div>`
-				Expect(RenderHTML5Body(source)).To(Equal(expected))
+				Expect(RenderHTML(source)).To(Equal(expected))
 			})
 		})
 
@@ -615,7 +615,7 @@ include::../../../test/includes/hello_world.go.txt[lines=1]
 <pre>package includes</pre>
 </div>
 </div>`
-				Expect(RenderHTML5Body(source)).To(Equal(expected))
+				Expect(RenderHTML(source)).To(Equal(expected))
 			})
 
 			It("should include multiple lines in listing block", func() {
@@ -629,7 +629,7 @@ include::../../../test/includes/hello_world.go.txt[lines=5..7]
 }</pre>
 </div>
 </div>`
-				Expect(RenderHTML5Body(source)).To(Equal(expected))
+				Expect(RenderHTML(source)).To(Equal(expected))
 			})
 
 			It("should include multiple ranges in listing block", func() {
@@ -645,7 +645,7 @@ func helloworld() {
 }</pre>
 </div>
 </div>`
-				Expect(RenderHTML5Body(source)).To(Equal(expected))
+				Expect(RenderHTML(source)).To(Equal(expected))
 			})
 		})
 	})
@@ -659,7 +659,7 @@ func helloworld() {
 <div class="sectionbody">
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("file inclusion with surrounding tag", func() {
@@ -672,7 +672,7 @@ func helloworld() {
 </div>
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("file inclusion with unclosed tag", func() {
@@ -685,7 +685,7 @@ func helloworld() {
 <div class="paragraph">
 <p>end</p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 			// verify error in logs
 			Expect(console).To(
 				ContainMessageWithLevel(
@@ -699,7 +699,7 @@ func helloworld() {
 			defer reset()
 			source := `include::../../../test/includes/tag-include.adoc[tag=unknown]`
 			expected := ``
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 			// verify error in logs
 			Expect(console).To(
 				ContainMessageWithLevel(
@@ -721,7 +721,7 @@ func helloworld() {
 </div>
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		Context("permutations", func() {
@@ -739,7 +739,7 @@ func helloworld() {
 </div>
 </div>
 </div>`
-				Expect(RenderHTML5Body(source)).To(Equal(expected))
+				Expect(RenderHTML(source)).To(Equal(expected))
 			})
 
 			It("all tagged regions", func() {
@@ -752,7 +752,7 @@ func helloworld() {
 </div>
 </div>
 </div>`
-				Expect(RenderHTML5Body(source)).To(Equal(expected))
+				Expect(RenderHTML(source)).To(Equal(expected))
 			})
 
 			It("all the lines outside and inside of tagged regions", func() {
@@ -768,7 +768,7 @@ func helloworld() {
 </div>
 </div>
 </div>`
-				Expect(RenderHTML5Body(source)).To(Equal(expected))
+				Expect(RenderHTML(source)).To(Equal(expected))
 			})
 
 			It("regions tagged doc, but not nested regions tagged content", func() {
@@ -778,7 +778,7 @@ func helloworld() {
 <div class="sectionbody">
 </div>
 </div>`
-				Expect(RenderHTML5Body(source)).To(Equal(expected))
+				Expect(RenderHTML(source)).To(Equal(expected))
 			})
 
 			It("all tagged regions, but excludes any regions tagged content", func() {
@@ -788,7 +788,7 @@ func helloworld() {
 <div class="sectionbody">
 </div>
 </div>`
-				Expect(RenderHTML5Body(source)).To(Equal(expected))
+				Expect(RenderHTML(source)).To(Equal(expected))
 			})
 
 			It("all tagged regions, but excludes any regions tagged content", func() {
@@ -801,7 +801,7 @@ func helloworld() {
 </div>
 </div>
 </div>`
-				Expect(RenderHTML5Body(source)).To(Equal(expected))
+				Expect(RenderHTML(source)).To(Equal(expected))
 			})
 
 			It("**;!* — selects only the regions of the document outside of tags", func() {
@@ -809,7 +809,7 @@ func helloworld() {
 				expected := `<div class="paragraph">
 <p>end</p>
 </div>`
-				Expect(RenderHTML5Body(source)).To(Equal(expected))
+				Expect(RenderHTML(source)).To(Equal(expected))
 			})
 		})
 	})
@@ -849,7 +849,7 @@ func helloworld() {
 </div>
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("should include child and grandchild content in listing block", func() {
@@ -877,7 +877,7 @@ last line of child
 last line of parent</pre>
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 	})
 
@@ -898,7 +898,7 @@ include::{includedir}/grandchild-include.adoc[]`
 </div>
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("should resolve path with attribute in delimited block", func() {
@@ -916,7 +916,7 @@ first line of grandchild
 last line of grandchild</pre>
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 	})
 
@@ -933,7 +933,7 @@ last line of grandchild</pre>
 				expected := `<div class="paragraph">
 <p>Unresolved directive in test.adoc - include::../../../test/includes/unknown.adoc[leveloffset=+1]</p>
 </div>`
-				Expect(RenderHTML5Body(source, configuration.WithFilename("test.adoc"))).To(Equal(expected))
+				Expect(RenderHTML(source, configuration.WithFilename("test.adoc"))).To(Equal(expected))
 				// verify error in logs
 				Expect(console).To(
 					ContainMessageWithLevel(
@@ -951,7 +951,7 @@ last line of grandchild</pre>
 				expected := `<div class="paragraph">
 <p>Unresolved directive in test.adoc - include::{includedir}/unknown.adoc[leveloffset=+1]</p>
 </div>`
-				Expect(RenderHTML5Body(source, configuration.WithFilename("test.adoc"))).To(Equal(expected))
+				Expect(RenderHTML(source, configuration.WithFilename("test.adoc"))).To(Equal(expected))
 				// verify error in logs
 				Expect(console).To(
 					ContainMessageWithLevel(
@@ -976,7 +976,7 @@ include::../../../test/includes/unknown.adoc[leveloffset=+1]
 <pre>Unresolved directive in test.adoc - include::../../../test/includes/unknown.adoc[leveloffset=+1]</pre>
 </div>
 </div>`
-				Expect(RenderHTML5Body(source, configuration.WithFilename("test.adoc"))).To(Equal(expected))
+				Expect(RenderHTML(source, configuration.WithFilename("test.adoc"))).To(Equal(expected))
 				// verify error in logs
 				Expect(console).To(
 					ContainMessageWithLevel(
@@ -998,7 +998,7 @@ include::{includedir}/unknown.adoc[leveloffset=+1]
 <pre>Unresolved directive in test.adoc - include::{includedir}/unknown.adoc[leveloffset=+1]</pre>
 </div>
 </div>`
-				Expect(RenderHTML5Body(source, configuration.WithFilename("test.adoc"))).To(Equal(expected))
+				Expect(RenderHTML(source, configuration.WithFilename("test.adoc"))).To(Equal(expected))
 				// verify error in logs
 				Expect(console).To(
 					ContainMessageWithLevel(

--- a/pkg/renderer/html5/footnote_test.go
+++ b/pkg/renderer/html5/footnote_test.go
@@ -25,7 +25,7 @@ var _ = Describe("footnotes", func() {
 <a href="#_footnoteref_1">1</a>. a note for foo
 </div>
 </div>`
-		Expect(RenderHTML5Body(source)).To(Equal(expected))
+		Expect(RenderHTML(source)).To(Equal(expected))
 	})
 
 	It("rich footnote in a paragraph", func() {
@@ -39,7 +39,7 @@ var _ = Describe("footnotes", func() {
 <a href="#_footnoteref_1">1</a>. some <strong>rich</strong> <a href="https://foo.com">content</a>
 </div>
 </div>`
-		Expect(RenderHTML5Body(source)).To(Equal(expected))
+		Expect(RenderHTML(source)).To(Equal(expected))
 	})
 
 	It("footnoteref with valid ref in a paragraph", func() {
@@ -53,7 +53,7 @@ var _ = Describe("footnotes", func() {
 <a href="#_footnoteref_1">1</a>. a note for foo
 </div>
 </div>`
-		Expect(RenderHTML5Body(source)).To(Equal(expected))
+		Expect(RenderHTML(source)).To(Equal(expected))
 	})
 
 	It("footnoteref with invalid ref in a paragraph", func() {
@@ -67,7 +67,7 @@ var _ = Describe("footnotes", func() {
 <a href="#_footnoteref_1">1</a>. a note for foo
 </div>
 </div>`
-		Expect(RenderHTML5Body(source)).To(Equal(expected))
+		Expect(RenderHTML(source)).To(Equal(expected))
 	})
 
 	It("footnotes everywhere", func() {
@@ -108,6 +108,6 @@ a paragraph with another footnote:[baz]`
 <a href="#_footnoteref_3">3</a>. baz
 </div>
 </div>`
-		Expect(RenderHTML5Body(source)).To(Equal(expected))
+		Expect(RenderHTML(source)).To(Equal(expected))
 	})
 })

--- a/pkg/renderer/html5/html5_test.go
+++ b/pkg/renderer/html5/html5_test.go
@@ -41,7 +41,7 @@ Last updated {{.LastUpdated}}
 </body>
 </html>`
 			now := time.Now()
-			Expect(RenderHTML5Body(source, configuration.WithHeaderFooter(true),
+			Expect(RenderHTML(source, configuration.WithHeaderFooter(true),
 				configuration.WithCSS("/path/to/style.css"),
 				configuration.WithLastUpdated(now))).
 				To(MatchHTML5Template(expected, now))

--- a/pkg/renderer/html5/image_test.go
+++ b/pkg/renderer/html5/image_test.go
@@ -19,7 +19,7 @@ var _ = Describe("images", func() {
 <img src="foo.png" alt="foo">
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("block image with alt", func() {
@@ -30,7 +30,7 @@ var _ = Describe("images", func() {
 <img src="foo.png" alt="foo image">
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("block image with alt and dimensions", func() {
@@ -41,7 +41,7 @@ var _ = Describe("images", func() {
 <img src="foo.png" alt="foo image" width="600" height="400">
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("block image with title, alt and dimensions", func() {
@@ -55,7 +55,7 @@ image::images/foo.png[the foo.png image,600,400]`
 </div>
 <div class="title">Figure 1. A title to foobar</div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("block image with role above", func() {
@@ -69,7 +69,7 @@ image::foo.png[foo image, 600, 400]`
 </div>
 <div class="title">Figure 1. mytitle</div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("block image with id, title and role inline", func() {
@@ -80,7 +80,7 @@ image::foo.png[foo image, 600, 400]`
 </div>
 <div class="title">Figure 1. mytitle</div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("2 block images", func() {
@@ -96,7 +96,7 @@ image::appa.png[]`
 <img src="appa.png" alt="appa">
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 	})
@@ -110,7 +110,7 @@ image::appa.png[]`
 				expected := `<div class="paragraph">
 <p><span class="image"><img src="app.png" alt="app"></span></p>
 </div>`
-				Expect(RenderHTML5Body(source)).To(Equal(expected))
+				Expect(RenderHTML(source)).To(Equal(expected))
 			})
 
 			It("inline image with id, title and role", func() {
@@ -118,7 +118,7 @@ image::appa.png[]`
 				expected := `<div class="paragraph">
 <p><span class="image myrole"><img src="foo.png" alt="foo" title="mytitle"></span></p>
 </div>`
-				Expect(RenderHTML5Body(source)).To(Equal(expected))
+				Expect(RenderHTML(source)).To(Equal(expected))
 			})
 
 			It("inline image with alt", func() {
@@ -126,7 +126,7 @@ image::appa.png[]`
 				expected := `<div class="paragraph">
 <p><span class="image"><img src="foo.png" alt="foo image"></span></p>
 </div>`
-				Expect(RenderHTML5Body(source)).To(Equal(expected))
+				Expect(RenderHTML(source)).To(Equal(expected))
 			})
 
 			It("inline image with alt and dimensions", func() {
@@ -134,7 +134,7 @@ image::appa.png[]`
 				expected := `<div class="paragraph">
 <p><span class="image"><img src="foo.png" alt="foo image" width="600" height="400"></span></p>
 </div>`
-				Expect(RenderHTML5Body(source)).To(Equal(expected))
+				Expect(RenderHTML(source)).To(Equal(expected))
 			})
 
 			It("paragraph with inline image with alt and dimensions", func() {
@@ -142,7 +142,7 @@ image::appa.png[]`
 				expected := `<div class="paragraph">
 <p>a foo <span class="image"><img src="foo.png" alt="foo image" width="600" height="400"></span> bar</p>
 </div>`
-				Expect(RenderHTML5Body(source)).To(Equal(expected))
+				Expect(RenderHTML(source)).To(Equal(expected))
 			})
 		})
 
@@ -153,7 +153,7 @@ image::appa.png[]`
 				expected := `<div class="paragraph">
 <p>a foo image::foo.png[foo image, 600, 400] bar</p>
 </div>`
-				Expect(RenderHTML5Body(source)).To(Equal(expected))
+				Expect(RenderHTML(source)).To(Equal(expected))
 			})
 		})
 	})
@@ -169,7 +169,7 @@ image::foo.png[]`
 <img src="./assets/foo.png" alt="foo">
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("2 block images with relative locations and imagesdir changed in-between", func() {
@@ -189,7 +189,7 @@ image::bar.png[]`
 <img src="./assets2/bar.png" alt="bar">
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("block image with absolute URL", func() {
@@ -201,7 +201,7 @@ image::https://example.com/foo.png[]`
 <img src="https://example.com/foo.png" alt="foo">
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("block image with absolute filepath", func() {
@@ -213,7 +213,7 @@ image::/bar/foo.png[]`
 <img src="/bar/foo.png" alt="foo">
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("block image with absolute file scheme and path", func() {
@@ -225,7 +225,7 @@ image::file:///bar/foo.png[]`
 <img src="file:///bar/foo.png" alt="foo">
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 	})
 })

--- a/pkg/renderer/html5/index_terms_test.go
+++ b/pkg/renderer/html5/index_terms_test.go
@@ -14,7 +14,7 @@ var _ = Describe("index terms", func() {
 		expected := `<div class="paragraph">
 <p>a paragraph with an index term.</p>
 </div>`
-		Expect(RenderHTML5Body(source)).To(Equal(expected))
+		Expect(RenderHTML(source)).To(Equal(expected))
 	})
 
 	It("index term in separate paragraph line", func() {
@@ -24,7 +24,7 @@ a paragraph with an index term.`
 <p>foo_bar_baz <em>italic</em>
 a paragraph with an index term.</p>
 </div>`
-		Expect(RenderHTML5Body(source)).To(Equal(expected))
+		Expect(RenderHTML(source)).To(Equal(expected))
 	})
 })
 
@@ -35,7 +35,7 @@ var _ = Describe("concealed index terms", func() {
 		expected := `<div class="paragraph">
 <p>a paragraph with an index term .</p>
 </div>`
-		Expect(RenderHTML5Body(source)).To(Equal(expected))
+		Expect(RenderHTML(source)).To(Equal(expected))
 	})
 
 	It("concealed index term in single paragraph line", func() {
@@ -44,7 +44,7 @@ a paragraph with an index term.`
 		expected := `<div class="paragraph">
 <p>a paragraph with an index term.</p>
 </div>`
-		Expect(RenderHTML5Body(source)).To(Equal(expected))
+		Expect(RenderHTML(source)).To(Equal(expected))
 	})
 
 	It("concealed index term in single paragraph line", func() {
@@ -53,7 +53,7 @@ a paragraph with an index term.`
 		expected := `<div class="paragraph">
 <p>a paragraph with an index term.</p>
 </div>`
-		Expect(RenderHTML5Body(source)).To(Equal(expected))
+		Expect(RenderHTML(source)).To(Equal(expected))
 	})
 
 	It("concealed index term in labeled list term", func() {
@@ -79,6 +79,6 @@ discarded.</p>
 </dd>
 </dl>
 </div>`
-		Expect(RenderHTML5Body(source)).To(Equal(expected))
+		Expect(RenderHTML(source)).To(Equal(expected))
 	})
 })

--- a/pkg/renderer/html5/labeled_list_test.go
+++ b/pkg/renderer/html5/labeled_list_test.go
@@ -39,7 +39,7 @@ on 2 lines, too.</p>
 </dd>
 </dl>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("labeled list with a quoted text in term and in description", func() {
@@ -53,7 +53,7 @@ on 2 lines, too.</p>
 </dd>
 </dl>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("labeled list with an empty entry", func() {
@@ -68,7 +68,7 @@ item 2:: description 2.`
 </dd>
 </dl>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("labeled list with an image", func() {
@@ -86,7 +86,7 @@ item 2:: description 2.`
 </dd>
 </dl>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("labeled list with script injection", func() {
@@ -99,7 +99,7 @@ item 2:: description 2.`
 </dd>
 </dl>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("labeled list with fenced block", func() {
@@ -126,7 +126,7 @@ item 2:: description 2.`
 </dd>
 </dl>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("labeled list with nested lists using regular layout", func() {
@@ -163,7 +163,7 @@ item 2:: something simple`
 </dd>
 </dl>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("labeled list with title", func() {
@@ -183,7 +183,7 @@ second term:: definition of the second term`
 </dd>
 </dl>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 	})
@@ -223,7 +223,7 @@ on 2 lines, too.</p>
 </tr>
 </table>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("labeled list with nested lists using horizontal layout", func() {
@@ -269,7 +269,7 @@ item 2
 </tr>
 </table>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 	})
@@ -297,7 +297,7 @@ item 2:: description 2.`
 </dd>
 </dl>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("labeled list with blockcontinuation", func() {
@@ -333,7 +333,7 @@ another delimited block
 </dl>
 </div>`
 
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("labeled list with multiple item continuations", func() {
@@ -402,7 +402,7 @@ tip
 </dl>
 </div>`
 
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("labeled list without continuation", func() {
@@ -438,7 +438,7 @@ another delimited block
 </div>
 </div>`
 
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 	})
 
@@ -475,7 +475,7 @@ Item 3 description`
 </dd>
 </dl>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 	})
 
@@ -501,7 +501,7 @@ What is the answer to the Ultimate Question?:: 42`
 </li>
 </ol>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 	})
 
@@ -545,7 +545,7 @@ paragraph attached to grandparent list item`
 </dd>
 </dl>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("attach to parent labeled list item", func() {
@@ -585,7 +585,7 @@ paragraph attached to parent list item`
 </dd>
 </dl>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("attach to child labeled list item", func() {
@@ -624,7 +624,7 @@ paragraph attached to child list item`
 </dd>
 </dl>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 	})
 })

--- a/pkg/renderer/html5/link_test.go
+++ b/pkg/renderer/html5/link_test.go
@@ -17,7 +17,7 @@ var _ = Describe("links", func() {
 			expected := `<div class="paragraph">
 <p>a link to <a href="https://foo.com" class="bare">https://foo.com</a>.</p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("external link with quoted text", func() {
@@ -25,7 +25,7 @@ var _ = Describe("links", func() {
 			expected := `<div class="paragraph">
 <p><a href="https://foo.com"><em>a</em> <strong>b</strong> <code>c</code></a></p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("external link with text having comma", func() {
@@ -33,7 +33,7 @@ var _ = Describe("links", func() {
 			expected := `<div class="paragraph">
 <p><a href="https://foo.com">A, B, and C</a></p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("external link inside a multiline paragraph", func() {
@@ -45,7 +45,7 @@ next lines`
 and more text on the
 next lines</p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		Context("with document attribute substitutions", func() {
@@ -59,7 +59,7 @@ a link to {url}`
 				expected := `<div class="paragraph">
 <p>a link to <a href="https://foo2.bar" class="bare">https://foo2.bar</a></p>
 </div>`
-				Expect(RenderHTML5Body(source)).To(Equal(expected))
+				Expect(RenderHTML(source)).To(Equal(expected))
 			})
 
 			It("external link with two document attribute substitutions only", func() {
@@ -70,7 +70,7 @@ a link to {scheme}://{path}`
 				expected := `<div class="paragraph">
 <p>a link to <a href="https://foo.bar" class="bare">https://foo.bar</a></p>
 </div>`
-				Expect(RenderHTML5Body(source)).To(Equal(expected))
+				Expect(RenderHTML(source)).To(Equal(expected))
 			})
 
 			It("external link with two document attribute substitutions and a reset", func() {
@@ -83,7 +83,7 @@ a link to {scheme}://{path}`
 				expected := `<div class="paragraph">
 <p>a link to <a href="https://{path}" class="bare">https://{path}</a></p>
 </div>`
-				Expect(RenderHTML5Body(source)).To(Equal(expected))
+				Expect(RenderHTML(source)).To(Equal(expected))
 			})
 
 			It("external link with document attribute in section 0 title", func() {
@@ -104,7 +104,7 @@ a link to {scheme}://{path}`
 <div class="sectionbody">
 </div>
 </div>`
-				Expect(RenderHTML5Body(source)).To(Equal(expected))
+				Expect(RenderHTML(source)).To(Equal(expected))
 			})
 
 			It("external link with two document attribute substitutions and a reset", func() {
@@ -117,7 +117,7 @@ a link to {scheme}://{path} and https://foo.baz`
 				expected := `<div class="paragraph">
 <p>a link to <a href="https://{path}" class="bare">https://{path}</a> and <a href="https://foo.baz" class="bare">https://foo.baz</a></p>
 </div>`
-				Expect(RenderHTML5Body(source)).To(Equal(expected))
+				Expect(RenderHTML(source)).To(Equal(expected))
 			})
 		})
 	})
@@ -129,7 +129,7 @@ a link to {scheme}://{path} and https://foo.baz`
 			expected := `<div class="paragraph">
 <p>a link to <a href="foo.adoc" class="bare">foo.adoc</a>.</p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("relative link to doc with text", func() {
@@ -137,7 +137,7 @@ a link to {scheme}://{path} and https://foo.baz`
 			expected := `<div class="paragraph">
 <p>a link to <a href="foo.adoc">foo doc</a>.</p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("relative link with text having comma", func() {
@@ -145,7 +145,7 @@ a link to {scheme}://{path} and https://foo.baz`
 			expected := `<div class="paragraph">
 <p>a link to <a href="foo.adoc">A, B, and C</a></p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("relative link to external URL with text", func() {
@@ -153,7 +153,7 @@ a link to {scheme}://{path} and https://foo.baz`
 			expected := `<div class="paragraph">
 <p>a link to <a href="https://foo.bar">foo doc</a>.</p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("invalid relative link to doc", func() {
@@ -161,7 +161,7 @@ a link to {scheme}://{path} and https://foo.baz`
 			expected := `<div class="paragraph">
 <p>a link to link:foo.adoc.</p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("relative link with quoted text", func() {
@@ -169,7 +169,7 @@ a link to {scheme}://{path} and https://foo.baz`
 			expected := `<div class="paragraph">
 <p><a href="/"><em>a</em> <strong>b</strong> <code>c</code></a></p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		Context("with document attribute substitutions", func() {
@@ -184,7 +184,7 @@ a link to {scheme}:{path}[] and https://foo.baz`
 				expected := `<div class="paragraph">
 <p>a link to <a href="{path}" class="bare">{path}</a> and <a href="https://foo.baz" class="bare">https://foo.baz</a></p>
 </div>`
-				Expect(RenderHTML5Body(source)).To(Equal(expected))
+				Expect(RenderHTML(source)).To(Equal(expected))
 			})
 		})
 	})

--- a/pkg/renderer/html5/literal_block_test.go
+++ b/pkg/renderer/html5/literal_block_test.go
@@ -18,7 +18,7 @@ var _ = Describe("literal blocks", func() {
 <pre>some literal content</pre>
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("literal block from paragraph with single space on first line", func() {
@@ -32,7 +32,7 @@ on 3
 lines.</pre>
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("literal block from paragraph with same spaces on each line", func() {
@@ -46,7 +46,7 @@ on 3
 lines.</pre>
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("literal block from paragraph with single spaces on each line", func() {
@@ -60,7 +60,7 @@ lines.</pre>
     has some heading spaces preserved.</pre>
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("mixing literal block with attributes followed by a paragraph ", func() {
@@ -78,7 +78,7 @@ a normal paragraph.`
 <div class="paragraph">
 <p>a normal paragraph.</p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 	})
 
@@ -100,7 +100,7 @@ a normal paragraph.`
 <div class="paragraph">
 <p>a normal paragraph.</p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 	})
@@ -124,7 +124,7 @@ a normal paragraph.`
 <div class="paragraph">
 <p>a normal paragraph.</p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("literal block from 2-lines paragraph with attribute", func() {
@@ -145,7 +145,7 @@ on two lines.</pre>
 <div class="paragraph">
 <p>a normal paragraph.</p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 	})
 

--- a/pkg/renderer/html5/ordered_list_test.go
+++ b/pkg/renderer/html5/ordered_list_test.go
@@ -22,7 +22,7 @@ var _ = Describe("ordered lists", func() {
 </li>
 </ol>
 </div>`
-		Expect(RenderHTML5Body(source)).To(Equal(expected))
+		Expect(RenderHTML(source)).To(Equal(expected))
 	})
 
 	It("ordered list item with explicit start only", func() {
@@ -35,7 +35,7 @@ var _ = Describe("ordered lists", func() {
 </li>
 </ol>
 </div>`
-		Expect(RenderHTML5Body(source)).To(Equal(expected))
+		Expect(RenderHTML(source)).To(Equal(expected))
 	})
 
 	It("ordered list item with explicit quoted numbering and start", func() {
@@ -48,7 +48,7 @@ var _ = Describe("ordered lists", func() {
 </li>
 </ol>
 </div>`
-		Expect(RenderHTML5Body(source)).To(Equal(expected))
+		Expect(RenderHTML(source)).To(Equal(expected))
 	})
 
 	It("ordered list with paragraph continuation", func() {
@@ -65,7 +65,7 @@ foo`
 </li>
 </ol>
 </div>`
-		Expect(RenderHTML5Body(source)).To(Equal(expected))
+		Expect(RenderHTML(source)).To(Equal(expected))
 	})
 
 	It("ordered list with delimited block continuation", func() {
@@ -86,7 +86,7 @@ foo
 </li>
 </ol>
 </div>`
-		Expect(RenderHTML5Body(source)).To(Equal(expected))
+		Expect(RenderHTML(source)).To(Equal(expected))
 	})
 
 	It("ordered list with unnumbered items", func() {
@@ -134,7 +134,7 @@ foo
 </li>
 </ol>
 </div>`
-		Expect(RenderHTML5Body(source)).To(Equal(expected))
+		Expect(RenderHTML(source)).To(Equal(expected))
 	})
 
 	It("ordered list mixed with unordered list - simple case", func() {
@@ -178,7 +178,7 @@ foo
 </li>
 </ol>
 </div>`
-		Expect(RenderHTML5Body(source)).To(Equal(expected))
+		Expect(RenderHTML(source)).To(Equal(expected))
 	})
 
 	It("ordered list mixed with unordered list - complex case", func() {
@@ -303,7 +303,7 @@ extra lines.</p>
 </li>
 </ul>
 </div>`
-		Expect(RenderHTML5Body(source)).To(Equal(expected))
+		Expect(RenderHTML(source)).To(Equal(expected))
 	})
 
 	It("all kinds of lists - complex case 3", func() {
@@ -347,7 +347,7 @@ a. foo
 </li>
 </ul>
 </div>`
-		Expect(RenderHTML5Body(source)).To(Equal(expected))
+		Expect(RenderHTML(source)).To(Equal(expected))
 	})
 
 	It("drop principal text in list item", func() {
@@ -381,7 +381,7 @@ print("one")
 </li>
 </ol>
 </div>`
-		Expect(RenderHTML5Body(source)).To(Equal(expected))
+		Expect(RenderHTML(source)).To(Equal(expected))
 	})
 
 	Context("attach to ordered list item ancestor", func() {
@@ -418,7 +418,7 @@ paragraph attached to grandparent list item`
 </li>
 </ol>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("attach to parent ordered list item", func() {
@@ -452,7 +452,7 @@ paragraph attached to parent list item`
 </li>
 </ol>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("attach to child ordered list item", func() {
@@ -485,7 +485,7 @@ paragraph attached to child list item`
 </li>
 </ol>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 	})
 })

--- a/pkg/renderer/html5/paragraph_test.go
+++ b/pkg/renderer/html5/paragraph_test.go
@@ -18,7 +18,7 @@ var _ = Describe("paragraphs", func() {
 <p><strong>bold content</strong>
 &amp; more content afterwards</p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("a standalone paragraph with trailing spaces", func() {
@@ -28,7 +28,7 @@ var _ = Describe("paragraphs", func() {
 <p><strong>bold content</strong>
    &amp; more content afterwards&#8230;&#8203;</p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("a standalone paragraph with an ID and a title", func() {
@@ -39,7 +39,7 @@ var _ = Describe("paragraphs", func() {
 <div class="doctitle">a title</div>
 <p><strong>bold content</strong> with more content afterwards&#8230;&#8203;</p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("2 paragraphs and blank line", func() {
@@ -55,7 +55,7 @@ and here another paragraph
 <div class="paragraph">
 <p>and here another paragraph</p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("paragraph with single quotes", func() {
@@ -63,7 +63,7 @@ and here another paragraph
 			expected := `<div class="paragraph">
 <p>a &#39;subsection&#39; paragraph.</p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("empty paragraph", func() {
@@ -71,7 +71,7 @@ and here another paragraph
 			expected := `<div class="paragraph">
 <p></p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 
 		})
 
@@ -81,7 +81,7 @@ some content`
 			expected := `<div class="paragraph text-left">
 <p>some content</p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 
 		})
 	})
@@ -97,7 +97,7 @@ baz`
 bar
 baz</p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("with paragraph attribute", func() {
@@ -111,7 +111,7 @@ baz`
 bar<br>
 baz</p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("with document attribute", func() {
@@ -124,7 +124,7 @@ baz`
 bar<br>
 baz</p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("paragraph with document attribute resets", func() {
@@ -136,7 +136,7 @@ a paragraph written by {author}.`
 			expected := `<div class="paragraph">
 <p>a paragraph written by Xavier.</p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 	})
 
@@ -156,7 +156,7 @@ this is a note.
 </tr>
 </table>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("multiline warning admonition paragraph", func() {
@@ -175,7 +175,7 @@ warning!
 </tr>
 </table>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("admonition note paragraph with id and title", func() {
@@ -195,7 +195,7 @@ this is a note.
 </tr>
 </table>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 	})
 
@@ -216,7 +216,7 @@ this is a caution!
 </tr>
 </table>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("multiline caution admonition paragraph with title and id", func() {
@@ -239,7 +239,7 @@ this is a
 </tr>
 </table>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 	})
 
@@ -255,7 +255,7 @@ I am a verse paragraph.`
 <cite>verse title</cite>
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("paragraph as a verse with author, title and other attributes", func() {
@@ -271,7 +271,7 @@ I am a verse paragraph.`
 <cite>verse title</cite>
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("paragraph as a verse with empty title", func() {
@@ -283,7 +283,7 @@ I am a verse paragraph.`
 &#8212; john doe
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("paragraph as a verse without title", func() {
@@ -295,7 +295,7 @@ I am a verse paragraph.`
 &#8212; john doe
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("paragraph as a verse with empty author", func() {
@@ -304,7 +304,7 @@ I am a verse paragraph.`
 			expected := `<div class="verseblock">
 <pre class="content">I am a verse paragraph.</pre>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("paragraph as a verse without author", func() {
@@ -313,7 +313,7 @@ I am a verse paragraph.`
 			expected := `<div class="verseblock">
 <pre class="content">I am a verse paragraph.</pre>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("image block as a verse", func() {
@@ -326,7 +326,7 @@ image::foo.png[]`
 <cite>verse title</cite>
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 	})
 
@@ -344,7 +344,7 @@ some <strong>quote</strong> content
 <cite>quote title</cite>
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("paragraph as a quote with author, title and other attributes", func() {
@@ -362,7 +362,7 @@ I am a quote paragraph.
 <cite>quote title</cite>
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("paragraph as a quote with empty title", func() {
@@ -376,7 +376,7 @@ I am a quote paragraph.
 &#8212; john doe
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("paragraph as a quote without title", func() {
@@ -390,7 +390,7 @@ I am a quote paragraph.
 &#8212; john doe
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("paragraph as a quote with empty author", func() {
@@ -401,7 +401,7 @@ I am a quote paragraph.`
 I am a quote paragraph.
 </blockquote>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("paragraph as a quote without author", func() {
@@ -412,7 +412,7 @@ I am a quote paragraph.`
 I am a quote paragraph.
 </blockquote>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("inline image within a quote", func() {
@@ -427,7 +427,7 @@ a foo <span class="image"><img src="foo.png" alt="foo"></span>
 <cite>quote title</cite>
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("image block is NOT a quote", func() {
@@ -438,7 +438,7 @@ image::foo.png[]`
 <img src="foo.png" alt="foo">
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 	})

--- a/pkg/renderer/html5/passthrough_test.go
+++ b/pkg/renderer/html5/passthrough_test.go
@@ -17,7 +17,7 @@ var _ = Describe("passthroughs", func() {
 			expected := `<div class="paragraph">
 <p></p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("an empty tripleplus passthrough in a paragraph", func() {
@@ -25,7 +25,7 @@ var _ = Describe("passthroughs", func() {
 			expected := `<div class="paragraph">
 <p> with more content afterwards&#8230;&#8203;</p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("a standalone tripleplus passthrough", func() {
@@ -33,7 +33,7 @@ var _ = Describe("passthroughs", func() {
 			expected := `<div class="paragraph">
 <p>*bold content*</p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("tripleplus passthrough in paragraph", func() {
@@ -41,7 +41,7 @@ var _ = Describe("passthroughs", func() {
 			expected := `<div class="paragraph">
 <p>The text <u>underline & me</u> is underlined.</p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 	})
 
@@ -52,7 +52,7 @@ var _ = Describe("passthroughs", func() {
 			expected := `<div class="paragraph">
 <p>++</p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("an empty singleplus passthrough in a paragraph", func() {
@@ -60,7 +60,7 @@ var _ = Describe("passthroughs", func() {
 			expected := `<div class="paragraph">
 <p>++ with more content afterwards&#8230;&#8203;</p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("a singleplus passthrough", func() {
@@ -68,7 +68,7 @@ var _ = Describe("passthroughs", func() {
 			expected := `<div class="paragraph">
 <p>*bold content*</p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("singleplus passthrough in paragraph", func() {
@@ -76,7 +76,7 @@ var _ = Describe("passthroughs", func() {
 			expected := `<div class="paragraph">
 <p>The text &lt;u&gt;underline me&lt;/u&gt; is not underlined.</p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("invalid singleplus passthrough in paragraph", func() {
@@ -84,7 +84,7 @@ var _ = Describe("passthroughs", func() {
 			expected := `<div class="paragraph">
 <p>The text + <strong>hello</strong>, world + is not passed through.</p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 	})
 
@@ -95,7 +95,7 @@ var _ = Describe("passthroughs", func() {
 			expected := `<div class="paragraph">
 <p>hello</p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("passthrough macro with words", func() {
@@ -103,7 +103,7 @@ var _ = Describe("passthroughs", func() {
 			expected := `<div class="paragraph">
 <p>hello, world</p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("empty passthrough macro", func() {
@@ -111,7 +111,7 @@ var _ = Describe("passthroughs", func() {
 			expected := `<div class="paragraph">
 <p></p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("passthrough macro with spaces", func() {
@@ -119,7 +119,7 @@ var _ = Describe("passthroughs", func() {
 			expected := `<div class="paragraph">
 <p> *hello*, world </p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("passthrough macro with line break", func() {
@@ -128,7 +128,7 @@ var _ = Describe("passthroughs", func() {
 <p>hello,
 world</p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 	})
 
@@ -139,7 +139,7 @@ world</p>
 			expected := `<div class="paragraph">
 <p><strong>hello</strong></p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("passthrough macro with quoted word in sentence and trailing spaces", func() {
@@ -147,7 +147,7 @@ world</p>
 			expected := `<div class="paragraph">
 <p> a <strong>hello</strong>, world </p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("passthrough macro within paragraph", func() {
@@ -155,7 +155,7 @@ world</p>
 			expected := `<div class="paragraph">
 <p>an  <strong>hello</strong>, world  mention</p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 	})
 })

--- a/pkg/renderer/html5/quoted_text_test.go
+++ b/pkg/renderer/html5/quoted_text_test.go
@@ -16,7 +16,7 @@ var _ = Describe("quoted texts", func() {
 			expected := `<div class="paragraph">
 <p><strong>bold content</strong></p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("bold content in sentence", func() {
@@ -24,7 +24,7 @@ var _ = Describe("quoted texts", func() {
 			expected := `<div class="paragraph">
 <p>some <strong>bold content</strong>.</p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 	})
 
@@ -35,7 +35,7 @@ var _ = Describe("quoted texts", func() {
 			expected := `<div class="paragraph">
 <p><em>italic content</em></p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("italic content in sentence", func() {
@@ -44,7 +44,7 @@ var _ = Describe("quoted texts", func() {
 			expected := `<div class="paragraph">
 <p>some <em>italic content</em>.</p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 	})
 
@@ -55,7 +55,7 @@ var _ = Describe("quoted texts", func() {
 			expected := `<div class="paragraph">
 <p><code>monospace content</code></p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("monospace content in sentence", func() {
@@ -64,7 +64,7 @@ var _ = Describe("quoted texts", func() {
 			expected := `<div class="paragraph">
 <p>some <code>monospace content</code>.</p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 	})
 
@@ -75,7 +75,7 @@ var _ = Describe("quoted texts", func() {
 			expected := `<div class="paragraph">
 <p><sub>subscriptcontent</sub></p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("subscript content in sentence", func() {
@@ -84,7 +84,7 @@ var _ = Describe("quoted texts", func() {
 			expected := `<div class="paragraph">
 <p>some <sub>subscriptcontent</sub>.</p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 	})
 
@@ -95,7 +95,7 @@ var _ = Describe("quoted texts", func() {
 			expected := `<div class="paragraph">
 <p><sup>superscriptcontent</sup></p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("superscript content in sentence", func() {
@@ -104,7 +104,7 @@ var _ = Describe("quoted texts", func() {
 			expected := `<div class="paragraph">
 <p>some <sup>superscriptcontent</sup>.</p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 	})
 
@@ -116,7 +116,7 @@ var _ = Describe("quoted texts", func() {
 			expected := `<div class="paragraph">
 <p><strong>some *nested bold</strong> content*.</p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("italic content within bold quote in sentence", func() {
@@ -124,7 +124,7 @@ var _ = Describe("quoted texts", func() {
 			expected := `<div class="paragraph">
 <p>some <strong>bold and <em>italic content</em></strong> together.</p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 	})
 
@@ -135,7 +135,7 @@ var _ = Describe("quoted texts", func() {
 			expected := `<div class="paragraph">
 <p>some *bold and <em>italic content</em> * together.</p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("invalid italic content within bold quote in sentence", func() {
@@ -144,7 +144,7 @@ var _ = Describe("quoted texts", func() {
 			expected := `<div class="paragraph">
 <p>some <strong>bold and _italic content _ together</strong>.</p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 	})
 
@@ -155,7 +155,7 @@ var _ = Describe("quoted texts", func() {
 			expected := `<div class="paragraph">
 <p>some *bold content*.</p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("italic content within escaped bold quote in sentence", func() {
@@ -163,7 +163,7 @@ var _ = Describe("quoted texts", func() {
 			expected := `<div class="paragraph">
 <p>some *bold and <em>italic content</em>* together.</p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 	})
@@ -175,7 +175,7 @@ var _ = Describe("quoted texts", func() {
 			expected := `<div class="paragraph">
 <p><code>*a</code></p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("unbalanced bold in monospace - case 2", func() {
@@ -183,7 +183,7 @@ var _ = Describe("quoted texts", func() {
 			expected := `<div class="paragraph">
 <p><code>a*b</code></p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("italic in monospace", func() {
@@ -191,7 +191,7 @@ var _ = Describe("quoted texts", func() {
 			expected := `<div class="paragraph">
 <p><code><em>a</em></code></p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("unbalanced italic in monospace", func() {
@@ -199,7 +199,7 @@ var _ = Describe("quoted texts", func() {
 			expected := `<div class="paragraph">
 <p><code>a_b</code></p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("unparsed bold in monospace", func() {
@@ -207,7 +207,7 @@ var _ = Describe("quoted texts", func() {
 			expected := `<div class="paragraph">
 <p><code>a*b*</code></p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("parsed subscript in monospace", func() {
@@ -215,7 +215,7 @@ var _ = Describe("quoted texts", func() {
 			expected := `<div class="paragraph">
 <p><code>a<sub>b</sub></code></p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("multiline in monospace - case 1", func() {
@@ -224,7 +224,7 @@ var _ = Describe("quoted texts", func() {
 <p><code>a
 b</code></p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("multiline in monospace - case 2", func() {
@@ -233,7 +233,7 @@ b</code></p>
 <p><code>a
 <strong>b</strong></code></p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("link in bold", func() {
@@ -241,7 +241,7 @@ b</code></p>
 			expected := `<div class="paragraph">
 <p><strong>a <a href="/">b</a></strong></p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("image in bold", func() {
@@ -249,7 +249,7 @@ b</code></p>
 			expected := `<div class="paragraph">
 <p><strong>a <span class="image"><img src="foo.png" alt="foo"></span></strong></p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("singleplus passthrough in bold", func() {
@@ -257,7 +257,7 @@ b</code></p>
 			expected := `<div class="paragraph">
 <p><strong>a image:foo.png[]</strong></p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("tripleplus passthrough in bold", func() {
@@ -265,7 +265,7 @@ b</code></p>
 			expected := `<div class="paragraph">
 <p><strong>a image:foo.png[]</strong></p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("link in italic", func() {
@@ -273,7 +273,7 @@ b</code></p>
 			expected := `<div class="paragraph">
 <p><em>a <a href="/">b</a></em></p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("image in italic", func() {
@@ -281,7 +281,7 @@ b</code></p>
 			expected := `<div class="paragraph">
 <p><em>a <span class="image"><img src="foo.png" alt="foo"></span></em></p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("singleplus passthrough in italic", func() {
@@ -289,7 +289,7 @@ b</code></p>
 			expected := `<div class="paragraph">
 <p><em>a image:foo.png[]</em></p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("tripleplus passthrough in italic", func() {
@@ -297,7 +297,7 @@ b</code></p>
 			expected := `<div class="paragraph">
 <p><em>a image:foo.png[]</em></p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("link in monospace", func() {
@@ -305,7 +305,7 @@ b</code></p>
 			expected := `<div class="paragraph">
 <p><code>a <a href="/">b</a></code></p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("image in monospace", func() {
@@ -313,7 +313,7 @@ b</code></p>
 			expected := `<div class="paragraph">
 <p><code>a <span class="image"><img src="foo.png" alt="foo"></span></code></p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("singleplus passthrough in monospace", func() {
@@ -321,7 +321,7 @@ b</code></p>
 			expected := `<div class="paragraph">
 <p><code>a image:foo.png[]</code></p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("tripleplus passthrough in monospace", func() {
@@ -329,7 +329,7 @@ b</code></p>
 			expected := `<div class="paragraph">
 <p><code>a image:foo.png[]</code></p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 	})

--- a/pkg/renderer/html5/section_test.go
+++ b/pkg/renderer/html5/section_test.go
@@ -16,7 +16,7 @@ var _ = Describe("sections", func() {
 			// top-level section is not rendered per-say,
 			// but the section will be used to set the HTML page's <title> element
 			expected := ``
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("section level 1 alone", func() {
@@ -28,7 +28,7 @@ var _ = Describe("sections", func() {
 <div class="sectionbody">
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("section level 2 alone", func() {
@@ -38,7 +38,7 @@ var _ = Describe("sections", func() {
 			expected := `<div class="sect2">
 <h3 id="_a_title">a title</h3>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("section level 1 with just bold content", func() {
@@ -48,7 +48,7 @@ var _ = Describe("sections", func() {
 <div class="sectionbody">
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("section level 2 with nested bold content", func() {
@@ -56,7 +56,7 @@ var _ = Describe("sections", func() {
 			expected := `<div class="sect2">
 <h3 id="_a_section_title_with_bold_content">a section title, with <strong>bold content</strong></h3>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("section level 1 with custom ID", func() {
@@ -70,7 +70,7 @@ var _ = Describe("sections", func() {
 <div class="sectionbody">
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("section level 1 with custom prefix id", func() {
@@ -83,7 +83,7 @@ var _ = Describe("sections", func() {
 <div class="sectionbody">
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("sections with same title", func() {
@@ -100,7 +100,7 @@ var _ = Describe("sections", func() {
 <div class="sectionbody">
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 	})
 
@@ -125,7 +125,7 @@ and a second paragraph`
 </div>
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("section with just a paragraph", func() {
@@ -137,7 +137,7 @@ a paragraph`
 			expected := `<div class="paragraph">
 <p>a paragraph</p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("header with preamble then section level 1", func() {
@@ -170,7 +170,7 @@ with some text`
 </div>
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("header with preamble then 2 sections level 1", func() {
@@ -215,7 +215,7 @@ with some text, too`
 </div>
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("section with listing block and subsection", func() {
@@ -247,7 +247,7 @@ Listing block content is commonly used to preserve code input.</pre>
 </div>
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 	})
 
@@ -278,7 +278,7 @@ here</p>
 </div>
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("should not include preamble wrapper", func() {
@@ -301,7 +301,7 @@ here</p>
 </div>
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 	})
 })

--- a/pkg/renderer/html5/string_test.go
+++ b/pkg/renderer/html5/string_test.go
@@ -18,7 +18,7 @@ var _ = Describe("strings", func() {
 			expected := `<div class="paragraph">
 <p>some text&#8230;&#8203;</p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 	})
 })

--- a/pkg/renderer/html5/table_of_contents_test.go
+++ b/pkg/renderer/html5/table_of_contents_test.go
@@ -83,7 +83,7 @@ A preamble...
 <div class="sectionbody">
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("toc with custom level", func() {
@@ -171,7 +171,7 @@ A preamble...
 <div class="sectionbody">
 </div>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("document with no section", func() {
@@ -183,7 +183,7 @@ level 1 sections not exists.`
 			expected := `<div class="paragraph">
 <p>level 1 sections not exists.</p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 
 		})
 	})

--- a/pkg/renderer/html5/table_test.go
+++ b/pkg/renderer/html5/table_test.go
@@ -25,7 +25,7 @@ var _ = Describe("tables", func() {
 </tr>
 </tbody>
 </table>`
-		Expect(RenderHTML5Body(source)).To(Equal(expected))
+		Expect(RenderHTML(source)).To(Equal(expected))
 	})
 
 	It("1-line table with 3 cells", func() {
@@ -46,7 +46,7 @@ var _ = Describe("tables", func() {
 </tr>
 </tbody>
 </table>`
-		Expect(RenderHTML5Body(source)).To(Equal(expected))
+		Expect(RenderHTML(source)).To(Equal(expected))
 	})
 
 	It("table with title, headers and 1 line per cell", func() {
@@ -83,7 +83,7 @@ var _ = Describe("tables", func() {
 </tr>
 </tbody>
 </table>`
-		Expect(RenderHTML5Body(source)).To(Equal(expected))
+		Expect(RenderHTML(source)).To(Equal(expected))
 	})
 
 	It("empty table ", func() {
@@ -91,7 +91,7 @@ var _ = Describe("tables", func() {
 |===`
 		expected := `<table class="tableblock frame-all grid-all stretch">
 </table>`
-		Expect(RenderHTML5Body(source)).To(Equal(expected))
+		Expect(RenderHTML(source)).To(Equal(expected))
 	})
 
 	It("2 tables with 1 counter", func() {
@@ -128,7 +128,7 @@ var _ = Describe("tables", func() {
 </tr>
 </tbody>
 </table>`
-		Expect(RenderHTML5Body(source)).To(Equal(expected))
+		Expect(RenderHTML(source)).To(Equal(expected))
 	})
 
 	It("2 tables with 2 counters", func() {
@@ -167,7 +167,7 @@ var _ = Describe("tables", func() {
 </tr>
 </tbody>
 </table>`
-		Expect(RenderHTML5Body(source)).To(Equal(expected))
+		Expect(RenderHTML(source)).To(Equal(expected))
 	})
 
 })

--- a/pkg/renderer/html5/unordered_list_test.go
+++ b/pkg/renderer/html5/unordered_list_test.go
@@ -26,7 +26,7 @@ var _ = Describe("unordered lists", func() {
 </li>
 </ul>
 </div>`
-		Expect(RenderHTML5Body(source)).To(Equal(expected))
+		Expect(RenderHTML(source)).To(Equal(expected))
 	})
 
 	It("simple unordered list with no title then a paragraph", func() {
@@ -51,7 +51,7 @@ and a standalone paragraph`
 <div class="paragraph">
 <p>and a standalone paragraph</p>
 </div>`
-		Expect(RenderHTML5Body(source)).To(Equal(expected))
+		Expect(RenderHTML(source)).To(Equal(expected))
 	})
 
 	It("simple unordered list with id, title and role", func() {
@@ -71,7 +71,7 @@ and a standalone paragraph`
 </li>
 </ul>
 </div>`
-		Expect(RenderHTML5Body(source)).To(Equal(expected))
+		Expect(RenderHTML(source)).To(Equal(expected))
 	})
 
 	It("simple unordered list with id, title and role", func() {
@@ -91,7 +91,7 @@ and a standalone paragraph`
 </li>
 </ul>
 </div>`
-		Expect(RenderHTML5Body(source)).To(Equal(expected))
+		Expect(RenderHTML(source)).To(Equal(expected))
 	})
 
 	It("simple unordered list with continuation", func() {
@@ -113,7 +113,7 @@ foo
 </li>
 </ul>
 </div>`
-		Expect(RenderHTML5Body(source)).To(Equal(expected))
+		Expect(RenderHTML(source)).To(Equal(expected))
 	})
 
 	It("nested unordered lists without a title", func() {
@@ -141,7 +141,7 @@ foo
 </li>
 </ul>
 </div>`
-		Expect(RenderHTML5Body(source)).To(Equal(expected))
+		Expect(RenderHTML(source)).To(Equal(expected))
 	})
 
 	It("nested unordered lists with a title", func() {
@@ -170,7 +170,7 @@ foo
 </li>
 </ul>
 </div>`
-		Expect(RenderHTML5Body(source)).To(Equal(expected))
+		Expect(RenderHTML(source)).To(Equal(expected))
 	})
 
 	It("unordered list with item continuation", func() {
@@ -205,7 +205,7 @@ another delimited block
 </li>
 </ul>
 </div>`
-		Expect(RenderHTML5Body(source)).To(Equal(expected))
+		Expect(RenderHTML(source)).To(Equal(expected))
 	})
 
 	It("unordered list without item continuation", func() {
@@ -241,7 +241,7 @@ another delimited block
 <pre>another delimited block</pre>
 </div>
 </div>`
-		Expect(RenderHTML5Body(source)).To(Equal(expected))
+		Expect(RenderHTML(source)).To(Equal(expected))
 	})
 })
 
@@ -270,7 +270,7 @@ var _ = Describe("checklists", func() {
 </li>
 </ul>
 </div>`
-		Expect(RenderHTML5Body(source)).To(Equal(expected))
+		Expect(RenderHTML(source)).To(Equal(expected))
 	})
 
 	It("parent checklist with title and nested checklist", func() {
@@ -304,7 +304,7 @@ var _ = Describe("checklists", func() {
 </li>
 </ul>
 </div>`
-		Expect(RenderHTML5Body(source)).To(Equal(expected))
+		Expect(RenderHTML(source)).To(Equal(expected))
 	})
 
 	It("parent checklist with role and nested normal list", func() {
@@ -333,7 +333,7 @@ var _ = Describe("checklists", func() {
 </li>
 </ul>
 </div>`
-		Expect(RenderHTML5Body(source)).To(Equal(expected))
+		Expect(RenderHTML(source)).To(Equal(expected))
 	})
 
 	Context("attach to unordered list item ancestor", func() {
@@ -370,7 +370,7 @@ paragraph attached to grandparent list item`
 </li>
 </ul>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("attach to parent unordered list item", func() {
@@ -404,7 +404,7 @@ paragraph attached to parent list item`
 </li>
 </ul>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("attach to child unordered list item", func() {
@@ -437,7 +437,7 @@ paragraph attached to child list item`
 </li>
 </ul>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 	})
 })

--- a/pkg/renderer/html5/user_macro_test.go
+++ b/pkg/renderer/html5/user_macro_test.go
@@ -23,7 +23,7 @@ var _ = Describe("user macros", func() {
 			expected := `<div class="paragraph">
 <p>hello::[]</p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("user macro block", func() {
@@ -34,7 +34,7 @@ var _ = Describe("user macros", func() {
 <span>hello world</span>
 </div>
 </div>`
-			Expect(RenderHTML5Body(source, configuration.WithMacroTemplate(helloMacroTmpl.Name(), helloMacroTmpl))).To(Equal(expected))
+			Expect(RenderHTML(source, configuration.WithMacroTemplate(helloMacroTmpl.Name(), helloMacroTmpl))).To(Equal(expected))
 		})
 
 		It("user macro block with attribute", func() {
@@ -45,7 +45,7 @@ var _ = Describe("user macros", func() {
 <span>hello world!!!!</span>
 </div>
 </div>`
-			Expect(RenderHTML5Body(source, configuration.WithMacroTemplate(helloMacroTmpl.Name(), helloMacroTmpl))).To(Equal(expected))
+			Expect(RenderHTML(source, configuration.WithMacroTemplate(helloMacroTmpl.Name(), helloMacroTmpl))).To(Equal(expected))
 		})
 
 		It("user macro block with value", func() {
@@ -56,7 +56,7 @@ var _ = Describe("user macros", func() {
 <span>hello JohnDoe</span>
 </div>
 </div>`
-			Expect(RenderHTML5Body(source, configuration.WithMacroTemplate(helloMacroTmpl.Name(), helloMacroTmpl))).To(Equal(expected))
+			Expect(RenderHTML(source, configuration.WithMacroTemplate(helloMacroTmpl.Name(), helloMacroTmpl))).To(Equal(expected))
 		})
 
 		It("user macro block with value and attributes", func() {
@@ -67,7 +67,7 @@ var _ = Describe("user macros", func() {
 <span>Hi JohnDoe!!</span>
 </div>
 </div>`
-			Expect(RenderHTML5Body(source, configuration.WithMacroTemplate(helloMacroTmpl.Name(), helloMacroTmpl))).To(Equal(expected))
+			Expect(RenderHTML(source, configuration.WithMacroTemplate(helloMacroTmpl.Name(), helloMacroTmpl))).To(Equal(expected))
 		})
 
 		It("undefined inline macro", func() {
@@ -76,7 +76,7 @@ var _ = Describe("user macros", func() {
 			expected := `<div class="paragraph">
 <p>hello:[]</p>
 </div>`
-			Expect(RenderHTML5Body(source)).To(Equal(expected))
+			Expect(RenderHTML(source)).To(Equal(expected))
 		})
 
 		It("inline macro", func() {
@@ -85,7 +85,7 @@ var _ = Describe("user macros", func() {
 			expected := `<div class="paragraph">
 <p>AAA <span>hello world</span></p>
 </div>`
-			Expect(RenderHTML5Body(source, configuration.WithMacroTemplate(helloMacroTmpl.Name(), helloMacroTmpl))).To(Equal(expected))
+			Expect(RenderHTML(source, configuration.WithMacroTemplate(helloMacroTmpl.Name(), helloMacroTmpl))).To(Equal(expected))
 		})
 
 		It("inline macro with attribute", func() {
@@ -94,7 +94,7 @@ var _ = Describe("user macros", func() {
 			expected := `<div class="paragraph">
 <p>AAA <span>hello world!!!!!</span></p>
 </div>`
-			Expect(RenderHTML5Body(source, configuration.WithMacroTemplate(helloMacroTmpl.Name(), helloMacroTmpl))).To(Equal(expected))
+			Expect(RenderHTML(source, configuration.WithMacroTemplate(helloMacroTmpl.Name(), helloMacroTmpl))).To(Equal(expected))
 		})
 
 		It("inline macro with value", func() {
@@ -103,7 +103,7 @@ var _ = Describe("user macros", func() {
 			expected := `<div class="paragraph">
 <p>AAA <span>hello JohnDoe</span></p>
 </div>`
-			Expect(RenderHTML5Body(source, configuration.WithMacroTemplate(helloMacroTmpl.Name(), helloMacroTmpl))).To(Equal(expected))
+			Expect(RenderHTML(source, configuration.WithMacroTemplate(helloMacroTmpl.Name(), helloMacroTmpl))).To(Equal(expected))
 		})
 
 		It("inline macro with value and attributes", func() {
@@ -112,7 +112,7 @@ var _ = Describe("user macros", func() {
 			expected := `<div class="paragraph">
 <p>AAA <span>Hi JohnDoe!!</span></p>
 </div>`
-			Expect(RenderHTML5Body(source, configuration.WithMacroTemplate(helloMacroTmpl.Name(), helloMacroTmpl))).To(Equal(expected))
+			Expect(RenderHTML(source, configuration.WithMacroTemplate(helloMacroTmpl.Name(), helloMacroTmpl))).To(Equal(expected))
 		})
 
 	})

--- a/testsupport/render_html5.go
+++ b/testsupport/render_html5.go
@@ -11,8 +11,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// RenderHTML5Body renders the HTML body using the given source
-func RenderHTML5Body(actual string, settings ...configuration.Setting) (string, error) {
+// RenderHTML renders the HTML body using the given source
+func RenderHTML(actual string, settings ...configuration.Setting) (string, error) {
 	config := configuration.NewConfiguration(settings...)
 	contentReader := strings.NewReader(actual)
 	resultWriter := bytes.NewBuffer(nil)

--- a/testsupport/render_html5_test.go
+++ b/testsupport/render_html5_test.go
@@ -13,7 +13,7 @@ var _ = Describe("html5 body renderer", func() {
 		// given
 		actual := "hello, world!"
 		// when
-		result, err := testsupport.RenderHTML5Body(actual)
+		result, err := testsupport.RenderHTML(actual)
 		// then
 		expected := `<div class="paragraph">
 <p>hello, world!</p>


### PR DESCRIPTION
rename to RenderHTML since the matcher can also
render full HTML documents.

Fixes #523

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>