### PR TITLE
chore(build): set iteration count on benchmarks (100x)

### DIFF
--- a/make/bench.mk
+++ b/make/bench.mk
@@ -5,6 +5,7 @@ bench: generate-optimized
 	@go test -cpuprofile=tmp/bench/reports/$(GIT_BRANCH_NAME)-$(GIT_COMMIT_ID_SHORT).cpu.prof \
 		-memprofile tmp/bench/reports/$(GIT_BRANCH_NAME)-$(GIT_COMMIT_ID_SHORT).mem.prof \
 		-bench=. \
+		-benchtime=100x \
 		github.com/bytesparadise/libasciidoc \
 		-run=XXX
 	@echo "generate CPU reports..."


### PR DESCRIPTION
setting an iteration count instead of letting the benchmark
toolo decided how many iterations are enough.
This will allow for better comparisons of proposed changes

Fixes #575

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
