### PR TITLE
feat(renderer): role not honored on h1 titles (#583)

### DIFF
--- a/pkg/renderer/html5/html5.go
+++ b/pkg/renderer/html5/html5.go
@@ -32,7 +32,7 @@ func init() {
 <link type="text/css" rel="stylesheet" href="{{ .CSS }}">{{ end }}
 <title>{{ escape .Title }}</title>
 </head>
-<body class="{{ .Doctype }}">{{ if .IncludeHeader }}
+<body class="{{ .Doctype }}{{ if .Role }} {{ .Role }}{{ end }}">{{ if .IncludeHeader }}
 {{ .Header }}{{ end }}
 <div id="content">
 {{ .Content }}
@@ -87,6 +87,7 @@ func Render(ctx renderer.Context, doc types.Document, output io.Writer) (types.M
 			Title         string
 			Authors       string
 			Header        string
+			Role          string
 			Content       htmltemplate.HTML
 			RevNumber     string
 			LastUpdated   string
@@ -99,6 +100,7 @@ func Render(ctx renderer.Context, doc types.Document, output io.Writer) (types.M
 			Title:         string(renderedTitle),
 			Authors:       renderAuthors(doc.Attributes.GetAuthors()),
 			Header:        string(renderedHeader),
+			Role:          documentRole(doc),
 			Content:       htmltemplate.HTML(string(renderedContent)), //nolint: gosec
 			RevNumber:     doc.Attributes.GetAsStringWithDefault("revnumber", ""),
 			LastUpdated:   ctx.Config.LastUpdated.Format(configuration.LastUpdatedFormat),
@@ -190,6 +192,13 @@ func splitAndRenderForManpage(ctx renderer.Context, doc types.Document) ([]byte,
 	result.WriteString("\n")
 	result.Write(renderedContent)
 	return []byte{}, result.Bytes(), nil
+}
+
+func documentRole(doc types.Document) string {
+	if header, exists := doc.Header(); exists {
+		return header.Attributes.GetAsString(types.AttrRole)
+	}
+	return ""
 }
 
 func renderAuthors(authors []types.DocumentAuthor) string {

--- a/pkg/renderer/html5/html5_test.go
+++ b/pkg/renderer/html5/html5_test.go
@@ -46,6 +46,40 @@ Last updated {{.LastUpdated}}
 			To(MatchHTMLTemplate(expected, now))
 	})
 
+	It("header with role", func() {
+		source := `[.my_role]
+= My Title`
+		expected := `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="generator" content="libasciidoc">
+<link type="text/css" rel="stylesheet" href="/path/to/style.css">
+<title>My Title</title>
+</head>
+<body class="article my_role">
+<div id="header">
+<h1>My Title</h1>
+</div>
+<div id="content">
+
+</div>
+<div id="footer">
+<div id="footer-text">
+Last updated {{.LastUpdated}}
+</div>
+</div>
+</body>
+</html>`
+		now := time.Now()
+		Expect(RenderHTML(source, configuration.WithHeaderFooter(true),
+			configuration.WithCSS("/path/to/style.css"),
+			configuration.WithLastUpdated(now))).
+			To(MatchHTMLTemplate(expected, now))
+	})
+
 	It("should include adoc file without leveloffset from relative file", func() {
 		source := "include::../../../../test/includes/grandchild-include.adoc[]" // with filename `tmp/foo.adoc`, we are virtually in a subfolder
 		expectedContent := `<div class="sect1">


### PR DESCRIPTION
This adds support for setting the role on a level 0 title,
which will cause the class for the document body to be set.