### PR TITLE
refactor(parser/renderer): address golangci errors

### DIFF
--- a/pkg/parser/document_processing.go
+++ b/pkg/parser/document_processing.go
@@ -40,10 +40,7 @@ func ParseDocument(r io.Reader, config configuration.Configuration) (types.Docum
 
 	blocks, footnotes := processFootnotes(blocks.([]interface{}))
 	// now, rearrange elements in a hierarchical manner
-	doc, err := rearrangeSections(blocks.([]interface{}))
-	if err != nil {
-		return types.Document{}, err
-	}
+	doc := rearrangeSections(blocks.([]interface{}))
 	// also, set the footnotes
 	doc.Footnotes = footnotes
 	// now, add front-matter attributes

--- a/pkg/parser/document_processing_rearrange_sections.go
+++ b/pkg/parser/document_processing_rearrange_sections.go
@@ -8,7 +8,7 @@ import (
 )
 
 // rearrangeSections moves elements into section to obtain a hierarchical document instead of a flat thing
-func rearrangeSections(blocks []interface{}) (types.Document, error) {
+func rearrangeSections(blocks []interface{}) types.Document {
 
 	// use same logic as with list items:
 	// only append a child section to her parent section when
@@ -61,7 +61,7 @@ func rearrangeSections(blocks []interface{}) (types.Document, error) {
 		Attributes:        types.DocumentAttributes{},
 		Elements:          tle,
 		ElementReferences: elementRefs,
-	}, nil
+	}
 }
 
 func referenceSection(e types.Section, elementRefs types.ElementReferences) {

--- a/pkg/parser/document_processing_rearrange_sections_test.go
+++ b/pkg/parser/document_processing_rearrange_sections_test.go
@@ -163,8 +163,7 @@ var _ = Describe("rearrange sections", func() {
 				},
 			},
 		}
-		result, err := rearrangeSections(actual)
-		Expect(err).ToNot(HaveOccurred())
+		result := rearrangeSections(actual)
 		Expect(result).To(Equal(expected))
 	})
 
@@ -323,8 +322,7 @@ var _ = Describe("rearrange sections", func() {
 				},
 			},
 		}
-		result, err := rearrangeSections(actual)
-		Expect(err).ToNot(HaveOccurred())
+		result := rearrangeSections(actual)
 		Expect(result).To(Equal(expected))
 	})
 
@@ -483,8 +481,7 @@ var _ = Describe("rearrange sections", func() {
 				},
 			},
 		}
-		result, err := rearrangeSections(actual)
-		Expect(err).ToNot(HaveOccurred())
+		result := rearrangeSections(actual)
 		Expect(result).To(Equal(expected))
 	})
 

--- a/pkg/renderer/html5/elements.go
+++ b/pkg/renderer/html5/elements.go
@@ -107,7 +107,7 @@ func renderElement(ctx renderer.Context, element interface{}) ([]byte, error) {
 	case types.ImageBlock:
 		return renderImageBlock(ctx, e)
 	case types.InlineImage:
-		return renderInlineImage(ctx, e)
+		return renderInlineImage(e)
 	case types.DelimitedBlock:
 		return renderDelimitedBlock(ctx, e)
 	case types.Table:
@@ -119,7 +119,7 @@ func renderElement(ctx renderer.Context, element interface{}) ([]byte, error) {
 	case types.StringElement:
 		return renderStringElement(ctx, e)
 	case types.FootnoteReference:
-		return renderFootnoteReference(ctx, e)
+		return renderFootnoteReference(e)
 	case types.LineBreak:
 		return renderLineBreak()
 	case types.UserMacro:
@@ -127,7 +127,7 @@ func renderElement(ctx renderer.Context, element interface{}) ([]byte, error) {
 	case types.IndexTerm:
 		return renderIndexTerm(ctx, e)
 	case types.ConcealedIndexTerm:
-		return renderConcealedIndexTerm(ctx, e)
+		return renderConcealedIndexTerm(e)
 	default:
 		return nil, errors.Errorf("unsupported type of element: %T", element)
 	}
@@ -158,7 +158,7 @@ func renderPlainText(ctx renderer.Context, element interface{}) ([]byte, error) 
 		return renderLines(ctx, element.Lines, PlainText())
 	case types.FootnoteReference:
 		// footnotes are rendered in HTML so they can appear as such in the table of contents
-		return renderFootnoteReferencePlainText(ctx, element)
+		return renderFootnoteReferencePlainText(element)
 	default:
 		return nil, errors.Errorf("unable to render plain string for element of type '%T'", element)
 	}

--- a/pkg/renderer/html5/footnote_reference.go
+++ b/pkg/renderer/html5/footnote_reference.go
@@ -57,7 +57,7 @@ func renderFootnoteIndex(idx int) string {
 	return strconv.Itoa(idx + 1)
 }
 
-func renderFootnoteReference(_ renderer.Context, note types.FootnoteReference) ([]byte, error) {
+func renderFootnoteReference(note types.FootnoteReference) ([]byte, error) {
 	result := bytes.NewBuffer(nil)
 	if note.ID != types.InvalidFootnoteReference && !note.Duplicate {
 		// valid case for a footnote with content, with our without an explicit reference
@@ -97,7 +97,7 @@ func renderFootnoteReference(_ renderer.Context, note types.FootnoteReference) (
 	return result.Bytes(), nil
 }
 
-func renderFootnoteReferencePlainText(_ renderer.Context, note types.FootnoteReference) ([]byte, error) {
+func renderFootnoteReferencePlainText(note types.FootnoteReference) ([]byte, error) {
 	result := bytes.NewBuffer(nil)
 	if note.ID != types.InvalidFootnoteReference {
 		// valid case for a footnte with content, with our without an explicit reference

--- a/pkg/renderer/html5/image.go
+++ b/pkg/renderer/html5/image.go
@@ -64,7 +64,7 @@ func renderImageBlock(ctx renderer.Context, img types.ImageBlock) ([]byte, error
 	return result.Bytes(), nil
 }
 
-func renderInlineImage(ctx renderer.Context, img types.InlineImage) ([]byte, error) {
+func renderInlineImage(img types.InlineImage) ([]byte, error) {
 	result := bytes.NewBuffer(nil)
 	err := inlineImageTmpl.Execute(result, struct {
 		Role   string

--- a/pkg/renderer/html5/index_term.go
+++ b/pkg/renderer/html5/index_term.go
@@ -9,6 +9,6 @@ func renderIndexTerm(ctx renderer.Context, t types.IndexTerm) ([]byte, error) {
 	return renderInlineElements(ctx, t.Term)
 }
 
-func renderConcealedIndexTerm(_ renderer.Context, _ types.ConcealedIndexTerm) ([]byte, error) {
+func renderConcealedIndexTerm(_ types.ConcealedIndexTerm) ([]byte, error) {
 	return []byte{}, nil // do not render
 }

--- a/pkg/renderer/html5/table_of_contents.go
+++ b/pkg/renderer/html5/table_of_contents.go
@@ -88,7 +88,7 @@ func renderTableOfContentsSections(ctx renderer.Context, sections []types.ToCSec
 		return template.HTML(""), errors.Wrap(err, "failed to render document ToC")
 	}
 	log.Debugf("retrieved sections for ToC: %+v", sections)
-	return template.HTML(resultBuf.String()), nil
+	return template.HTML(resultBuf.String()), nil //nolint: gosec
 }
 
 // NewTableOfContents initializes a TableOfContents from the sections


### PR DESCRIPTION
Address errors reported by `golangci-lint ./...`

Fixes #541

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>