### PR TITLE
Refactor bench and profile make targets

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -11,7 +11,7 @@ on:
 
 
 jobs:
-  
+
   test:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -19,22 +19,22 @@ jobs:
         go-version: [1.13.x, 1.14.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     name: ${{ matrix.os }} with Go ${{ matrix.go-version }}
-    
+
     steps:
     - name: Install Go
       uses: actions/setup-go@v2
       with:
         go-version: ${{ matrix.go-version }}
-    
+
     - name: Checkout code
       uses: actions/checkout@v2
-      
-    - name: Build 
+
+    - name: Build
       run: |
         make build
-      
+
     - name: Lint
-      if: runner.os == 'Linux' 
+      if: runner.os == 'Linux'
       run: |
         make lint
 
@@ -43,15 +43,15 @@ jobs:
         make test-with-coverage
 
     - name: Codecov
-      if: runner.os == 'Linux' 
+      if: runner.os == 'Linux'
       uses: codecov/codecov-action@v1.0.6
       with:
         # Path to coverage file to upload
         file: coverage.txt
 
-    - name: bench
-      if: runner.os == 'Linux' 
+    - name: Smoke Test Benchmarks
+      if: runner.os == 'Linux'
       run: |
-        make bench
-  
-  
+        make bench-smoke
+
+

--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ coverage.txt
 !pkg/**/*.html
 *libasciidoc.html
 profile*.*
+!make/*.mk

--- a/make/bench.mk
+++ b/make/bench.mk
@@ -1,32 +1,20 @@
 .PHONY: bench
-## run the benchmarks on the parser
+## run the top-level benchmarks
 bench: generate-optimized
 	@mkdir -p ./tmp/bench/reports
-	@go test -cpuprofile=tmp/bench/reports/$(GIT_BRANCH_NAME)-$(GIT_COMMIT_ID_SHORT).cpu.prof \
-		-memprofile tmp/bench/reports/$(GIT_BRANCH_NAME)-$(GIT_COMMIT_ID_SHORT).mem.prof \
-		-bench=. \
-		-benchtime=100x \
+	@go test -bench=. -benchmem -count=5 -run=XXX \
 		github.com/bytesparadise/libasciidoc \
-		-run=XXX
-	@echo "generate CPU reports..."
-	@go tool pprof -text -output=tmp/bench/reports/$(GIT_BRANCH_NAME)-$(GIT_COMMIT_ID_SHORT).cpu.txt \
-		tmp/bench/reports/$(GIT_BRANCH_NAME)-$(GIT_COMMIT_ID_SHORT).cpu.prof
-ifndef CI
-	@go tool pprof -svg -output=tmp/bench/reports/$(GIT_BRANCH_NAME)-$(GIT_COMMIT_ID_SHORT).cpu.svg \
-		tmp/bench/reports/$(GIT_BRANCH_NAME)-$(GIT_COMMIT_ID_SHORT).cpu.prof
-endif
-	@echo "generate memory reports"
-	@go tool pprof -text -output=tmp/bench/reports/$(GIT_BRANCH_NAME)-$(GIT_COMMIT_ID_SHORT).mem.txt \
-		tmp/bench/reports/$(GIT_BRANCH_NAME)-$(GIT_COMMIT_ID_SHORT).mem.prof
-ifndef CI
-	@go tool pprof -svg -output=tmp/bench/reports/$(GIT_BRANCH_NAME)-$(GIT_COMMIT_ID_SHORT).mem.svg \
-		tmp/bench/reports/$(GIT_BRANCH_NAME)-$(GIT_COMMIT_ID_SHORT).mem.prof
-endif
+		| tee tmp/bench/reports/$(GIT_BRANCH_NAME)-$(GIT_COMMIT_ID_SHORT).bench
+	@echo "generated tmp/bench/reports/$(GIT_BRANCH_NAME)-$(GIT_COMMIT_ID_SHORT).bench"
 
-
+.PHONY: bench-smoke
+## smoke test the top-level benchmarks
+bench-smoke: generate-optimized
+	@go test -bench=. -benchmem -benchtime=1x -run=XXX \
+		github.com/bytesparadise/libasciidoc
 
 .PHONY: bench-parser
-## run the benchmarks on the parser
+## run the benchmarks on the parser
 bench-parser: generate
 	@ginkgo -tags bench -focus "real-world doc-based benchmarks" -memprofile=./tmp/bench/bench.memory pkg/parser
 	@ginkgo -tags bench -focus "basic stats" pkg/parser

--- a/make/profile.mk
+++ b/make/profile.mk
@@ -1,0 +1,25 @@
+.PHONY: profile
+## run the profilers on the parser
+profile: generate-optimized
+	@mkdir -p ./tmp/bench/reports
+	@go test -cpuprofile=tmp/bench/reports/$(GIT_BRANCH_NAME)-$(GIT_COMMIT_ID_SHORT).cpu.prof \
+		-memprofile tmp/bench/reports/$(GIT_BRANCH_NAME)-$(GIT_COMMIT_ID_SHORT).mem.prof \
+		-bench=. \
+		-benchtime=1x \
+		github.com/bytesparadise/libasciidoc \
+		-run=XXX
+	@echo "generate CPU reports..."
+	@go tool pprof -text -output=tmp/bench/reports/$(GIT_BRANCH_NAME)-$(GIT_COMMIT_ID_SHORT).cpu.txt \
+		tmp/bench/reports/$(GIT_BRANCH_NAME)-$(GIT_COMMIT_ID_SHORT).cpu.prof
+ifndef CI
+	@go tool pprof -svg -output=tmp/bench/reports/$(GIT_BRANCH_NAME)-$(GIT_COMMIT_ID_SHORT).cpu.svg \
+		tmp/bench/reports/$(GIT_BRANCH_NAME)-$(GIT_COMMIT_ID_SHORT).cpu.prof
+endif
+	@echo "generate memory reports"
+	@go tool pprof -text -output=tmp/bench/reports/$(GIT_BRANCH_NAME)-$(GIT_COMMIT_ID_SHORT).mem.txt \
+		tmp/bench/reports/$(GIT_BRANCH_NAME)-$(GIT_COMMIT_ID_SHORT).mem.prof
+ifndef CI
+	@go tool pprof -svg -output=tmp/bench/reports/$(GIT_BRANCH_NAME)-$(GIT_COMMIT_ID_SHORT).mem.svg \
+		tmp/bench/reports/$(GIT_BRANCH_NAME)-$(GIT_COMMIT_ID_SHORT).mem.prof
+endif
+


### PR DESCRIPTION
Create a separate `profile` target for profiling. Only run the
benchmarks once in this target.

Update `bench` target to make five passes and save the output to a file
for use with `benchstat`.

Add a `bench-smoke` target to smoke test the top-level benchmarks by
running them only once.  This target is run via CI to ensure that the
benchmarks are functional.

Fixes #580