### PR TITLE
chore(build): build on Windows with GitHub Actions

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -13,12 +13,12 @@ on:
 jobs:
   
   test:
-    runs-on: ${{ matrix.platform }}
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         go-version: [1.13.x, 1.14.x]
-        platform: [ubuntu-latest, macos-latest, windows-latest]
-    name: ${{ matrix.platform }} with Go ${{ matrix.go-version }}
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    name: ${{ matrix.os }} with Go ${{ matrix.go-version }}
     
     steps:
     - name: Install Go
@@ -40,5 +40,11 @@ jobs:
     - name: Test
       run: |
         make test-with-coverage
+
+    - name: Codecov
+      uses: codecov/codecov-action@v1.0.6
+      with:
+        # Path to coverage file to upload
+        file: coverage.txt
     
   

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -42,6 +42,7 @@ jobs:
         make test-with-coverage
 
     - name: Codecov
+      if: runner.os == 'Linux' 
       uses: codecov/codecov-action@v1.0.6
       with:
         # Path to coverage file to upload

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -17,12 +17,12 @@ jobs:
     strategy:
       matrix:
         go-version: [1.13.x, 1.14.x]
-        platform: [ubuntu-latest, macos-latest]
+        platform: [ubuntu-latest, macos-latest, windows-latest]
     name: ${{ matrix.platform }} with Go ${{ matrix.go-version }}
     
     steps:
     - name: Install Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
         go-version: ${{ matrix.go-version }}
     
@@ -33,16 +33,12 @@ jobs:
       run: 
         make install-devtools
       
-    - name: Test on Linux and macOS
-      if: runner.os == 'Linux' || runner.os == 'macOS'
+    - name: Build 
       run: |
-        export PATH=$PATH:$(go env GOPATH)/bin
-        make test-with-coverage
-    
-    - name: Build on Linux/macOS
-      if: runner.os == 'Linux' || runner.os == 'macOS'
-      run: |
-        export PATH=$PATH:$(go env GOPATH)/bin
         make build
       
+    - name: Test
+      run: |
+        make test-with-coverage
+    
   

--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,7 @@ test: generate-optimized
 test-with-coverage: generate-optimized
 	@echo $(COVERPKGS)
 	@ginkgo -r --randomizeAllSpecs --randomizeSuites --failOnPending --trace --race --compilers=0  --cover -coverpkg $(COVERPKGS)
+	@gover . coverage.txt
 
 .PHONY: test-fixtures
 ## run all fixtures tests


### PR DESCRIPTION
Use `actions/setup-go@v2` so that installed tools are available in `PATH`

Fixes #518