### PR TITLE
fix(renderer): do not HTML escape content twice in source blocks

### DIFF
--- a/pkg/renderer/html5/delimited_block.go
+++ b/pkg/renderer/html5/delimited_block.go
@@ -62,10 +62,9 @@ func init() {
 		})
 
 	sourceBlockContentTmpl = newTextTemplate("source block content",
-		`{{ $ctx := .Context }}{{ with .Data }}{{ render $ctx .Elements | printf "%s" | escape }}{{ end }}`,
+		`{{ $ctx := .Context }}{{ with .Data }}{{ render $ctx .Elements | printf "%s" }}{{ end }}`,
 		texttemplate.FuncMap{
 			"render": renderElements,
-			"escape": EscapeString,
 		})
 
 	exampleBlockTmpl = newTextTemplate("example block", `{{ $ctx := .Context }}{{ with .Data }}<div {{ if .ID }}id="{{ .ID }}" {{ end }}class="exampleblock">{{ if .Title }}

--- a/pkg/renderer/html5/delimited_block_test.go
+++ b/pkg/renderer/html5/delimited_block_test.go
@@ -336,6 +336,63 @@ end</code></pre>
 </div>`
 			Expect(RenderHTML(source)).To(MatchHTML(expected))
 		})
+		It("with callouts and syntax highlighting", func() {
+			source := `[source,java]
+----
+@QuarkusTest
+public class GreetingResourceTest {
+
+    @InjectMock
+    @RestClient // <1>
+    GreetingService greetingService;
+
+    @Test
+    public void testHelloEndpoint() {
+        Mockito.when(greetingService.hello()).thenReturn("hello from mockito");
+
+        given()
+          .when().get("/hello")
+          .then()
+             .statusCode(200)
+             .body(is("hello from mockito"));
+    }
+
+}
+----
+<1> We need to use the @RestClient CDI qualifier, since Quarkus creates the GreetingService bean with this qualifier.
+`
+			expected := `<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-java" data-lang="java">@QuarkusTest
+public class GreetingResourceTest {
+
+    @InjectMock
+    @RestClient // <b class="conum">(1)</b>
+    GreetingService greetingService;
+
+    @Test
+    public void testHelloEndpoint() {
+        Mockito.when(greetingService.hello()).thenReturn("hello from mockito");
+
+        given()
+          .when().get("/hello")
+          .then()
+             .statusCode(200)
+             .body(is("hello from mockito"));
+    }
+
+}</code></pre>
+</div>
+</div>
+<div class="colist arabic">
+<ol>
+<li>
+<p>We need to use the @RestClient CDI qualifier, since Quarkus creates the GreetingService bean with this qualifier.</p>
+</li>
+</ol>
+</div>`
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+		})
 	})
 
 	Context("example blocks", func() {


### PR DESCRIPTION
remove call to `escape` on the content of the source block

Fixes #570

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>