### PR TITLE
Add support for (TM) and (R) in markup.

### DIFF
--- a/pkg/renderer/html5/string.go
+++ b/pkg/renderer/html5/string.go
@@ -21,7 +21,7 @@ func renderStringElement(ctx renderer.Context, str types.StringElement) ([]byte,
 	if err != nil {
 		return []byte{}, errors.Wrapf(err, "unable to render string")
 	}
-	result := convert(buf.String(), ellipsis, copyright)
+	result := convert(buf.String(), ellipsis, copyright, trademark, registered)
 	return []byte(result), nil
 }
 
@@ -31,6 +31,14 @@ func ellipsis(source string) string {
 
 func copyright(source string) string {
 	return strings.Replace(source, "(C)", "&#169;", -1)
+}
+
+func trademark(source string) string {
+	return strings.Replace(source, "(TM)", "&#153;", -1)
+}
+
+func registered(source string) string {
+	return strings.Replace(source, "(R)", "&#174;", -1)
 }
 
 type converter func(string) string

--- a/pkg/renderer/html5/string_test.go
+++ b/pkg/renderer/html5/string_test.go
@@ -11,8 +11,6 @@ var _ = Describe("strings", func() {
 
 	It("text with ellipsis", func() {
 		source := `some text...`
-		// top-level section is not rendered per-say,
-		// but the section will be used to set the HTML page's <title> element
 		expected := `<div class="paragraph">
 <p>some text&#8230;&#8203;</p>
 </div>`
@@ -21,10 +19,35 @@ var _ = Describe("strings", func() {
 
 	It("text with copyright", func() {
 		source := `Copyright (C)`
-		// top-level section is not rendered per-say,
-		// but the section will be used to set the HTML page's <title> element
 		expected := `<div class="paragraph">
 <p>Copyright &#169;</p>
+</div>`
+		Expect(RenderHTML(source)).To(MatchHTML(expected))
+	})
+
+	It("text with trademark", func() {
+		source := `TheRightThing(TM)`
+		expected := `<div class="paragraph">
+<p>TheRightThing&#153;</p>
+</div>`
+		Expect(RenderHTML(source)).To(MatchHTML(expected))
+	})
+
+	It("text with registered", func() {
+		source := `TheRightThing(R)`
+		expected := `<div class="paragraph">
+<p>TheRightThing&#174;</p>
+</div>`
+		Expect(RenderHTML(source)).To(MatchHTML(expected))
+	})
+
+	It("title with registered", func() {
+		// We will often want to use these symbols in headers.
+		source := `== Registered(R)`
+		expected := `<div class="sect1">
+<h2 id="_registered_r">Registered&#174;</h2>
+<div class="sectionbody">
+</div>
 </div>`
 		Expect(RenderHTML(source)).To(MatchHTML(expected))
 	})


### PR DESCRIPTION
This adds trademark and registered trademark symbols.

I thought about adding support for the single and double arrows and emdash substitutions as well, but those are harder.

The arrows contain < and > and need to parsed and replaced before the &gt; and &lt; entities get substituted (so order of parsing is a problem).  The emdash actually needs a little context as well, as it only gets replaced when it is flanked appropriately, and it also can cause spaces to get replaced with thin spaces if it is flanked by spaces on both sides.
