### PR TITLE
feat(renderer): support Copyright character replacement

### DIFF
--- a/pkg/renderer/html5/string.go
+++ b/pkg/renderer/html5/string.go
@@ -21,12 +21,16 @@ func renderStringElement(ctx renderer.Context, str types.StringElement) ([]byte,
 	if err != nil {
 		return []byte{}, errors.Wrapf(err, "unable to render string")
 	}
-	result := convert(buf.String(), ellipsis)
+	result := convert(buf.String(), ellipsis, copyright)
 	return []byte(result), nil
 }
 
 func ellipsis(source string) string {
 	return strings.Replace(source, "...", "&#8230;&#8203;", -1)
+}
+
+func copyright(source string) string {
+	return strings.Replace(source, "(C)", "&#169;", -1)
 }
 
 type converter func(string) string

--- a/pkg/renderer/html5/string_test.go
+++ b/pkg/renderer/html5/string_test.go
@@ -9,16 +9,23 @@ import (
 
 var _ = Describe("strings", func() {
 
-	Context("ellipsis conversion", func() {
-
-		It("text with ellipsis", func() {
-			source := `some text...`
-			// top-level section is not rendered per-say,
-			// but the section will be used to set the HTML page's <title> element
-			expected := `<div class="paragraph">
+	It("text with ellipsis", func() {
+		source := `some text...`
+		// top-level section is not rendered per-say,
+		// but the section will be used to set the HTML page's <title> element
+		expected := `<div class="paragraph">
 <p>some text&#8230;&#8203;</p>
 </div>`
-			Expect(RenderHTML(source)).To(Equal(expected))
-		})
+		Expect(RenderHTML(source)).To(Equal(expected))
+	})
+
+	It("text with copyright", func() {
+		source := `Copyright (C)`
+		// top-level section is not rendered per-say,
+		// but the section will be used to set the HTML page's <title> element
+		expected := `<div class="paragraph">
+<p>Copyright &#169;</p>
+</div>`
+		Expect(RenderHTML(source)).To(Equal(expected))
 	})
 })


### PR DESCRIPTION
replace `(C)` with `&#169;`

Fixes #524

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>