### PR TITLE
refactor(renderer): discard quote replacement in HTML

### DIFF
--- a/libasciidoc_test.go
+++ b/libasciidoc_test.go
@@ -296,7 +296,7 @@ Free use of this software is granted under the terms of the MIT License.`
 
 				expectedContent := `<h2 id="_name">Name</h2>
 <div class="sectionbody">
-<p>eve - analyzes an image to determine if it&#39;s a picture of a life form</p>
+<p>eve - analyzes an image to determine if it's a picture of a life form</p>
 </div>
 <div class="sect1">
 <h2 id="_synopsis">Synopsis</h2>
@@ -355,7 +355,7 @@ Free use of this software is granted under the terms of the MIT License.`
 <h1>eve(1) Manual Page</h1>
 <h2 id="_name">Name</h2>
 <div class="sectionbody">
-<p>eve - analyzes an image to determine if it&#39;s a picture of a life form</p>
+<p>eve - analyzes an image to determine if it's a picture of a life form</p>
 </div>
 </div>
 <div id="content">
@@ -434,7 +434,7 @@ Free use of this software is granted under the terms of the MIT License.`
 <h2 id="_foo">Foo</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p>eve - analyzes an image to determine if it&#39;s a picture of a life form</p>
+<p>eve - analyzes an image to determine if it's a picture of a life form</p>
 </div>
 </div>
 </div>

--- a/pkg/renderer/html5/delimited_block_test.go
+++ b/pkg/renderer/html5/delimited_block_test.go
@@ -130,10 +130,10 @@ end
 ----`
 			expected := `<div class="listingblock">
 <div class="content">
-<pre class="highlight"><code>require &#39;sinatra&#39;
+<pre class="highlight"><code>require 'sinatra'
 
-get &#39;/hi&#39; do
-  &#34;Hello World!&#34;
+get '/hi' do
+  "Hello World!"
 end</code></pre>
 </div>
 </div>`
@@ -154,10 +154,10 @@ end
 			expected := `<div class="listingblock">
 <div class="title">Source block title</div>
 <div class="content">
-<pre class="highlight"><code class="language-ruby" data-lang="ruby">require &#39;sinatra&#39;
+<pre class="highlight"><code class="language-ruby" data-lang="ruby">require 'sinatra'
 
-get &#39;/hi&#39; do
-  &#34;Hello World!&#34;
+get '/hi' do
+  "Hello World!"
 end</code></pre>
 </div>
 </div>`
@@ -178,10 +178,10 @@ end
 			expected := `<div class="listingblock">
 <div class="title">Source block title</div>
 <div class="content">
-<pre class="highlight"><code class="language-ruby" data-lang="ruby">require &#39;sinatra&#39;
+<pre class="highlight"><code class="language-ruby" data-lang="ruby">require 'sinatra'
 
-get &#39;/hi&#39; do
-  &#34;Hello World!&#34;
+get '/hi' do
+  "Hello World!"
 end</code></pre>
 </div>
 </div>`
@@ -202,10 +202,10 @@ end
 			expected := `<div id="id-for-source-block" class="listingblock">
 <div class="title">app.rb</div>
 <div class="content">
-<pre class="highlight"><code class="language-ruby" data-lang="ruby">require &#39;sinatra&#39;
+<pre class="highlight"><code class="language-ruby" data-lang="ruby">require 'sinatra'
 
-get &#39;/hi&#39; do
-  &#34;Hello World!&#34;
+get '/hi' do
+  "Hello World!"
 end</code></pre>
 </div>
 </div>`
@@ -297,7 +297,7 @@ and "more" content
 <p><strong>bold content</strong></p>
 </div>
 <div class="paragraph">
-<p>and &#34;more&#34; content</p>
+<p>and "more" content</p>
 </div>
 </div>
 </div>`

--- a/pkg/renderer/html5/file_inclusion_test.go
+++ b/pkg/renderer/html5/file_inclusion_test.go
@@ -234,11 +234,11 @@ include::../../../test/includes/hello_world.go.txt[]`
 <p>package includes</p>
 </div>
 <div class="paragraph">
-<p>import &#34;fmt&#34;</p>
+<p>import "fmt"</p>
 </div>
 <div class="paragraph">
 <p>func helloworld() {
-	fmt.Println(&#34;hello, world!&#34;)
+	fmt.Println("hello, world!")
 }</p>
 </div>`
 		Expect(RenderHTML(source)).To(MatchHTML(expected))
@@ -285,11 +285,11 @@ include::../../../test/includes/hello_world.go.txt[]`
 <p>package includes</p>
 </div>
 <div class="paragraph">
-<p>import &#34;fmt&#34;</p>
+<p>import "fmt"</p>
 </div>
 <div class="paragraph">
 <p>func helloworld() {
-	fmt.Println(&#34;hello, world!&#34;)
+	fmt.Println("hello, world!")
 }</p>
 </div>
 </div>
@@ -455,10 +455,10 @@ include::../../../test/includes/hello_world.go.txt[]
 <div class="content">
 <pre>package includes
 
-import &#34;fmt&#34;
+import "fmt"
 
 func helloworld() {
-	fmt.Println(&#34;hello, world!&#34;)
+	fmt.Println("hello, world!")
 }</pre>
 </div>
 </div>`
@@ -493,11 +493,11 @@ include::../../../test/includes/hello_world.go.txt[]
 <p>package includes</p>
 </div>
 <div class="paragraph">
-<p>import &#34;fmt&#34;</p>
+<p>import "fmt"</p>
 </div>
 <div class="paragraph">
 <p>func helloworld() {
-	fmt.Println(&#34;hello, world!&#34;)
+	fmt.Println("hello, world!")
 }</p>
 </div>
 </div>
@@ -515,11 +515,11 @@ ____`
 <p>package includes</p>
 </div>
 <div class="paragraph">
-<p>import &#34;fmt&#34;</p>
+<p>import "fmt"</p>
 </div>
 <div class="paragraph">
 <p>func helloworld() {
-	fmt.Println(&#34;hello, world!&#34;)
+	fmt.Println("hello, world!")
 }</p>
 </div>
 </blockquote>
@@ -535,10 +535,10 @@ ____`
 				expected := `<div class="verseblock">
 <pre class="content">package includes
 
-import &#34;fmt&#34;
+import "fmt"
 
 func helloworld() {
-	fmt.Println(&#34;hello, world!&#34;)
+	fmt.Println("hello, world!")
 }</pre>
 </div>`
 				Expect(RenderHTML(source)).To(MatchHTML(expected))
@@ -554,11 +554,11 @@ include::../../../test/includes/hello_world.go.txt[]
 <p>package includes</p>
 </div>
 <div class="paragraph">
-<p>import &#34;fmt&#34;</p>
+<p>import "fmt"</p>
 </div>
 <div class="paragraph">
 <p>func helloworld() {
-	fmt.Println(&#34;hello, world!&#34;)
+	fmt.Println("hello, world!")
 }</p>
 </div>
 </div>
@@ -584,7 +584,7 @@ include::../../../test/includes/hello_world.go.txt[]
 				source := `include::../../../test/includes/hello_world.go.txt[lines=5..7]`
 				expected := `<div class="paragraph">
 <p>func helloworld() {
-	fmt.Println(&#34;hello, world!&#34;)
+	fmt.Println("hello, world!")
 }</p>
 </div>`
 				Expect(RenderHTML(source)).To(MatchHTML(expected))
@@ -597,7 +597,7 @@ include::../../../test/includes/hello_world.go.txt[]
 </div>
 <div class="paragraph">
 <p>func helloworld() {
-	fmt.Println(&#34;hello, world!&#34;)
+	fmt.Println("hello, world!")
 }</p>
 </div>`
 				Expect(RenderHTML(source)).To(MatchHTML(expected))
@@ -625,7 +625,7 @@ include::../../../test/includes/hello_world.go.txt[lines=5..7]
 				expected := `<div class="listingblock">
 <div class="content">
 <pre>func helloworld() {
-	fmt.Println(&#34;hello, world!&#34;)
+	fmt.Println("hello, world!")
 }</pre>
 </div>
 </div>`
@@ -641,7 +641,7 @@ include::../../../test/includes/hello_world.go.txt[lines=1..2;5..7]
 <pre>package includes
 
 func helloworld() {
-	fmt.Println(&#34;hello, world!&#34;)
+	fmt.Println("hello, world!")
 }</pre>
 </div>
 </div>`

--- a/pkg/renderer/html5/html5_test.go
+++ b/pkg/renderer/html5/html5_test.go
@@ -180,7 +180,7 @@ Free use of this software is granted under the terms of the MIT License.`
 <h1>eve(1) Manual Page</h1>
 <h2 id="_name">Name</h2>
 <div class="sectionbody">
-<p>eve - analyzes an image to determine if it&#39;s a picture of a life form</p>
+<p>eve - analyzes an image to determine if it's a picture of a life form</p>
 </div>
 </div>
 <div id="content">
@@ -203,7 +203,7 @@ Free use of this software is granted under the terms of the MIT License.`
 </dd>
 <dt class="hdlist1"><strong>-c, --capture</strong></dt>
 <dd>
-<p>Capture specimen if it&#39;s a picture of a life form.</p>
+<p>Capture specimen if it's a picture of a life form.</p>
 </dd>
 </dl>
 </div>
@@ -308,7 +308,7 @@ Free use of this software is granted under the terms of the MIT License.`
 
 		expected := `<h2 id="_name">Name</h2>
 <div class="sectionbody">
-<p>eve - analyzes an image to determine if it&#39;s a picture of a life form</p>
+<p>eve - analyzes an image to determine if it's a picture of a life form</p>
 </div>
 <div class="sect1">
 <h2 id="_synopsis">Synopsis</h2>
@@ -329,7 +329,7 @@ Free use of this software is granted under the terms of the MIT License.`
 </dd>
 <dt class="hdlist1"><strong>-c, --capture</strong></dt>
 <dd>
-<p>Capture specimen if it&#39;s a picture of a life form.</p>
+<p>Capture specimen if it's a picture of a life form.</p>
 </dd>
 </dl>
 </div>

--- a/pkg/renderer/html5/html_escape.go
+++ b/pkg/renderer/html5/html_escape.go
@@ -17,8 +17,8 @@ var htmlEscaper = strings.NewReplacer(
 	`&#`, "&#", // assume this is for an character entity and this keep as-is
 	// standard escape combinations
 	`&`, "&amp;",
-	`'`, "&#39;", // "&#39;" is shorter than "&apos;" and apos was not in HTML until HTML5.
 	`<`, "&lt;",
 	`>`, "&gt;",
-	`"`, "&#34;", // "&#34;" is shorter than "&quot;".
+	// `'`, "&#39;", // "&#39;" is shorter than "&apos;" and apos was not in HTML until HTML5.
+	// `"`, "&#34;", // "&#34;" is shorter than "&quot;".
 )

--- a/pkg/renderer/html5/labeled_list_test.go
+++ b/pkg/renderer/html5/labeled_list_test.go
@@ -95,7 +95,7 @@ item 2:: description 2.`
 <dl>
 <dt class="hdlist1">item 1</dt>
 <dd>
-<p>&lt;script&gt;alert(&#34;foo!&#34;)&lt;/script&gt;</p>
+<p>&lt;script&gt;alert("foo!")&lt;/script&gt;</p>
 </dd>
 </dl>
 </div>`

--- a/pkg/renderer/html5/ordered_list_test.go
+++ b/pkg/renderer/html5/ordered_list_test.go
@@ -367,7 +367,7 @@ print("one")
 <p></p>
 <div class="listingblock">
 <div class="content">
-<pre>print(&#34;one&#34;)</pre>
+<pre>print("one")</pre>
 </div>
 </div>
 </li>
@@ -375,7 +375,7 @@ print("one")
 <p></p>
 <div class="listingblock">
 <div class="content">
-<pre>print(&#34;one&#34;)</pre>
+<pre>print("one")</pre>
 </div>
 </div>
 </li>

--- a/pkg/renderer/html5/paragraph_test.go
+++ b/pkg/renderer/html5/paragraph_test.go
@@ -61,7 +61,7 @@ and here another paragraph
 		It("paragraph with single quotes", func() {
 			source := `a 'subsection' paragraph.`
 			expected := `<div class="paragraph">
-<p>a &#39;subsection&#39; paragraph.</p>
+<p>a 'subsection' paragraph.</p>
 </div>`
 			Expect(RenderHTML(source)).To(MatchHTML(expected))
 		})

--- a/test/fixtures/supported/lists.html
+++ b/test/fixtures/supported/lists.html
@@ -309,7 +309,7 @@ This is test, only a test.
 <p>level 3
 This is a new line inside an unordered list using &#43; symbol.
 We can even force content to start on a separate line&#8230;&#8203;<br>
-Amazing, isn&#39;t it?</p>
+Amazing, isn't it?</p>
 <div class="ulist">
 <ul>
 <li>

--- a/test/fixtures/supported/sample.html
+++ b/test/fixtures/supported/sample.html
@@ -26,7 +26,7 @@ This is test, only a test.
 <div class="sect2">
 <h3 id="id_section_a_subsection">Section A Subsection</h3>
 <div class="paragraph">
-<p><strong>Section A</strong> &#39;subsection&#39; paragraph.</p>
+<p><strong>Section A</strong> 'subsection' paragraph.</p>
 </div>
 </div>
 </div>


### PR DESCRIPTION
No need to replace `'` and `"` with `&#39;` and `&#34;`.

Fixes #565

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>