### PR TITLE
feat(renderer): include authors in 'meta' tag

### DIFF
--- a/libasciidoc_test.go
+++ b/libasciidoc_test.go
@@ -240,7 +240,7 @@ a paragraph with _italic content_`
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="generator" content="libasciidoc">
 <link type="text/css" rel="stylesheet" href="path/to/style.css">

--- a/pkg/renderer/html5/document_details_test.go
+++ b/pkg/renderer/html5/document_details_test.go
@@ -26,9 +26,10 @@ v1.0, March 22, 2020: Containment
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="generator" content="libasciidoc">
+<meta name="author" content="Xavier">
 <title>Document Title</title>
 </head>
 <body class="article">
@@ -61,16 +62,17 @@ Last updated {{.LastUpdated}}
 
 		It("header with 2 authors and no revision", func() {
 			source := `= Document Title
-John Foo Doe <johndoe@example.com>; Lazarus het_Draeke <lazarus@asciidoctor.org>`
+John Foo Doe <johndoe@example.com>; Jane Doe <janedoe@example.com>`
 			// top-level section is not rendered per-say,
 			// but the section will be used to set the HTML page's <title> element
 			expected := `<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="generator" content="libasciidoc">
+<meta name="author" content="John Foo Doe; Jane Doe">
 <title>Document Title</title>
 </head>
 <body class="article">
@@ -79,8 +81,8 @@ John Foo Doe <johndoe@example.com>; Lazarus het_Draeke <lazarus@asciidoctor.org>
 <div class="details">
 <span id="author" class="author">John Foo Doe</span><br>
 <span id="email" class="email"><a href="mailto:johndoe@example.com">johndoe@example.com</a></span><br>
-<span id="author2" class="author">Lazarus het Draeke</span><br>
-<span id="email2" class="email"><a href="mailto:lazarus@asciidoctor.org">lazarus@asciidoctor.org</a></span><br>
+<span id="author2" class="author">Jane Doe</span><br>
+<span id="email2" class="email"><a href="mailto:janedoe@example.com">janedoe@example.com</a></span><br>
 </div>
 </div>
 <div id="content">
@@ -111,7 +113,7 @@ a paragraph`
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="generator" content="libasciidoc">
 <title>Document Title</title>
@@ -147,7 +149,7 @@ a paragraph`
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="generator" content="libasciidoc">
 <title>Document Title</title>
@@ -180,7 +182,7 @@ a paragraph`
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="generator" content="libasciidoc">
 <title>Document Title</title>
@@ -215,7 +217,7 @@ a paragraph`
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="generator" content="libasciidoc">
 <title>Document Title</title>

--- a/pkg/renderer/html5/html5.go
+++ b/pkg/renderer/html5/html5.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	htmltemplate "html/template"
 	"io"
+	"strings"
 	texttemplate "text/template"
 
 	"github.com/bytesparadise/libasciidoc/pkg/configuration"
@@ -24,10 +25,11 @@ func init() {
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">{{ if .Generator }}
 <meta name="generator" content="{{ .Generator }}">{{ end }}{{ if .CSS}}
-<link type="text/css" rel="stylesheet" href="{{ .CSS }}">{{ end }}
+<link type="text/css" rel="stylesheet" href="{{ .CSS }}">{{ end }}{{ if .Authors }}
+<meta name="author" content="{{ .Authors }}">{{ end }}
 <title>{{ escape .Title }}</title>
 </head>
 <body class="{{ .Doctype }}">{{ if .IncludeHeader }}
@@ -84,6 +86,7 @@ func Render(ctx renderer.Context, doc types.Document, output io.Writer) (types.M
 			Generator     string
 			Doctype       string
 			Title         string
+			Authors       string
 			Header        string
 			Content       htmltemplate.HTML
 			RevNumber     string
@@ -95,6 +98,7 @@ func Render(ctx renderer.Context, doc types.Document, output io.Writer) (types.M
 			Generator:     "libasciidoc", // TODO: externalize this value and include the lib version ?
 			Doctype:       doc.Attributes.GetAsStringWithDefault(types.AttrDocType, "article"),
 			Title:         string(renderedTitle),
+			Authors:       renderAuthors(doc.Attributes.GetAuthors()),
 			Header:        string(renderedHeader),
 			Content:       htmltemplate.HTML(string(renderedContent)), //nolint: gosec
 			RevNumber:     revNumber,
@@ -187,6 +191,14 @@ func splitAndRenderForManpage(ctx renderer.Context, doc types.Document) ([]byte,
 	result.WriteString("\n")
 	result.Write(renderedContent)
 	return []byte{}, result.Bytes(), nil
+}
+
+func renderAuthors(authors []types.DocumentAuthor) string {
+	authorStrs := make([]string, len(authors))
+	for i, author := range authors {
+		authorStrs[i] = author.FullName
+	}
+	return strings.Join(authorStrs, "; ")
 }
 
 func renderDocumentTitle(ctx renderer.Context, doc types.Document) ([]byte, error) {

--- a/pkg/renderer/html5/html5_test.go
+++ b/pkg/renderer/html5/html5_test.go
@@ -19,7 +19,7 @@ var _ = Describe("document header", func() {
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="generator" content="libasciidoc">
 <link type="text/css" rel="stylesheet" href="/path/to/style.css">
@@ -168,10 +168,11 @@ Free use of this software is granted under the terms of the MIT License.`
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="generator" content="libasciidoc">
 <link type="text/css" rel="stylesheet" href="/path/to/style.css">
+<meta name="author" content="Andrew Stanton">
 <title>eve(1)</title>
 </head>
 <body class="manpage">

--- a/pkg/types/document_attributes.go
+++ b/pkg/types/document_attributes.go
@@ -95,6 +95,14 @@ func (a DocumentAttributes) GetAsStringWithDefault(key, defaultValue string) str
 	return defaultValue
 }
 
+// GetAuthors returns the authors or empty slice if none was set in the document
+func (a DocumentAttributes) GetAuthors() []DocumentAuthor {
+	if authors, ok := a[AttrAuthors].([]DocumentAuthor); ok {
+		return authors
+	}
+	return []DocumentAuthor{}
+}
+
 // DocumentAttributesWithOverrides the document attributes with some overrides provided by the CLI (for example)
 type DocumentAttributesWithOverrides struct {
 	Content   map[string]interface{}


### PR DESCRIPTION
Include authors (semicolon-separated list) in a
`<meta name="author">` tag in the document head

Fixes #543

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>