### PR TITLE
fix(types): `CalloutListItem` must implement `DocumentElement`

### DIFF
--- a/pkg/renderer/html5/delimited_block_test.go
+++ b/pkg/renderer/html5/delimited_block_test.go
@@ -135,13 +135,14 @@ import <1>
 			Expect(RenderHTML(source)).To(MatchHTML(expected))
 		})
 
-		It("with multiple callouts on different lines", func() {
+		It("with multiple callouts and blankline between calloutitems", func() {
 			source := `----
 import <1>
 
 func foo() {} <2>
 ----
 <1> an import
+
 <2> a func`
 			expected := `<div class="listingblock">
 <div class="content">

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -734,7 +734,7 @@ func NewOrderedListItem(prefix OrderedListItemPrefix, elements []interface{}, at
 	}, nil
 }
 
-// GetAttributes returns the elements of this UnorderedListItem
+// GetAttributes returns the elements of this OrderedListItem
 func (i OrderedListItem) GetAttributes() ElementAttributes {
 	return i.Attributes
 }
@@ -1007,7 +1007,7 @@ func NewLabeledListItem(level int, term []interface{}, description interface{}, 
 	}, nil
 }
 
-// GetAttributes returns the elements of this UnorderedListItem
+// GetAttributes returns the elements of this LabeledListItem
 func (i LabeledListItem) GetAttributes() ElementAttributes {
 	return i.Attributes
 }
@@ -1419,6 +1419,15 @@ type CalloutListItem struct {
 	Attributes ElementAttributes
 	Ref        int
 	Elements   []interface{}
+}
+
+var _ ListItem = &CalloutListItem{}
+
+var _ DocumentElement = &CalloutListItem{}
+
+// GetAttributes returns the elements of this CalloutListItem
+func (i CalloutListItem) GetAttributes() ElementAttributes {
+	return i.Attributes
 }
 
 // AddElement add an element to this CalloutListItem


### PR DESCRIPTION
fixes #568

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>