### PR TITLE
refactor(test): add document matchers

### DIFF
--- a/pkg/parser/blank_line_test.go
+++ b/pkg/parser/blank_line_test.go
@@ -34,7 +34,7 @@ second paragraph`
 				},
 			},
 		}
-		Expect(ParseDraftDocument(source)).To(Equal(expected))
+		Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 	})
 	It("blank line with spaces and tabs between 2 paragraphs and after second paragraph", func() {
 		source := `first paragraph
@@ -66,7 +66,7 @@ second paragraph
 				},
 			},
 		}
-		Expect(ParseDraftDocument(source)).To(Equal(expected))
+		Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 	})
 
 })

--- a/pkg/parser/check_list_test.go
+++ b/pkg/parser/check_list_test.go
@@ -109,7 +109,7 @@ var _ = Describe("checked lists - document", func() {
 				},
 			},
 		}
-		Expect(ParseDocument(source)).To(Equal(expected))
+		Expect(ParseDocument(source)).To(MatchDocument(expected))
 	})
 
 	It("parent checklist with title and nested checklist", func() {
@@ -237,7 +237,7 @@ var _ = Describe("checked lists - document", func() {
 				},
 			},
 		}
-		Expect(ParseDocument(source)).To(Equal(expected))
+		Expect(ParseDocument(source)).To(MatchDocument(expected))
 	})
 
 	It("parent checklist with title and nested normal list", func() {
@@ -340,6 +340,6 @@ var _ = Describe("checked lists - document", func() {
 				},
 			},
 		}
-		Expect(ParseDocument(source)).To(Equal(expected))
+		Expect(ParseDocument(source)).To(MatchDocument(expected))
 	})
 })

--- a/pkg/parser/comment_test.go
+++ b/pkg/parser/comment_test.go
@@ -23,7 +23,7 @@ var _ = Describe("comments", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("single line comment with prefixing spaces alone", func() {
@@ -35,7 +35,7 @@ var _ = Describe("comments", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("single line comment with prefixing tabs alone", func() {
@@ -47,7 +47,7 @@ var _ = Describe("comments", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("single line comment at end of line", func() {
@@ -64,7 +64,7 @@ var _ = Describe("comments", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("single line comment within a paragraph", func() {
@@ -89,7 +89,7 @@ another line`
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("single line comment within a paragraph with tab", func() {
@@ -114,7 +114,7 @@ another line`
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 		})
 
@@ -141,7 +141,7 @@ with multiple lines
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("comment block with paragraphs around", func() {
@@ -183,7 +183,7 @@ a second paragraph`
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 		})
 	})
@@ -201,7 +201,7 @@ a second paragraph`
 					FootnoteReferences: types.FootnoteReferences{},
 					Elements:           []interface{}{},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("single line comment with prefixing spaces alone", func() {
@@ -213,7 +213,7 @@ a second paragraph`
 					FootnoteReferences: types.FootnoteReferences{},
 					Elements:           []interface{}{},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("single line comment with prefixing tabs alone", func() {
@@ -225,7 +225,7 @@ a second paragraph`
 					FootnoteReferences: types.FootnoteReferences{},
 					Elements:           []interface{}{},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("single line comment at end of line", func() {
@@ -246,7 +246,7 @@ a second paragraph`
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("single line comment within a paragraph", func() {
@@ -272,7 +272,7 @@ another line`
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("single line comment within a paragraph with tab", func() {
@@ -298,7 +298,7 @@ another line`
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 		})
 
@@ -316,7 +316,7 @@ with multiple lines
 					FootnoteReferences: types.FootnoteReferences{},
 					Elements:           []interface{}{},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("comment block with paragraphs around", func() {
@@ -350,7 +350,7 @@ a second paragraph`
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 		})
 
@@ -403,7 +403,7 @@ a second paragraph`
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("comment in preamble", func() {
@@ -474,7 +474,7 @@ a second paragraph`
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 	})
 

--- a/pkg/parser/cross_reference_test.go
+++ b/pkg/parser/cross_reference_test.go
@@ -52,7 +52,7 @@ with some content linked to <<thetitle>>!`
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
 		It("cross reference with custom id and label", func() {
@@ -95,7 +95,7 @@ with some content linked to <<thetitle,a label to the title>>!`
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 	})
 
@@ -139,7 +139,7 @@ with some content linked to <<thetitle,a label to the title>>!`
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
 		It("external cross reference to other doc with document attribute in location", func() {
@@ -178,7 +178,7 @@ with some content linked to <<thetitle,a label to the title>>!`
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 	})
 })
@@ -237,7 +237,7 @@ with some content linked to <<thetitle>>!`
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("cross reference with custom id and label", func() {
@@ -290,7 +290,7 @@ with some content linked to <<thetitle,a label to the title>>!`
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 	})
 
@@ -338,7 +338,7 @@ with some content linked to <<thetitle,a label to the title>>!`
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("external cross reference to other doc with document attribute in location and label with special chars", func() {
@@ -383,7 +383,7 @@ some content linked to xref:{foo}[another_doc()]!`
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 	})
 })

--- a/pkg/parser/delimited_block_test.go
+++ b/pkg/parser/delimited_block_test.go
@@ -127,7 +127,7 @@ var _ = Describe("delimited blocks - draft", func() {
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
 		It("fenced block after a paragraph", func() {
@@ -161,7 +161,7 @@ var _ = Describe("delimited blocks - draft", func() {
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
 		It("fenced block with unclosed delimiter", func() {
@@ -443,7 +443,7 @@ then a normal paragraph.`
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
 		It("listing block just after a paragraph", func() {
@@ -479,7 +479,7 @@ some listing code
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
 		It("listing block with unclosed delimiter", func() {
@@ -747,7 +747,7 @@ paragraphs
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 	})
 
@@ -1591,7 +1591,7 @@ var _ = Describe("delimited blocks - final document", func() {
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("fenced block with no line", func() {
@@ -1609,7 +1609,7 @@ var _ = Describe("delimited blocks - final document", func() {
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("fenced block with multiple lines alone", func() {
@@ -1654,7 +1654,7 @@ var _ = Describe("delimited blocks - final document", func() {
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("fenced block with multiple lines then a paragraph", func() {
@@ -1707,7 +1707,7 @@ var _ = Describe("delimited blocks - final document", func() {
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("fenced block after a paragraph", func() {
@@ -1745,7 +1745,7 @@ var _ = Describe("delimited blocks - final document", func() {
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("fenced block with unclosed delimiter", func() {
@@ -1774,7 +1774,7 @@ var _ = Describe("delimited blocks - final document", func() {
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("fenced block with external link inside", func() {
@@ -1828,7 +1828,7 @@ var _ = Describe("delimited blocks - final document", func() {
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 	})
 
@@ -1862,7 +1862,7 @@ some listing code
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("listing block with no line", func() {
@@ -1881,7 +1881,7 @@ some listing code
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("listing block with multiple lines alone", func() {
@@ -1931,7 +1931,7 @@ in the middle
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("listing block with unrendered list", func() {
@@ -1974,7 +1974,7 @@ in the middle
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("listing block with multiple lines then a paragraph", func() {
@@ -2034,7 +2034,7 @@ then a normal paragraph.`
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("listing block just after a paragraph", func() {
@@ -2074,7 +2074,7 @@ some listing code
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("listing block with unclosed delimiter", func() {
@@ -2104,7 +2104,7 @@ End of file here.`
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 	})
 
@@ -2138,7 +2138,7 @@ some listing code
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("example block with single line starting with a dot", func() {
@@ -2169,7 +2169,7 @@ some listing code
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("example block with multiple lines", func() {
@@ -2246,7 +2246,7 @@ with *bold content*
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("example block with unclosed delimiter", func() {
@@ -2276,7 +2276,7 @@ End of file here`
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("example block with title", func() {
@@ -2310,7 +2310,7 @@ foo
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("example block starting delimiter only", func() {
@@ -2328,7 +2328,7 @@ foo
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 	})
 
@@ -2365,7 +2365,7 @@ foo
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 
 		})
 
@@ -2415,7 +2415,7 @@ paragraphs
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 	})
 
@@ -2465,7 +2465,7 @@ ____`
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("multi-line quote with author only", func() {
@@ -2552,7 +2552,7 @@ ____
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("single-line quote with title only", func() {
@@ -2588,7 +2588,7 @@ ____
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("multi-line quote with rendered lists and block and without author and title", func() {
@@ -2678,7 +2678,7 @@ ____`
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("multi-line quote with rendered list and without author and title", func() {
@@ -2767,7 +2767,7 @@ ____`
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("empty quote without author and title", func() {
@@ -2789,7 +2789,7 @@ ____`
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("unclosed quote without author and title", func() {
@@ -2823,7 +2823,7 @@ foo
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 	})
 
@@ -2873,7 +2873,7 @@ ____`
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("multi-line verse with unrendered list and author only", func() {
@@ -2921,7 +2921,7 @@ ____
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("multi-line verse with title only", func() {
@@ -2957,7 +2957,7 @@ ____
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("multi-line verse with unrendered lists and block without author and title", func() {
@@ -3015,7 +3015,7 @@ ____`
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("multi-line verse with unrendered list without author and title", func() {
@@ -3064,7 +3064,7 @@ ____`
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("empty verse without author and title", func() {
@@ -3086,7 +3086,7 @@ ____`
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("unclosed verse without author and title", func() {
@@ -3120,7 +3120,7 @@ foo
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 	})
 
@@ -3183,7 +3183,7 @@ end
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("with title, source and languages attributes", func() {
@@ -3246,7 +3246,7 @@ end
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("with id, title, source and languages attributes", func() {
@@ -3312,7 +3312,7 @@ end
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 	})
 
@@ -3357,7 +3357,7 @@ some *verse* content
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("sidebar block with title, paragraph and sourcecode block", func() {
@@ -3427,7 +3427,7 @@ bar
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 	})
 })

--- a/pkg/parser/document_attributes_test.go
+++ b/pkg/parser/document_attributes_test.go
@@ -48,7 +48,7 @@ This journey continues.`
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		Context("document authors", func() {
@@ -94,7 +94,7 @@ John  Foo    Doe  <johndoe@example.com>`
 							},
 						},
 					}
-					Expect(ParseDocument(source)).To(Equal(expected))
+					Expect(ParseDocument(source)).To(MatchDocument(expected))
 				})
 
 				It("lastname with underscores", func() {
@@ -135,7 +135,7 @@ Jane the_Doe <jane@example.com>`
 							},
 						},
 					}
-					Expect(ParseDocument(source)).To(Equal(expected))
+					Expect(ParseDocument(source)).To(MatchDocument(expected))
 				})
 
 				It("with middlename and composed lastname", func() {
@@ -177,7 +177,7 @@ Jane Foo the Doe <jane@example.com>`
 							},
 						},
 					}
-					Expect(ParseDocument(source)).To(Equal(expected))
+					Expect(ParseDocument(source)).To(MatchDocument(expected))
 				})
 
 				It("firstname and lastname only", func() {
@@ -216,7 +216,7 @@ John Doe`
 							},
 						},
 					}
-					Expect(ParseDocument(source)).To(Equal(expected))
+					Expect(ParseDocument(source)).To(MatchDocument(expected))
 				})
 
 				It("firstname only", func() {
@@ -254,7 +254,7 @@ Doe`
 							},
 						},
 					}
-					Expect(ParseDocument(source)).To(Equal(expected))
+					Expect(ParseDocument(source)).To(MatchDocument(expected))
 				})
 
 				It("alternate author input", func() {
@@ -294,7 +294,7 @@ Doe`
 							},
 						},
 					}
-					Expect(ParseDocument(source)).To(Equal(expected))
+					Expect(ParseDocument(source)).To(MatchDocument(expected))
 				})
 			})
 
@@ -348,7 +348,7 @@ John  Foo Doe  <johndoe@example.com>; Jane the_Doe <jane@example.com>`
 							},
 						},
 					}
-					Expect(ParseDocument(source)).To(Equal(expected))
+					Expect(ParseDocument(source)).To(MatchDocument(expected))
 				})
 			})
 
@@ -380,7 +380,7 @@ John  Foo Doe  <johndoe@example.com>; Jane the_Doe <jane@example.com>`
 							},
 						},
 					}
-					Expect(ParseDocument(source)).To(Equal(expected))
+					Expect(ParseDocument(source)).To(MatchDocument(expected))
 				})
 
 				It("authors after a single comment line", func() {
@@ -432,7 +432,7 @@ John  Foo Doe  <johndoe@example.com>; Jane the_Doe <jane@example.com>`
 							},
 						},
 					}
-					Expect(ParseDocument(source)).To(Equal(expected))
+					Expect(ParseDocument(source)).To(MatchDocument(expected))
 				})
 
 				It("authors after a comment block", func() {
@@ -486,7 +486,7 @@ John  Foo Doe  <johndoe@example.com>; Jane the_Doe <jane@example.com>`
 							},
 						},
 					}
-					Expect(ParseDocument(source)).To(Equal(expected))
+					Expect(ParseDocument(source)).To(MatchDocument(expected))
 				})
 			})
 		})
@@ -538,7 +538,7 @@ John  Foo Doe  <johndoe@example.com>; Jane the_Doe <jane@example.com>`
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("full document revision with a comment before author", func() {
@@ -587,7 +587,7 @@ John  Foo Doe  <johndoe@example.com>; Jane the_Doe <jane@example.com>`
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("full document revision with a comment before revision", func() {
@@ -636,7 +636,7 @@ John  Foo Doe  <johndoe@example.com>; Jane the_Doe <jane@example.com>`
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("revision with revnumber and revdate only", func() {
@@ -682,7 +682,7 @@ John  Foo Doe  <johndoe@example.com>; Jane the_Doe <jane@example.com>`
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("revision with revnumber and revdate - with colon separator", func() {
@@ -728,7 +728,7 @@ John  Foo Doe  <johndoe@example.com>; Jane the_Doe <jane@example.com>`
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 			It("revision with revnumber only - comma suffix", func() {
 				source := `= title
@@ -771,7 +771,7 @@ John  Foo Doe  <johndoe@example.com>; Jane the_Doe <jane@example.com>`
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("revision with revdate as number - spaces and no prefix no suffix", func() {
@@ -815,7 +815,7 @@ John  Foo Doe  <johndoe@example.com>; Jane the_Doe <jane@example.com>`
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("revision with revdate as alphanum - spaces and no prefix no suffix", func() {
@@ -859,7 +859,7 @@ John  Foo Doe  <johndoe@example.com>; Jane the_Doe <jane@example.com>`
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("revision with revnumber only", func() {
@@ -903,7 +903,7 @@ John  Foo Doe  <johndoe@example.com>; Jane the_Doe <jane@example.com>`
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("revision with spaces and capital revnumber ", func() {
@@ -947,7 +947,7 @@ John  Foo Doe  <johndoe@example.com>; Jane the_Doe <jane@example.com>`
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("revision only - with comma separator", func() {
@@ -991,7 +991,7 @@ John  Foo Doe  <johndoe@example.com>; Jane the_Doe <jane@example.com>`
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("revision with revnumber plus comma and colon separators", func() {
@@ -1035,7 +1035,7 @@ John  Foo Doe  <johndoe@example.com>; Jane the_Doe <jane@example.com>`
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("revision with revnumber and empty revremark", func() {
@@ -1080,7 +1080,7 @@ v1.0:`
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 		})
@@ -1108,7 +1108,7 @@ v1.0:`
 					FootnoteReferences: types.FootnoteReferences{},
 					Elements:           []interface{}{},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("attributes and paragraph without blank line in-between", func() {
@@ -1139,7 +1139,7 @@ a paragraph`
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("contiguous attributes and paragraph with blank line in-between", func() {
@@ -1169,7 +1169,7 @@ a paragraph`
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("splitted attributes and paragraph with blank line in-between", func() {
@@ -1203,7 +1203,7 @@ a paragraph`
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("no header and attributes in body", func() {
@@ -1233,7 +1233,7 @@ a paragraph`
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 		})
 
@@ -1261,7 +1261,7 @@ a paragraph written by {author}.`
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("paragraph with attribute resets", func() {
@@ -1288,7 +1288,7 @@ a paragraph written by {author}.`
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("header with 2 authors, revision and attributes", func() {
@@ -1362,7 +1362,7 @@ This journey continues`
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("paragraph with attribute substitution from front-matter", func() {
@@ -1389,7 +1389,7 @@ a paragraph written by {author}.`
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 		})
 
@@ -1427,7 +1427,7 @@ a paragraph written by {author}.`
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("invalid attribute names", func() {
@@ -1452,7 +1452,7 @@ a paragraph written by {author}.`
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 	})
 

--- a/pkg/parser/document_processing_test.go
+++ b/pkg/parser/document_processing_test.go
@@ -162,7 +162,7 @@ Preamble comes here
 				Footnotes:          types.Footnotes{},
 				FootnoteReferences: types.FootnoteReferences{},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 	})
 

--- a/pkg/parser/element_attributes_test.go
+++ b/pkg/parser/element_attributes_test.go
@@ -321,7 +321,7 @@ a paragraph`
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
 		It("blank lines after id, role and title attributes", func() {
@@ -350,7 +350,7 @@ a paragraph`
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 	})
 })

--- a/pkg/parser/file_inclusion_test.go
+++ b/pkg/parser/file_inclusion_test.go
@@ -201,7 +201,7 @@ var _ = Describe("file inclusions - draft with preprocessing", func() {
 				},
 			},
 		}
-		Expect(ParseDraftDocument(source)).To(Equal(expected))
+		Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		// verify no error/warning in logs
 		Expect(console).ToNot(ContainAnyMessageWithLevels(log.ErrorLevel, log.WarnLevel))
 	})
@@ -234,7 +234,7 @@ var _ = Describe("file inclusions - draft with preprocessing", func() {
 				},
 			},
 		}
-		Expect(ParseDraftDocument(source)).To(Equal(expected))
+		Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 	})
 
 	It("should not include section 0 when attribute exists", func() {
@@ -272,7 +272,7 @@ include::{includedir}/chapter-a.adoc[]`
 				},
 			},
 		}
-		Expect(ParseDraftDocument(source)).To(Equal(expected))
+		Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 	})
 
 	It("should not further process with non-asciidoc files", func() {
@@ -812,7 +812,7 @@ include::{includedir}/include.foo[]`
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
 		It("should include adoc file within listing block", func() {
@@ -850,7 +850,7 @@ include::../../test/includes/chapter-a.adoc[]
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
 		It("should include adoc file within example block", func() {
@@ -888,7 +888,7 @@ include::../../test/includes/chapter-a.adoc[]
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
 		It("should include adoc file within quote block", func() {
@@ -926,7 +926,7 @@ ____`
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
 		It("should include adoc file within verse block", func() {
@@ -967,7 +967,7 @@ ____`
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
 		It("should include adoc file within sidebar block", func() {
@@ -1005,7 +1005,7 @@ include::../../test/includes/chapter-a.adoc[]
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
 		It("should include adoc file within passthrough block", func() {
@@ -1044,7 +1044,7 @@ include::../../test/includes/chapter-a.adoc[]
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 	})
 
@@ -1068,7 +1068,7 @@ include::../../test/includes/chapter-a.adoc[]
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("file inclusion with multiple unquoted lines", func() {
@@ -1088,7 +1088,7 @@ include::../../test/includes/chapter-a.adoc[]
 						types.BlankLine{},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("file inclusion with multiple unquoted ranges", func() {
@@ -1113,7 +1113,7 @@ include::../../test/includes/chapter-a.adoc[]
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("file inclusion with invalid unquoted range - case 1", func() {
@@ -1143,7 +1143,7 @@ include::../../test/includes/chapter-a.adoc[]
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("file inclusion with invalid unquoted range - case 2", func() {
@@ -1162,7 +1162,7 @@ include::../../test/includes/chapter-a.adoc[]
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 		})
 
@@ -1186,7 +1186,7 @@ include::../../test/includes/chapter-a.adoc[]
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 				// verify no error/warning in logs
 				Expect(console).ToNot(ContainAnyMessageWithLevels(log.ErrorLevel, log.WarnLevel))
 			})
@@ -1208,7 +1208,7 @@ include::../../test/includes/chapter-a.adoc[]
 						types.BlankLine{},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("file inclusion with multiple quoted ranges", func() {
@@ -1234,7 +1234,7 @@ include::../../test/includes/chapter-a.adoc[]
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("file inclusion with invalid quoted range - case 1", func() {
@@ -1264,7 +1264,7 @@ include::../../test/includes/chapter-a.adoc[]
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("file inclusion with invalid quoted range - case 2", func() {
@@ -1294,7 +1294,7 @@ include::../../test/includes/chapter-a.adoc[]
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("file inclusion with ignored tags", func() {
@@ -1314,7 +1314,7 @@ include::../../test/includes/chapter-a.adoc[]
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 		})
 	})
@@ -1339,7 +1339,7 @@ include::../../test/includes/chapter-a.adoc[]
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			// verify no error/warning in logs
 			Expect(console).ToNot(ContainAnyMessageWithLevels(log.ErrorLevel, log.WarnLevel))
 		})
@@ -1374,7 +1374,7 @@ include::../../test/includes/chapter-a.adoc[]
 					types.BlankLine{},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			// verify no error/warning in logs
 			Expect(console).ToNot(ContainAnyMessageWithLevels(log.ErrorLevel, log.WarnLevel))
 		})
@@ -1411,7 +1411,7 @@ include::../../test/includes/chapter-a.adoc[]
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			// verify error in logs
 			Expect(console).To(
 				ContainMessageWithLevel(
@@ -1430,7 +1430,7 @@ include::../../test/includes/chapter-a.adoc[]
 				Blocks: []interface{}{},
 			}
 			// when/then
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			// verify error in logs
 			Expect(console).To(
 				ContainMessageWithLevel(
@@ -1478,7 +1478,7 @@ include::../../test/includes/chapter-a.adoc[]
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
 		Context("permutations", func() {
@@ -1522,7 +1522,7 @@ include::../../test/includes/chapter-a.adoc[]
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("all tagged regions", func() {
@@ -1553,7 +1553,7 @@ include::../../test/includes/chapter-a.adoc[]
 						types.BlankLine{},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("all the lines outside and inside of tagged regions", func() {
@@ -1595,7 +1595,7 @@ include::../../test/includes/chapter-a.adoc[]
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("regions tagged doc, but not nested regions tagged content", func() {
@@ -1615,7 +1615,7 @@ include::../../test/includes/chapter-a.adoc[]
 						types.BlankLine{},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("all tagged regions, but excludes any regions tagged content", func() {
@@ -1635,7 +1635,7 @@ include::../../test/includes/chapter-a.adoc[]
 						types.BlankLine{},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("all tagged regions, but excludes any regions tagged content", func() {
@@ -1666,7 +1666,7 @@ include::../../test/includes/chapter-a.adoc[]
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("**;!* — selects only the regions of the document outside of tags", func() {
@@ -1686,7 +1686,7 @@ include::../../test/includes/chapter-a.adoc[]
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 		})
 	})
@@ -1712,7 +1712,7 @@ include::../../test/includes/chapter-a.adoc[]
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			// verify error in logs
 			Expect(console).To(
 				ContainMessageWithLevel(
@@ -1741,7 +1741,7 @@ include::../../test/includes/chapter-a.adoc[]
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			// verify error in logs
 			Expect(console).To(
 				ContainMessageWithLevel(
@@ -1778,7 +1778,7 @@ include::../../test/includes/unknown.adoc[leveloffset=+1]
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			// verify error in logs
 			Expect(console).To(
 				ContainMessageWithLevel(
@@ -1940,7 +1940,7 @@ include::{includedir}/grandchild-include.adoc[]
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 	})
 
@@ -2003,7 +2003,7 @@ include::../../test/includes/hello_world.go.txt[]
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
 		It("include go file with a simple range", func() {
@@ -2031,7 +2031,7 @@ include::../../test/includes/hello_world.go.txt[lines=1]
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 	})
 })
@@ -2191,7 +2191,7 @@ var _ = Describe("file inclusions - final document", func() {
 				},
 			},
 		}
-		Expect(ParseDocument(source)).To(Equal(expected))
+		Expect(ParseDocument(source)).To(MatchDocument(expected))
 	})
 
 	It("should include child and grandchild content with relative then absolute level offset", func() {
@@ -2347,7 +2347,7 @@ var _ = Describe("file inclusions - final document", func() {
 				},
 			},
 		}
-		Expect(ParseDocument(source)).To(Equal(expected))
+		Expect(ParseDocument(source)).To(MatchDocument(expected))
 	})
 
 })

--- a/pkg/parser/footnote_test.go
+++ b/pkg/parser/footnote_test.go
@@ -42,7 +42,7 @@ var _ = Describe("footnotes - draft", func() {
 				},
 			},
 		}
-		Expect(ParseDraftDocument(source)).To(Equal(expected)) // need to get the whole document here
+		Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected)) // need to get the whole document here
 	})
 
 	It("footnote with single-line rich content", func() {
@@ -97,7 +97,7 @@ var _ = Describe("footnotes - draft", func() {
 				},
 			},
 		}
-		Expect(ParseDraftDocument(source)).To(Equal(expected)) // need to get the whole document here
+		Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected)) // need to get the whole document here
 	})
 
 	It("footnote in a paragraph", func() {
@@ -124,7 +124,7 @@ var _ = Describe("footnotes - draft", func() {
 				},
 			},
 		}
-		Expect(ParseDraftDocument(source)).To(Equal(expected)) // need to get the whole document here
+		Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected)) // need to get the whole document here
 	})
 
 	It("multiple footnotes including a reference", func() {
@@ -184,7 +184,7 @@ Another outrageous statement.footnote:disclaimer[]`
 				},
 			},
 		}
-		Expect(ParseDraftDocument(source)).To(Equal(expected))
+		Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 	})
 
 	It("footnotes in document", func() {
@@ -277,7 +277,7 @@ a paragraph with another footnote:[baz]`
 				},
 			},
 		}
-		Expect(ParseDraftDocument(source)).To(Equal(expected)) // need to get the whole document here
+		Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected)) // need to get the whole document here
 	})
 })
 
@@ -319,7 +319,7 @@ var _ = Describe("footnotes - document", func() {
 				},
 			},
 		}
-		Expect(ParseDocument(source)).To(Equal(expected)) // need to get the whole document here
+		Expect(ParseDocument(source)).To(MatchDocument(expected)) // need to get the whole document here
 	})
 
 	It("footnote with single-line rich content", func() {
@@ -380,7 +380,7 @@ var _ = Describe("footnotes - document", func() {
 				},
 			},
 		}
-		Expect(ParseDocument(source)).To(Equal(expected)) // need to get the whole document here
+		Expect(ParseDocument(source)).To(MatchDocument(expected)) // need to get the whole document here
 	})
 
 	It("footnote in a paragraph", func() {
@@ -414,7 +414,7 @@ var _ = Describe("footnotes - document", func() {
 				},
 			},
 		}
-		Expect(ParseDocument(source)).To(Equal(expected)) // need to get the whole document here
+		Expect(ParseDocument(source)).To(MatchDocument(expected)) // need to get the whole document here
 	})
 
 	It("multiple footnotes including a reference", func() {
@@ -487,7 +487,7 @@ Another outrageous statement.footnote:disclaimer[]`
 				},
 			},
 		}
-		Expect(ParseDocument(source)).To(Equal(expected))
+		Expect(ParseDocument(source)).To(MatchDocument(expected))
 	})
 
 	It("footnotes in document", func() {
@@ -596,6 +596,6 @@ a paragraph with another footnote:[baz]`
 				},
 			},
 		}
-		Expect(ParseDocument(source)).To(Equal(expected)) // need to get the whole document here
+		Expect(ParseDocument(source)).To(MatchDocument(expected)) // need to get the whole document here
 	})
 })

--- a/pkg/parser/frontmatter_test.go
+++ b/pkg/parser/frontmatter_test.go
@@ -38,7 +38,7 @@ first paragraph`
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
 		It("empty front-matter", func() {
@@ -62,7 +62,7 @@ first paragraph`
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 	})
 
@@ -98,7 +98,7 @@ first paragraph`
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("empty front-matter", func() {
@@ -122,7 +122,7 @@ first paragraph`
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 	})
 

--- a/pkg/parser/image_test.go
+++ b/pkg/parser/image_test.go
@@ -28,7 +28,7 @@ var _ = Describe("images", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("block image with empty alt and trailing spaces", func() {
@@ -45,7 +45,7 @@ var _ = Describe("images", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("block image with line return", func() {
@@ -64,7 +64,7 @@ var _ = Describe("images", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("block image with 1 empty blank line", func() {
@@ -84,7 +84,7 @@ var _ = Describe("images", func() {
 						types.BlankLine{},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("block image with 2 blank lines with spaces and tabs", func() {
@@ -103,7 +103,7 @@ var _ = Describe("images", func() {
 						types.BlankLine{},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("block image with alt", func() {
@@ -122,7 +122,7 @@ var _ = Describe("images", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("block image with dimensions and id link title meta", func() {
@@ -150,7 +150,7 @@ image::images/foo.png[the foo.png image, 600, 400]`
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("2 block images", func() {
@@ -176,7 +176,7 @@ image::images/bar.png[]`
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 		})
 
@@ -202,7 +202,7 @@ image::images/bar.png[]`
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("image block with implicit imagesdir document attribute", func() {
@@ -230,7 +230,7 @@ image::foo.png[]`
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("image block with document attribute in URL", func() {
@@ -258,7 +258,7 @@ image::{dir}/foo.png[]`
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("image block with implicit imagesdir", func() {
@@ -286,7 +286,7 @@ image::foo.png[]`
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("image block with explicit duplicate imagesdir document attribute", func() {
@@ -314,7 +314,7 @@ image::{imagesdir}/foo.png[]`
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 		})
 
@@ -339,7 +339,7 @@ image::{imagesdir}/foo.png[]`
 							},
 						},
 					}
-					Expect(ParseDraftDocument(source)).To(Equal(expected))
+					Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 				})
 			})
 
@@ -359,7 +359,7 @@ image::{imagesdir}/foo.png[]`
 							},
 						},
 					}
-					Expect(ParseDraftDocument(source)).To(Equal(expected))
+					Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 				})
 			})
 		})
@@ -390,7 +390,7 @@ image::{imagesdir}/foo.png[]`
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("inline image with empty alt and trailing spaces", func() {
@@ -417,7 +417,7 @@ image::{imagesdir}/foo.png[]`
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("inline image surrounded with test", func() {
@@ -447,7 +447,7 @@ image::{imagesdir}/foo.png[]`
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("inline image with alt alone", func() {
@@ -473,7 +473,7 @@ image::{imagesdir}/foo.png[]`
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("inline image with alt and width", func() {
@@ -500,7 +500,7 @@ image::{imagesdir}/foo.png[]`
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("inline image with alt, width and height", func() {
@@ -528,7 +528,7 @@ image::{imagesdir}/foo.png[]`
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("inline image with alt, but empty width and height", func() {
@@ -554,7 +554,7 @@ image::{imagesdir}/foo.png[]`
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("inline image with single other attribute only", func() {
@@ -581,7 +581,7 @@ image::{imagesdir}/foo.png[]`
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("inline image with multiple other attributes only", func() {
@@ -610,7 +610,7 @@ image::{imagesdir}/foo.png[]`
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("inline image with alt, width, height and other attributes", func() {
@@ -642,7 +642,7 @@ image::{imagesdir}/foo.png[]`
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("inline image in a paragraph with space after colon", func() {
@@ -669,7 +669,7 @@ image::{imagesdir}/foo.png[]`
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("inline image in a paragraph without space separator", func() {
@@ -696,7 +696,7 @@ image::{imagesdir}/foo.png[]`
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("image block with document attribute in URL", func() {
@@ -723,7 +723,7 @@ image::{imagesdir}/foo.png[]`
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 		})
 
@@ -756,7 +756,7 @@ image::{imagesdir}/foo.png[]`
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("inline image with document attribute in URL", func() {
@@ -793,7 +793,7 @@ an image:{dir}/foo.png[].`
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("inline image with implicit imagesdir document attribute", func() {
@@ -830,7 +830,7 @@ an image:foo.png[].`
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("inline image with explicit duplicate imagesdir document attribute", func() {
@@ -867,7 +867,7 @@ an image:{imagesdir}/foo.png[].`
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 		})
 
@@ -889,7 +889,7 @@ an image:{imagesdir}/foo.png[].`
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 		})
 	})

--- a/pkg/parser/index_terms_test.go
+++ b/pkg/parser/index_terms_test.go
@@ -38,7 +38,7 @@ var _ = Describe("index terms", func() {
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
 		It("index term in separate paragraph line", func() {
@@ -72,7 +72,7 @@ a paragraph with an index term.`
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 	})
 
@@ -107,7 +107,7 @@ a paragraph with an index term.`
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("index term in single paragraph line", func() {
@@ -148,7 +148,7 @@ a paragraph with an index term.`
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 	})
 })
@@ -180,7 +180,7 @@ var _ = Describe("concealed index terms", func() {
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
 		It("concealed index term in separate paragraph line", func() {
@@ -206,7 +206,7 @@ a paragraph with an index term.`
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 	})
 
@@ -240,7 +240,7 @@ a paragraph with an index term.`
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("concealed index term in single paragraph line", func() {
@@ -270,7 +270,7 @@ a paragraph with an index term.`
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 	})
 })

--- a/pkg/parser/labeled_list_test.go
+++ b/pkg/parser/labeled_list_test.go
@@ -40,7 +40,7 @@ on 2 lines`
 				},
 			},
 		}
-		Expect(ParseDraftDocument(source)).To(Equal(expected))
+		Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 	})
 
 	It("labeled list with a single term and no description", func() {
@@ -59,7 +59,7 @@ on 2 lines`
 				},
 			},
 		}
-		Expect(ParseDraftDocument(source)).To(Equal(expected))
+		Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 	})
 
 	It("labeled list with a quoted text in term and in description", func() {
@@ -101,7 +101,7 @@ on 2 lines`
 				},
 			},
 		}
-		Expect(ParseDraftDocument(source)).To(Equal(expected))
+		Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 	})
 
 	It("labeled list with a horizontal layout attribute", func() {
@@ -132,7 +132,7 @@ Item1:: foo`
 				},
 			},
 		}
-		Expect(ParseDraftDocument(source)).To(Equal(expected))
+		Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 	})
 
 	It("labeled list with a single term and a blank line", func() {
@@ -152,7 +152,7 @@ Item1:: foo`
 				},
 			},
 		}
-		Expect(ParseDraftDocument(source)).To(Equal(expected))
+		Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 	})
 
 	It("labeled list with multiple sibling items", func() {
@@ -223,7 +223,7 @@ Item 3 description`
 				},
 			},
 		}
-		Expect(ParseDraftDocument(source)).To(Equal(expected))
+		Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 	})
 
 	It("labeled list with multiple nested items", func() {
@@ -294,7 +294,7 @@ Item 3 description`
 				},
 			},
 		}
-		Expect(ParseDraftDocument(source)).To(Equal(expected))
+		Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 	})
 
 	It("labeled list with nested unordered list - case 1", func() {
@@ -368,7 +368,7 @@ Item with description:: something simple`
 			},
 		}
 
-		Expect(ParseDraftDocument(source)).To(Equal(expected))
+		Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 	})
 
 	It("labeled list with a single item and paragraph", func() {
@@ -412,7 +412,7 @@ a normal paragraph.`
 				},
 			},
 		}
-		Expect(ParseDraftDocument(source)).To(Equal(expected))
+		Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 	})
 
 	It("labeled list with item continuation", func() {
@@ -499,7 +499,7 @@ another fenced block
 				},
 			},
 		}
-		Expect(ParseDraftDocument(source)).To(Equal(expected))
+		Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 	})
 
 	It("labeled list without item continuation", func() {
@@ -576,7 +576,7 @@ another fenced block
 				},
 			},
 		}
-		Expect(ParseDraftDocument(source)).To(Equal(expected))
+		Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 	})
 
 	It("labeled list with multiple item continuations", func() {
@@ -692,7 +692,7 @@ TIP: tip`
 				},
 			},
 		}
-		Expect(ParseDraftDocument(source)).To(Equal(expected))
+		Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 	})
 
 	It("labeled list with nested unordered list - case 2", func() {
@@ -728,7 +728,7 @@ TIP: tip`
 				},
 			},
 		}
-		Expect(ParseDraftDocument(source)).To(Equal(expected))
+		Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 	})
 
 	It("labeled list with title", func() {
@@ -783,7 +783,7 @@ second term:: definition of the second term`
 				},
 			},
 		}
-		Expect(ParseDraftDocument(source)).To(Equal(expected))
+		Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 	})
 
 	It("max level of labeled items - case 1", func() {
@@ -882,7 +882,7 @@ level 1:: description 1`
 				},
 			},
 		}
-		Expect(ParseDraftDocument(source)).To(Equal(expected))
+		Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 	})
 
 	It("max level of labeled items - case 2", func() {
@@ -981,7 +981,7 @@ level 2::: description 2`
 				},
 			},
 		}
-		Expect(ParseDraftDocument(source)).To(Equal(expected))
+		Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 	})
 })
 
@@ -1027,7 +1027,7 @@ on 2 lines`
 				},
 			},
 		}
-		Expect(ParseDocument(source)).To(Equal(expected))
+		Expect(ParseDocument(source)).To(MatchDocument(expected))
 	})
 
 	It("labeled list with a single term and no description", func() {
@@ -1056,7 +1056,7 @@ on 2 lines`
 				},
 			},
 		}
-		Expect(ParseDocument(source)).To(Equal(expected))
+		Expect(ParseDocument(source)).To(MatchDocument(expected))
 	})
 
 	It("labeled list with a quoted text in term and in description", func() {
@@ -1112,7 +1112,7 @@ on 2 lines`
 				},
 			},
 		}
-		Expect(ParseDocument(source)).To(Equal(expected))
+		Expect(ParseDocument(source)).To(MatchDocument(expected))
 	})
 	It("labeled list with a index term", func() {
 		source := "((`foo`))::\n" +
@@ -1171,7 +1171,7 @@ on 2 lines`
 				},
 			},
 		}
-		Expect(ParseDocument(source)).To(Equal(expected))
+		Expect(ParseDocument(source)).To(MatchDocument(expected))
 	})
 
 	It("labeled list with a concealed index term in term", func() {
@@ -1223,7 +1223,7 @@ on 2 lines`
 				},
 			},
 		}
-		Expect(ParseDocument(source)).To(Equal(expected))
+		Expect(ParseDocument(source)).To(MatchDocument(expected))
 	})
 
 	It("labeled list with a horizontal layout attribute", func() {
@@ -1264,7 +1264,7 @@ Item1:: foo`
 				},
 			},
 		}
-		Expect(ParseDocument(source)).To(Equal(expected))
+		Expect(ParseDocument(source)).To(MatchDocument(expected))
 	})
 
 	It("labeled list with a single term and a blank line", func() {
@@ -1294,7 +1294,7 @@ Item1:: foo`
 				},
 			},
 		}
-		Expect(ParseDocument(source)).To(Equal(expected))
+		Expect(ParseDocument(source)).To(MatchDocument(expected))
 	})
 
 	It("labeled list with multiple sibling items", func() {
@@ -1377,7 +1377,7 @@ Item 3 description`
 				},
 			},
 		}
-		Expect(ParseDocument(source)).To(Equal(expected))
+		Expect(ParseDocument(source)).To(MatchDocument(expected))
 	})
 
 	It("labeled list with multiple nested items", func() {
@@ -1470,7 +1470,7 @@ Item 3 description`
 				},
 			},
 		}
-		Expect(ParseDocument(source)).To(Equal(expected))
+		Expect(ParseDocument(source)).To(MatchDocument(expected))
 	})
 
 	It("labeled list with nested unordered list - case 1", func() {
@@ -1560,7 +1560,7 @@ Item with description:: something simple`
 			},
 		}
 
-		Expect(ParseDocument(source)).To(Equal(expected))
+		Expect(ParseDocument(source)).To(MatchDocument(expected))
 	})
 
 	It("labeled list with a single item and paragraph", func() {
@@ -1613,7 +1613,7 @@ a normal paragraph.`
 				},
 			},
 		}
-		Expect(ParseDocument(source)).To(Equal(expected))
+		Expect(ParseDocument(source)).To(MatchDocument(expected))
 	})
 
 	It("labeled list with item continuation", func() {
@@ -1705,7 +1705,7 @@ another fenced block
 			},
 		}
 
-		Expect(ParseDocument(source)).To(Equal(expected))
+		Expect(ParseDocument(source)).To(MatchDocument(expected))
 	})
 
 	It("labeled list without item continuation", func() {
@@ -1798,7 +1798,7 @@ another fenced block
 				},
 			},
 		}
-		Expect(ParseDocument(source)).To(Equal(expected))
+		Expect(ParseDocument(source)).To(MatchDocument(expected))
 	})
 
 	It("labeled list with nested unordered list - case 2", func() {
@@ -1849,7 +1849,7 @@ another fenced block
 				},
 			},
 		}
-		Expect(ParseDocument(source)).To(Equal(expected))
+		Expect(ParseDocument(source)).To(MatchDocument(expected))
 	})
 
 	It("labeled list with title", func() {
@@ -1913,7 +1913,7 @@ second term:: definition of the second term`
 				},
 			},
 		}
-		Expect(ParseDocument(source)).To(Equal(expected))
+		Expect(ParseDocument(source)).To(MatchDocument(expected))
 	})
 
 	It("max level of labeled items - case 1", func() {
@@ -2031,7 +2031,7 @@ level 1:: description 1`
 				},
 			},
 		}
-		Expect(ParseDocument(source)).To(Equal(expected))
+		Expect(ParseDocument(source)).To(MatchDocument(expected))
 	})
 
 	It("max level of labeled items - case 2", func() {
@@ -2149,7 +2149,7 @@ level 2::: description 2`
 				},
 			},
 		}
-		Expect(ParseDocument(source)).To(Equal(expected))
+		Expect(ParseDocument(source)).To(MatchDocument(expected))
 	})
 
 	It("labeled list item with predefined attribute", func() {
@@ -2186,6 +2186,6 @@ level 2::: description 2`
 				},
 			},
 		}
-		Expect(ParseDocument(source)).To(Equal(expected))
+		Expect(ParseDocument(source)).To(MatchDocument(expected))
 	})
 })

--- a/pkg/parser/link_test.go
+++ b/pkg/parser/link_test.go
@@ -368,7 +368,7 @@ next lines`
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("external link in bold text", func() {
@@ -401,7 +401,7 @@ next lines`
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 		})
@@ -754,7 +754,7 @@ a link to {scheme}:{path}[] and https://foo.baz`
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			Context("text attribute with comma", func() {
@@ -909,7 +909,7 @@ a link to {url}`
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("external link with a document attribute substitution for the whole URL", func() {
@@ -936,7 +936,7 @@ a link to {url}`
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("external link with two document attribute substitutions", func() {
@@ -977,7 +977,7 @@ a link to {scheme}://{path}`
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("external link with two document attribute substitutions in bold text", func() {
@@ -1034,7 +1034,7 @@ a link to *{scheme}://{path}[] and https://foo.baz[]*`
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 		})
 	})
@@ -1073,7 +1073,7 @@ a link to *{scheme}://{path}[] and https://foo.baz[]*`
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("external link with special characters", func() {
@@ -1104,7 +1104,7 @@ a link to *{scheme}://{path}[] and https://foo.baz[]*`
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("external link in bold text", func() {
@@ -1141,7 +1141,7 @@ a link to *{scheme}://{path}[] and https://foo.baz[]*`
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("external link in italic text", func() {
@@ -1178,7 +1178,7 @@ a link to *{scheme}://{path}[] and https://foo.baz[]*`
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		Context("with document attribute substitutions", func() {
@@ -1218,7 +1218,7 @@ a link to {url}`
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("external link with two document attribute substitutions only", func() {
@@ -1268,7 +1268,7 @@ a link to {scheme}://{path} and https://foo.baz`
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("external link with two document attribute substitutions in bold text", func() {
@@ -1323,7 +1323,7 @@ a link to *{scheme}://{path}[] and https://foo.baz[]*`
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("external link with two document attribute substitutions and a reset", func() {
@@ -1374,7 +1374,7 @@ a link to {scheme}://{path} and https://foo.baz`
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("external link with document attribute in section 0 title", func() {
@@ -1427,7 +1427,7 @@ a link to {scheme}://{path} and https://foo.baz`
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("external link with document attribute in section 1 title", func() {
@@ -1481,7 +1481,7 @@ a link to {scheme}://{path} and https://foo.baz`
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 		})
 

--- a/pkg/parser/literal_block_test.go
+++ b/pkg/parser/literal_block_test.go
@@ -75,7 +75,7 @@ a normal paragraph.`
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 	})
 
@@ -131,7 +131,7 @@ a normal paragraph.`
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 	})
 
@@ -164,7 +164,7 @@ a normal paragraph.`
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
 		It("literal block from 2-lines paragraph with attribute", func() {
@@ -201,7 +201,7 @@ a normal paragraph.`
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 	})
 

--- a/pkg/parser/mixed_lists_test.go
+++ b/pkg/parser/mixed_lists_test.go
@@ -136,7 +136,7 @@ var _ = Describe("mixed lists - document", func() {
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 	})
 
@@ -371,7 +371,7 @@ var _ = Describe("mixed lists - document", func() {
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("complex case 2 - mixed lists", func() {
@@ -777,7 +777,7 @@ ii) ordered 1.2.ii
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("complex case 4 - mixed lists", func() {
@@ -856,7 +856,7 @@ Operating Systems::
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("complex case 5 - mixed lists and a paragraph", func() {
@@ -1204,7 +1204,7 @@ a paragraph
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 	})
 
@@ -1287,7 +1287,7 @@ a paragraph
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("same list with custom number style on sublist", func() {
@@ -1389,7 +1389,7 @@ a paragraph
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("distinct lists with blankline and item attribute - case 1", func() {
@@ -1478,7 +1478,7 @@ a paragraph
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("distinct lists with blankline and item attribute - case 2", func() {
@@ -1584,7 +1584,7 @@ a paragraph
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("same list with single comment line inside", func() {
@@ -1638,7 +1638,7 @@ a paragraph
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("same list with multiple comment lines inside", func() {
@@ -1694,7 +1694,7 @@ a paragraph
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("distinct lists separated by single comment line", func() {
@@ -1754,7 +1754,7 @@ a paragraph
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("distinct lists separated by multiple comment lines", func() {
@@ -1816,7 +1816,7 @@ a paragraph
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 	})
 })

--- a/pkg/parser/ordered_list_test.go
+++ b/pkg/parser/ordered_list_test.go
@@ -36,7 +36,7 @@ var _ = Describe("ordered lists - draft", func() {
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
 		It("ordered list item with arabic numbering style", func() {
@@ -51,7 +51,7 @@ var _ = Describe("ordered lists - draft", func() {
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
 		It("ordered list item with lower alpha numbering style", func() {
@@ -66,7 +66,7 @@ var _ = Describe("ordered lists - draft", func() {
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
 		It("ordered list item with upper alpha numbering style", func() {
@@ -81,7 +81,7 @@ var _ = Describe("ordered lists - draft", func() {
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
 		It("ordered list item with lower roman numbering style", func() {
@@ -96,7 +96,7 @@ var _ = Describe("ordered lists - draft", func() {
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
 		It("ordered list item with upper roman numbering style", func() {
@@ -111,7 +111,7 @@ var _ = Describe("ordered lists - draft", func() {
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
 		It("ordered list item with explicit numbering style", func() {
@@ -136,7 +136,7 @@ var _ = Describe("ordered lists - draft", func() {
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
 		It("ordered list item with explicit start only", func() {
@@ -154,7 +154,7 @@ var _ = Describe("ordered lists - draft", func() {
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
 		It("ordered list item with explicit quoted numbering and start", func() {
@@ -173,7 +173,7 @@ var _ = Describe("ordered lists - draft", func() {
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
 		It("max level of ordered items - case 1", func() {
@@ -292,7 +292,7 @@ var _ = Describe("ordered lists - draft", func() {
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
 		It("max level of ordered items - case 2", func() {
@@ -411,7 +411,7 @@ var _ = Describe("ordered lists - draft", func() {
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 	})
 
@@ -455,7 +455,7 @@ var _ = Describe("ordered lists - draft", func() {
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
 		It("ordered list with unnumbered items", func() {
@@ -496,7 +496,7 @@ var _ = Describe("ordered lists - draft", func() {
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
 		It("ordered list with custom numbering on child items with tabs ", func() {
@@ -621,7 +621,7 @@ var _ = Describe("ordered lists - draft", func() {
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
 		It("ordered list with all default styles and blank lines", func() {
@@ -726,7 +726,7 @@ var _ = Describe("ordered lists - draft", func() {
 					types.BlankLine{},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 	})
 
@@ -769,7 +769,7 @@ var _ = Describe("ordered lists - draft", func() {
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
 		It("ordered list with numbered items", func() {
@@ -841,7 +841,7 @@ b. item 2.a`
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 	})
 
@@ -931,7 +931,7 @@ another delimited block
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
 		It("ordered list with item continuation - case 2", func() {
@@ -1017,7 +1017,7 @@ print("one")
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 	})
 })
@@ -1059,7 +1059,7 @@ var _ = Describe("ordered lists - document", func() {
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("ordered list item with arabic numbering style", func() {
@@ -1083,7 +1083,7 @@ var _ = Describe("ordered lists - document", func() {
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("ordered list item with lower alpha numbering style", func() {
@@ -1107,7 +1107,7 @@ var _ = Describe("ordered lists - document", func() {
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("ordered list item with upper alpha numbering style", func() {
@@ -1132,7 +1132,7 @@ var _ = Describe("ordered lists - document", func() {
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("ordered list item with lower roman numbering style", func() {
@@ -1156,7 +1156,7 @@ var _ = Describe("ordered lists - document", func() {
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("ordered list item with upper roman numbering style", func() {
@@ -1180,7 +1180,7 @@ var _ = Describe("ordered lists - document", func() {
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("ordered list item with predefined attribute", func() {
@@ -1213,7 +1213,7 @@ var _ = Describe("ordered lists - document", func() {
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("ordered list item with explicit numbering style", func() {
@@ -1247,7 +1247,7 @@ var _ = Describe("ordered lists - document", func() {
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("ordered list item with explicit start only", func() {
@@ -1274,7 +1274,7 @@ var _ = Describe("ordered lists - document", func() {
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("ordered list item with explicit quoted numbering and start", func() {
@@ -1302,7 +1302,7 @@ var _ = Describe("ordered lists - document", func() {
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("max level of ordered items - case 1", func() {
@@ -1450,7 +1450,7 @@ var _ = Describe("ordered lists - document", func() {
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("max level of ordered items - case 2", func() {
@@ -1598,7 +1598,7 @@ var _ = Describe("ordered lists - document", func() {
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 	})
 
@@ -1651,7 +1651,7 @@ var _ = Describe("ordered lists - document", func() {
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("ordered list with unnumbered items", func() {
@@ -1701,7 +1701,7 @@ var _ = Describe("ordered lists - document", func() {
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("ordered list with custom numbering on child items with tabs ", func() {
@@ -1850,7 +1850,7 @@ var _ = Describe("ordered lists - document", func() {
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("ordered list with all default styles and blank lines", func() {
@@ -1976,7 +1976,7 @@ var _ = Describe("ordered lists - document", func() {
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 	})
 
@@ -2028,7 +2028,7 @@ var _ = Describe("ordered lists - document", func() {
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("ordered list with numbered items", func() {
@@ -2119,7 +2119,7 @@ b. item 2.a`
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 	})
 
@@ -2212,7 +2212,7 @@ another delimited block
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("ordered list with item continuation - case 2", func() {
@@ -2289,7 +2289,7 @@ print("one")
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 	})
 })

--- a/pkg/parser/paragraph_test.go
+++ b/pkg/parser/paragraph_test.go
@@ -151,7 +151,7 @@ a paragraph`
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("empty paragraph", func() {
@@ -168,7 +168,7 @@ a paragraph`
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 	})
 
@@ -376,7 +376,7 @@ And no space after [CAUTION] either.`
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 	})
 
@@ -714,7 +714,7 @@ image::foo.png[]`
 				},
 			},
 		}
-		Expect(ParseDocument(source)).To(Equal(expected))
+		Expect(ParseDocument(source)).To(MatchDocument(expected))
 	})
 
 })

--- a/pkg/parser/q_a_list_test.go
+++ b/pkg/parser/q_a_list_test.go
@@ -75,6 +75,6 @@ What is the answer to the Ultimate Question?:: 42`
 				},
 			},
 		}
-		Expect(ParseDocument(source)).To(Equal(expected))
+		Expect(ParseDocument(source)).To(MatchDocument(expected))
 	})
 })

--- a/pkg/parser/quoted_text_test.go
+++ b/pkg/parser/quoted_text_test.go
@@ -32,7 +32,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("bold text with 2 words", func() {
@@ -54,7 +54,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("bold text with 3 words", func() {
@@ -76,7 +76,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("italic text with 3 words in single quote", func() {
@@ -98,7 +98,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("monospace text with 3 words", func() {
@@ -120,7 +120,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("invalid subscript text with 3 words", func() {
@@ -137,7 +137,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("invalid superscript text with 3 words", func() {
@@ -154,7 +154,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("bold text within italic text", func() {
@@ -183,7 +183,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("monospace text within bold text within italic quote", func() {
@@ -217,7 +217,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("italic text within italic text", func() {
@@ -240,7 +240,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("non-bold text then bold text", func() {
@@ -265,7 +265,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 			It("non-italic text then italic text", func() {
 				source := "non_italic_content _italic content_"
@@ -289,7 +289,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("non-monospace text then monospace text", func() {
@@ -314,7 +314,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("subscript text attached", func() {
@@ -338,7 +338,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("superscript text attached", func() {
@@ -362,7 +362,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("invalid subscript text with 3 words", func() {
@@ -379,7 +379,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 		})
 
@@ -404,7 +404,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("italic text with 3 words in double quote", func() {
@@ -426,7 +426,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("monospace text with 3 words in double quote", func() {
@@ -448,7 +448,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("superscript text within italic text", func() {
@@ -477,7 +477,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("superscript text within italic text within bold quote", func() {
@@ -511,7 +511,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 		})
 
@@ -537,7 +537,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("inline content with invalid bold text - use case 1", func() {
@@ -554,7 +554,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("inline content with invalid bold text - use case 2", func() {
@@ -571,7 +571,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("inline content with invalid bold text - use case 3", func() {
@@ -588,7 +588,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("invalid italic text within bold text", func() {
@@ -613,7 +613,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("italic text within invalid bold text", func() {
@@ -637,7 +637,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("inline content with invalid subscript text - use case 1", func() {
@@ -654,7 +654,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("inline content with invalid subscript text - use case 2", func() {
@@ -671,7 +671,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("inline content with invalid subscript text - use case 3", func() {
@@ -688,7 +688,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("inline content with invalid superscript text - use case 1", func() {
@@ -706,7 +706,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("inline content with invalid superscript text - use case 2", func() {
@@ -724,7 +724,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("inline content with invalid superscript text - use case 3", func() {
@@ -742,7 +742,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 		})
 
@@ -776,7 +776,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("single-quote bold within single-quote bold text", func() {
@@ -800,7 +800,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("double-quote bold within double-quote bold text", func() {
@@ -830,7 +830,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("single-quote bold within double-quote bold text", func() {
@@ -860,7 +860,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("double-quote bold within single-quote bold text", func() {
@@ -890,7 +890,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("single-quote italic within single-quote italic text", func() {
@@ -914,7 +914,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("double-quote italic within double-quote italic text", func() {
@@ -944,7 +944,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("single-quote italic within double-quote italic text", func() {
@@ -974,7 +974,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("double-quote italic within single-quote italic text", func() {
@@ -1004,7 +1004,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("single-quote monospace within single-quote monospace text", func() {
@@ -1028,7 +1028,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("double-quote monospace within double-quote monospace text", func() {
@@ -1058,7 +1058,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("single-quote monospace within double-quote monospace text", func() {
@@ -1088,7 +1088,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("double-quote monospace within single-quote monospace text", func() {
@@ -1118,7 +1118,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("unbalanced bold in monospace - case 1", func() {
@@ -1140,7 +1140,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("unbalanced bold in monospace - case 2", func() {
@@ -1162,7 +1162,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("italic in monospace", func() {
@@ -1189,7 +1189,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("unbalanced italic in monospace", func() {
@@ -1211,7 +1211,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("unparsed bold in monospace", func() {
@@ -1233,7 +1233,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("parsed subscript in monospace", func() {
@@ -1261,7 +1261,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("multiline in single quoted monospace - case 1", func() {
@@ -1283,7 +1283,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("multiline in double quoted monospace - case 1", func() {
@@ -1305,7 +1305,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("multiline in single quoted  monospace - case 2", func() {
@@ -1333,7 +1333,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("multiline in double quoted  monospace - case 2", func() {
@@ -1361,7 +1361,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("link in bold", func() {
@@ -1399,7 +1399,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("image in bold", func() {
@@ -1431,7 +1431,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("singleplus passthrough in bold", func() {
@@ -1459,7 +1459,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("tripleplus passthrough in bold", func() {
@@ -1487,7 +1487,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("link in italic", func() {
@@ -1525,7 +1525,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("image in italic", func() {
@@ -1557,7 +1557,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("singleplus passthrough in italic", func() {
@@ -1585,7 +1585,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("tripleplus passthrough in italic", func() {
@@ -1613,7 +1613,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("link in monospace", func() {
@@ -1651,7 +1651,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("image in monospace", func() {
@@ -1683,7 +1683,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("singleplus passthrough in monospace", func() {
@@ -1712,7 +1712,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 			It("tripleplus passthrough in monospace", func() {
@@ -1741,7 +1741,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 		})
@@ -1769,7 +1769,7 @@ var _ = Describe("quoted texts", func() {
 							},
 						},
 					}
-					Expect(ParseDraftDocument(source)).To(Equal(expected))
+					Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 				})
 
 				It("unbalanced bold text - extra on right", func() {
@@ -1793,7 +1793,7 @@ var _ = Describe("quoted texts", func() {
 							},
 						},
 					}
-					Expect(ParseDraftDocument(source)).To(Equal(expected))
+					Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 				})
 			})
 
@@ -1819,7 +1819,7 @@ var _ = Describe("quoted texts", func() {
 							},
 						},
 					}
-					Expect(ParseDraftDocument(source)).To(Equal(expected))
+					Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 				})
 
 				It("unbalanced italic text - extra on right", func() {
@@ -1842,7 +1842,7 @@ var _ = Describe("quoted texts", func() {
 							},
 						},
 					}
-					Expect(ParseDraftDocument(source)).To(Equal(expected))
+					Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 				})
 			})
 
@@ -1868,7 +1868,7 @@ var _ = Describe("quoted texts", func() {
 							},
 						},
 					}
-					Expect(ParseDraftDocument(source)).To(Equal(expected))
+					Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 				})
 
 				It("unbalanced monospace text - extra on right", func() {
@@ -1891,7 +1891,7 @@ var _ = Describe("quoted texts", func() {
 							},
 						},
 					}
-					Expect(ParseDraftDocument(source)).To(Equal(expected))
+					Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 				})
 			})
 
@@ -1909,7 +1909,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(Equal(expected))
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
 		})
@@ -1934,7 +1934,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDraftDocument(source)).To(Equal(expected))
+						Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 					})
 
 					It("escaped bold text with multiple backslashes", func() {
@@ -1951,7 +1951,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDraftDocument(source)).To(Equal(expected))
+						Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 					})
 
 					It("escaped bold text with double quote", func() {
@@ -1968,7 +1968,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDraftDocument(source)).To(Equal(expected))
+						Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 					})
 
 					It("escaped bold text with double quote and more backslashes", func() {
@@ -1985,7 +1985,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDraftDocument(source)).To(Equal(expected))
+						Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 					})
 
 					It("escaped bold text with unbalanced double quote", func() {
@@ -2002,7 +2002,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDraftDocument(source)).To(Equal(expected))
+						Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 					})
 
 					It("escaped bold text with unbalanced double quote and more backslashes", func() {
@@ -2019,7 +2019,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDraftDocument(source)).To(Equal(expected))
+						Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 					})
 				})
 
@@ -2046,7 +2046,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDraftDocument(source)).To(Equal(expected))
+						Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 					})
 
 					It("escaped bold text with unbalanced double quote and nested italic test", func() {
@@ -2070,7 +2070,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDraftDocument(source)).To(Equal(expected))
+						Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 					})
 
 					It("escaped bold text with nested italic", func() {
@@ -2094,7 +2094,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDraftDocument(source)).To(Equal(expected))
+						Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 					})
 				})
 
@@ -2118,7 +2118,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDraftDocument(source)).To(Equal(expected))
+						Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 					})
 
 					It("escaped italic text with single quote and more backslashes", func() {
@@ -2135,7 +2135,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDraftDocument(source)).To(Equal(expected))
+						Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 					})
 
 					It("escaped italic text with double quote with 2 backslashes", func() {
@@ -2152,7 +2152,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDraftDocument(source)).To(Equal(expected))
+						Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 					})
 
 					It("escaped italic text with double quote with 3 backslashes", func() {
@@ -2169,7 +2169,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDraftDocument(source)).To(Equal(expected))
+						Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 					})
 
 					It("escaped italic text with unbalanced double quote", func() {
@@ -2186,7 +2186,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDraftDocument(source)).To(Equal(expected))
+						Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 					})
 
 					It("escaped italic text with unbalanced double quote and more backslashes", func() {
@@ -2203,7 +2203,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDraftDocument(source)).To(Equal(expected))
+						Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 					})
 				})
 
@@ -2230,7 +2230,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDraftDocument(source)).To(Equal(expected))
+						Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 					})
 
 					It("escaped italic text with unbalanced double quote and nested bold test", func() {
@@ -2254,7 +2254,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDraftDocument(source)).To(Equal(expected))
+						Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 					})
 
 					It("escaped italic text with nested bold text", func() {
@@ -2278,7 +2278,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDraftDocument(source)).To(Equal(expected))
+						Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 					})
 				})
 			})
@@ -2301,7 +2301,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDraftDocument(source)).To(Equal(expected))
+						Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 					})
 
 					It("escaped monospace text with single quote and more backslashes", func() {
@@ -2318,7 +2318,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDraftDocument(source)).To(Equal(expected))
+						Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 					})
 
 					It("escaped monospace text with double quote", func() {
@@ -2335,7 +2335,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDraftDocument(source)).To(Equal(expected))
+						Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 					})
 
 					It("escaped monospace text with double quote and more backslashes", func() {
@@ -2352,7 +2352,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDraftDocument(source)).To(Equal(expected))
+						Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 					})
 
 					It("escaped monospace text with unbalanced double quote", func() {
@@ -2369,7 +2369,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDraftDocument(source)).To(Equal(expected))
+						Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 					})
 
 					It("escaped monospace text with unbalanced double quote and more backslashes", func() {
@@ -2386,7 +2386,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDraftDocument(source)).To(Equal(expected))
+						Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 					})
 				})
 
@@ -2413,7 +2413,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDraftDocument(source)).To(Equal(expected))
+						Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 					})
 
 					It("escaped monospace text with unbalanced double backquote and nested bold test", func() {
@@ -2437,7 +2437,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDraftDocument(source)).To(Equal(expected))
+						Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 					})
 
 					It("escaped monospace text with nested bold text", func() {
@@ -2461,7 +2461,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDraftDocument(source)).To(Equal(expected))
+						Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 					})
 				})
 			})
@@ -2484,7 +2484,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDraftDocument(source)).To(Equal(expected))
+						Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 					})
 
 					It("escaped subscript text with single quote and more backslashes", func() {
@@ -2501,7 +2501,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDraftDocument(source)).To(Equal(expected))
+						Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 					})
 
 				})
@@ -2529,7 +2529,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDraftDocument(source)).To(Equal(expected))
+						Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 					})
 
 					It("escaped subscript text with nested bold text", func() {
@@ -2553,7 +2553,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDraftDocument(source)).To(Equal(expected))
+						Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 					})
 				})
 			})
@@ -2576,7 +2576,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDraftDocument(source)).To(Equal(expected))
+						Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 					})
 
 					It("escaped superscript text with single quote and more backslashes", func() {
@@ -2593,7 +2593,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDraftDocument(source)).To(Equal(expected))
+						Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 					})
 
 				})
@@ -2621,7 +2621,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDraftDocument(source)).To(Equal(expected))
+						Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 					})
 
 					It("escaped superscript text with unbalanced double backquote and nested bold test", func() {
@@ -2645,7 +2645,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDraftDocument(source)).To(Equal(expected))
+						Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 					})
 
 					It("escaped superscript text with nested bold text - case 2", func() {
@@ -2669,7 +2669,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDraftDocument(source)).To(Equal(expected))
+						Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 					})
 				})
 			})
@@ -2702,7 +2702,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("bold text with 2 words", func() {
@@ -2728,7 +2728,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("bold text with 3 words", func() {
@@ -2754,7 +2754,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("italic text with 3 words in single quote", func() {
@@ -2780,7 +2780,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("monospace text with 3 words", func() {
@@ -2806,7 +2806,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("invalid subscript text with 3 words", func() {
@@ -2827,7 +2827,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("invalid superscript text with 3 words", func() {
@@ -2848,7 +2848,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("bold text within italic text", func() {
@@ -2881,7 +2881,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("monospace text within bold text within italic quote", func() {
@@ -2919,7 +2919,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("italic text within italic text", func() {
@@ -2946,7 +2946,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("subscript text attached", func() {
@@ -2974,7 +2974,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("superscript text attached", func() {
@@ -3002,7 +3002,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("invalid subscript text with 3 words", func() {
@@ -3023,7 +3023,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 		})
@@ -3053,7 +3053,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("italic text with 3 words in double quote", func() {
@@ -3079,7 +3079,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("monospace text with 3 words in double quote", func() {
@@ -3105,7 +3105,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("superscript text within italic text", func() {
@@ -3138,7 +3138,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("superscript text within italic text within bold quote", func() {
@@ -3176,7 +3176,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 		})
 
@@ -3206,7 +3206,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("inline content with invalid bold text - use case 1", func() {
@@ -3227,7 +3227,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("inline content with invalid bold text - use case 2", func() {
@@ -3248,7 +3248,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("inline content with invalid bold text - use case 3", func() {
@@ -3269,7 +3269,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("invalid italic text within bold text", func() {
@@ -3298,7 +3298,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("italic text within invalid bold text", func() {
@@ -3326,7 +3326,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("inline content with invalid subscript text - use case 1", func() {
@@ -3347,7 +3347,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("inline content with invalid subscript text - use case 2", func() {
@@ -3368,7 +3368,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("inline content with invalid subscript text - use case 3", func() {
@@ -3389,7 +3389,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("inline content with invalid superscript text - use case 1", func() {
@@ -3411,7 +3411,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("inline content with invalid superscript text - use case 2", func() {
@@ -3433,7 +3433,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("inline content with invalid superscript text - use case 3", func() {
@@ -3455,7 +3455,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 		})
 
@@ -3493,7 +3493,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("single-quote bold within single-quote bold text", func() {
@@ -3521,7 +3521,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("double-quote bold within double-quote bold text", func() {
@@ -3555,7 +3555,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("single-quote bold within double-quote bold text", func() {
@@ -3589,7 +3589,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("double-quote bold within single-quote bold text", func() {
@@ -3623,7 +3623,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("single-quote italic within single-quote italic text", func() {
@@ -3651,7 +3651,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("double-quote italic within double-quote italic text", func() {
@@ -3685,7 +3685,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("single-quote italic within double-quote italic text", func() {
@@ -3719,7 +3719,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("double-quote italic within single-quote italic text", func() {
@@ -3753,7 +3753,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("single-quote monospace within single-quote monospace text", func() {
@@ -3781,7 +3781,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("double-quote monospace within double-quote monospace text", func() {
@@ -3815,7 +3815,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("single-quote monospace within double-quote monospace text", func() {
@@ -3849,7 +3849,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("double-quote monospace within single-quote monospace text", func() {
@@ -3883,7 +3883,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("unbalanced bold in monospace - case 1", func() {
@@ -3909,7 +3909,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("unbalanced bold in monospace - case 2", func() {
@@ -3935,7 +3935,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("italic in monospace", func() {
@@ -3966,7 +3966,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("unbalanced italic in monospace", func() {
@@ -3992,7 +3992,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("unparsed bold in monospace", func() {
@@ -4018,7 +4018,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("parsed subscript in monospace", func() {
@@ -4050,7 +4050,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("multiline in single quoted monospace - case 1", func() {
@@ -4076,7 +4076,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("multiline in double quoted monospace - case 1", func() {
@@ -4102,7 +4102,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("multiline in single quoted  monospace - case 2", func() {
@@ -4134,7 +4134,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("multiline in double quoted  monospace - case 2", func() {
@@ -4166,7 +4166,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("link in bold", func() {
@@ -4208,7 +4208,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("image in bold", func() {
@@ -4246,7 +4246,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("singleplus passthrough in bold", func() {
@@ -4278,7 +4278,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("tripleplus passthrough in bold", func() {
@@ -4310,7 +4310,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("link in italic", func() {
@@ -4352,7 +4352,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("image in italic", func() {
@@ -4390,7 +4390,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("singleplus passthrough in italic", func() {
@@ -4422,7 +4422,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("tripleplus passthrough in italic", func() {
@@ -4454,7 +4454,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("link in monospace", func() {
@@ -4496,7 +4496,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("image in monospace", func() {
@@ -4534,7 +4534,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("singleplus passthrough in monospace", func() {
@@ -4567,7 +4567,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 			It("tripleplus passthrough in monospace", func() {
@@ -4600,7 +4600,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 		})
@@ -4632,7 +4632,7 @@ var _ = Describe("quoted texts", func() {
 							},
 						},
 					}
-					Expect(ParseDocument(source)).To(Equal(expected))
+					Expect(ParseDocument(source)).To(MatchDocument(expected))
 				})
 
 				It("unbalanced bold text - extra on right", func() {
@@ -4660,7 +4660,7 @@ var _ = Describe("quoted texts", func() {
 							},
 						},
 					}
-					Expect(ParseDocument(source)).To(Equal(expected))
+					Expect(ParseDocument(source)).To(MatchDocument(expected))
 				})
 			})
 
@@ -4690,7 +4690,7 @@ var _ = Describe("quoted texts", func() {
 							},
 						},
 					}
-					Expect(ParseDocument(source)).To(Equal(expected))
+					Expect(ParseDocument(source)).To(MatchDocument(expected))
 				})
 
 				It("unbalanced italic text - extra on right", func() {
@@ -4717,7 +4717,7 @@ var _ = Describe("quoted texts", func() {
 							},
 						},
 					}
-					Expect(ParseDocument(source)).To(Equal(expected))
+					Expect(ParseDocument(source)).To(MatchDocument(expected))
 				})
 			})
 
@@ -4747,7 +4747,7 @@ var _ = Describe("quoted texts", func() {
 							},
 						},
 					}
-					Expect(ParseDocument(source)).To(Equal(expected))
+					Expect(ParseDocument(source)).To(MatchDocument(expected))
 				})
 
 				It("unbalanced monospace text - extra on right", func() {
@@ -4774,7 +4774,7 @@ var _ = Describe("quoted texts", func() {
 							},
 						},
 					}
-					Expect(ParseDocument(source)).To(Equal(expected))
+					Expect(ParseDocument(source)).To(MatchDocument(expected))
 				})
 			})
 
@@ -4796,7 +4796,7 @@ var _ = Describe("quoted texts", func() {
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(Equal(expected))
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
 		})
@@ -4825,7 +4825,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDocument(source)).To(Equal(expected))
+						Expect(ParseDocument(source)).To(MatchDocument(expected))
 					})
 
 					It("escaped bold text with multiple backslashes", func() {
@@ -4846,7 +4846,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDocument(source)).To(Equal(expected))
+						Expect(ParseDocument(source)).To(MatchDocument(expected))
 					})
 
 					It("escaped bold text with double quote", func() {
@@ -4867,7 +4867,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDocument(source)).To(Equal(expected))
+						Expect(ParseDocument(source)).To(MatchDocument(expected))
 					})
 
 					It("escaped bold text with double quote and more backslashes", func() {
@@ -4888,7 +4888,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDocument(source)).To(Equal(expected))
+						Expect(ParseDocument(source)).To(MatchDocument(expected))
 					})
 
 					It("escaped bold text with unbalanced double quote", func() {
@@ -4909,7 +4909,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDocument(source)).To(Equal(expected))
+						Expect(ParseDocument(source)).To(MatchDocument(expected))
 					})
 
 					It("escaped bold text with unbalanced double quote and more backslashes", func() {
@@ -4930,7 +4930,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDocument(source)).To(Equal(expected))
+						Expect(ParseDocument(source)).To(MatchDocument(expected))
 					})
 				})
 
@@ -4961,7 +4961,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDocument(source)).To(Equal(expected))
+						Expect(ParseDocument(source)).To(MatchDocument(expected))
 					})
 
 					It("escaped bold text with unbalanced double quote and nested italic test", func() {
@@ -4989,7 +4989,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDocument(source)).To(Equal(expected))
+						Expect(ParseDocument(source)).To(MatchDocument(expected))
 					})
 
 					It("escaped bold text with nested italic", func() {
@@ -5017,7 +5017,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDocument(source)).To(Equal(expected))
+						Expect(ParseDocument(source)).To(MatchDocument(expected))
 					})
 				})
 
@@ -5045,7 +5045,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDocument(source)).To(Equal(expected))
+						Expect(ParseDocument(source)).To(MatchDocument(expected))
 					})
 
 					It("escaped italic text with single quote and more backslashes", func() {
@@ -5066,7 +5066,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDocument(source)).To(Equal(expected))
+						Expect(ParseDocument(source)).To(MatchDocument(expected))
 					})
 
 					It("escaped italic text with double quote with 2 backslashes", func() {
@@ -5087,7 +5087,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDocument(source)).To(Equal(expected))
+						Expect(ParseDocument(source)).To(MatchDocument(expected))
 					})
 
 					It("escaped italic text with double quote with 3 backslashes", func() {
@@ -5108,7 +5108,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDocument(source)).To(Equal(expected))
+						Expect(ParseDocument(source)).To(MatchDocument(expected))
 					})
 
 					It("escaped italic text with unbalanced double quote", func() {
@@ -5129,7 +5129,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDocument(source)).To(Equal(expected))
+						Expect(ParseDocument(source)).To(MatchDocument(expected))
 					})
 
 					It("escaped italic text with unbalanced double quote and more backslashes", func() {
@@ -5150,7 +5150,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDocument(source)).To(Equal(expected))
+						Expect(ParseDocument(source)).To(MatchDocument(expected))
 					})
 				})
 
@@ -5181,7 +5181,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDocument(source)).To(Equal(expected))
+						Expect(ParseDocument(source)).To(MatchDocument(expected))
 					})
 
 					It("escaped italic text with unbalanced double quote and nested bold test", func() {
@@ -5209,7 +5209,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDocument(source)).To(Equal(expected))
+						Expect(ParseDocument(source)).To(MatchDocument(expected))
 					})
 
 					It("escaped italic text with nested bold text", func() {
@@ -5237,7 +5237,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDocument(source)).To(Equal(expected))
+						Expect(ParseDocument(source)).To(MatchDocument(expected))
 					})
 				})
 			})
@@ -5264,7 +5264,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDocument(source)).To(Equal(expected))
+						Expect(ParseDocument(source)).To(MatchDocument(expected))
 					})
 
 					It("escaped monospace text with single quote and more backslashes", func() {
@@ -5285,7 +5285,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDocument(source)).To(Equal(expected))
+						Expect(ParseDocument(source)).To(MatchDocument(expected))
 					})
 
 					It("escaped monospace text with double quote", func() {
@@ -5306,7 +5306,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDocument(source)).To(Equal(expected))
+						Expect(ParseDocument(source)).To(MatchDocument(expected))
 					})
 
 					It("escaped monospace text with double quote and more backslashes", func() {
@@ -5327,7 +5327,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDocument(source)).To(Equal(expected))
+						Expect(ParseDocument(source)).To(MatchDocument(expected))
 					})
 
 					It("escaped monospace text with unbalanced double quote", func() {
@@ -5348,7 +5348,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDocument(source)).To(Equal(expected))
+						Expect(ParseDocument(source)).To(MatchDocument(expected))
 					})
 
 					It("escaped monospace text with unbalanced double quote and more backslashes", func() {
@@ -5369,7 +5369,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDocument(source)).To(Equal(expected))
+						Expect(ParseDocument(source)).To(MatchDocument(expected))
 					})
 				})
 
@@ -5400,7 +5400,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDocument(source)).To(Equal(expected))
+						Expect(ParseDocument(source)).To(MatchDocument(expected))
 					})
 
 					It("escaped monospace text with unbalanced double backquote and nested bold test", func() {
@@ -5428,7 +5428,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDocument(source)).To(Equal(expected))
+						Expect(ParseDocument(source)).To(MatchDocument(expected))
 					})
 
 					It("escaped monospace text with nested bold text", func() {
@@ -5456,7 +5456,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDocument(source)).To(Equal(expected))
+						Expect(ParseDocument(source)).To(MatchDocument(expected))
 					})
 				})
 			})
@@ -5483,7 +5483,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDocument(source)).To(Equal(expected))
+						Expect(ParseDocument(source)).To(MatchDocument(expected))
 					})
 
 					It("escaped subscript text with single quote and more backslashes", func() {
@@ -5504,7 +5504,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDocument(source)).To(Equal(expected))
+						Expect(ParseDocument(source)).To(MatchDocument(expected))
 					})
 
 				})
@@ -5536,7 +5536,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDocument(source)).To(Equal(expected))
+						Expect(ParseDocument(source)).To(MatchDocument(expected))
 					})
 
 					It("escaped subscript text with nested bold text", func() {
@@ -5564,7 +5564,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDocument(source)).To(Equal(expected))
+						Expect(ParseDocument(source)).To(MatchDocument(expected))
 					})
 				})
 			})
@@ -5591,7 +5591,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDocument(source)).To(Equal(expected))
+						Expect(ParseDocument(source)).To(MatchDocument(expected))
 					})
 
 					It("escaped superscript text with single quote and more backslashes", func() {
@@ -5612,7 +5612,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDocument(source)).To(Equal(expected))
+						Expect(ParseDocument(source)).To(MatchDocument(expected))
 					})
 
 				})
@@ -5644,7 +5644,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDocument(source)).To(Equal(expected))
+						Expect(ParseDocument(source)).To(MatchDocument(expected))
 					})
 
 					It("escaped superscript text with unbalanced double backquote and nested bold test", func() {
@@ -5672,7 +5672,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDocument(source)).To(Equal(expected))
+						Expect(ParseDocument(source)).To(MatchDocument(expected))
 					})
 
 					It("escaped superscript text with nested bold text - case 2", func() {
@@ -5700,7 +5700,7 @@ var _ = Describe("quoted texts", func() {
 								},
 							},
 						}
-						Expect(ParseDocument(source)).To(Equal(expected))
+						Expect(ParseDocument(source)).To(MatchDocument(expected))
 					})
 				})
 			})
@@ -5745,7 +5745,7 @@ var _ = Describe("quoted texts - final document", func() {
 				},
 			},
 		}
-		Expect(ParseDocument(source)).To(Equal(expected))
+		Expect(ParseDocument(source)).To(MatchDocument(expected))
 	})
 
 	It("image in italic", func() {
@@ -5783,7 +5783,7 @@ var _ = Describe("quoted texts - final document", func() {
 				},
 			},
 		}
-		Expect(ParseDocument(source)).To(Equal(expected))
+		Expect(ParseDocument(source)).To(MatchDocument(expected))
 	})
 
 	It("image in monospace", func() {
@@ -5821,6 +5821,6 @@ var _ = Describe("quoted texts - final document", func() {
 				},
 			},
 		}
-		Expect(ParseDocument(source)).To(Equal(expected))
+		Expect(ParseDocument(source)).To(MatchDocument(expected))
 	})
 })

--- a/pkg/parser/section_test.go
+++ b/pkg/parser/section_test.go
@@ -27,7 +27,7 @@ var _ = Describe("sections - draft", func() {
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
 		It("header with many spaces around content", func() {
@@ -45,7 +45,7 @@ var _ = Describe("sections - draft", func() {
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
 		It("header and paragraph", func() {
@@ -75,7 +75,7 @@ and a paragraph`
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
 		It("two sections with level 0", func() {
@@ -106,7 +106,7 @@ and a paragraph`
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
 		It("section level 1 alone", func() {
@@ -124,7 +124,7 @@ and a paragraph`
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
 		It("section level 1 with quoted text", func() {
@@ -147,7 +147,7 @@ and a paragraph`
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
 		It("section level 0 with nested section level 1", func() {
@@ -177,7 +177,7 @@ and a paragraph`
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
 		It("section level 0 with nested section level 2", func() {
@@ -207,7 +207,7 @@ and a paragraph`
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
 		It("section level 1 with immediate paragraph", func() {
@@ -234,7 +234,7 @@ and a paragraph`
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
 		It("section level 1 with a paragraph separated by empty line", func() {
@@ -263,7 +263,7 @@ and a paragraph`
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
 		It("section level 1 with a paragraph separated by non-empty line", func() {
@@ -290,7 +290,7 @@ and a paragraph`
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
 		It("section levels 1, 2, 3, 2", func() {
@@ -367,7 +367,7 @@ a paragraph`
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
 		It("single section with custom IDs", func() {
@@ -389,7 +389,7 @@ a paragraph`
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
 		It("multiple sections with custom IDs", func() {
@@ -451,7 +451,7 @@ a paragraph`
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
 		It("sections with same title", func() {
@@ -481,7 +481,7 @@ a paragraph`
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
 		It("section with link in title", func() {
@@ -508,7 +508,7 @@ a paragraph`
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
 		It("section 0, 1 and paragraph with bold quote", func() {
@@ -568,7 +568,7 @@ a paragraph with *bold content*`
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 	})
@@ -587,7 +587,7 @@ a paragraph with *bold content*`
 						},
 					},
 				}}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
 		It("header invalid - header space", func() {
@@ -605,7 +605,7 @@ a paragraph with *bold content*`
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
 		It("header with invalid section1", func() {
@@ -635,7 +635,7 @@ a paragraph with *bold content*`
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
 	})
@@ -670,7 +670,7 @@ Doc Writer <thedoc@asciidoctor.org>`
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 	})
 })
@@ -702,7 +702,7 @@ var _ = Describe("sections - document", func() {
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("header with many spaces around content", func() {
@@ -728,7 +728,7 @@ var _ = Describe("sections - document", func() {
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("header and paragraph", func() {
@@ -766,7 +766,7 @@ and a paragraph`
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("two sections with level 0", func() {
@@ -807,7 +807,7 @@ and a paragraph`
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("section level 1 alone", func() {
@@ -833,7 +833,7 @@ and a paragraph`
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("section level 1 with quoted text", func() {
@@ -864,7 +864,7 @@ and a paragraph`
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("section level 0 with nested section level 1", func() {
@@ -905,7 +905,7 @@ and a paragraph`
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("section level 0 with nested section level 2", func() {
@@ -946,7 +946,7 @@ and a paragraph`
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("section level 1 with immediate paragraph", func() {
@@ -982,7 +982,7 @@ and a paragraph`
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("section level 1 with a paragraph separated by empty line", func() {
@@ -1019,7 +1019,7 @@ and a paragraph`
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("section level 1 with a paragraph separated by non-empty line", func() {
@@ -1054,7 +1054,7 @@ and a paragraph`
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("section levels 1, 2, 3, 2", func() {
@@ -1153,7 +1153,7 @@ a paragraph`
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("section levels 1, 2, 3, 3", func() {
@@ -1252,7 +1252,7 @@ a paragraph`
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("section levels 1, 3, 4, 4", func() {
@@ -1351,7 +1351,7 @@ a paragraph`
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("single section with custom IDs", func() {
@@ -1379,7 +1379,7 @@ a paragraph`
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("multiple sections with custom IDs", func() {
@@ -1449,7 +1449,7 @@ a paragraph`
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("sections with same title", func() {
@@ -1490,7 +1490,7 @@ a paragraph`
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("section level 0 with nested section level 1 and custom ID prefix", func() {
@@ -1534,7 +1534,7 @@ a paragraph`
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("section level 0 with nested sections level 1 and custom ID prefixes - with idprefix as doc attribute", func() {
@@ -1594,7 +1594,7 @@ a paragraph`
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("section level 0 with nested sections level 1 and custom ID prefixes - without idprefix as doc attribute", func() {
@@ -1655,7 +1655,7 @@ a paragraph`
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 	})
 
@@ -1678,7 +1678,7 @@ a paragraph`
 						},
 					},
 				}}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("header invalid - missing space", func() {
@@ -1698,7 +1698,7 @@ a paragraph`
 						},
 					},
 				}}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("header invalid - header space", func() {
@@ -1720,7 +1720,7 @@ a paragraph`
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("header with invalid section1", func() {
@@ -1757,7 +1757,7 @@ a paragraph`
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 	})
@@ -1796,7 +1796,7 @@ Doc Writer <thedoc@asciidoctor.org>`
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 	})
 })

--- a/pkg/parser/unordered_list_test.go
+++ b/pkg/parser/unordered_list_test.go
@@ -34,7 +34,7 @@ var _ = Describe("unordered lists - draft", func() {
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
 		It("unordered list with ID, title, role and a single item", func() {
@@ -67,7 +67,7 @@ var _ = Describe("unordered lists - draft", func() {
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 		It("unordered list with a title and a single item", func() {
 			source := `.a title
@@ -94,7 +94,7 @@ var _ = Describe("unordered lists - draft", func() {
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
 		It("unordered list with 2 items with stars", func() {
@@ -142,7 +142,7 @@ var _ = Describe("unordered lists - draft", func() {
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
 		It("unordered list based on article.adoc (with heading spaces)", func() {
@@ -289,7 +289,7 @@ var _ = Describe("unordered lists - draft", func() {
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
 		It("unordered list with 2 items with carets", func() {
@@ -337,7 +337,7 @@ var _ = Describe("unordered lists - draft", func() {
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
 		It("unordered list with items with mixed styles", func() {
@@ -430,7 +430,7 @@ var _ = Describe("unordered lists - draft", func() {
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
 		It("unordered list with 2 items with empty line in-between", func() {
@@ -481,7 +481,7 @@ var _ = Describe("unordered lists - draft", func() {
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 		It("unordered list with 2 items on multiple lines", func() {
 			source := `* item 1
@@ -530,7 +530,7 @@ on 2 lines, too.`
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 		It("unordered lists with 2 empty lines in-between", func() {
 			source := `* an item in the first list
@@ -575,7 +575,7 @@ on 2 lines, too.`
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected)) // parse the whole document to get 2 lists
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected)) // parse the whole document to get 2 lists
 		})
 
 		It("unordered list with items on 3 levels", func() {
@@ -719,7 +719,7 @@ on 2 lines, too.`
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
 		It("max level of unordered items - case 1", func() {
@@ -844,7 +844,7 @@ on 2 lines, too.`
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
 		It("max level of unordered items - case 2", func() {
@@ -968,7 +968,7 @@ on 2 lines, too.`
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 	})
 
@@ -1063,7 +1063,7 @@ on 2 lines, too.`
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
 		It("invalid list item", func() {
@@ -1080,7 +1080,7 @@ on 2 lines, too.`
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 	})
 
@@ -1172,7 +1172,7 @@ another delimited block
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
 		It("unordered list with item continuation - case 2", func() {
@@ -1328,7 +1328,7 @@ The {plus} symbol is on a new line.
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
 		It("unordered list without item continuation", func() {
@@ -1408,7 +1408,7 @@ another delimited block
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 	})
 
@@ -1485,7 +1485,7 @@ paragraph attached to grand parent list item`
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
 		It("attach to parent item", func() {
@@ -1558,7 +1558,7 @@ paragraph attached to parent list item`
 					},
 				},
 			}
-			Expect(ParseDraftDocument(source)).To(Equal(expected))
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 	})
 })
@@ -1598,7 +1598,7 @@ var _ = Describe("unordered lists - document", func() {
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("unordered list with ID, title, role and a single item", func() {
@@ -1640,7 +1640,7 @@ var _ = Describe("unordered lists - document", func() {
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 		It("unordered list with a title and a single item", func() {
 			source := `.a title
@@ -1676,7 +1676,7 @@ var _ = Describe("unordered lists - document", func() {
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("unordered list with 2 items with stars", func() {
@@ -1733,7 +1733,7 @@ var _ = Describe("unordered lists - document", func() {
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("unordered list based on article.adoc (with heading spaces)", func() {
@@ -1904,7 +1904,7 @@ var _ = Describe("unordered lists - document", func() {
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("unordered list with 2 items with carets", func() {
@@ -1961,7 +1961,7 @@ var _ = Describe("unordered lists - document", func() {
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("unordered list with items with mixed styles", func() {
@@ -2078,7 +2078,7 @@ var _ = Describe("unordered lists - document", func() {
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("unordered list with 2 items with empty line in-between", func() {
@@ -2137,7 +2137,7 @@ var _ = Describe("unordered lists - document", func() {
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 		It("unordered list with 2 items on multiple lines", func() {
 			source := `* item 1
@@ -2195,7 +2195,7 @@ on 2 lines, too.`
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 		It("unordered lists with 2 empty lines in-between", func() {
 			// the first blank lines after the first list is swallowed (for the list item)
@@ -2248,7 +2248,7 @@ on 2 lines, too.`
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected)) // parse the whole document to get 2 lists
+			Expect(ParseDocument(source)).To(MatchDocument(expected)) // parse the whole document to get 2 lists
 		})
 
 		It("unordered list with items on 3 levels", func() {
@@ -2416,7 +2416,7 @@ on 2 lines, too.`
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("max level of unordered items - case 1", func() {
@@ -2570,7 +2570,7 @@ on 2 lines, too.`
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("max level of unordered items - case 2", func() {
@@ -2724,7 +2724,7 @@ on 2 lines, too.`
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("unordered list item with predefined attribute", func() {
@@ -2758,7 +2758,7 @@ on 2 lines, too.`
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 	})
 
@@ -2872,7 +2872,7 @@ on 2 lines, too.`
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("invalid list item", func() {
@@ -2893,7 +2893,7 @@ on 2 lines, too.`
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 	})
 
@@ -2988,7 +2988,7 @@ another delimited block
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("unordered list with item continuation - case 2", func() {
@@ -3158,7 +3158,7 @@ The {plus} symbol is on a new line.
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("unordered list without item continuation", func() {
@@ -3252,7 +3252,7 @@ another delimited block
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 	})
 
@@ -3345,7 +3345,7 @@ paragraph attached to grand parent list item`
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
 		It("attach to parent item", func() {
@@ -3434,7 +3434,7 @@ paragraph attached to parent list item`
 					},
 				},
 			}
-			Expect(ParseDocument(source)).To(Equal(expected))
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 	})
 })

--- a/testsupport/document_matcher.go
+++ b/testsupport/document_matcher.go
@@ -1,0 +1,47 @@
+package testsupport
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/bytesparadise/libasciidoc/pkg/types"
+
+	"github.com/davecgh/go-spew/spew"
+	gomegatypes "github.com/onsi/gomega/types"
+	"github.com/pkg/errors"
+	"github.com/sergi/go-diff/diffmatchpatch"
+)
+
+// MatchDocument a custom matcher to verify that a document matches the given expectation
+// Similar to the standard `Equal` matcher, but display a diff when the values don't match
+func MatchDocument(expected types.Document) gomegatypes.GomegaMatcher {
+	return &documentMatcher{
+		expected: expected,
+	}
+}
+
+type documentMatcher struct {
+	expected types.Document
+	diffs    string
+}
+
+func (m *documentMatcher) Match(actual interface{}) (success bool, err error) {
+	if _, ok := actual.(types.Document); !ok {
+		return false, errors.Errorf("MatchDocument matcher expects a Document (actual: %T)", actual)
+	}
+	if !reflect.DeepEqual(m.expected, actual) {
+		dmp := diffmatchpatch.New()
+		diffs := dmp.DiffMain(spew.Sdump(actual), spew.Sdump(m.expected), true)
+		m.diffs = dmp.DiffPrettyText(diffs)
+		return false, nil
+	}
+	return true, nil
+}
+
+func (m *documentMatcher) FailureMessage(_ interface{}) (message string) {
+	return fmt.Sprintf("expected documents to match:\n%s", m.diffs)
+}
+
+func (m *documentMatcher) NegatedFailureMessage(_ interface{}) (message string) {
+	return fmt.Sprintf("expected documents not to match:\n%s", m.diffs)
+}

--- a/testsupport/document_matcher_test.go
+++ b/testsupport/document_matcher_test.go
@@ -1,0 +1,90 @@
+package testsupport_test
+
+import (
+	"fmt"
+
+	"github.com/bytesparadise/libasciidoc/pkg/types"
+	"github.com/bytesparadise/libasciidoc/testsupport"
+
+	"github.com/davecgh/go-spew/spew"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/sergi/go-diff/diffmatchpatch"
+)
+
+var _ = Describe("document matcher", func() {
+
+	// given
+	expected := types.Document{
+		Elements: []interface{}{
+			types.Paragraph{
+				Lines: [][]interface{}{
+					{
+						types.StringElement{
+							Content: "a paragraph.",
+						},
+					},
+				},
+			},
+		},
+	}
+	matcher := testsupport.MatchDocument(expected)
+
+	It("should match", func() {
+		// given
+		actual := types.Document{
+			Elements: []interface{}{
+				types.Paragraph{
+					Lines: [][]interface{}{
+						{
+							types.StringElement{
+								Content: "a paragraph.",
+							},
+						},
+					},
+				},
+			},
+		}
+		// when
+		result, err := matcher.Match(actual)
+		// then
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(BeTrue())
+	})
+
+	It("should not match", func() {
+		// given
+		actual := types.Document{
+			Elements: []interface{}{
+				types.Paragraph{
+					Lines: [][]interface{}{
+						{
+							types.StringElement{
+								Content: "another paragraph.",
+							},
+						},
+					},
+				},
+			},
+		}
+		// when
+		result, err := matcher.Match(actual)
+		// then
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(BeFalse())
+		dmp := diffmatchpatch.New()
+		diffs := dmp.DiffMain(spew.Sdump(actual), spew.Sdump(expected), true)
+		Expect(matcher.FailureMessage(actual)).To(Equal(fmt.Sprintf("expected documents to match:\n%s", dmp.DiffPrettyText(diffs))))
+		Expect(matcher.NegatedFailureMessage(actual)).To(Equal(fmt.Sprintf("expected documents not to match:\n%s", dmp.DiffPrettyText(diffs))))
+	})
+
+	It("should return error when invalid type is input", func() {
+		// when
+		result, err := matcher.Match(1)
+		// then
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(Equal("MatchDocument matcher expects a Document (actual: int)"))
+		Expect(result).To(BeFalse())
+	})
+
+})

--- a/testsupport/draft_document_matcher.go
+++ b/testsupport/draft_document_matcher.go
@@ -1,0 +1,47 @@
+package testsupport
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/bytesparadise/libasciidoc/pkg/types"
+
+	"github.com/davecgh/go-spew/spew"
+	gomegatypes "github.com/onsi/gomega/types"
+	"github.com/pkg/errors"
+	"github.com/sergi/go-diff/diffmatchpatch"
+)
+
+// MatchDraftDocument a custom matcher to verify that a document matches the given expectation
+// Similar to the standard `Equal` matcher, but display a diff when the values don't match
+func MatchDraftDocument(expected types.DraftDocument) gomegatypes.GomegaMatcher {
+	return &draftDocumentMatcher{
+		expected: expected,
+	}
+}
+
+type draftDocumentMatcher struct {
+	expected types.DraftDocument
+	diffs    string
+}
+
+func (m *draftDocumentMatcher) Match(actual interface{}) (success bool, err error) {
+	if _, ok := actual.(types.DraftDocument); !ok {
+		return false, errors.Errorf("MatchDraftDocument matcher expects a DraftDocument (actual: %T)", actual)
+	}
+	if !reflect.DeepEqual(m.expected, actual) {
+		dmp := diffmatchpatch.New()
+		diffs := dmp.DiffMain(spew.Sdump(actual), spew.Sdump(m.expected), true)
+		m.diffs = dmp.DiffPrettyText(diffs)
+		return false, nil
+	}
+	return true, nil
+}
+
+func (m *draftDocumentMatcher) FailureMessage(_ interface{}) (message string) {
+	return fmt.Sprintf("expected draft documents to match:\n%s", m.diffs)
+}
+
+func (m *draftDocumentMatcher) NegatedFailureMessage(_ interface{}) (message string) {
+	return fmt.Sprintf("expected draft documents not to match:\n%s", m.diffs)
+}

--- a/testsupport/draft_document_matcher_test.go
+++ b/testsupport/draft_document_matcher_test.go
@@ -1,0 +1,90 @@
+package testsupport_test
+
+import (
+	"fmt"
+
+	"github.com/bytesparadise/libasciidoc/pkg/types"
+	"github.com/bytesparadise/libasciidoc/testsupport"
+
+	"github.com/davecgh/go-spew/spew"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/sergi/go-diff/diffmatchpatch"
+)
+
+var _ = Describe("draft document matcher", func() {
+
+	// given
+	expected := types.DraftDocument{
+		Blocks: []interface{}{
+			types.Paragraph{
+				Lines: [][]interface{}{
+					{
+						types.StringElement{
+							Content: "a paragraph.",
+						},
+					},
+				},
+			},
+		},
+	}
+	matcher := testsupport.MatchDraftDocument(expected)
+
+	It("should match", func() {
+		// given
+		actual := types.DraftDocument{
+			Blocks: []interface{}{
+				types.Paragraph{
+					Lines: [][]interface{}{
+						{
+							types.StringElement{
+								Content: "a paragraph.",
+							},
+						},
+					},
+				},
+			},
+		}
+		// when
+		result, err := matcher.Match(actual)
+		// then
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(BeTrue())
+	})
+
+	It("should not match", func() {
+		// given
+		actual := types.DraftDocument{
+			Blocks: []interface{}{
+				types.Paragraph{
+					Lines: [][]interface{}{
+						{
+							types.StringElement{
+								Content: "another paragraph.",
+							},
+						},
+					},
+				},
+			},
+		}
+		// when
+		result, err := matcher.Match(actual)
+		// then
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(BeFalse())
+		dmp := diffmatchpatch.New()
+		diffs := dmp.DiffMain(spew.Sdump(actual), spew.Sdump(expected), true)
+		Expect(matcher.FailureMessage(actual)).To(Equal(fmt.Sprintf("expected draft documents to match:\n%s", dmp.DiffPrettyText(diffs))))
+		Expect(matcher.NegatedFailureMessage(actual)).To(Equal(fmt.Sprintf("expected draft documents not to match:\n%s", dmp.DiffPrettyText(diffs))))
+	})
+
+	It("should return error when invalid type is input", func() {
+		// when
+		result, err := matcher.Match(1)
+		// then
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(Equal("MatchDraftDocument matcher expects a DraftDocument (actual: int)"))
+		Expect(result).To(BeFalse())
+	})
+
+})


### PR DESCRIPTION
Create custom Gomega matchers for Document and DraftDocument
Use go-spew and go-diff to provide meaningfull failure messages
when the actual value does not match the expectation

Fixes #536

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>