### PR TITLE
feat(parser/render) Support typographic quote marks

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"unicode"
 	"unicode/utf8"
 
@@ -2705,35 +2706,433 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "Section",
-			pos:  position{line: 369, col: 1, offset: 12503},
+			name: "QuotedString",
+			pos:  position{line: 370, col: 1, offset: 12551},
 			expr: &actionExpr{
-				pos: position{line: 369, col: 12, offset: 12514},
+				pos: position{line: 370, col: 17, offset: 12567},
+				run: (*parser).callonQuotedString1,
+				expr: &labeledExpr{
+					pos:   position{line: 370, col: 17, offset: 12567},
+					label: "qs",
+					expr: &choiceExpr{
+						pos: position{line: 370, col: 21, offset: 12571},
+						alternatives: []interface{}{
+							&ruleRefExpr{
+								pos:  position{line: 370, col: 21, offset: 12571},
+								name: "SingleQuotedString",
+							},
+							&ruleRefExpr{
+								pos:  position{line: 370, col: 42, offset: 12592},
+								name: "DoubleQuotedString",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "SingleQuotedString",
+			pos:  position{line: 374, col: 1, offset: 12640},
+			expr: &actionExpr{
+				pos: position{line: 374, col: 23, offset: 12662},
+				run: (*parser).callonSingleQuotedString1,
+				expr: &seqExpr{
+					pos: position{line: 374, col: 23, offset: 12662},
+					exprs: []interface{}{
+						&litMatcher{
+							pos:        position{line: 374, col: 23, offset: 12662},
+							val:        "'`",
+							ignoreCase: false,
+							want:       "\"'`\"",
+						},
+						&labeledExpr{
+							pos:   position{line: 374, col: 28, offset: 12667},
+							label: "elements",
+							expr: &ruleRefExpr{
+								pos:  position{line: 374, col: 37, offset: 12676},
+								name: "SingleQuotedStringElements",
+							},
+						},
+						&litMatcher{
+							pos:        position{line: 374, col: 64, offset: 12703},
+							val:        "`'",
+							ignoreCase: false,
+							want:       "\"`'\"",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "SingleQuotedStringElements",
+			pos:  position{line: 378, col: 1, offset: 12814},
+			expr: &actionExpr{
+				pos: position{line: 378, col: 31, offset: 12844},
+				run: (*parser).callonSingleQuotedStringElements1,
+				expr: &labeledExpr{
+					pos:   position{line: 378, col: 31, offset: 12844},
+					label: "elements",
+					expr: &oneOrMoreExpr{
+						pos: position{line: 378, col: 41, offset: 12854},
+						expr: &ruleRefExpr{
+							pos:  position{line: 378, col: 41, offset: 12854},
+							name: "SingleQuotedStringElement",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "SingleQuotedStringElement",
+			pos:  position{line: 383, col: 1, offset: 13019},
+			expr: &actionExpr{
+				pos: position{line: 383, col: 30, offset: 13048},
+				run: (*parser).callonSingleQuotedStringElement1,
+				expr: &labeledExpr{
+					pos:   position{line: 383, col: 30, offset: 13048},
+					label: "element",
+					expr: &choiceExpr{
+						pos: position{line: 384, col: 9, offset: 13067},
+						alternatives: []interface{}{
+							&ruleRefExpr{
+								pos:  position{line: 384, col: 9, offset: 13067},
+								name: "LineBreak",
+							},
+							&oneOrMoreExpr{
+								pos: position{line: 385, col: 11, offset: 13113},
+								expr: &ruleRefExpr{
+									pos:  position{line: 385, col: 11, offset: 13113},
+									name: "Space",
+								},
+							},
+							&ruleRefExpr{
+								pos:  position{line: 386, col: 11, offset: 13131},
+								name: "InlineIcon",
+							},
+							&ruleRefExpr{
+								pos:  position{line: 387, col: 11, offset: 13153},
+								name: "InlineImage",
+							},
+							&ruleRefExpr{
+								pos:  position{line: 388, col: 11, offset: 13176},
+								name: "InlineFootnote",
+							},
+							&ruleRefExpr{
+								pos:  position{line: 389, col: 11, offset: 13202},
+								name: "InlinePassthrough",
+							},
+							&ruleRefExpr{
+								pos:  position{line: 390, col: 11, offset: 13231},
+								name: "Link",
+							},
+							&ruleRefExpr{
+								pos:  position{line: 391, col: 11, offset: 13247},
+								name: "AttributeSubstitution",
+							},
+							&ruleRefExpr{
+								pos:  position{line: 392, col: 11, offset: 13280},
+								name: "BoldText",
+							},
+							&ruleRefExpr{
+								pos:  position{line: 393, col: 11, offset: 13300},
+								name: "ItalicText",
+							},
+							&ruleRefExpr{
+								pos:  position{line: 394, col: 11, offset: 13322},
+								name: "MarkedText",
+							},
+							&ruleRefExpr{
+								pos:  position{line: 395, col: 11, offset: 13344},
+								name: "SubscriptText",
+							},
+							&ruleRefExpr{
+								pos:  position{line: 396, col: 11, offset: 13369},
+								name: "SuperscriptText",
+							},
+							&seqExpr{
+								pos: position{line: 397, col: 11, offset: 13396},
+								exprs: []interface{}{
+									&notExpr{
+										pos: position{line: 397, col: 11, offset: 13396},
+										expr: &litMatcher{
+											pos:        position{line: 397, col: 12, offset: 13397},
+											val:        "`'",
+											ignoreCase: false,
+											want:       "\"`'\"",
+										},
+									},
+									&ruleRefExpr{
+										pos:  position{line: 397, col: 17, offset: 13402},
+										name: "MonospaceText",
+									},
+								},
+							},
+							&ruleRefExpr{
+								pos:  position{line: 398, col: 11, offset: 13427},
+								name: "DoubleQuotedString",
+							},
+							&ruleRefExpr{
+								pos:  position{line: 399, col: 11, offset: 13457},
+								name: "SingleQuotedStringFallbackCharacter",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "SingleQuotedStringFallbackCharacter",
+			pos:  position{line: 403, col: 1, offset: 13527},
+			expr: &choiceExpr{
+				pos: position{line: 403, col: 41, offset: 13567},
+				alternatives: []interface{}{
+					&charClassMatcher{
+						pos:        position{line: 403, col: 41, offset: 13567},
+						val:        "[^\\r\\n`]",
+						chars:      []rune{'\r', '\n', '`'},
+						ignoreCase: false,
+						inverted:   true,
+					},
+					&actionExpr{
+						pos: position{line: 403, col: 52, offset: 13578},
+						run: (*parser).callonSingleQuotedStringFallbackCharacter3,
+						expr: &seqExpr{
+							pos: position{line: 403, col: 52, offset: 13578},
+							exprs: []interface{}{
+								&litMatcher{
+									pos:        position{line: 403, col: 52, offset: 13578},
+									val:        "`",
+									ignoreCase: false,
+									want:       "\"`\"",
+								},
+								&notExpr{
+									pos: position{line: 403, col: 56, offset: 13582},
+									expr: &litMatcher{
+										pos:        position{line: 403, col: 57, offset: 13583},
+										val:        "'",
+										ignoreCase: false,
+										want:       "\"'\"",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "DoubleQuotedString",
+			pos:  position{line: 407, col: 1, offset: 13646},
+			expr: &actionExpr{
+				pos: position{line: 407, col: 23, offset: 13668},
+				run: (*parser).callonDoubleQuotedString1,
+				expr: &seqExpr{
+					pos: position{line: 407, col: 23, offset: 13668},
+					exprs: []interface{}{
+						&litMatcher{
+							pos:        position{line: 407, col: 23, offset: 13668},
+							val:        "\"`",
+							ignoreCase: false,
+							want:       "\"\\\"`\"",
+						},
+						&labeledExpr{
+							pos:   position{line: 407, col: 29, offset: 13674},
+							label: "elements",
+							expr: &ruleRefExpr{
+								pos:  position{line: 407, col: 38, offset: 13683},
+								name: "DoubleQuotedStringElements",
+							},
+						},
+						&litMatcher{
+							pos:        position{line: 407, col: 65, offset: 13710},
+							val:        "`\"",
+							ignoreCase: false,
+							want:       "\"`\\\"\"",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "DoubleQuotedStringElements",
+			pos:  position{line: 412, col: 1, offset: 13824},
+			expr: &actionExpr{
+				pos: position{line: 412, col: 31, offset: 13854},
+				run: (*parser).callonDoubleQuotedStringElements1,
+				expr: &labeledExpr{
+					pos:   position{line: 412, col: 31, offset: 13854},
+					label: "elements",
+					expr: &oneOrMoreExpr{
+						pos: position{line: 412, col: 41, offset: 13864},
+						expr: &ruleRefExpr{
+							pos:  position{line: 412, col: 41, offset: 13864},
+							name: "DoubleQuotedStringElement",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "DoubleQuotedStringElement",
+			pos:  position{line: 417, col: 1, offset: 14029},
+			expr: &actionExpr{
+				pos: position{line: 417, col: 30, offset: 14058},
+				run: (*parser).callonDoubleQuotedStringElement1,
+				expr: &labeledExpr{
+					pos:   position{line: 417, col: 30, offset: 14058},
+					label: "element",
+					expr: &choiceExpr{
+						pos: position{line: 418, col: 9, offset: 14077},
+						alternatives: []interface{}{
+							&ruleRefExpr{
+								pos:  position{line: 418, col: 9, offset: 14077},
+								name: "LineBreak",
+							},
+							&ruleRefExpr{
+								pos:  position{line: 420, col: 11, offset: 14142},
+								name: "InlineIcon",
+							},
+							&ruleRefExpr{
+								pos:  position{line: 421, col: 11, offset: 14164},
+								name: "InlineImage",
+							},
+							&ruleRefExpr{
+								pos:  position{line: 422, col: 11, offset: 14187},
+								name: "InlineFootnote",
+							},
+							&ruleRefExpr{
+								pos:  position{line: 423, col: 11, offset: 14213},
+								name: "InlinePassthrough",
+							},
+							&ruleRefExpr{
+								pos:  position{line: 424, col: 11, offset: 14242},
+								name: "Link",
+							},
+							&ruleRefExpr{
+								pos:  position{line: 425, col: 11, offset: 14258},
+								name: "AttributeSubstitution",
+							},
+							&ruleRefExpr{
+								pos:  position{line: 426, col: 11, offset: 14291},
+								name: "BoldText",
+							},
+							&ruleRefExpr{
+								pos:  position{line: 427, col: 11, offset: 14311},
+								name: "ItalicText",
+							},
+							&ruleRefExpr{
+								pos:  position{line: 428, col: 11, offset: 14333},
+								name: "MarkedText",
+							},
+							&ruleRefExpr{
+								pos:  position{line: 429, col: 11, offset: 14355},
+								name: "SubscriptText",
+							},
+							&ruleRefExpr{
+								pos:  position{line: 430, col: 11, offset: 14380},
+								name: "SuperscriptText",
+							},
+							&seqExpr{
+								pos: position{line: 431, col: 11, offset: 14407},
+								exprs: []interface{}{
+									&notExpr{
+										pos: position{line: 431, col: 11, offset: 14407},
+										expr: &litMatcher{
+											pos:        position{line: 431, col: 12, offset: 14408},
+											val:        "`\"",
+											ignoreCase: false,
+											want:       "\"`\\\"\"",
+										},
+									},
+									&ruleRefExpr{
+										pos:  position{line: 431, col: 18, offset: 14414},
+										name: "MonospaceText",
+									},
+								},
+							},
+							&ruleRefExpr{
+								pos:  position{line: 432, col: 11, offset: 14439},
+								name: "SingleQuotedString",
+							},
+							&ruleRefExpr{
+								pos:  position{line: 433, col: 11, offset: 14469},
+								name: "DoubleQuotedStringFallbackCharacter",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "DoubleQuotedStringFallbackCharacter",
+			pos:  position{line: 437, col: 1, offset: 14547},
+			expr: &actionExpr{
+				pos: position{line: 437, col: 41, offset: 14587},
+				run: (*parser).callonDoubleQuotedStringFallbackCharacter1,
+				expr: &choiceExpr{
+					pos: position{line: 437, col: 42, offset: 14588},
+					alternatives: []interface{}{
+						&charClassMatcher{
+							pos:        position{line: 437, col: 42, offset: 14588},
+							val:        "[^\\r\\n`]",
+							chars:      []rune{'\r', '\n', '`'},
+							ignoreCase: false,
+							inverted:   true,
+						},
+						&seqExpr{
+							pos: position{line: 437, col: 53, offset: 14599},
+							exprs: []interface{}{
+								&litMatcher{
+									pos:        position{line: 437, col: 53, offset: 14599},
+									val:        "`",
+									ignoreCase: false,
+									want:       "\"`\"",
+								},
+								&notExpr{
+									pos: position{line: 437, col: 57, offset: 14603},
+									expr: &litMatcher{
+										pos:        position{line: 437, col: 58, offset: 14604},
+										val:        "\"",
+										ignoreCase: false,
+										want:       "\"\\\"\"",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Section",
+			pos:  position{line: 444, col: 1, offset: 14776},
+			expr: &actionExpr{
+				pos: position{line: 444, col: 12, offset: 14787},
 				run: (*parser).callonSection1,
 				expr: &seqExpr{
-					pos: position{line: 369, col: 12, offset: 12514},
+					pos: position{line: 444, col: 12, offset: 14787},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 369, col: 12, offset: 12514},
+							pos:   position{line: 444, col: 12, offset: 14787},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 369, col: 23, offset: 12525},
+								pos: position{line: 444, col: 23, offset: 14798},
 								expr: &ruleRefExpr{
-									pos:  position{line: 369, col: 24, offset: 12526},
+									pos:  position{line: 444, col: 24, offset: 14799},
 									name: "Attributes",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 370, col: 5, offset: 12544},
+							pos:   position{line: 445, col: 5, offset: 14817},
 							label: "level",
 							expr: &actionExpr{
-								pos: position{line: 370, col: 12, offset: 12551},
+								pos: position{line: 445, col: 12, offset: 14824},
 								run: (*parser).callonSection7,
 								expr: &oneOrMoreExpr{
-									pos: position{line: 370, col: 12, offset: 12551},
+									pos: position{line: 445, col: 12, offset: 14824},
 									expr: &litMatcher{
-										pos:        position{line: 370, col: 13, offset: 12552},
+										pos:        position{line: 445, col: 13, offset: 14825},
 										val:        "=",
 										ignoreCase: false,
 										want:       "\"=\"",
@@ -2742,37 +3141,37 @@ var g = &grammar{
 							},
 						},
 						&andCodeExpr{
-							pos: position{line: 374, col: 5, offset: 12647},
+							pos: position{line: 449, col: 5, offset: 14920},
 							run: (*parser).callonSection10,
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 378, col: 5, offset: 12803},
+							pos: position{line: 453, col: 5, offset: 15076},
 							expr: &ruleRefExpr{
-								pos:  position{line: 378, col: 5, offset: 12803},
+								pos:  position{line: 453, col: 5, offset: 15076},
 								name: "Space",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 378, col: 12, offset: 12810},
+							pos:   position{line: 453, col: 12, offset: 15083},
 							label: "title",
 							expr: &ruleRefExpr{
-								pos:  position{line: 378, col: 19, offset: 12817},
+								pos:  position{line: 453, col: 19, offset: 15090},
 								name: "TitleElements",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 378, col: 34, offset: 12832},
+							pos:   position{line: 453, col: 34, offset: 15105},
 							label: "id",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 378, col: 38, offset: 12836},
+								pos: position{line: 453, col: 38, offset: 15109},
 								expr: &ruleRefExpr{
-									pos:  position{line: 378, col: 38, offset: 12836},
+									pos:  position{line: 453, col: 38, offset: 15109},
 									name: "InlineElementID",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 378, col: 56, offset: 12854},
+							pos:  position{line: 453, col: 56, offset: 15127},
 							name: "EOL",
 						},
 					},
@@ -2781,34 +3180,34 @@ var g = &grammar{
 		},
 		{
 			name: "TitleElements",
-			pos:  position{line: 382, col: 1, offset: 12964},
+			pos:  position{line: 457, col: 1, offset: 15237},
 			expr: &actionExpr{
-				pos: position{line: 382, col: 18, offset: 12981},
+				pos: position{line: 457, col: 18, offset: 15254},
 				run: (*parser).callonTitleElements1,
 				expr: &labeledExpr{
-					pos:   position{line: 382, col: 18, offset: 12981},
+					pos:   position{line: 457, col: 18, offset: 15254},
 					label: "elements",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 382, col: 27, offset: 12990},
+						pos: position{line: 457, col: 27, offset: 15263},
 						expr: &seqExpr{
-							pos: position{line: 382, col: 28, offset: 12991},
+							pos: position{line: 457, col: 28, offset: 15264},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 382, col: 28, offset: 12991},
+									pos: position{line: 457, col: 28, offset: 15264},
 									expr: &ruleRefExpr{
-										pos:  position{line: 382, col: 29, offset: 12992},
+										pos:  position{line: 457, col: 29, offset: 15265},
 										name: "Newline",
 									},
 								},
 								&notExpr{
-									pos: position{line: 382, col: 37, offset: 13000},
+									pos: position{line: 457, col: 37, offset: 15273},
 									expr: &ruleRefExpr{
-										pos:  position{line: 382, col: 38, offset: 13001},
+										pos:  position{line: 457, col: 38, offset: 15274},
 										name: "InlineElementID",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 382, col: 54, offset: 13017},
+									pos:  position{line: 457, col: 54, offset: 15290},
 									name: "TitleElement",
 								},
 							},
@@ -2819,65 +3218,69 @@ var g = &grammar{
 		},
 		{
 			name: "TitleElement",
-			pos:  position{line: 386, col: 1, offset: 13142},
+			pos:  position{line: 461, col: 1, offset: 15415},
 			expr: &actionExpr{
-				pos: position{line: 386, col: 17, offset: 13158},
+				pos: position{line: 461, col: 17, offset: 15431},
 				run: (*parser).callonTitleElement1,
 				expr: &labeledExpr{
-					pos:   position{line: 386, col: 17, offset: 13158},
+					pos:   position{line: 461, col: 17, offset: 15431},
 					label: "element",
 					expr: &choiceExpr{
-						pos: position{line: 386, col: 26, offset: 13167},
+						pos: position{line: 461, col: 26, offset: 15440},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 386, col: 26, offset: 13167},
+								pos:  position{line: 461, col: 26, offset: 15440},
 								name: "Word",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 387, col: 11, offset: 13183},
+								pos:  position{line: 462, col: 11, offset: 15456},
 								name: "LineBreak",
 							},
 							&oneOrMoreExpr{
-								pos: position{line: 388, col: 11, offset: 13229},
+								pos: position{line: 463, col: 11, offset: 15502},
 								expr: &ruleRefExpr{
-									pos:  position{line: 388, col: 11, offset: 13229},
+									pos:  position{line: 463, col: 11, offset: 15502},
 									name: "Space",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 389, col: 11, offset: 13248},
+								pos:  position{line: 464, col: 11, offset: 15521},
 								name: "CrossReference",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 390, col: 11, offset: 13274},
+								pos:  position{line: 465, col: 11, offset: 15547},
 								name: "InlinePassthrough",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 391, col: 11, offset: 13303},
+								pos:  position{line: 466, col: 11, offset: 15576},
 								name: "InlineIcon",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 392, col: 11, offset: 13325},
+								pos:  position{line: 467, col: 11, offset: 15598},
 								name: "InlineImage",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 393, col: 11, offset: 13348},
+								pos:  position{line: 468, col: 11, offset: 15621},
 								name: "Link",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 394, col: 11, offset: 13364},
+								pos:  position{line: 469, col: 11, offset: 15637},
 								name: "InlineFootnote",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 395, col: 11, offset: 13390},
+								pos:  position{line: 470, col: 11, offset: 15663},
+								name: "QuotedString",
+							},
+							&ruleRefExpr{
+								pos:  position{line: 471, col: 11, offset: 15687},
 								name: "QuotedText",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 396, col: 11, offset: 13412},
+								pos:  position{line: 472, col: 11, offset: 15709},
 								name: "AttributeSubstitution",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 397, col: 11, offset: 13445},
+								pos:  position{line: 473, col: 11, offset: 15742},
 								name: "AnyChar",
 							},
 						},
@@ -2887,18 +3290,18 @@ var g = &grammar{
 		},
 		{
 			name: "TableOfContentsPlaceHolder",
-			pos:  position{line: 404, col: 1, offset: 13603},
+			pos:  position{line: 480, col: 1, offset: 15900},
 			expr: &seqExpr{
-				pos: position{line: 404, col: 31, offset: 13633},
+				pos: position{line: 480, col: 31, offset: 15930},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 404, col: 31, offset: 13633},
+						pos:        position{line: 480, col: 31, offset: 15930},
 						val:        "toc::[]",
 						ignoreCase: false,
 						want:       "\"toc::[]\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 404, col: 41, offset: 13643},
+						pos:  position{line: 480, col: 41, offset: 15940},
 						name: "EOL",
 					},
 				},
@@ -2906,40 +3309,40 @@ var g = &grammar{
 		},
 		{
 			name: "UserMacroBlock",
-			pos:  position{line: 409, col: 1, offset: 13759},
+			pos:  position{line: 485, col: 1, offset: 16056},
 			expr: &actionExpr{
-				pos: position{line: 409, col: 19, offset: 13777},
+				pos: position{line: 485, col: 19, offset: 16074},
 				run: (*parser).callonUserMacroBlock1,
 				expr: &seqExpr{
-					pos: position{line: 409, col: 19, offset: 13777},
+					pos: position{line: 485, col: 19, offset: 16074},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 409, col: 19, offset: 13777},
+							pos:   position{line: 485, col: 19, offset: 16074},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 409, col: 25, offset: 13783},
+								pos:  position{line: 485, col: 25, offset: 16080},
 								name: "UserMacroName",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 409, col: 40, offset: 13798},
+							pos:        position{line: 485, col: 40, offset: 16095},
 							val:        "::",
 							ignoreCase: false,
 							want:       "\"::\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 409, col: 45, offset: 13803},
+							pos:   position{line: 485, col: 45, offset: 16100},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 409, col: 52, offset: 13810},
+								pos:  position{line: 485, col: 52, offset: 16107},
 								name: "UserMacroValue",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 409, col: 68, offset: 13826},
+							pos:   position{line: 485, col: 68, offset: 16123},
 							label: "attrs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 409, col: 75, offset: 13833},
+								pos:  position{line: 485, col: 75, offset: 16130},
 								name: "UserMacroAttributes",
 							},
 						},
@@ -2949,40 +3352,40 @@ var g = &grammar{
 		},
 		{
 			name: "InlineUserMacro",
-			pos:  position{line: 413, col: 1, offset: 13952},
+			pos:  position{line: 489, col: 1, offset: 16249},
 			expr: &actionExpr{
-				pos: position{line: 413, col: 20, offset: 13971},
+				pos: position{line: 489, col: 20, offset: 16268},
 				run: (*parser).callonInlineUserMacro1,
 				expr: &seqExpr{
-					pos: position{line: 413, col: 20, offset: 13971},
+					pos: position{line: 489, col: 20, offset: 16268},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 413, col: 20, offset: 13971},
+							pos:   position{line: 489, col: 20, offset: 16268},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 413, col: 26, offset: 13977},
+								pos:  position{line: 489, col: 26, offset: 16274},
 								name: "UserMacroName",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 413, col: 41, offset: 13992},
+							pos:        position{line: 489, col: 41, offset: 16289},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 413, col: 45, offset: 13996},
+							pos:   position{line: 489, col: 45, offset: 16293},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 413, col: 52, offset: 14003},
+								pos:  position{line: 489, col: 52, offset: 16300},
 								name: "UserMacroValue",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 413, col: 68, offset: 14019},
+							pos:   position{line: 489, col: 68, offset: 16316},
 							label: "attrs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 413, col: 75, offset: 14026},
+								pos:  position{line: 489, col: 75, offset: 16323},
 								name: "UserMacroAttributes",
 							},
 						},
@@ -2992,14 +3395,14 @@ var g = &grammar{
 		},
 		{
 			name: "UserMacroName",
-			pos:  position{line: 417, col: 1, offset: 14146},
+			pos:  position{line: 493, col: 1, offset: 16443},
 			expr: &actionExpr{
-				pos: position{line: 417, col: 18, offset: 14163},
+				pos: position{line: 493, col: 18, offset: 16460},
 				run: (*parser).callonUserMacroName1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 417, col: 19, offset: 14164},
+					pos: position{line: 493, col: 19, offset: 16461},
 					expr: &charClassMatcher{
-						pos:        position{line: 417, col: 19, offset: 14164},
+						pos:        position{line: 493, col: 19, offset: 16461},
 						val:        "[\\pL0-9_-]",
 						chars:      []rune{'_', '-'},
 						ranges:     []rune{'0', '9'},
@@ -3012,14 +3415,14 @@ var g = &grammar{
 		},
 		{
 			name: "UserMacroValue",
-			pos:  position{line: 421, col: 1, offset: 14217},
+			pos:  position{line: 497, col: 1, offset: 16514},
 			expr: &actionExpr{
-				pos: position{line: 421, col: 19, offset: 14235},
+				pos: position{line: 497, col: 19, offset: 16532},
 				run: (*parser).callonUserMacroValue1,
 				expr: &zeroOrMoreExpr{
-					pos: position{line: 421, col: 19, offset: 14235},
+					pos: position{line: 497, col: 19, offset: 16532},
 					expr: &charClassMatcher{
-						pos:        position{line: 421, col: 19, offset: 14235},
+						pos:        position{line: 497, col: 19, offset: 16532},
 						val:        "[^:[ \\r\\n]",
 						chars:      []rune{':', '[', ' ', '\r', '\n'},
 						ignoreCase: false,
@@ -3030,32 +3433,32 @@ var g = &grammar{
 		},
 		{
 			name: "UserMacroAttributes",
-			pos:  position{line: 425, col: 1, offset: 14287},
+			pos:  position{line: 501, col: 1, offset: 16584},
 			expr: &actionExpr{
-				pos: position{line: 425, col: 24, offset: 14310},
+				pos: position{line: 501, col: 24, offset: 16607},
 				run: (*parser).callonUserMacroAttributes1,
 				expr: &seqExpr{
-					pos: position{line: 425, col: 24, offset: 14310},
+					pos: position{line: 501, col: 24, offset: 16607},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 425, col: 24, offset: 14310},
+							pos:        position{line: 501, col: 24, offset: 16607},
 							val:        "[",
 							ignoreCase: false,
 							want:       "\"[\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 425, col: 28, offset: 14314},
+							pos:   position{line: 501, col: 28, offset: 16611},
 							label: "attrs",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 425, col: 34, offset: 14320},
+								pos: position{line: 501, col: 34, offset: 16617},
 								expr: &ruleRefExpr{
-									pos:  position{line: 425, col: 35, offset: 14321},
+									pos:  position{line: 501, col: 35, offset: 16618},
 									name: "GenericAttribute",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 425, col: 54, offset: 14340},
+							pos:        position{line: 501, col: 54, offset: 16637},
 							val:        "]",
 							ignoreCase: false,
 							want:       "\"]\"",
@@ -3066,41 +3469,41 @@ var g = &grammar{
 		},
 		{
 			name: "FileInclusion",
-			pos:  position{line: 432, col: 1, offset: 14529},
+			pos:  position{line: 508, col: 1, offset: 16826},
 			expr: &actionExpr{
-				pos: position{line: 432, col: 18, offset: 14546},
+				pos: position{line: 508, col: 18, offset: 16843},
 				run: (*parser).callonFileInclusion1,
 				expr: &seqExpr{
-					pos: position{line: 432, col: 18, offset: 14546},
+					pos: position{line: 508, col: 18, offset: 16843},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 432, col: 18, offset: 14546},
+							pos:   position{line: 508, col: 18, offset: 16843},
 							label: "incl",
 							expr: &actionExpr{
-								pos: position{line: 432, col: 24, offset: 14552},
+								pos: position{line: 508, col: 24, offset: 16849},
 								run: (*parser).callonFileInclusion4,
 								expr: &seqExpr{
-									pos: position{line: 432, col: 24, offset: 14552},
+									pos: position{line: 508, col: 24, offset: 16849},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 432, col: 24, offset: 14552},
+											pos:        position{line: 508, col: 24, offset: 16849},
 											val:        "include::",
 											ignoreCase: false,
 											want:       "\"include::\"",
 										},
 										&labeledExpr{
-											pos:   position{line: 432, col: 36, offset: 14564},
+											pos:   position{line: 508, col: 36, offset: 16861},
 											label: "path",
 											expr: &ruleRefExpr{
-												pos:  position{line: 432, col: 42, offset: 14570},
+												pos:  position{line: 508, col: 42, offset: 16867},
 												name: "FileLocation",
 											},
 										},
 										&labeledExpr{
-											pos:   position{line: 432, col: 56, offset: 14584},
+											pos:   position{line: 508, col: 56, offset: 16881},
 											label: "inlineAttributes",
 											expr: &ruleRefExpr{
-												pos:  position{line: 432, col: 74, offset: 14602},
+												pos:  position{line: 508, col: 74, offset: 16899},
 												name: "FileIncludeAttributes",
 											},
 										},
@@ -3109,14 +3512,14 @@ var g = &grammar{
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 434, col: 8, offset: 14751},
+							pos: position{line: 510, col: 8, offset: 17048},
 							expr: &ruleRefExpr{
-								pos:  position{line: 434, col: 8, offset: 14751},
+								pos:  position{line: 510, col: 8, offset: 17048},
 								name: "Space",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 434, col: 15, offset: 14758},
+							pos:  position{line: 510, col: 15, offset: 17055},
 							name: "EOL",
 						},
 					},
@@ -3125,37 +3528,37 @@ var g = &grammar{
 		},
 		{
 			name: "FileIncludeAttributes",
-			pos:  position{line: 438, col: 1, offset: 14814},
+			pos:  position{line: 514, col: 1, offset: 17111},
 			expr: &actionExpr{
-				pos: position{line: 438, col: 26, offset: 14839},
+				pos: position{line: 514, col: 26, offset: 17136},
 				run: (*parser).callonFileIncludeAttributes1,
 				expr: &seqExpr{
-					pos: position{line: 438, col: 26, offset: 14839},
+					pos: position{line: 514, col: 26, offset: 17136},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 438, col: 26, offset: 14839},
+							pos:        position{line: 514, col: 26, offset: 17136},
 							val:        "[",
 							ignoreCase: false,
 							want:       "\"[\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 438, col: 30, offset: 14843},
+							pos:   position{line: 514, col: 30, offset: 17140},
 							label: "attrs",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 438, col: 36, offset: 14849},
+								pos: position{line: 514, col: 36, offset: 17146},
 								expr: &choiceExpr{
-									pos: position{line: 438, col: 37, offset: 14850},
+									pos: position{line: 514, col: 37, offset: 17147},
 									alternatives: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 438, col: 37, offset: 14850},
+											pos:  position{line: 514, col: 37, offset: 17147},
 											name: "LineRangesAttribute",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 438, col: 59, offset: 14872},
+											pos:  position{line: 514, col: 59, offset: 17169},
 											name: "TagRangesAttribute",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 438, col: 80, offset: 14893},
+											pos:  position{line: 514, col: 80, offset: 17190},
 											name: "GenericAttribute",
 										},
 									},
@@ -3163,7 +3566,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 438, col: 99, offset: 14912},
+							pos:        position{line: 514, col: 99, offset: 17209},
 							val:        "]",
 							ignoreCase: false,
 							want:       "\"]\"",
@@ -3174,31 +3577,31 @@ var g = &grammar{
 		},
 		{
 			name: "LineRangesAttribute",
-			pos:  position{line: 442, col: 1, offset: 14988},
+			pos:  position{line: 518, col: 1, offset: 17285},
 			expr: &actionExpr{
-				pos: position{line: 442, col: 24, offset: 15011},
+				pos: position{line: 518, col: 24, offset: 17308},
 				run: (*parser).callonLineRangesAttribute1,
 				expr: &seqExpr{
-					pos: position{line: 442, col: 24, offset: 15011},
+					pos: position{line: 518, col: 24, offset: 17308},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 442, col: 24, offset: 15011},
+							pos:        position{line: 518, col: 24, offset: 17308},
 							val:        "lines=",
 							ignoreCase: false,
 							want:       "\"lines=\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 442, col: 33, offset: 15020},
+							pos:   position{line: 518, col: 33, offset: 17317},
 							label: "lines",
 							expr: &ruleRefExpr{
-								pos:  position{line: 442, col: 40, offset: 15027},
+								pos:  position{line: 518, col: 40, offset: 17324},
 								name: "LineRangesAttributeValue",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 442, col: 66, offset: 15053},
+							pos: position{line: 518, col: 66, offset: 17350},
 							expr: &litMatcher{
-								pos:        position{line: 442, col: 66, offset: 15053},
+								pos:        position{line: 518, col: 66, offset: 17350},
 								val:        ",",
 								ignoreCase: false,
 								want:       "\",\"",
@@ -3210,73 +3613,73 @@ var g = &grammar{
 		},
 		{
 			name: "LineRangesAttributeValue",
-			pos:  position{line: 446, col: 1, offset: 15116},
+			pos:  position{line: 522, col: 1, offset: 17413},
 			expr: &actionExpr{
-				pos: position{line: 446, col: 29, offset: 15144},
+				pos: position{line: 522, col: 29, offset: 17441},
 				run: (*parser).callonLineRangesAttributeValue1,
 				expr: &seqExpr{
-					pos: position{line: 446, col: 29, offset: 15144},
+					pos: position{line: 522, col: 29, offset: 17441},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 446, col: 29, offset: 15144},
+							pos:   position{line: 522, col: 29, offset: 17441},
 							label: "value",
 							expr: &choiceExpr{
-								pos: position{line: 446, col: 36, offset: 15151},
+								pos: position{line: 522, col: 36, offset: 17448},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 446, col: 36, offset: 15151},
+										pos:  position{line: 522, col: 36, offset: 17448},
 										name: "MultipleLineRanges",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 447, col: 11, offset: 15269},
+										pos:  position{line: 523, col: 11, offset: 17566},
 										name: "MultipleQuotedLineRanges",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 448, col: 11, offset: 15306},
+										pos:  position{line: 524, col: 11, offset: 17603},
 										name: "MultiLineRange",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 449, col: 11, offset: 15333},
+										pos:  position{line: 525, col: 11, offset: 17630},
 										name: "MultiLineQuotedRange",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 450, col: 11, offset: 15366},
+										pos:  position{line: 526, col: 11, offset: 17663},
 										name: "SingleLineQuotedRange",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 451, col: 11, offset: 15399},
+										pos:  position{line: 527, col: 11, offset: 17696},
 										name: "SingleLineRange",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 452, col: 11, offset: 15427},
+										pos:  position{line: 528, col: 11, offset: 17724},
 										name: "UndefinedLineRange",
 									},
 								},
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 452, col: 31, offset: 15447},
+							pos: position{line: 528, col: 31, offset: 17744},
 							expr: &ruleRefExpr{
-								pos:  position{line: 452, col: 31, offset: 15447},
+								pos:  position{line: 528, col: 31, offset: 17744},
 								name: "Space",
 							},
 						},
 						&choiceExpr{
-							pos: position{line: 452, col: 39, offset: 15455},
+							pos: position{line: 528, col: 39, offset: 17752},
 							alternatives: []interface{}{
 								&andExpr{
-									pos: position{line: 452, col: 39, offset: 15455},
+									pos: position{line: 528, col: 39, offset: 17752},
 									expr: &litMatcher{
-										pos:        position{line: 452, col: 40, offset: 15456},
+										pos:        position{line: 528, col: 40, offset: 17753},
 										val:        ",",
 										ignoreCase: false,
 										want:       "\",\"",
 									},
 								},
 								&andExpr{
-									pos: position{line: 452, col: 46, offset: 15462},
+									pos: position{line: 528, col: 46, offset: 17759},
 									expr: &litMatcher{
-										pos:        position{line: 452, col: 47, offset: 15463},
+										pos:        position{line: 528, col: 47, offset: 17760},
 										val:        "]",
 										ignoreCase: false,
 										want:       "\"]\"",
@@ -3290,59 +3693,59 @@ var g = &grammar{
 		},
 		{
 			name: "MultipleLineRanges",
-			pos:  position{line: 456, col: 1, offset: 15499},
+			pos:  position{line: 532, col: 1, offset: 17796},
 			expr: &actionExpr{
-				pos: position{line: 456, col: 23, offset: 15521},
+				pos: position{line: 532, col: 23, offset: 17818},
 				run: (*parser).callonMultipleLineRanges1,
 				expr: &seqExpr{
-					pos: position{line: 456, col: 23, offset: 15521},
+					pos: position{line: 532, col: 23, offset: 17818},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 456, col: 23, offset: 15521},
+							pos:   position{line: 532, col: 23, offset: 17818},
 							label: "first",
 							expr: &choiceExpr{
-								pos: position{line: 456, col: 30, offset: 15528},
+								pos: position{line: 532, col: 30, offset: 17825},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 456, col: 30, offset: 15528},
+										pos:  position{line: 532, col: 30, offset: 17825},
 										name: "MultiLineRange",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 456, col: 47, offset: 15545},
+										pos:  position{line: 532, col: 47, offset: 17842},
 										name: "SingleLineRange",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 457, col: 5, offset: 15568},
+							pos:   position{line: 533, col: 5, offset: 17865},
 							label: "others",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 457, col: 12, offset: 15575},
+								pos: position{line: 533, col: 12, offset: 17872},
 								expr: &actionExpr{
-									pos: position{line: 457, col: 13, offset: 15576},
+									pos: position{line: 533, col: 13, offset: 17873},
 									run: (*parser).callonMultipleLineRanges9,
 									expr: &seqExpr{
-										pos: position{line: 457, col: 13, offset: 15576},
+										pos: position{line: 533, col: 13, offset: 17873},
 										exprs: []interface{}{
 											&litMatcher{
-												pos:        position{line: 457, col: 13, offset: 15576},
+												pos:        position{line: 533, col: 13, offset: 17873},
 												val:        ";",
 												ignoreCase: false,
 												want:       "\";\"",
 											},
 											&labeledExpr{
-												pos:   position{line: 457, col: 17, offset: 15580},
+												pos:   position{line: 533, col: 17, offset: 17877},
 												label: "other",
 												expr: &choiceExpr{
-													pos: position{line: 457, col: 24, offset: 15587},
+													pos: position{line: 533, col: 24, offset: 17884},
 													alternatives: []interface{}{
 														&ruleRefExpr{
-															pos:  position{line: 457, col: 24, offset: 15587},
+															pos:  position{line: 533, col: 24, offset: 17884},
 															name: "MultiLineRange",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 457, col: 41, offset: 15604},
+															pos:  position{line: 533, col: 41, offset: 17901},
 															name: "SingleLineRange",
 														},
 													},
@@ -3359,65 +3762,65 @@ var g = &grammar{
 		},
 		{
 			name: "MultipleQuotedLineRanges",
-			pos:  position{line: 463, col: 1, offset: 15748},
+			pos:  position{line: 539, col: 1, offset: 18045},
 			expr: &actionExpr{
-				pos: position{line: 463, col: 29, offset: 15776},
+				pos: position{line: 539, col: 29, offset: 18073},
 				run: (*parser).callonMultipleQuotedLineRanges1,
 				expr: &seqExpr{
-					pos: position{line: 463, col: 29, offset: 15776},
+					pos: position{line: 539, col: 29, offset: 18073},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 463, col: 29, offset: 15776},
+							pos:        position{line: 539, col: 29, offset: 18073},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 463, col: 34, offset: 15781},
+							pos:   position{line: 539, col: 34, offset: 18078},
 							label: "first",
 							expr: &choiceExpr{
-								pos: position{line: 463, col: 41, offset: 15788},
+								pos: position{line: 539, col: 41, offset: 18085},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 463, col: 41, offset: 15788},
+										pos:  position{line: 539, col: 41, offset: 18085},
 										name: "MultiLineRange",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 463, col: 58, offset: 15805},
+										pos:  position{line: 539, col: 58, offset: 18102},
 										name: "SingleLineRange",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 464, col: 5, offset: 15828},
+							pos:   position{line: 540, col: 5, offset: 18125},
 							label: "others",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 464, col: 12, offset: 15835},
+								pos: position{line: 540, col: 12, offset: 18132},
 								expr: &actionExpr{
-									pos: position{line: 464, col: 13, offset: 15836},
+									pos: position{line: 540, col: 13, offset: 18133},
 									run: (*parser).callonMultipleQuotedLineRanges10,
 									expr: &seqExpr{
-										pos: position{line: 464, col: 13, offset: 15836},
+										pos: position{line: 540, col: 13, offset: 18133},
 										exprs: []interface{}{
 											&litMatcher{
-												pos:        position{line: 464, col: 13, offset: 15836},
+												pos:        position{line: 540, col: 13, offset: 18133},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&labeledExpr{
-												pos:   position{line: 464, col: 17, offset: 15840},
+												pos:   position{line: 540, col: 17, offset: 18137},
 												label: "other",
 												expr: &choiceExpr{
-													pos: position{line: 464, col: 24, offset: 15847},
+													pos: position{line: 540, col: 24, offset: 18144},
 													alternatives: []interface{}{
 														&ruleRefExpr{
-															pos:  position{line: 464, col: 24, offset: 15847},
+															pos:  position{line: 540, col: 24, offset: 18144},
 															name: "MultiLineRange",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 464, col: 41, offset: 15864},
+															pos:  position{line: 540, col: 41, offset: 18161},
 															name: "SingleLineRange",
 														},
 													},
@@ -3429,7 +3832,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 466, col: 9, offset: 15919},
+							pos:        position{line: 542, col: 9, offset: 18216},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -3440,32 +3843,32 @@ var g = &grammar{
 		},
 		{
 			name: "MultiLineRange",
-			pos:  position{line: 470, col: 1, offset: 16013},
+			pos:  position{line: 546, col: 1, offset: 18310},
 			expr: &actionExpr{
-				pos: position{line: 470, col: 19, offset: 16031},
+				pos: position{line: 546, col: 19, offset: 18328},
 				run: (*parser).callonMultiLineRange1,
 				expr: &seqExpr{
-					pos: position{line: 470, col: 19, offset: 16031},
+					pos: position{line: 546, col: 19, offset: 18328},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 470, col: 19, offset: 16031},
+							pos:   position{line: 546, col: 19, offset: 18328},
 							label: "start",
 							expr: &ruleRefExpr{
-								pos:  position{line: 470, col: 26, offset: 16038},
+								pos:  position{line: 546, col: 26, offset: 18335},
 								name: "NUMBER",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 470, col: 34, offset: 16046},
+							pos:        position{line: 546, col: 34, offset: 18343},
 							val:        "..",
 							ignoreCase: false,
 							want:       "\"..\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 470, col: 39, offset: 16051},
+							pos:   position{line: 546, col: 39, offset: 18348},
 							label: "end",
 							expr: &ruleRefExpr{
-								pos:  position{line: 470, col: 44, offset: 16056},
+								pos:  position{line: 546, col: 44, offset: 18353},
 								name: "NUMBER",
 							},
 						},
@@ -3475,43 +3878,43 @@ var g = &grammar{
 		},
 		{
 			name: "MultiLineQuotedRange",
-			pos:  position{line: 474, col: 1, offset: 16148},
+			pos:  position{line: 550, col: 1, offset: 18445},
 			expr: &actionExpr{
-				pos: position{line: 474, col: 25, offset: 16172},
+				pos: position{line: 550, col: 25, offset: 18469},
 				run: (*parser).callonMultiLineQuotedRange1,
 				expr: &seqExpr{
-					pos: position{line: 474, col: 25, offset: 16172},
+					pos: position{line: 550, col: 25, offset: 18469},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 474, col: 25, offset: 16172},
+							pos:        position{line: 550, col: 25, offset: 18469},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 474, col: 30, offset: 16177},
+							pos:   position{line: 550, col: 30, offset: 18474},
 							label: "start",
 							expr: &ruleRefExpr{
-								pos:  position{line: 474, col: 37, offset: 16184},
+								pos:  position{line: 550, col: 37, offset: 18481},
 								name: "NUMBER",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 474, col: 45, offset: 16192},
+							pos:        position{line: 550, col: 45, offset: 18489},
 							val:        "..",
 							ignoreCase: false,
 							want:       "\"..\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 474, col: 50, offset: 16197},
+							pos:   position{line: 550, col: 50, offset: 18494},
 							label: "end",
 							expr: &ruleRefExpr{
-								pos:  position{line: 474, col: 55, offset: 16202},
+								pos:  position{line: 550, col: 55, offset: 18499},
 								name: "NUMBER",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 474, col: 63, offset: 16210},
+							pos:        position{line: 550, col: 63, offset: 18507},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -3522,15 +3925,15 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineRange",
-			pos:  position{line: 478, col: 1, offset: 16299},
+			pos:  position{line: 554, col: 1, offset: 18596},
 			expr: &actionExpr{
-				pos: position{line: 478, col: 20, offset: 16318},
+				pos: position{line: 554, col: 20, offset: 18615},
 				run: (*parser).callonSingleLineRange1,
 				expr: &labeledExpr{
-					pos:   position{line: 478, col: 20, offset: 16318},
+					pos:   position{line: 554, col: 20, offset: 18615},
 					label: "singleline",
 					expr: &ruleRefExpr{
-						pos:  position{line: 478, col: 32, offset: 16330},
+						pos:  position{line: 554, col: 32, offset: 18627},
 						name: "NUMBER",
 					},
 				},
@@ -3538,29 +3941,29 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineQuotedRange",
-			pos:  position{line: 482, col: 1, offset: 16429},
+			pos:  position{line: 558, col: 1, offset: 18726},
 			expr: &actionExpr{
-				pos: position{line: 482, col: 26, offset: 16454},
+				pos: position{line: 558, col: 26, offset: 18751},
 				run: (*parser).callonSingleLineQuotedRange1,
 				expr: &seqExpr{
-					pos: position{line: 482, col: 26, offset: 16454},
+					pos: position{line: 558, col: 26, offset: 18751},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 482, col: 26, offset: 16454},
+							pos:        position{line: 558, col: 26, offset: 18751},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 482, col: 31, offset: 16459},
+							pos:   position{line: 558, col: 31, offset: 18756},
 							label: "singleline",
 							expr: &ruleRefExpr{
-								pos:  position{line: 482, col: 43, offset: 16471},
+								pos:  position{line: 558, col: 43, offset: 18768},
 								name: "NUMBER",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 482, col: 51, offset: 16479},
+							pos:        position{line: 558, col: 51, offset: 18776},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -3571,14 +3974,14 @@ var g = &grammar{
 		},
 		{
 			name: "UndefinedLineRange",
-			pos:  position{line: 486, col: 1, offset: 16575},
+			pos:  position{line: 562, col: 1, offset: 18872},
 			expr: &actionExpr{
-				pos: position{line: 486, col: 23, offset: 16597},
+				pos: position{line: 562, col: 23, offset: 18894},
 				run: (*parser).callonUndefinedLineRange1,
 				expr: &zeroOrMoreExpr{
-					pos: position{line: 486, col: 23, offset: 16597},
+					pos: position{line: 562, col: 23, offset: 18894},
 					expr: &charClassMatcher{
-						pos:        position{line: 486, col: 23, offset: 16597},
+						pos:        position{line: 562, col: 23, offset: 18894},
 						val:        "[^\\], ]",
 						chars:      []rune{']', ',', ' '},
 						ignoreCase: false,
@@ -3589,24 +3992,24 @@ var g = &grammar{
 		},
 		{
 			name: "TagRangesAttribute",
-			pos:  position{line: 490, col: 1, offset: 16646},
+			pos:  position{line: 566, col: 1, offset: 18943},
 			expr: &actionExpr{
-				pos: position{line: 490, col: 23, offset: 16668},
+				pos: position{line: 566, col: 23, offset: 18965},
 				run: (*parser).callonTagRangesAttribute1,
 				expr: &seqExpr{
-					pos: position{line: 490, col: 23, offset: 16668},
+					pos: position{line: 566, col: 23, offset: 18965},
 					exprs: []interface{}{
 						&choiceExpr{
-							pos: position{line: 490, col: 24, offset: 16669},
+							pos: position{line: 566, col: 24, offset: 18966},
 							alternatives: []interface{}{
 								&litMatcher{
-									pos:        position{line: 490, col: 24, offset: 16669},
+									pos:        position{line: 566, col: 24, offset: 18966},
 									val:        "tags=",
 									ignoreCase: false,
 									want:       "\"tags=\"",
 								},
 								&litMatcher{
-									pos:        position{line: 490, col: 34, offset: 16679},
+									pos:        position{line: 566, col: 34, offset: 18976},
 									val:        "tag=",
 									ignoreCase: false,
 									want:       "\"tag=\"",
@@ -3614,17 +4017,17 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 490, col: 42, offset: 16687},
+							pos:   position{line: 566, col: 42, offset: 18984},
 							label: "tags",
 							expr: &ruleRefExpr{
-								pos:  position{line: 490, col: 48, offset: 16693},
+								pos:  position{line: 566, col: 48, offset: 18990},
 								name: "TagRangesAttributeValue",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 490, col: 73, offset: 16718},
+							pos: position{line: 566, col: 73, offset: 19015},
 							expr: &litMatcher{
-								pos:        position{line: 490, col: 73, offset: 16718},
+								pos:        position{line: 566, col: 73, offset: 19015},
 								val:        ",",
 								ignoreCase: false,
 								want:       "\",\"",
@@ -3636,44 +4039,44 @@ var g = &grammar{
 		},
 		{
 			name: "TagRangesAttributeValue",
-			pos:  position{line: 494, col: 1, offset: 16871},
+			pos:  position{line: 570, col: 1, offset: 19168},
 			expr: &actionExpr{
-				pos: position{line: 494, col: 28, offset: 16898},
+				pos: position{line: 570, col: 28, offset: 19195},
 				run: (*parser).callonTagRangesAttributeValue1,
 				expr: &seqExpr{
-					pos: position{line: 494, col: 28, offset: 16898},
+					pos: position{line: 570, col: 28, offset: 19195},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 494, col: 28, offset: 16898},
+							pos:   position{line: 570, col: 28, offset: 19195},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 494, col: 35, offset: 16905},
+								pos:  position{line: 570, col: 35, offset: 19202},
 								name: "MultipleTagRanges",
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 494, col: 54, offset: 16924},
+							pos: position{line: 570, col: 54, offset: 19221},
 							expr: &ruleRefExpr{
-								pos:  position{line: 494, col: 54, offset: 16924},
+								pos:  position{line: 570, col: 54, offset: 19221},
 								name: "Space",
 							},
 						},
 						&choiceExpr{
-							pos: position{line: 494, col: 62, offset: 16932},
+							pos: position{line: 570, col: 62, offset: 19229},
 							alternatives: []interface{}{
 								&andExpr{
-									pos: position{line: 494, col: 62, offset: 16932},
+									pos: position{line: 570, col: 62, offset: 19229},
 									expr: &litMatcher{
-										pos:        position{line: 494, col: 63, offset: 16933},
+										pos:        position{line: 570, col: 63, offset: 19230},
 										val:        ",",
 										ignoreCase: false,
 										want:       "\",\"",
 									},
 								},
 								&andExpr{
-									pos: position{line: 494, col: 69, offset: 16939},
+									pos: position{line: 570, col: 69, offset: 19236},
 									expr: &litMatcher{
-										pos:        position{line: 494, col: 70, offset: 16940},
+										pos:        position{line: 570, col: 70, offset: 19237},
 										val:        "]",
 										ignoreCase: false,
 										want:       "\"]\"",
@@ -3687,43 +4090,43 @@ var g = &grammar{
 		},
 		{
 			name: "MultipleTagRanges",
-			pos:  position{line: 498, col: 1, offset: 16976},
+			pos:  position{line: 574, col: 1, offset: 19273},
 			expr: &actionExpr{
-				pos: position{line: 498, col: 22, offset: 16997},
+				pos: position{line: 574, col: 22, offset: 19294},
 				run: (*parser).callonMultipleTagRanges1,
 				expr: &seqExpr{
-					pos: position{line: 498, col: 22, offset: 16997},
+					pos: position{line: 574, col: 22, offset: 19294},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 498, col: 22, offset: 16997},
+							pos:   position{line: 574, col: 22, offset: 19294},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 498, col: 29, offset: 17004},
+								pos:  position{line: 574, col: 29, offset: 19301},
 								name: "TagRange",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 499, col: 5, offset: 17019},
+							pos:   position{line: 575, col: 5, offset: 19316},
 							label: "others",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 499, col: 12, offset: 17026},
+								pos: position{line: 575, col: 12, offset: 19323},
 								expr: &actionExpr{
-									pos: position{line: 499, col: 13, offset: 17027},
+									pos: position{line: 575, col: 13, offset: 19324},
 									run: (*parser).callonMultipleTagRanges7,
 									expr: &seqExpr{
-										pos: position{line: 499, col: 13, offset: 17027},
+										pos: position{line: 575, col: 13, offset: 19324},
 										exprs: []interface{}{
 											&litMatcher{
-												pos:        position{line: 499, col: 13, offset: 17027},
+												pos:        position{line: 575, col: 13, offset: 19324},
 												val:        ";",
 												ignoreCase: false,
 												want:       "\";\"",
 											},
 											&labeledExpr{
-												pos:   position{line: 499, col: 17, offset: 17031},
+												pos:   position{line: 575, col: 17, offset: 19328},
 												label: "other",
 												expr: &ruleRefExpr{
-													pos:  position{line: 499, col: 24, offset: 17038},
+													pos:  position{line: 575, col: 24, offset: 19335},
 													name: "TagRange",
 												},
 											},
@@ -3738,25 +4141,25 @@ var g = &grammar{
 		},
 		{
 			name: "TagRange",
-			pos:  position{line: 505, col: 1, offset: 17175},
+			pos:  position{line: 581, col: 1, offset: 19472},
 			expr: &choiceExpr{
-				pos: position{line: 505, col: 13, offset: 17187},
+				pos: position{line: 581, col: 13, offset: 19484},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 505, col: 13, offset: 17187},
+						pos: position{line: 581, col: 13, offset: 19484},
 						run: (*parser).callonTagRange2,
 						expr: &labeledExpr{
-							pos:   position{line: 505, col: 13, offset: 17187},
+							pos:   position{line: 581, col: 13, offset: 19484},
 							label: "tag",
 							expr: &choiceExpr{
-								pos: position{line: 505, col: 18, offset: 17192},
+								pos: position{line: 581, col: 18, offset: 19489},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 505, col: 18, offset: 17192},
+										pos:  position{line: 581, col: 18, offset: 19489},
 										name: "Alphanums",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 505, col: 30, offset: 17204},
+										pos:  position{line: 581, col: 30, offset: 19501},
 										name: "TagWildcard",
 									},
 								},
@@ -3764,29 +4167,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 507, col: 5, offset: 17274},
+						pos: position{line: 583, col: 5, offset: 19571},
 						run: (*parser).callonTagRange7,
 						expr: &seqExpr{
-							pos: position{line: 507, col: 5, offset: 17274},
+							pos: position{line: 583, col: 5, offset: 19571},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 507, col: 5, offset: 17274},
+									pos:        position{line: 583, col: 5, offset: 19571},
 									val:        "!",
 									ignoreCase: false,
 									want:       "\"!\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 507, col: 9, offset: 17278},
+									pos:   position{line: 583, col: 9, offset: 19575},
 									label: "tag",
 									expr: &choiceExpr{
-										pos: position{line: 507, col: 14, offset: 17283},
+										pos: position{line: 583, col: 14, offset: 19580},
 										alternatives: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 507, col: 14, offset: 17283},
+												pos:  position{line: 583, col: 14, offset: 19580},
 												name: "Alphanums",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 507, col: 26, offset: 17295},
+												pos:  position{line: 583, col: 26, offset: 19592},
 												name: "TagWildcard",
 											},
 										},
@@ -3800,23 +4203,23 @@ var g = &grammar{
 		},
 		{
 			name: "TagWildcard",
-			pos:  position{line: 511, col: 1, offset: 17367},
+			pos:  position{line: 587, col: 1, offset: 19664},
 			expr: &actionExpr{
-				pos: position{line: 511, col: 16, offset: 17382},
+				pos: position{line: 587, col: 16, offset: 19679},
 				run: (*parser).callonTagWildcard1,
 				expr: &seqExpr{
-					pos: position{line: 511, col: 16, offset: 17382},
+					pos: position{line: 587, col: 16, offset: 19679},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 511, col: 16, offset: 17382},
+							pos:   position{line: 587, col: 16, offset: 19679},
 							label: "stars",
 							expr: &actionExpr{
-								pos: position{line: 511, col: 23, offset: 17389},
+								pos: position{line: 587, col: 23, offset: 19686},
 								run: (*parser).callonTagWildcard4,
 								expr: &oneOrMoreExpr{
-									pos: position{line: 511, col: 23, offset: 17389},
+									pos: position{line: 587, col: 23, offset: 19686},
 									expr: &litMatcher{
-										pos:        position{line: 511, col: 24, offset: 17390},
+										pos:        position{line: 587, col: 24, offset: 19687},
 										val:        "*",
 										ignoreCase: false,
 										want:       "\"*\"",
@@ -3825,7 +4228,7 @@ var g = &grammar{
 							},
 						},
 						&andCodeExpr{
-							pos: position{line: 514, col: 5, offset: 17447},
+							pos: position{line: 590, col: 5, offset: 19744},
 							run: (*parser).callonTagWildcard7,
 						},
 					},
@@ -3834,18 +4237,18 @@ var g = &grammar{
 		},
 		{
 			name: "VerbatimFileContent",
-			pos:  position{line: 522, col: 1, offset: 17697},
+			pos:  position{line: 598, col: 1, offset: 19994},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 522, col: 24, offset: 17720},
+				pos: position{line: 598, col: 24, offset: 20017},
 				expr: &choiceExpr{
-					pos: position{line: 522, col: 25, offset: 17721},
+					pos: position{line: 598, col: 25, offset: 20018},
 					alternatives: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 522, col: 25, offset: 17721},
+							pos:  position{line: 598, col: 25, offset: 20018},
 							name: "FileInclusion",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 522, col: 41, offset: 17737},
+							pos:  position{line: 598, col: 41, offset: 20034},
 							name: "VerbatimFileLine",
 						},
 					},
@@ -3854,30 +4257,30 @@ var g = &grammar{
 		},
 		{
 			name: "VerbatimFileLine",
-			pos:  position{line: 524, col: 1, offset: 17759},
+			pos:  position{line: 600, col: 1, offset: 20056},
 			expr: &actionExpr{
-				pos: position{line: 524, col: 21, offset: 17779},
+				pos: position{line: 600, col: 21, offset: 20076},
 				run: (*parser).callonVerbatimFileLine1,
 				expr: &seqExpr{
-					pos: position{line: 524, col: 21, offset: 17779},
+					pos: position{line: 600, col: 21, offset: 20076},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 524, col: 21, offset: 17779},
+							pos: position{line: 600, col: 21, offset: 20076},
 							expr: &ruleRefExpr{
-								pos:  position{line: 524, col: 22, offset: 17780},
+								pos:  position{line: 600, col: 22, offset: 20077},
 								name: "EOF",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 524, col: 26, offset: 17784},
+							pos:   position{line: 600, col: 26, offset: 20081},
 							label: "content",
 							expr: &actionExpr{
-								pos: position{line: 524, col: 35, offset: 17793},
+								pos: position{line: 600, col: 35, offset: 20090},
 								run: (*parser).callonVerbatimFileLine6,
 								expr: &zeroOrMoreExpr{
-									pos: position{line: 524, col: 35, offset: 17793},
+									pos: position{line: 600, col: 35, offset: 20090},
 									expr: &charClassMatcher{
-										pos:        position{line: 524, col: 35, offset: 17793},
+										pos:        position{line: 600, col: 35, offset: 20090},
 										val:        "[^\\r\\n]",
 										chars:      []rune{'\r', '\n'},
 										ignoreCase: false,
@@ -3887,7 +4290,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 526, col: 12, offset: 17857},
+							pos:  position{line: 602, col: 12, offset: 20154},
 							name: "EOL",
 						},
 					},
@@ -3896,34 +4299,34 @@ var g = &grammar{
 		},
 		{
 			name: "IncludedFileLine",
-			pos:  position{line: 533, col: 1, offset: 18063},
+			pos:  position{line: 609, col: 1, offset: 20360},
 			expr: &actionExpr{
-				pos: position{line: 533, col: 21, offset: 18083},
+				pos: position{line: 609, col: 21, offset: 20380},
 				run: (*parser).callonIncludedFileLine1,
 				expr: &seqExpr{
-					pos: position{line: 533, col: 21, offset: 18083},
+					pos: position{line: 609, col: 21, offset: 20380},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 533, col: 21, offset: 18083},
+							pos:   position{line: 609, col: 21, offset: 20380},
 							label: "content",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 533, col: 29, offset: 18091},
+								pos: position{line: 609, col: 29, offset: 20388},
 								expr: &choiceExpr{
-									pos: position{line: 533, col: 30, offset: 18092},
+									pos: position{line: 609, col: 30, offset: 20389},
 									alternatives: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 533, col: 30, offset: 18092},
+											pos:  position{line: 609, col: 30, offset: 20389},
 											name: "IncludedFileStartTag",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 533, col: 53, offset: 18115},
+											pos:  position{line: 609, col: 53, offset: 20412},
 											name: "IncludedFileEndTag",
 										},
 										&actionExpr{
-											pos: position{line: 533, col: 74, offset: 18136},
+											pos: position{line: 609, col: 74, offset: 20433},
 											run: (*parser).callonIncludedFileLine8,
 											expr: &anyMatcher{
-												line: 533, col: 74, offset: 18136,
+												line: 609, col: 74, offset: 20433,
 											},
 										},
 									},
@@ -3931,7 +4334,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 533, col: 107, offset: 18169},
+							pos:  position{line: 609, col: 107, offset: 20466},
 							name: "EOL",
 						},
 					},
@@ -3940,33 +4343,33 @@ var g = &grammar{
 		},
 		{
 			name: "IncludedFileStartTag",
-			pos:  position{line: 537, col: 1, offset: 18244},
+			pos:  position{line: 613, col: 1, offset: 20541},
 			expr: &actionExpr{
-				pos: position{line: 537, col: 25, offset: 18268},
+				pos: position{line: 613, col: 25, offset: 20565},
 				run: (*parser).callonIncludedFileStartTag1,
 				expr: &seqExpr{
-					pos: position{line: 537, col: 25, offset: 18268},
+					pos: position{line: 613, col: 25, offset: 20565},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 537, col: 25, offset: 18268},
+							pos:        position{line: 613, col: 25, offset: 20565},
 							val:        "tag::",
 							ignoreCase: false,
 							want:       "\"tag::\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 537, col: 33, offset: 18276},
+							pos:   position{line: 613, col: 33, offset: 20573},
 							label: "tag",
 							expr: &actionExpr{
-								pos: position{line: 537, col: 38, offset: 18281},
+								pos: position{line: 613, col: 38, offset: 20578},
 								run: (*parser).callonIncludedFileStartTag5,
 								expr: &ruleRefExpr{
-									pos:  position{line: 537, col: 38, offset: 18281},
+									pos:  position{line: 613, col: 38, offset: 20578},
 									name: "Alphanums",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 537, col: 78, offset: 18321},
+							pos:        position{line: 613, col: 78, offset: 20618},
 							val:        "[]",
 							ignoreCase: false,
 							want:       "\"[]\"",
@@ -3977,33 +4380,33 @@ var g = &grammar{
 		},
 		{
 			name: "IncludedFileEndTag",
-			pos:  position{line: 541, col: 1, offset: 18390},
+			pos:  position{line: 617, col: 1, offset: 20687},
 			expr: &actionExpr{
-				pos: position{line: 541, col: 23, offset: 18412},
+				pos: position{line: 617, col: 23, offset: 20709},
 				run: (*parser).callonIncludedFileEndTag1,
 				expr: &seqExpr{
-					pos: position{line: 541, col: 23, offset: 18412},
+					pos: position{line: 617, col: 23, offset: 20709},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 541, col: 23, offset: 18412},
+							pos:        position{line: 617, col: 23, offset: 20709},
 							val:        "end::",
 							ignoreCase: false,
 							want:       "\"end::\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 541, col: 31, offset: 18420},
+							pos:   position{line: 617, col: 31, offset: 20717},
 							label: "tag",
 							expr: &actionExpr{
-								pos: position{line: 541, col: 36, offset: 18425},
+								pos: position{line: 617, col: 36, offset: 20722},
 								run: (*parser).callonIncludedFileEndTag5,
 								expr: &ruleRefExpr{
-									pos:  position{line: 541, col: 36, offset: 18425},
+									pos:  position{line: 617, col: 36, offset: 20722},
 									name: "Alphanums",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 541, col: 76, offset: 18465},
+							pos:        position{line: 617, col: 76, offset: 20762},
 							val:        "[]",
 							ignoreCase: false,
 							want:       "\"[]\"",
@@ -4014,32 +4417,32 @@ var g = &grammar{
 		},
 		{
 			name: "ListParagraph",
-			pos:  position{line: 548, col: 1, offset: 18636},
+			pos:  position{line: 624, col: 1, offset: 20933},
 			expr: &choiceExpr{
-				pos: position{line: 548, col: 18, offset: 18653},
+				pos: position{line: 624, col: 18, offset: 20950},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 548, col: 18, offset: 18653},
+						pos: position{line: 624, col: 18, offset: 20950},
 						run: (*parser).callonListParagraph2,
 						expr: &labeledExpr{
-							pos:   position{line: 548, col: 18, offset: 18653},
+							pos:   position{line: 624, col: 18, offset: 20950},
 							label: "comment",
 							expr: &ruleRefExpr{
-								pos:  position{line: 548, col: 27, offset: 18662},
+								pos:  position{line: 624, col: 27, offset: 20959},
 								name: "SingleLineComment",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 550, col: 9, offset: 18721},
+						pos: position{line: 626, col: 9, offset: 21018},
 						run: (*parser).callonListParagraph5,
 						expr: &labeledExpr{
-							pos:   position{line: 550, col: 9, offset: 18721},
+							pos:   position{line: 626, col: 9, offset: 21018},
 							label: "lines",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 550, col: 15, offset: 18727},
+								pos: position{line: 626, col: 15, offset: 21024},
 								expr: &ruleRefExpr{
-									pos:  position{line: 550, col: 16, offset: 18728},
+									pos:  position{line: 626, col: 16, offset: 21025},
 									name: "ListParagraphLine",
 								},
 							},
@@ -4050,96 +4453,96 @@ var g = &grammar{
 		},
 		{
 			name: "ListParagraphLine",
-			pos:  position{line: 554, col: 1, offset: 18824},
+			pos:  position{line: 630, col: 1, offset: 21121},
 			expr: &actionExpr{
-				pos: position{line: 554, col: 22, offset: 18845},
+				pos: position{line: 630, col: 22, offset: 21142},
 				run: (*parser).callonListParagraphLine1,
 				expr: &seqExpr{
-					pos: position{line: 554, col: 22, offset: 18845},
+					pos: position{line: 630, col: 22, offset: 21142},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 554, col: 22, offset: 18845},
+							pos: position{line: 630, col: 22, offset: 21142},
 							expr: &ruleRefExpr{
-								pos:  position{line: 554, col: 23, offset: 18846},
+								pos:  position{line: 630, col: 23, offset: 21143},
 								name: "EOF",
 							},
 						},
 						&notExpr{
-							pos: position{line: 555, col: 5, offset: 18855},
+							pos: position{line: 631, col: 5, offset: 21152},
 							expr: &ruleRefExpr{
-								pos:  position{line: 555, col: 6, offset: 18856},
+								pos:  position{line: 631, col: 6, offset: 21153},
 								name: "BlankLine",
 							},
 						},
 						&notExpr{
-							pos: position{line: 556, col: 5, offset: 18872},
+							pos: position{line: 632, col: 5, offset: 21169},
 							expr: &ruleRefExpr{
-								pos:  position{line: 556, col: 6, offset: 18873},
+								pos:  position{line: 632, col: 6, offset: 21170},
 								name: "SingleLineComment",
 							},
 						},
 						&notExpr{
-							pos: position{line: 557, col: 5, offset: 18896},
+							pos: position{line: 633, col: 5, offset: 21193},
 							expr: &ruleRefExpr{
-								pos:  position{line: 557, col: 6, offset: 18897},
+								pos:  position{line: 633, col: 6, offset: 21194},
 								name: "OrderedListItemPrefix",
 							},
 						},
 						&notExpr{
-							pos: position{line: 558, col: 5, offset: 18924},
+							pos: position{line: 634, col: 5, offset: 21221},
 							expr: &ruleRefExpr{
-								pos:  position{line: 558, col: 6, offset: 18925},
+								pos:  position{line: 634, col: 6, offset: 21222},
 								name: "UnorderedListItemPrefix",
 							},
 						},
 						&notExpr{
-							pos: position{line: 559, col: 5, offset: 18954},
+							pos: position{line: 635, col: 5, offset: 21251},
 							expr: &ruleRefExpr{
-								pos:  position{line: 559, col: 6, offset: 18955},
+								pos:  position{line: 635, col: 6, offset: 21252},
 								name: "CalloutListItemPrefix",
 							},
 						},
 						&notExpr{
-							pos: position{line: 560, col: 5, offset: 18982},
+							pos: position{line: 636, col: 5, offset: 21279},
 							expr: &ruleRefExpr{
-								pos:  position{line: 560, col: 6, offset: 18983},
+								pos:  position{line: 636, col: 6, offset: 21280},
 								name: "ListItemContinuation",
 							},
 						},
 						&notExpr{
-							pos: position{line: 561, col: 5, offset: 19009},
+							pos: position{line: 637, col: 5, offset: 21306},
 							expr: &ruleRefExpr{
-								pos:  position{line: 561, col: 6, offset: 19010},
+								pos:  position{line: 637, col: 6, offset: 21307},
 								name: "ElementAttribute",
 							},
 						},
 						&notExpr{
-							pos: position{line: 562, col: 5, offset: 19032},
+							pos: position{line: 638, col: 5, offset: 21329},
 							expr: &ruleRefExpr{
-								pos:  position{line: 562, col: 6, offset: 19033},
+								pos:  position{line: 638, col: 6, offset: 21330},
 								name: "BlockDelimiter",
 							},
 						},
 						&notExpr{
-							pos: position{line: 563, col: 5, offset: 19053},
+							pos: position{line: 639, col: 5, offset: 21350},
 							expr: &ruleRefExpr{
-								pos:  position{line: 563, col: 6, offset: 19054},
+								pos:  position{line: 639, col: 6, offset: 21351},
 								name: "LabeledListItemPrefix",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 564, col: 5, offset: 19082},
+							pos:   position{line: 640, col: 5, offset: 21379},
 							label: "line",
 							expr: &actionExpr{
-								pos: position{line: 564, col: 11, offset: 19088},
+								pos: position{line: 640, col: 11, offset: 21385},
 								run: (*parser).callonListParagraphLine24,
 								expr: &labeledExpr{
-									pos:   position{line: 564, col: 11, offset: 19088},
+									pos:   position{line: 640, col: 11, offset: 21385},
 									label: "elements",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 564, col: 20, offset: 19097},
+										pos: position{line: 640, col: 20, offset: 21394},
 										expr: &ruleRefExpr{
-											pos:  position{line: 564, col: 21, offset: 19098},
+											pos:  position{line: 640, col: 21, offset: 21395},
 											name: "InlineElement",
 										},
 									},
@@ -4147,7 +4550,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 566, col: 12, offset: 19199},
+							pos:  position{line: 642, col: 12, offset: 21496},
 							name: "EOL",
 						},
 					},
@@ -4156,25 +4559,25 @@ var g = &grammar{
 		},
 		{
 			name: "ListItemContinuation",
-			pos:  position{line: 570, col: 1, offset: 19242},
+			pos:  position{line: 646, col: 1, offset: 21539},
 			expr: &seqExpr{
-				pos: position{line: 570, col: 25, offset: 19266},
+				pos: position{line: 646, col: 25, offset: 21563},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 570, col: 25, offset: 19266},
+						pos:        position{line: 646, col: 25, offset: 21563},
 						val:        "+",
 						ignoreCase: false,
 						want:       "\"+\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 570, col: 29, offset: 19270},
+						pos: position{line: 646, col: 29, offset: 21567},
 						expr: &ruleRefExpr{
-							pos:  position{line: 570, col: 29, offset: 19270},
+							pos:  position{line: 646, col: 29, offset: 21567},
 							name: "Space",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 570, col: 36, offset: 19277},
+						pos:  position{line: 646, col: 36, offset: 21574},
 						name: "Newline",
 					},
 				},
@@ -4182,22 +4585,22 @@ var g = &grammar{
 		},
 		{
 			name: "ContinuedListItemElement",
-			pos:  position{line: 572, col: 1, offset: 19351},
+			pos:  position{line: 648, col: 1, offset: 21648},
 			expr: &actionExpr{
-				pos: position{line: 572, col: 29, offset: 19379},
+				pos: position{line: 648, col: 29, offset: 21676},
 				run: (*parser).callonContinuedListItemElement1,
 				expr: &seqExpr{
-					pos: position{line: 572, col: 29, offset: 19379},
+					pos: position{line: 648, col: 29, offset: 21676},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 572, col: 29, offset: 19379},
+							pos:  position{line: 648, col: 29, offset: 21676},
 							name: "ListItemContinuation",
 						},
 						&labeledExpr{
-							pos:   position{line: 572, col: 50, offset: 19400},
+							pos:   position{line: 648, col: 50, offset: 21697},
 							label: "element",
 							expr: &ruleRefExpr{
-								pos:  position{line: 572, col: 58, offset: 19408},
+								pos:  position{line: 648, col: 58, offset: 21705},
 								name: "ContinuedListItemContent",
 							},
 						},
@@ -4207,80 +4610,80 @@ var g = &grammar{
 		},
 		{
 			name: "ContinuedListItemContent",
-			pos:  position{line: 576, col: 1, offset: 19518},
+			pos:  position{line: 652, col: 1, offset: 21815},
 			expr: &actionExpr{
-				pos: position{line: 576, col: 29, offset: 19546},
+				pos: position{line: 652, col: 29, offset: 21843},
 				run: (*parser).callonContinuedListItemContent1,
 				expr: &seqExpr{
-					pos: position{line: 576, col: 29, offset: 19546},
+					pos: position{line: 652, col: 29, offset: 21843},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 576, col: 29, offset: 19546},
+							pos: position{line: 652, col: 29, offset: 21843},
 							expr: &ruleRefExpr{
-								pos:  position{line: 576, col: 30, offset: 19547},
+								pos:  position{line: 652, col: 30, offset: 21844},
 								name: "EOF",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 577, col: 5, offset: 19557},
+							pos:   position{line: 653, col: 5, offset: 21854},
 							label: "content",
 							expr: &choiceExpr{
-								pos: position{line: 577, col: 14, offset: 19566},
+								pos: position{line: 653, col: 14, offset: 21863},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 577, col: 14, offset: 19566},
+										pos:  position{line: 653, col: 14, offset: 21863},
 										name: "DelimitedBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 578, col: 11, offset: 19592},
+										pos:  position{line: 654, col: 11, offset: 21889},
 										name: "FileInclusion",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 579, col: 11, offset: 19617},
+										pos:  position{line: 655, col: 11, offset: 21914},
 										name: "VerseParagraph",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 580, col: 11, offset: 19672},
+										pos:  position{line: 656, col: 11, offset: 21969},
 										name: "ImageBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 581, col: 11, offset: 19695},
+										pos:  position{line: 657, col: 11, offset: 21992},
 										name: "OrderedListItem",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 582, col: 11, offset: 19723},
+										pos:  position{line: 658, col: 11, offset: 22020},
 										name: "UnorderedListItem",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 583, col: 11, offset: 19753},
+										pos:  position{line: 659, col: 11, offset: 22050},
 										name: "LabeledListItem",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 585, col: 11, offset: 19820},
+										pos:  position{line: 661, col: 11, offset: 22117},
 										name: "BlankLine",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 586, col: 11, offset: 19872},
+										pos:  position{line: 662, col: 11, offset: 22169},
 										name: "LiteralBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 587, col: 11, offset: 19897},
+										pos:  position{line: 663, col: 11, offset: 22194},
 										name: "AttributeDeclaration",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 588, col: 11, offset: 19930},
+										pos:  position{line: 664, col: 11, offset: 22227},
 										name: "AttributeReset",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 589, col: 11, offset: 19957},
+										pos:  position{line: 665, col: 11, offset: 22254},
 										name: "TableOfContentsPlaceHolder",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 590, col: 11, offset: 19995},
+										pos:  position{line: 666, col: 11, offset: 22292},
 										name: "UserMacroBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 591, col: 11, offset: 20021},
+										pos:  position{line: 667, col: 11, offset: 22318},
 										name: "ContinuedParagraph",
 									},
 								},
@@ -4292,37 +4695,37 @@ var g = &grammar{
 		},
 		{
 			name: "OrderedListItem",
-			pos:  position{line: 598, col: 1, offset: 20191},
+			pos:  position{line: 674, col: 1, offset: 22488},
 			expr: &actionExpr{
-				pos: position{line: 598, col: 20, offset: 20210},
+				pos: position{line: 674, col: 20, offset: 22507},
 				run: (*parser).callonOrderedListItem1,
 				expr: &seqExpr{
-					pos: position{line: 598, col: 20, offset: 20210},
+					pos: position{line: 674, col: 20, offset: 22507},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 598, col: 20, offset: 20210},
+							pos:   position{line: 674, col: 20, offset: 22507},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 598, col: 31, offset: 20221},
+								pos: position{line: 674, col: 31, offset: 22518},
 								expr: &ruleRefExpr{
-									pos:  position{line: 598, col: 32, offset: 20222},
+									pos:  position{line: 674, col: 32, offset: 22519},
 									name: "Attributes",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 598, col: 45, offset: 20235},
+							pos:   position{line: 674, col: 45, offset: 22532},
 							label: "prefix",
 							expr: &ruleRefExpr{
-								pos:  position{line: 598, col: 53, offset: 20243},
+								pos:  position{line: 674, col: 53, offset: 22540},
 								name: "OrderedListItemPrefix",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 598, col: 76, offset: 20266},
+							pos:   position{line: 674, col: 76, offset: 22563},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 598, col: 85, offset: 20275},
+								pos:  position{line: 674, col: 85, offset: 22572},
 								name: "OrderedListItemContent",
 							},
 						},
@@ -4332,42 +4735,42 @@ var g = &grammar{
 		},
 		{
 			name: "OrderedListItemPrefix",
-			pos:  position{line: 602, col: 1, offset: 20419},
+			pos:  position{line: 678, col: 1, offset: 22716},
 			expr: &actionExpr{
-				pos: position{line: 603, col: 5, offset: 20450},
+				pos: position{line: 679, col: 5, offset: 22747},
 				run: (*parser).callonOrderedListItemPrefix1,
 				expr: &seqExpr{
-					pos: position{line: 603, col: 5, offset: 20450},
+					pos: position{line: 679, col: 5, offset: 22747},
 					exprs: []interface{}{
 						&zeroOrMoreExpr{
-							pos: position{line: 603, col: 5, offset: 20450},
+							pos: position{line: 679, col: 5, offset: 22747},
 							expr: &ruleRefExpr{
-								pos:  position{line: 603, col: 5, offset: 20450},
+								pos:  position{line: 679, col: 5, offset: 22747},
 								name: "Space",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 603, col: 12, offset: 20457},
+							pos:   position{line: 679, col: 12, offset: 22754},
 							label: "prefix",
 							expr: &choiceExpr{
-								pos: position{line: 605, col: 9, offset: 20522},
+								pos: position{line: 681, col: 9, offset: 22819},
 								alternatives: []interface{}{
 									&actionExpr{
-										pos: position{line: 605, col: 9, offset: 20522},
+										pos: position{line: 681, col: 9, offset: 22819},
 										run: (*parser).callonOrderedListItemPrefix7,
 										expr: &seqExpr{
-											pos: position{line: 605, col: 9, offset: 20522},
+											pos: position{line: 681, col: 9, offset: 22819},
 											exprs: []interface{}{
 												&labeledExpr{
-													pos:   position{line: 605, col: 9, offset: 20522},
+													pos:   position{line: 681, col: 9, offset: 22819},
 													label: "depth",
 													expr: &actionExpr{
-														pos: position{line: 605, col: 16, offset: 20529},
+														pos: position{line: 681, col: 16, offset: 22826},
 														run: (*parser).callonOrderedListItemPrefix10,
 														expr: &oneOrMoreExpr{
-															pos: position{line: 605, col: 16, offset: 20529},
+															pos: position{line: 681, col: 16, offset: 22826},
 															expr: &litMatcher{
-																pos:        position{line: 605, col: 17, offset: 20530},
+																pos:        position{line: 681, col: 17, offset: 22827},
 																val:        ".",
 																ignoreCase: false,
 																want:       "\".\"",
@@ -4376,22 +4779,22 @@ var g = &grammar{
 													},
 												},
 												&andCodeExpr{
-													pos: position{line: 609, col: 9, offset: 20634},
+													pos: position{line: 685, col: 9, offset: 22931},
 													run: (*parser).callonOrderedListItemPrefix13,
 												},
 											},
 										},
 									},
 									&actionExpr{
-										pos: position{line: 628, col: 11, offset: 21370},
+										pos: position{line: 704, col: 11, offset: 23667},
 										run: (*parser).callonOrderedListItemPrefix14,
 										expr: &seqExpr{
-											pos: position{line: 628, col: 11, offset: 21370},
+											pos: position{line: 704, col: 11, offset: 23667},
 											exprs: []interface{}{
 												&oneOrMoreExpr{
-													pos: position{line: 628, col: 11, offset: 21370},
+													pos: position{line: 704, col: 11, offset: 23667},
 													expr: &charClassMatcher{
-														pos:        position{line: 628, col: 12, offset: 21371},
+														pos:        position{line: 704, col: 12, offset: 23668},
 														val:        "[0-9]",
 														ranges:     []rune{'0', '9'},
 														ignoreCase: false,
@@ -4399,7 +4802,7 @@ var g = &grammar{
 													},
 												},
 												&litMatcher{
-													pos:        position{line: 628, col: 20, offset: 21379},
+													pos:        position{line: 704, col: 20, offset: 23676},
 													val:        ".",
 													ignoreCase: false,
 													want:       "\".\"",
@@ -4408,20 +4811,20 @@ var g = &grammar{
 										},
 									},
 									&actionExpr{
-										pos: position{line: 630, col: 13, offset: 21492},
+										pos: position{line: 706, col: 13, offset: 23789},
 										run: (*parser).callonOrderedListItemPrefix19,
 										expr: &seqExpr{
-											pos: position{line: 630, col: 13, offset: 21492},
+											pos: position{line: 706, col: 13, offset: 23789},
 											exprs: []interface{}{
 												&charClassMatcher{
-													pos:        position{line: 630, col: 14, offset: 21493},
+													pos:        position{line: 706, col: 14, offset: 23790},
 													val:        "[a-z]",
 													ranges:     []rune{'a', 'z'},
 													ignoreCase: false,
 													inverted:   false,
 												},
 												&litMatcher{
-													pos:        position{line: 630, col: 21, offset: 21500},
+													pos:        position{line: 706, col: 21, offset: 23797},
 													val:        ".",
 													ignoreCase: false,
 													want:       "\".\"",
@@ -4430,20 +4833,20 @@ var g = &grammar{
 										},
 									},
 									&actionExpr{
-										pos: position{line: 632, col: 13, offset: 21616},
+										pos: position{line: 708, col: 13, offset: 23913},
 										run: (*parser).callonOrderedListItemPrefix23,
 										expr: &seqExpr{
-											pos: position{line: 632, col: 13, offset: 21616},
+											pos: position{line: 708, col: 13, offset: 23913},
 											exprs: []interface{}{
 												&charClassMatcher{
-													pos:        position{line: 632, col: 14, offset: 21617},
+													pos:        position{line: 708, col: 14, offset: 23914},
 													val:        "[A-Z]",
 													ranges:     []rune{'A', 'Z'},
 													ignoreCase: false,
 													inverted:   false,
 												},
 												&litMatcher{
-													pos:        position{line: 632, col: 21, offset: 21624},
+													pos:        position{line: 708, col: 21, offset: 23921},
 													val:        ".",
 													ignoreCase: false,
 													want:       "\".\"",
@@ -4452,15 +4855,15 @@ var g = &grammar{
 										},
 									},
 									&actionExpr{
-										pos: position{line: 634, col: 13, offset: 21740},
+										pos: position{line: 710, col: 13, offset: 24037},
 										run: (*parser).callonOrderedListItemPrefix27,
 										expr: &seqExpr{
-											pos: position{line: 634, col: 13, offset: 21740},
+											pos: position{line: 710, col: 13, offset: 24037},
 											exprs: []interface{}{
 												&oneOrMoreExpr{
-													pos: position{line: 634, col: 13, offset: 21740},
+													pos: position{line: 710, col: 13, offset: 24037},
 													expr: &charClassMatcher{
-														pos:        position{line: 634, col: 14, offset: 21741},
+														pos:        position{line: 710, col: 14, offset: 24038},
 														val:        "[a-z]",
 														ranges:     []rune{'a', 'z'},
 														ignoreCase: false,
@@ -4468,7 +4871,7 @@ var g = &grammar{
 													},
 												},
 												&litMatcher{
-													pos:        position{line: 634, col: 22, offset: 21749},
+													pos:        position{line: 710, col: 22, offset: 24046},
 													val:        ")",
 													ignoreCase: false,
 													want:       "\")\"",
@@ -4477,15 +4880,15 @@ var g = &grammar{
 										},
 									},
 									&actionExpr{
-										pos: position{line: 636, col: 13, offset: 21865},
+										pos: position{line: 712, col: 13, offset: 24162},
 										run: (*parser).callonOrderedListItemPrefix32,
 										expr: &seqExpr{
-											pos: position{line: 636, col: 13, offset: 21865},
+											pos: position{line: 712, col: 13, offset: 24162},
 											exprs: []interface{}{
 												&oneOrMoreExpr{
-													pos: position{line: 636, col: 13, offset: 21865},
+													pos: position{line: 712, col: 13, offset: 24162},
 													expr: &charClassMatcher{
-														pos:        position{line: 636, col: 14, offset: 21866},
+														pos:        position{line: 712, col: 14, offset: 24163},
 														val:        "[A-Z]",
 														ranges:     []rune{'A', 'Z'},
 														ignoreCase: false,
@@ -4493,7 +4896,7 @@ var g = &grammar{
 													},
 												},
 												&litMatcher{
-													pos:        position{line: 636, col: 22, offset: 21874},
+													pos:        position{line: 712, col: 22, offset: 24171},
 													val:        ")",
 													ignoreCase: false,
 													want:       "\")\"",
@@ -4505,9 +4908,9 @@ var g = &grammar{
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 638, col: 12, offset: 21989},
+							pos: position{line: 714, col: 12, offset: 24286},
 							expr: &ruleRefExpr{
-								pos:  position{line: 638, col: 12, offset: 21989},
+								pos:  position{line: 714, col: 12, offset: 24286},
 								name: "Space",
 							},
 						},
@@ -4517,17 +4920,17 @@ var g = &grammar{
 		},
 		{
 			name: "OrderedListItemContent",
-			pos:  position{line: 642, col: 1, offset: 22028},
+			pos:  position{line: 718, col: 1, offset: 24325},
 			expr: &actionExpr{
-				pos: position{line: 642, col: 27, offset: 22054},
+				pos: position{line: 718, col: 27, offset: 24351},
 				run: (*parser).callonOrderedListItemContent1,
 				expr: &labeledExpr{
-					pos:   position{line: 642, col: 27, offset: 22054},
+					pos:   position{line: 718, col: 27, offset: 24351},
 					label: "elements",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 642, col: 37, offset: 22064},
+						pos: position{line: 718, col: 37, offset: 24361},
 						expr: &ruleRefExpr{
-							pos:  position{line: 642, col: 37, offset: 22064},
+							pos:  position{line: 718, col: 37, offset: 24361},
 							name: "ListParagraph",
 						},
 					},
@@ -4536,48 +4939,48 @@ var g = &grammar{
 		},
 		{
 			name: "UnorderedListItem",
-			pos:  position{line: 649, col: 1, offset: 22271},
+			pos:  position{line: 725, col: 1, offset: 24568},
 			expr: &actionExpr{
-				pos: position{line: 649, col: 22, offset: 22292},
+				pos: position{line: 725, col: 22, offset: 24589},
 				run: (*parser).callonUnorderedListItem1,
 				expr: &seqExpr{
-					pos: position{line: 649, col: 22, offset: 22292},
+					pos: position{line: 725, col: 22, offset: 24589},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 649, col: 22, offset: 22292},
+							pos:   position{line: 725, col: 22, offset: 24589},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 649, col: 33, offset: 22303},
+								pos: position{line: 725, col: 33, offset: 24600},
 								expr: &ruleRefExpr{
-									pos:  position{line: 649, col: 34, offset: 22304},
+									pos:  position{line: 725, col: 34, offset: 24601},
 									name: "Attributes",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 649, col: 47, offset: 22317},
+							pos:   position{line: 725, col: 47, offset: 24614},
 							label: "prefix",
 							expr: &ruleRefExpr{
-								pos:  position{line: 649, col: 55, offset: 22325},
+								pos:  position{line: 725, col: 55, offset: 24622},
 								name: "UnorderedListItemPrefix",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 649, col: 80, offset: 22350},
+							pos:   position{line: 725, col: 80, offset: 24647},
 							label: "checkstyle",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 649, col: 91, offset: 22361},
+								pos: position{line: 725, col: 91, offset: 24658},
 								expr: &ruleRefExpr{
-									pos:  position{line: 649, col: 92, offset: 22362},
+									pos:  position{line: 725, col: 92, offset: 24659},
 									name: "UnorderedListItemCheckStyle",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 649, col: 122, offset: 22392},
+							pos:   position{line: 725, col: 122, offset: 24689},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 649, col: 131, offset: 22401},
+								pos:  position{line: 725, col: 131, offset: 24698},
 								name: "UnorderedListItemContent",
 							},
 						},
@@ -4587,42 +4990,42 @@ var g = &grammar{
 		},
 		{
 			name: "UnorderedListItemPrefix",
-			pos:  position{line: 653, col: 1, offset: 22563},
+			pos:  position{line: 729, col: 1, offset: 24860},
 			expr: &actionExpr{
-				pos: position{line: 654, col: 5, offset: 22596},
+				pos: position{line: 730, col: 5, offset: 24893},
 				run: (*parser).callonUnorderedListItemPrefix1,
 				expr: &seqExpr{
-					pos: position{line: 654, col: 5, offset: 22596},
+					pos: position{line: 730, col: 5, offset: 24893},
 					exprs: []interface{}{
 						&zeroOrMoreExpr{
-							pos: position{line: 654, col: 5, offset: 22596},
+							pos: position{line: 730, col: 5, offset: 24893},
 							expr: &ruleRefExpr{
-								pos:  position{line: 654, col: 5, offset: 22596},
+								pos:  position{line: 730, col: 5, offset: 24893},
 								name: "Space",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 654, col: 12, offset: 22603},
+							pos:   position{line: 730, col: 12, offset: 24900},
 							label: "prefix",
 							expr: &choiceExpr{
-								pos: position{line: 654, col: 20, offset: 22611},
+								pos: position{line: 730, col: 20, offset: 24908},
 								alternatives: []interface{}{
 									&actionExpr{
-										pos: position{line: 656, col: 9, offset: 22670},
+										pos: position{line: 732, col: 9, offset: 24967},
 										run: (*parser).callonUnorderedListItemPrefix7,
 										expr: &seqExpr{
-											pos: position{line: 656, col: 9, offset: 22670},
+											pos: position{line: 732, col: 9, offset: 24967},
 											exprs: []interface{}{
 												&labeledExpr{
-													pos:   position{line: 656, col: 9, offset: 22670},
+													pos:   position{line: 732, col: 9, offset: 24967},
 													label: "depth",
 													expr: &actionExpr{
-														pos: position{line: 656, col: 16, offset: 22677},
+														pos: position{line: 732, col: 16, offset: 24974},
 														run: (*parser).callonUnorderedListItemPrefix10,
 														expr: &oneOrMoreExpr{
-															pos: position{line: 656, col: 16, offset: 22677},
+															pos: position{line: 732, col: 16, offset: 24974},
 															expr: &litMatcher{
-																pos:        position{line: 656, col: 17, offset: 22678},
+																pos:        position{line: 732, col: 17, offset: 24975},
 																val:        "*",
 																ignoreCase: false,
 																want:       "\"*\"",
@@ -4631,20 +5034,20 @@ var g = &grammar{
 													},
 												},
 												&andCodeExpr{
-													pos: position{line: 660, col: 9, offset: 22782},
+													pos: position{line: 736, col: 9, offset: 25079},
 													run: (*parser).callonUnorderedListItemPrefix13,
 												},
 											},
 										},
 									},
 									&labeledExpr{
-										pos:   position{line: 677, col: 14, offset: 23506},
+										pos:   position{line: 753, col: 14, offset: 25803},
 										label: "depth",
 										expr: &actionExpr{
-											pos: position{line: 677, col: 21, offset: 23513},
+											pos: position{line: 753, col: 21, offset: 25810},
 											run: (*parser).callonUnorderedListItemPrefix15,
 											expr: &litMatcher{
-												pos:        position{line: 677, col: 22, offset: 23514},
+												pos:        position{line: 753, col: 22, offset: 25811},
 												val:        "-",
 												ignoreCase: false,
 												want:       "\"-\"",
@@ -4655,9 +5058,9 @@ var g = &grammar{
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 679, col: 13, offset: 23602},
+							pos: position{line: 755, col: 13, offset: 25899},
 							expr: &ruleRefExpr{
-								pos:  position{line: 679, col: 13, offset: 23602},
+								pos:  position{line: 755, col: 13, offset: 25899},
 								name: "Space",
 							},
 						},
@@ -4667,53 +5070,53 @@ var g = &grammar{
 		},
 		{
 			name: "UnorderedListItemCheckStyle",
-			pos:  position{line: 683, col: 1, offset: 23642},
+			pos:  position{line: 759, col: 1, offset: 25939},
 			expr: &actionExpr{
-				pos: position{line: 683, col: 32, offset: 23673},
+				pos: position{line: 759, col: 32, offset: 25970},
 				run: (*parser).callonUnorderedListItemCheckStyle1,
 				expr: &seqExpr{
-					pos: position{line: 683, col: 32, offset: 23673},
+					pos: position{line: 759, col: 32, offset: 25970},
 					exprs: []interface{}{
 						&andExpr{
-							pos: position{line: 683, col: 32, offset: 23673},
+							pos: position{line: 759, col: 32, offset: 25970},
 							expr: &litMatcher{
-								pos:        position{line: 683, col: 33, offset: 23674},
+								pos:        position{line: 759, col: 33, offset: 25971},
 								val:        "[",
 								ignoreCase: false,
 								want:       "\"[\"",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 683, col: 37, offset: 23678},
+							pos:   position{line: 759, col: 37, offset: 25975},
 							label: "style",
 							expr: &choiceExpr{
-								pos: position{line: 684, col: 7, offset: 23693},
+								pos: position{line: 760, col: 7, offset: 25990},
 								alternatives: []interface{}{
 									&actionExpr{
-										pos: position{line: 684, col: 7, offset: 23693},
+										pos: position{line: 760, col: 7, offset: 25990},
 										run: (*parser).callonUnorderedListItemCheckStyle7,
 										expr: &litMatcher{
-											pos:        position{line: 684, col: 7, offset: 23693},
+											pos:        position{line: 760, col: 7, offset: 25990},
 											val:        "[ ]",
 											ignoreCase: false,
 											want:       "\"[ ]\"",
 										},
 									},
 									&actionExpr{
-										pos: position{line: 685, col: 7, offset: 23739},
+										pos: position{line: 761, col: 7, offset: 26036},
 										run: (*parser).callonUnorderedListItemCheckStyle9,
 										expr: &litMatcher{
-											pos:        position{line: 685, col: 7, offset: 23739},
+											pos:        position{line: 761, col: 7, offset: 26036},
 											val:        "[*]",
 											ignoreCase: false,
 											want:       "\"[*]\"",
 										},
 									},
 									&actionExpr{
-										pos: position{line: 686, col: 7, offset: 23783},
+										pos: position{line: 762, col: 7, offset: 26080},
 										run: (*parser).callonUnorderedListItemCheckStyle11,
 										expr: &litMatcher{
-											pos:        position{line: 686, col: 7, offset: 23783},
+											pos:        position{line: 762, col: 7, offset: 26080},
 											val:        "[x]",
 											ignoreCase: false,
 											want:       "\"[x]\"",
@@ -4723,9 +5126,9 @@ var g = &grammar{
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 687, col: 7, offset: 23826},
+							pos: position{line: 763, col: 7, offset: 26123},
 							expr: &ruleRefExpr{
-								pos:  position{line: 687, col: 7, offset: 23826},
+								pos:  position{line: 763, col: 7, offset: 26123},
 								name: "Space",
 							},
 						},
@@ -4735,17 +5138,17 @@ var g = &grammar{
 		},
 		{
 			name: "UnorderedListItemContent",
-			pos:  position{line: 691, col: 1, offset: 23872},
+			pos:  position{line: 767, col: 1, offset: 26169},
 			expr: &actionExpr{
-				pos: position{line: 691, col: 29, offset: 23900},
+				pos: position{line: 767, col: 29, offset: 26197},
 				run: (*parser).callonUnorderedListItemContent1,
 				expr: &labeledExpr{
-					pos:   position{line: 691, col: 29, offset: 23900},
+					pos:   position{line: 767, col: 29, offset: 26197},
 					label: "elements",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 691, col: 39, offset: 23910},
+						pos: position{line: 767, col: 39, offset: 26207},
 						expr: &ruleRefExpr{
-							pos:  position{line: 691, col: 39, offset: 23910},
+							pos:  position{line: 767, col: 39, offset: 26207},
 							name: "ListParagraph",
 						},
 					},
@@ -4754,47 +5157,47 @@ var g = &grammar{
 		},
 		{
 			name: "LabeledListItem",
-			pos:  position{line: 698, col: 1, offset: 24233},
+			pos:  position{line: 774, col: 1, offset: 26530},
 			expr: &actionExpr{
-				pos: position{line: 698, col: 20, offset: 24252},
+				pos: position{line: 774, col: 20, offset: 26549},
 				run: (*parser).callonLabeledListItem1,
 				expr: &seqExpr{
-					pos: position{line: 698, col: 20, offset: 24252},
+					pos: position{line: 774, col: 20, offset: 26549},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 698, col: 20, offset: 24252},
+							pos:   position{line: 774, col: 20, offset: 26549},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 698, col: 31, offset: 24263},
+								pos: position{line: 774, col: 31, offset: 26560},
 								expr: &ruleRefExpr{
-									pos:  position{line: 698, col: 32, offset: 24264},
+									pos:  position{line: 774, col: 32, offset: 26561},
 									name: "Attributes",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 698, col: 45, offset: 24277},
+							pos:   position{line: 774, col: 45, offset: 26574},
 							label: "term",
 							expr: &ruleRefExpr{
-								pos:  position{line: 698, col: 51, offset: 24283},
+								pos:  position{line: 774, col: 51, offset: 26580},
 								name: "VerbatimLabeledListItemTerm",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 698, col: 80, offset: 24312},
+							pos:   position{line: 774, col: 80, offset: 26609},
 							label: "separator",
 							expr: &ruleRefExpr{
-								pos:  position{line: 698, col: 91, offset: 24323},
+								pos:  position{line: 774, col: 91, offset: 26620},
 								name: "LabeledListItemSeparator",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 698, col: 117, offset: 24349},
+							pos:   position{line: 774, col: 117, offset: 26646},
 							label: "description",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 698, col: 129, offset: 24361},
+								pos: position{line: 774, col: 129, offset: 26658},
 								expr: &ruleRefExpr{
-									pos:  position{line: 698, col: 130, offset: 24362},
+									pos:  position{line: 774, col: 130, offset: 26659},
 									name: "LabeledListItemDescription",
 								},
 							},
@@ -4805,16 +5208,16 @@ var g = &grammar{
 		},
 		{
 			name: "LabeledListItemPrefix",
-			pos:  position{line: 702, col: 1, offset: 24512},
+			pos:  position{line: 778, col: 1, offset: 26809},
 			expr: &seqExpr{
-				pos: position{line: 702, col: 26, offset: 24537},
+				pos: position{line: 778, col: 26, offset: 26834},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 702, col: 26, offset: 24537},
+						pos:  position{line: 778, col: 26, offset: 26834},
 						name: "VerbatimLabeledListItemTerm",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 702, col: 54, offset: 24565},
+						pos:  position{line: 778, col: 54, offset: 26862},
 						name: "LabeledListItemSeparator",
 					},
 				},
@@ -4822,14 +5225,14 @@ var g = &grammar{
 		},
 		{
 			name: "VerbatimLabeledListItemChars",
-			pos:  position{line: 704, col: 1, offset: 24593},
+			pos:  position{line: 780, col: 1, offset: 26890},
 			expr: &choiceExpr{
-				pos: position{line: 704, col: 33, offset: 24625},
+				pos: position{line: 780, col: 33, offset: 26922},
 				alternatives: []interface{}{
 					&oneOrMoreExpr{
-						pos: position{line: 704, col: 33, offset: 24625},
+						pos: position{line: 780, col: 33, offset: 26922},
 						expr: &charClassMatcher{
-							pos:        position{line: 704, col: 33, offset: 24625},
+							pos:        position{line: 780, col: 33, offset: 26922},
 							val:        "[^:\\r\\n]",
 							chars:      []rune{':', '\r', '\n'},
 							ignoreCase: false,
@@ -4837,18 +5240,18 @@ var g = &grammar{
 						},
 					},
 					&seqExpr{
-						pos: position{line: 704, col: 45, offset: 24637},
+						pos: position{line: 780, col: 45, offset: 26934},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 704, col: 45, offset: 24637},
+								pos:        position{line: 780, col: 45, offset: 26934},
 								val:        ":",
 								ignoreCase: false,
 								want:       "\":\"",
 							},
 							&notExpr{
-								pos: position{line: 704, col: 49, offset: 24641},
+								pos: position{line: 780, col: 49, offset: 26938},
 								expr: &litMatcher{
-									pos:        position{line: 704, col: 50, offset: 24642},
+									pos:        position{line: 780, col: 50, offset: 26939},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
@@ -4861,20 +5264,20 @@ var g = &grammar{
 		},
 		{
 			name: "VerbatimLabeledListItemTerm",
-			pos:  position{line: 705, col: 1, offset: 24647},
+			pos:  position{line: 781, col: 1, offset: 26944},
 			expr: &actionExpr{
-				pos: position{line: 705, col: 32, offset: 24678},
+				pos: position{line: 781, col: 32, offset: 26975},
 				run: (*parser).callonVerbatimLabeledListItemTerm1,
 				expr: &labeledExpr{
-					pos:   position{line: 705, col: 32, offset: 24678},
+					pos:   position{line: 781, col: 32, offset: 26975},
 					label: "content",
 					expr: &actionExpr{
-						pos: position{line: 705, col: 42, offset: 24688},
+						pos: position{line: 781, col: 42, offset: 26985},
 						run: (*parser).callonVerbatimLabeledListItemTerm3,
 						expr: &oneOrMoreExpr{
-							pos: position{line: 705, col: 42, offset: 24688},
+							pos: position{line: 781, col: 42, offset: 26985},
 							expr: &ruleRefExpr{
-								pos:  position{line: 705, col: 42, offset: 24688},
+								pos:  position{line: 781, col: 42, offset: 26985},
 								name: "VerbatimLabeledListItemChars",
 							},
 						},
@@ -4884,36 +5287,36 @@ var g = &grammar{
 		},
 		{
 			name: "LabeledListItemTerm",
-			pos:  position{line: 711, col: 1, offset: 24849},
+			pos:  position{line: 787, col: 1, offset: 27146},
 			expr: &actionExpr{
-				pos: position{line: 711, col: 24, offset: 24872},
+				pos: position{line: 787, col: 24, offset: 27169},
 				run: (*parser).callonLabeledListItemTerm1,
 				expr: &labeledExpr{
-					pos:   position{line: 711, col: 24, offset: 24872},
+					pos:   position{line: 787, col: 24, offset: 27169},
 					label: "elements",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 711, col: 33, offset: 24881},
+						pos: position{line: 787, col: 33, offset: 27178},
 						expr: &seqExpr{
-							pos: position{line: 711, col: 34, offset: 24882},
+							pos: position{line: 787, col: 34, offset: 27179},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 711, col: 34, offset: 24882},
+									pos: position{line: 787, col: 34, offset: 27179},
 									expr: &ruleRefExpr{
-										pos:  position{line: 711, col: 35, offset: 24883},
+										pos:  position{line: 787, col: 35, offset: 27180},
 										name: "Newline",
 									},
 								},
 								&notExpr{
-									pos: position{line: 711, col: 43, offset: 24891},
+									pos: position{line: 787, col: 43, offset: 27188},
 									expr: &litMatcher{
-										pos:        position{line: 711, col: 44, offset: 24892},
+										pos:        position{line: 787, col: 44, offset: 27189},
 										val:        "::",
 										ignoreCase: false,
 										want:       "\"::\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 711, col: 49, offset: 24897},
+									pos:  position{line: 787, col: 49, offset: 27194},
 									name: "LabeledListItemTermElement",
 								},
 							},
@@ -4924,73 +5327,77 @@ var g = &grammar{
 		},
 		{
 			name: "LabeledListItemTermElement",
-			pos:  position{line: 715, col: 1, offset: 25028},
+			pos:  position{line: 791, col: 1, offset: 27325},
 			expr: &actionExpr{
-				pos: position{line: 715, col: 31, offset: 25058},
+				pos: position{line: 791, col: 31, offset: 27355},
 				run: (*parser).callonLabeledListItemTermElement1,
 				expr: &labeledExpr{
-					pos:   position{line: 715, col: 31, offset: 25058},
+					pos:   position{line: 791, col: 31, offset: 27355},
 					label: "element",
 					expr: &choiceExpr{
-						pos: position{line: 715, col: 40, offset: 25067},
+						pos: position{line: 791, col: 40, offset: 27364},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 715, col: 40, offset: 25067},
+								pos:  position{line: 791, col: 40, offset: 27364},
 								name: "Word",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 716, col: 11, offset: 25083},
+								pos:  position{line: 792, col: 11, offset: 27380},
 								name: "LineBreak",
 							},
 							&oneOrMoreExpr{
-								pos: position{line: 717, col: 11, offset: 25133},
+								pos: position{line: 793, col: 11, offset: 27430},
 								expr: &ruleRefExpr{
-									pos:  position{line: 717, col: 11, offset: 25133},
+									pos:  position{line: 793, col: 11, offset: 27430},
 									name: "Space",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 718, col: 11, offset: 25152},
+								pos:  position{line: 794, col: 11, offset: 27449},
 								name: "CrossReference",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 719, col: 11, offset: 25178},
+								pos:  position{line: 795, col: 11, offset: 27475},
 								name: "ConcealedIndexTerm",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 720, col: 11, offset: 25208},
+								pos:  position{line: 796, col: 11, offset: 27505},
 								name: "IndexTerm",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 721, col: 11, offset: 25229},
+								pos:  position{line: 797, col: 11, offset: 27526},
 								name: "InlinePassthrough",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 722, col: 11, offset: 25258},
+								pos:  position{line: 798, col: 11, offset: 27555},
 								name: "InlineIcon",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 723, col: 11, offset: 25280},
+								pos:  position{line: 799, col: 11, offset: 27577},
 								name: "InlineImage",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 724, col: 11, offset: 25304},
+								pos:  position{line: 800, col: 11, offset: 27601},
 								name: "Link",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 725, col: 11, offset: 25320},
+								pos:  position{line: 801, col: 11, offset: 27617},
 								name: "InlineFootnote",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 726, col: 11, offset: 25346},
+								pos:  position{line: 802, col: 11, offset: 27643},
+								name: "QuotedString",
+							},
+							&ruleRefExpr{
+								pos:  position{line: 803, col: 11, offset: 27667},
 								name: "QuotedText",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 727, col: 11, offset: 25368},
+								pos:  position{line: 804, col: 11, offset: 27689},
 								name: "AttributeSubstitution",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 728, col: 11, offset: 25401},
+								pos:  position{line: 805, col: 11, offset: 27722},
 								name: "AnyChar",
 							},
 						},
@@ -5000,23 +5407,23 @@ var g = &grammar{
 		},
 		{
 			name: "LabeledListItemSeparator",
-			pos:  position{line: 732, col: 1, offset: 25444},
+			pos:  position{line: 809, col: 1, offset: 27765},
 			expr: &actionExpr{
-				pos: position{line: 733, col: 5, offset: 25478},
+				pos: position{line: 810, col: 5, offset: 27799},
 				run: (*parser).callonLabeledListItemSeparator1,
 				expr: &seqExpr{
-					pos: position{line: 733, col: 5, offset: 25478},
+					pos: position{line: 810, col: 5, offset: 27799},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 733, col: 5, offset: 25478},
+							pos:   position{line: 810, col: 5, offset: 27799},
 							label: "separator",
 							expr: &actionExpr{
-								pos: position{line: 733, col: 16, offset: 25489},
+								pos: position{line: 810, col: 16, offset: 27810},
 								run: (*parser).callonLabeledListItemSeparator4,
 								expr: &oneOrMoreExpr{
-									pos: position{line: 733, col: 16, offset: 25489},
+									pos: position{line: 810, col: 16, offset: 27810},
 									expr: &litMatcher{
-										pos:        position{line: 733, col: 17, offset: 25490},
+										pos:        position{line: 810, col: 17, offset: 27811},
 										val:        ":",
 										ignoreCase: false,
 										want:       "\":\"",
@@ -5025,30 +5432,30 @@ var g = &grammar{
 							},
 						},
 						&andCodeExpr{
-							pos: position{line: 736, col: 5, offset: 25551},
+							pos: position{line: 813, col: 5, offset: 27872},
 							run: (*parser).callonLabeledListItemSeparator7,
 						},
 						&choiceExpr{
-							pos: position{line: 740, col: 6, offset: 25731},
+							pos: position{line: 817, col: 6, offset: 28052},
 							alternatives: []interface{}{
 								&oneOrMoreExpr{
-									pos: position{line: 740, col: 6, offset: 25731},
+									pos: position{line: 817, col: 6, offset: 28052},
 									expr: &choiceExpr{
-										pos: position{line: 740, col: 7, offset: 25732},
+										pos: position{line: 817, col: 7, offset: 28053},
 										alternatives: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 740, col: 7, offset: 25732},
+												pos:  position{line: 817, col: 7, offset: 28053},
 												name: "Space",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 740, col: 15, offset: 25740},
+												pos:  position{line: 817, col: 15, offset: 28061},
 												name: "Newline",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 740, col: 27, offset: 25752},
+									pos:  position{line: 817, col: 27, offset: 28073},
 									name: "EOL",
 								},
 							},
@@ -5059,17 +5466,17 @@ var g = &grammar{
 		},
 		{
 			name: "LabeledListItemDescription",
-			pos:  position{line: 744, col: 1, offset: 25796},
+			pos:  position{line: 821, col: 1, offset: 28117},
 			expr: &actionExpr{
-				pos: position{line: 744, col: 31, offset: 25826},
+				pos: position{line: 821, col: 31, offset: 28147},
 				run: (*parser).callonLabeledListItemDescription1,
 				expr: &labeledExpr{
-					pos:   position{line: 744, col: 31, offset: 25826},
+					pos:   position{line: 821, col: 31, offset: 28147},
 					label: "elements",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 744, col: 40, offset: 25835},
+						pos: position{line: 821, col: 40, offset: 28156},
 						expr: &ruleRefExpr{
-							pos:  position{line: 744, col: 41, offset: 25836},
+							pos:  position{line: 821, col: 41, offset: 28157},
 							name: "ListParagraph",
 						},
 					},
@@ -5078,55 +5485,55 @@ var g = &grammar{
 		},
 		{
 			name: "AdmonitionKind",
-			pos:  position{line: 751, col: 1, offset: 26034},
+			pos:  position{line: 828, col: 1, offset: 28355},
 			expr: &choiceExpr{
-				pos: position{line: 751, col: 19, offset: 26052},
+				pos: position{line: 828, col: 19, offset: 28373},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 751, col: 19, offset: 26052},
+						pos: position{line: 828, col: 19, offset: 28373},
 						run: (*parser).callonAdmonitionKind2,
 						expr: &litMatcher{
-							pos:        position{line: 751, col: 19, offset: 26052},
+							pos:        position{line: 828, col: 19, offset: 28373},
 							val:        "TIP",
 							ignoreCase: false,
 							want:       "\"TIP\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 753, col: 9, offset: 26100},
+						pos: position{line: 830, col: 9, offset: 28421},
 						run: (*parser).callonAdmonitionKind4,
 						expr: &litMatcher{
-							pos:        position{line: 753, col: 9, offset: 26100},
+							pos:        position{line: 830, col: 9, offset: 28421},
 							val:        "NOTE",
 							ignoreCase: false,
 							want:       "\"NOTE\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 755, col: 9, offset: 26150},
+						pos: position{line: 832, col: 9, offset: 28471},
 						run: (*parser).callonAdmonitionKind6,
 						expr: &litMatcher{
-							pos:        position{line: 755, col: 9, offset: 26150},
+							pos:        position{line: 832, col: 9, offset: 28471},
 							val:        "IMPORTANT",
 							ignoreCase: false,
 							want:       "\"IMPORTANT\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 757, col: 9, offset: 26210},
+						pos: position{line: 834, col: 9, offset: 28531},
 						run: (*parser).callonAdmonitionKind8,
 						expr: &litMatcher{
-							pos:        position{line: 757, col: 9, offset: 26210},
+							pos:        position{line: 834, col: 9, offset: 28531},
 							val:        "WARNING",
 							ignoreCase: false,
 							want:       "\"WARNING\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 759, col: 9, offset: 26266},
+						pos: position{line: 836, col: 9, offset: 28587},
 						run: (*parser).callonAdmonitionKind10,
 						expr: &litMatcher{
-							pos:        position{line: 759, col: 9, offset: 26266},
+							pos:        position{line: 836, col: 9, offset: 28587},
 							val:        "CAUTION",
 							ignoreCase: false,
 							want:       "\"CAUTION\"",
@@ -5137,48 +5544,48 @@ var g = &grammar{
 		},
 		{
 			name: "Paragraph",
-			pos:  position{line: 768, col: 1, offset: 26582},
+			pos:  position{line: 845, col: 1, offset: 28903},
 			expr: &choiceExpr{
-				pos: position{line: 770, col: 5, offset: 26631},
+				pos: position{line: 847, col: 5, offset: 28952},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 770, col: 5, offset: 26631},
+						pos: position{line: 847, col: 5, offset: 28952},
 						run: (*parser).callonParagraph2,
 						expr: &seqExpr{
-							pos: position{line: 770, col: 5, offset: 26631},
+							pos: position{line: 847, col: 5, offset: 28952},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 770, col: 5, offset: 26631},
+									pos:   position{line: 847, col: 5, offset: 28952},
 									label: "attributes",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 770, col: 16, offset: 26642},
+										pos: position{line: 847, col: 16, offset: 28963},
 										expr: &ruleRefExpr{
-											pos:  position{line: 770, col: 17, offset: 26643},
+											pos:  position{line: 847, col: 17, offset: 28964},
 											name: "Attributes",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 770, col: 30, offset: 26656},
+									pos:   position{line: 847, col: 30, offset: 28977},
 									label: "t",
 									expr: &ruleRefExpr{
-										pos:  position{line: 770, col: 33, offset: 26659},
+										pos:  position{line: 847, col: 33, offset: 28980},
 										name: "AdmonitionKind",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 770, col: 49, offset: 26675},
+									pos:        position{line: 847, col: 49, offset: 28996},
 									val:        ": ",
 									ignoreCase: false,
 									want:       "\": \"",
 								},
 								&labeledExpr{
-									pos:   position{line: 770, col: 54, offset: 26680},
+									pos:   position{line: 847, col: 54, offset: 29001},
 									label: "lines",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 770, col: 60, offset: 26686},
+										pos: position{line: 847, col: 60, offset: 29007},
 										expr: &ruleRefExpr{
-											pos:  position{line: 770, col: 61, offset: 26687},
+											pos:  position{line: 847, col: 61, offset: 29008},
 											name: "InlineElements",
 										},
 									},
@@ -5187,33 +5594,33 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 774, col: 5, offset: 26872},
+						pos: position{line: 851, col: 5, offset: 29193},
 						run: (*parser).callonParagraph13,
 						expr: &seqExpr{
-							pos: position{line: 774, col: 5, offset: 26872},
+							pos: position{line: 851, col: 5, offset: 29193},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 774, col: 5, offset: 26872},
+									pos:   position{line: 851, col: 5, offset: 29193},
 									label: "attributes",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 774, col: 16, offset: 26883},
+										pos: position{line: 851, col: 16, offset: 29204},
 										expr: &ruleRefExpr{
-											pos:  position{line: 774, col: 17, offset: 26884},
+											pos:  position{line: 851, col: 17, offset: 29205},
 											name: "Attributes",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 774, col: 30, offset: 26897},
+									pos:        position{line: 851, col: 30, offset: 29218},
 									val:        "> ",
 									ignoreCase: false,
 									want:       "\"> \"",
 								},
 								&labeledExpr{
-									pos:   position{line: 774, col: 35, offset: 26902},
+									pos:   position{line: 851, col: 35, offset: 29223},
 									label: "content",
 									expr: &ruleRefExpr{
-										pos:  position{line: 774, col: 44, offset: 26911},
+										pos:  position{line: 851, col: 44, offset: 29232},
 										name: "MarkdownQuoteBlockVerbatimContent",
 									},
 								},
@@ -5221,38 +5628,38 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 778, col: 5, offset: 27110},
+						pos: position{line: 855, col: 5, offset: 29431},
 						run: (*parser).callonParagraph21,
 						expr: &seqExpr{
-							pos: position{line: 778, col: 5, offset: 27110},
+							pos: position{line: 855, col: 5, offset: 29431},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 778, col: 5, offset: 27110},
+									pos:   position{line: 855, col: 5, offset: 29431},
 									label: "attributes",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 778, col: 16, offset: 27121},
+										pos: position{line: 855, col: 16, offset: 29442},
 										expr: &ruleRefExpr{
-											pos:  position{line: 778, col: 17, offset: 27122},
+											pos:  position{line: 855, col: 17, offset: 29443},
 											name: "Attributes",
 										},
 									},
 								},
 								&andCodeExpr{
-									pos: position{line: 778, col: 30, offset: 27135},
+									pos: position{line: 855, col: 30, offset: 29456},
 									run: (*parser).callonParagraph26,
 								},
 								&notExpr{
-									pos: position{line: 785, col: 7, offset: 27421},
+									pos: position{line: 862, col: 7, offset: 29742},
 									expr: &ruleRefExpr{
-										pos:  position{line: 785, col: 8, offset: 27422},
+										pos:  position{line: 862, col: 8, offset: 29743},
 										name: "BlockDelimiter",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 785, col: 23, offset: 27437},
+									pos:   position{line: 862, col: 23, offset: 29758},
 									label: "content",
 									expr: &ruleRefExpr{
-										pos:  position{line: 785, col: 32, offset: 27446},
+										pos:  position{line: 862, col: 32, offset: 29767},
 										name: "OpenPassthroughParagraphContent",
 									},
 								},
@@ -5260,36 +5667,36 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 789, col: 5, offset: 27647},
+						pos: position{line: 866, col: 5, offset: 29968},
 						run: (*parser).callonParagraph31,
 						expr: &seqExpr{
-							pos: position{line: 789, col: 5, offset: 27647},
+							pos: position{line: 866, col: 5, offset: 29968},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 789, col: 5, offset: 27647},
+									pos:   position{line: 866, col: 5, offset: 29968},
 									label: "attributes",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 789, col: 16, offset: 27658},
+										pos: position{line: 866, col: 16, offset: 29979},
 										expr: &ruleRefExpr{
-											pos:  position{line: 789, col: 17, offset: 27659},
+											pos:  position{line: 866, col: 17, offset: 29980},
 											name: "Attributes",
 										},
 									},
 								},
 								&notExpr{
-									pos: position{line: 789, col: 30, offset: 27672},
+									pos: position{line: 866, col: 30, offset: 29993},
 									expr: &ruleRefExpr{
-										pos:  position{line: 789, col: 31, offset: 27673},
+										pos:  position{line: 866, col: 31, offset: 29994},
 										name: "BlockDelimiter",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 789, col: 46, offset: 27688},
+									pos:   position{line: 866, col: 46, offset: 30009},
 									label: "lines",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 789, col: 52, offset: 27694},
+										pos: position{line: 866, col: 52, offset: 30015},
 										expr: &ruleRefExpr{
-											pos:  position{line: 789, col: 53, offset: 27695},
+											pos:  position{line: 866, col: 53, offset: 30016},
 											name: "InlineElements",
 										},
 									},
@@ -5302,36 +5709,36 @@ var g = &grammar{
 		},
 		{
 			name: "MarkdownQuoteBlockVerbatimContent",
-			pos:  position{line: 793, col: 1, offset: 27795},
+			pos:  position{line: 870, col: 1, offset: 30116},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 793, col: 38, offset: 27832},
+				pos: position{line: 870, col: 38, offset: 30153},
 				expr: &actionExpr{
-					pos: position{line: 793, col: 39, offset: 27833},
+					pos: position{line: 870, col: 39, offset: 30154},
 					run: (*parser).callonMarkdownQuoteBlockVerbatimContent2,
 					expr: &seqExpr{
-						pos: position{line: 793, col: 39, offset: 27833},
+						pos: position{line: 870, col: 39, offset: 30154},
 						exprs: []interface{}{
 							&notExpr{
-								pos: position{line: 793, col: 39, offset: 27833},
+								pos: position{line: 870, col: 39, offset: 30154},
 								expr: &ruleRefExpr{
-									pos:  position{line: 793, col: 40, offset: 27834},
+									pos:  position{line: 870, col: 40, offset: 30155},
 									name: "BlankLine",
 								},
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 793, col: 50, offset: 27844},
+								pos: position{line: 870, col: 50, offset: 30165},
 								expr: &litMatcher{
-									pos:        position{line: 793, col: 50, offset: 27844},
+									pos:        position{line: 870, col: 50, offset: 30165},
 									val:        "> ",
 									ignoreCase: false,
 									want:       "\"> \"",
 								},
 							},
 							&labeledExpr{
-								pos:   position{line: 793, col: 56, offset: 27850},
+								pos:   position{line: 870, col: 56, offset: 30171},
 								label: "content",
 								expr: &ruleRefExpr{
-									pos:  position{line: 793, col: 65, offset: 27859},
+									pos:  position{line: 870, col: 65, offset: 30180},
 									name: "VerbatimContent",
 								},
 							},
@@ -5342,29 +5749,29 @@ var g = &grammar{
 		},
 		{
 			name: "MarkdownQuoteBlockAttribution",
-			pos:  position{line: 797, col: 1, offset: 28004},
+			pos:  position{line: 874, col: 1, offset: 30325},
 			expr: &actionExpr{
-				pos: position{line: 797, col: 34, offset: 28037},
+				pos: position{line: 874, col: 34, offset: 30358},
 				run: (*parser).callonMarkdownQuoteBlockAttribution1,
 				expr: &seqExpr{
-					pos: position{line: 797, col: 34, offset: 28037},
+					pos: position{line: 874, col: 34, offset: 30358},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 797, col: 34, offset: 28037},
+							pos:        position{line: 874, col: 34, offset: 30358},
 							val:        "-- ",
 							ignoreCase: false,
 							want:       "\"-- \"",
 						},
 						&labeledExpr{
-							pos:   position{line: 797, col: 40, offset: 28043},
+							pos:   position{line: 874, col: 40, offset: 30364},
 							label: "author",
 							expr: &actionExpr{
-								pos: position{line: 797, col: 48, offset: 28051},
+								pos: position{line: 874, col: 48, offset: 30372},
 								run: (*parser).callonMarkdownQuoteBlockAttribution5,
 								expr: &oneOrMoreExpr{
-									pos: position{line: 797, col: 49, offset: 28052},
+									pos: position{line: 874, col: 49, offset: 30373},
 									expr: &charClassMatcher{
-										pos:        position{line: 797, col: 49, offset: 28052},
+										pos:        position{line: 874, col: 49, offset: 30373},
 										val:        "[^\\r\\n]",
 										chars:      []rune{'\r', '\n'},
 										ignoreCase: false,
@@ -5374,7 +5781,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 799, col: 8, offset: 28104},
+							pos:  position{line: 876, col: 8, offset: 30425},
 							name: "EOL",
 						},
 					},
@@ -5383,27 +5790,27 @@ var g = &grammar{
 		},
 		{
 			name: "OpenPassthroughParagraphContent",
-			pos:  position{line: 803, col: 1, offset: 28140},
+			pos:  position{line: 880, col: 1, offset: 30461},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 803, col: 36, offset: 28175},
+				pos: position{line: 880, col: 36, offset: 30496},
 				expr: &actionExpr{
-					pos: position{line: 803, col: 37, offset: 28176},
+					pos: position{line: 880, col: 37, offset: 30497},
 					run: (*parser).callonOpenPassthroughParagraphContent2,
 					expr: &seqExpr{
-						pos: position{line: 803, col: 37, offset: 28176},
+						pos: position{line: 880, col: 37, offset: 30497},
 						exprs: []interface{}{
 							&notExpr{
-								pos: position{line: 803, col: 37, offset: 28176},
+								pos: position{line: 880, col: 37, offset: 30497},
 								expr: &ruleRefExpr{
-									pos:  position{line: 803, col: 38, offset: 28177},
+									pos:  position{line: 880, col: 38, offset: 30498},
 									name: "BlankLine",
 								},
 							},
 							&labeledExpr{
-								pos:   position{line: 803, col: 48, offset: 28187},
+								pos:   position{line: 880, col: 48, offset: 30508},
 								label: "content",
 								expr: &ruleRefExpr{
-									pos:  position{line: 803, col: 57, offset: 28196},
+									pos:  position{line: 880, col: 57, offset: 30517},
 									name: "VerbatimContent",
 								},
 							},
@@ -5414,43 +5821,43 @@ var g = &grammar{
 		},
 		{
 			name: "SimpleParagraph",
-			pos:  position{line: 808, col: 1, offset: 28414},
+			pos:  position{line: 885, col: 1, offset: 30735},
 			expr: &actionExpr{
-				pos: position{line: 808, col: 20, offset: 28433},
+				pos: position{line: 885, col: 20, offset: 30754},
 				run: (*parser).callonSimpleParagraph1,
 				expr: &seqExpr{
-					pos: position{line: 808, col: 20, offset: 28433},
+					pos: position{line: 885, col: 20, offset: 30754},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 808, col: 20, offset: 28433},
+							pos:   position{line: 885, col: 20, offset: 30754},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 808, col: 31, offset: 28444},
+								pos: position{line: 885, col: 31, offset: 30765},
 								expr: &ruleRefExpr{
-									pos:  position{line: 808, col: 32, offset: 28445},
+									pos:  position{line: 885, col: 32, offset: 30766},
 									name: "Attributes",
 								},
 							},
 						},
 						&andCodeExpr{
-							pos: position{line: 809, col: 5, offset: 28464},
+							pos: position{line: 886, col: 5, offset: 30785},
 							run: (*parser).callonSimpleParagraph6,
 						},
 						&labeledExpr{
-							pos:   position{line: 817, col: 5, offset: 28758},
+							pos:   position{line: 894, col: 5, offset: 31079},
 							label: "firstLine",
 							expr: &ruleRefExpr{
-								pos:  position{line: 817, col: 16, offset: 28769},
+								pos:  position{line: 894, col: 16, offset: 31090},
 								name: "FirstParagraphLine",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 818, col: 5, offset: 28793},
+							pos:   position{line: 895, col: 5, offset: 31114},
 							label: "otherLines",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 818, col: 16, offset: 28804},
+								pos: position{line: 895, col: 16, offset: 31125},
 								expr: &ruleRefExpr{
-									pos:  position{line: 818, col: 17, offset: 28805},
+									pos:  position{line: 895, col: 17, offset: 31126},
 									name: "OtherParagraphLine",
 								},
 							},
@@ -5461,27 +5868,27 @@ var g = &grammar{
 		},
 		{
 			name: "FirstParagraphLine",
-			pos:  position{line: 822, col: 1, offset: 28943},
+			pos:  position{line: 899, col: 1, offset: 31264},
 			expr: &actionExpr{
-				pos: position{line: 823, col: 5, offset: 28971},
+				pos: position{line: 900, col: 5, offset: 31292},
 				run: (*parser).callonFirstParagraphLine1,
 				expr: &seqExpr{
-					pos: position{line: 823, col: 5, offset: 28971},
+					pos: position{line: 900, col: 5, offset: 31292},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 823, col: 5, offset: 28971},
+							pos:   position{line: 900, col: 5, offset: 31292},
 							label: "elements",
 							expr: &seqExpr{
-								pos: position{line: 823, col: 15, offset: 28981},
+								pos: position{line: 900, col: 15, offset: 31302},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 823, col: 15, offset: 28981},
+										pos:  position{line: 900, col: 15, offset: 31302},
 										name: "Word",
 									},
 									&zeroOrMoreExpr{
-										pos: position{line: 823, col: 20, offset: 28986},
+										pos: position{line: 900, col: 20, offset: 31307},
 										expr: &ruleRefExpr{
-											pos:  position{line: 823, col: 20, offset: 28986},
+											pos:  position{line: 900, col: 20, offset: 31307},
 											name: "InlineElement",
 										},
 									},
@@ -5489,7 +5896,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 823, col: 36, offset: 29002},
+							pos:  position{line: 900, col: 36, offset: 31323},
 							name: "EOL",
 						},
 					},
@@ -5498,15 +5905,15 @@ var g = &grammar{
 		},
 		{
 			name: "OtherParagraphLine",
-			pos:  position{line: 827, col: 1, offset: 29077},
+			pos:  position{line: 904, col: 1, offset: 31398},
 			expr: &actionExpr{
-				pos: position{line: 827, col: 23, offset: 29099},
+				pos: position{line: 904, col: 23, offset: 31420},
 				run: (*parser).callonOtherParagraphLine1,
 				expr: &labeledExpr{
-					pos:   position{line: 827, col: 23, offset: 29099},
+					pos:   position{line: 904, col: 23, offset: 31420},
 					label: "elements",
 					expr: &ruleRefExpr{
-						pos:  position{line: 827, col: 33, offset: 29109},
+						pos:  position{line: 904, col: 33, offset: 31430},
 						name: "InlineElements",
 					},
 				},
@@ -5514,46 +5921,46 @@ var g = &grammar{
 		},
 		{
 			name: "ContinuedParagraph",
-			pos:  position{line: 832, col: 1, offset: 29234},
+			pos:  position{line: 909, col: 1, offset: 31555},
 			expr: &choiceExpr{
-				pos: position{line: 834, col: 5, offset: 29292},
+				pos: position{line: 911, col: 5, offset: 31613},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 834, col: 5, offset: 29292},
+						pos: position{line: 911, col: 5, offset: 31613},
 						run: (*parser).callonContinuedParagraph2,
 						expr: &seqExpr{
-							pos: position{line: 834, col: 5, offset: 29292},
+							pos: position{line: 911, col: 5, offset: 31613},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 834, col: 5, offset: 29292},
+									pos:   position{line: 911, col: 5, offset: 31613},
 									label: "attributes",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 834, col: 16, offset: 29303},
+										pos: position{line: 911, col: 16, offset: 31624},
 										expr: &ruleRefExpr{
-											pos:  position{line: 834, col: 17, offset: 29304},
+											pos:  position{line: 911, col: 17, offset: 31625},
 											name: "Attributes",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 834, col: 30, offset: 29317},
+									pos:   position{line: 911, col: 30, offset: 31638},
 									label: "t",
 									expr: &ruleRefExpr{
-										pos:  position{line: 834, col: 33, offset: 29320},
+										pos:  position{line: 911, col: 33, offset: 31641},
 										name: "AdmonitionKind",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 834, col: 49, offset: 29336},
+									pos:        position{line: 911, col: 49, offset: 31657},
 									val:        ": ",
 									ignoreCase: false,
 									want:       "\": \"",
 								},
 								&labeledExpr{
-									pos:   position{line: 834, col: 54, offset: 29341},
+									pos:   position{line: 911, col: 54, offset: 31662},
 									label: "lines",
 									expr: &ruleRefExpr{
-										pos:  position{line: 834, col: 61, offset: 29348},
+										pos:  position{line: 911, col: 61, offset: 31669},
 										name: "ContinuedParagraphLines",
 									},
 								},
@@ -5561,27 +5968,27 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 838, col: 5, offset: 29552},
+						pos: position{line: 915, col: 5, offset: 31873},
 						run: (*parser).callonContinuedParagraph12,
 						expr: &seqExpr{
-							pos: position{line: 838, col: 5, offset: 29552},
+							pos: position{line: 915, col: 5, offset: 31873},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 838, col: 5, offset: 29552},
+									pos:   position{line: 915, col: 5, offset: 31873},
 									label: "attributes",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 838, col: 16, offset: 29563},
+										pos: position{line: 915, col: 16, offset: 31884},
 										expr: &ruleRefExpr{
-											pos:  position{line: 838, col: 17, offset: 29564},
+											pos:  position{line: 915, col: 17, offset: 31885},
 											name: "Attributes",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 838, col: 30, offset: 29577},
+									pos:   position{line: 915, col: 30, offset: 31898},
 									label: "lines",
 									expr: &ruleRefExpr{
-										pos:  position{line: 838, col: 37, offset: 29584},
+										pos:  position{line: 915, col: 37, offset: 31905},
 										name: "ContinuedParagraphLines",
 									},
 								},
@@ -5593,38 +6000,38 @@ var g = &grammar{
 		},
 		{
 			name: "ContinuedParagraphLines",
-			pos:  position{line: 842, col: 1, offset: 29689},
+			pos:  position{line: 919, col: 1, offset: 32010},
 			expr: &actionExpr{
-				pos: position{line: 842, col: 28, offset: 29716},
+				pos: position{line: 919, col: 28, offset: 32037},
 				run: (*parser).callonContinuedParagraphLines1,
 				expr: &seqExpr{
-					pos: position{line: 842, col: 28, offset: 29716},
+					pos: position{line: 919, col: 28, offset: 32037},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 842, col: 28, offset: 29716},
+							pos:   position{line: 919, col: 28, offset: 32037},
 							label: "firstLine",
 							expr: &ruleRefExpr{
-								pos:  position{line: 842, col: 39, offset: 29727},
+								pos:  position{line: 919, col: 39, offset: 32048},
 								name: "FirstParagraphLine",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 842, col: 59, offset: 29747},
+							pos:   position{line: 919, col: 59, offset: 32068},
 							label: "otherLines",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 842, col: 70, offset: 29758},
+								pos: position{line: 919, col: 70, offset: 32079},
 								expr: &seqExpr{
-									pos: position{line: 842, col: 71, offset: 29759},
+									pos: position{line: 919, col: 71, offset: 32080},
 									exprs: []interface{}{
 										&notExpr{
-											pos: position{line: 842, col: 71, offset: 29759},
+											pos: position{line: 919, col: 71, offset: 32080},
 											expr: &ruleRefExpr{
-												pos:  position{line: 842, col: 72, offset: 29760},
+												pos:  position{line: 919, col: 72, offset: 32081},
 												name: "ListItemContinuation",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 842, col: 93, offset: 29781},
+											pos:  position{line: 919, col: 93, offset: 32102},
 											name: "OtherParagraphLine",
 										},
 									},
@@ -5637,52 +6044,52 @@ var g = &grammar{
 		},
 		{
 			name: "VerseParagraph",
-			pos:  position{line: 846, col: 1, offset: 29891},
+			pos:  position{line: 923, col: 1, offset: 32212},
 			expr: &choiceExpr{
-				pos: position{line: 848, col: 5, offset: 29945},
+				pos: position{line: 925, col: 5, offset: 32266},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 848, col: 5, offset: 29945},
+						pos: position{line: 925, col: 5, offset: 32266},
 						run: (*parser).callonVerseParagraph2,
 						expr: &seqExpr{
-							pos: position{line: 848, col: 5, offset: 29945},
+							pos: position{line: 925, col: 5, offset: 32266},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 848, col: 5, offset: 29945},
+									pos:   position{line: 925, col: 5, offset: 32266},
 									label: "attributes",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 848, col: 16, offset: 29956},
+										pos: position{line: 925, col: 16, offset: 32277},
 										expr: &ruleRefExpr{
-											pos:  position{line: 848, col: 17, offset: 29957},
+											pos:  position{line: 925, col: 17, offset: 32278},
 											name: "Attributes",
 										},
 									},
 								},
 								&andCodeExpr{
-									pos: position{line: 849, col: 5, offset: 29975},
+									pos: position{line: 926, col: 5, offset: 32296},
 									run: (*parser).callonVerseParagraph7,
 								},
 								&labeledExpr{
-									pos:   position{line: 856, col: 5, offset: 30187},
+									pos:   position{line: 933, col: 5, offset: 32508},
 									label: "t",
 									expr: &ruleRefExpr{
-										pos:  position{line: 856, col: 8, offset: 30190},
+										pos:  position{line: 933, col: 8, offset: 32511},
 										name: "AdmonitionKind",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 856, col: 24, offset: 30206},
+									pos:        position{line: 933, col: 24, offset: 32527},
 									val:        ": ",
 									ignoreCase: false,
 									want:       "\": \"",
 								},
 								&labeledExpr{
-									pos:   position{line: 856, col: 29, offset: 30211},
+									pos:   position{line: 933, col: 29, offset: 32532},
 									label: "lines",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 856, col: 35, offset: 30217},
+										pos: position{line: 933, col: 35, offset: 32538},
 										expr: &ruleRefExpr{
-											pos:  position{line: 856, col: 36, offset: 30218},
+											pos:  position{line: 933, col: 36, offset: 32539},
 											name: "InlineElements",
 										},
 									},
@@ -5691,33 +6098,33 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 860, col: 5, offset: 30414},
+						pos: position{line: 937, col: 5, offset: 32735},
 						run: (*parser).callonVerseParagraph14,
 						expr: &seqExpr{
-							pos: position{line: 860, col: 5, offset: 30414},
+							pos: position{line: 937, col: 5, offset: 32735},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 860, col: 5, offset: 30414},
+									pos:   position{line: 937, col: 5, offset: 32735},
 									label: "attributes",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 860, col: 16, offset: 30425},
+										pos: position{line: 937, col: 16, offset: 32746},
 										expr: &ruleRefExpr{
-											pos:  position{line: 860, col: 17, offset: 30426},
+											pos:  position{line: 937, col: 17, offset: 32747},
 											name: "Attributes",
 										},
 									},
 								},
 								&andCodeExpr{
-									pos: position{line: 861, col: 5, offset: 30444},
+									pos: position{line: 938, col: 5, offset: 32765},
 									run: (*parser).callonVerseParagraph19,
 								},
 								&labeledExpr{
-									pos:   position{line: 868, col: 5, offset: 30656},
+									pos:   position{line: 945, col: 5, offset: 32977},
 									label: "lines",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 868, col: 11, offset: 30662},
+										pos: position{line: 945, col: 11, offset: 32983},
 										expr: &ruleRefExpr{
-											pos:  position{line: 868, col: 12, offset: 30663},
+											pos:  position{line: 945, col: 12, offset: 32984},
 											name: "InlineElements",
 										},
 									},
@@ -5730,57 +6137,57 @@ var g = &grammar{
 		},
 		{
 			name: "InlineElements",
-			pos:  position{line: 872, col: 1, offset: 30768},
+			pos:  position{line: 949, col: 1, offset: 33089},
 			expr: &actionExpr{
-				pos: position{line: 872, col: 19, offset: 30786},
+				pos: position{line: 949, col: 19, offset: 33107},
 				run: (*parser).callonInlineElements1,
 				expr: &seqExpr{
-					pos: position{line: 872, col: 19, offset: 30786},
+					pos: position{line: 949, col: 19, offset: 33107},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 872, col: 19, offset: 30786},
+							pos: position{line: 949, col: 19, offset: 33107},
 							expr: &ruleRefExpr{
-								pos:  position{line: 872, col: 20, offset: 30787},
+								pos:  position{line: 949, col: 20, offset: 33108},
 								name: "BlankLine",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 873, col: 5, offset: 30802},
+							pos:   position{line: 950, col: 5, offset: 33123},
 							label: "elements",
 							expr: &choiceExpr{
-								pos: position{line: 873, col: 15, offset: 30812},
+								pos: position{line: 950, col: 15, offset: 33133},
 								alternatives: []interface{}{
 									&actionExpr{
-										pos: position{line: 873, col: 15, offset: 30812},
+										pos: position{line: 950, col: 15, offset: 33133},
 										run: (*parser).callonInlineElements7,
 										expr: &labeledExpr{
-											pos:   position{line: 873, col: 15, offset: 30812},
+											pos:   position{line: 950, col: 15, offset: 33133},
 											label: "comment",
 											expr: &ruleRefExpr{
-												pos:  position{line: 873, col: 24, offset: 30821},
+												pos:  position{line: 950, col: 24, offset: 33142},
 												name: "SingleLineComment",
 											},
 										},
 									},
 									&actionExpr{
-										pos: position{line: 875, col: 9, offset: 30915},
+										pos: position{line: 952, col: 9, offset: 33236},
 										run: (*parser).callonInlineElements10,
 										expr: &seqExpr{
-											pos: position{line: 875, col: 9, offset: 30915},
+											pos: position{line: 952, col: 9, offset: 33236},
 											exprs: []interface{}{
 												&labeledExpr{
-													pos:   position{line: 875, col: 9, offset: 30915},
+													pos:   position{line: 952, col: 9, offset: 33236},
 													label: "elements",
 													expr: &oneOrMoreExpr{
-														pos: position{line: 875, col: 18, offset: 30924},
+														pos: position{line: 952, col: 18, offset: 33245},
 														expr: &ruleRefExpr{
-															pos:  position{line: 875, col: 19, offset: 30925},
+															pos:  position{line: 952, col: 19, offset: 33246},
 															name: "InlineElement",
 														},
 													},
 												},
 												&ruleRefExpr{
-													pos:  position{line: 875, col: 35, offset: 30941},
+													pos:  position{line: 952, col: 35, offset: 33262},
 													name: "EOL",
 												},
 											},
@@ -5795,94 +6202,98 @@ var g = &grammar{
 		},
 		{
 			name: "InlineElement",
-			pos:  position{line: 881, col: 1, offset: 31064},
+			pos:  position{line: 958, col: 1, offset: 33385},
 			expr: &actionExpr{
-				pos: position{line: 882, col: 5, offset: 31088},
+				pos: position{line: 959, col: 5, offset: 33409},
 				run: (*parser).callonInlineElement1,
 				expr: &labeledExpr{
-					pos:   position{line: 882, col: 5, offset: 31088},
+					pos:   position{line: 959, col: 5, offset: 33409},
 					label: "element",
 					expr: &choiceExpr{
-						pos: position{line: 882, col: 14, offset: 31097},
+						pos: position{line: 959, col: 14, offset: 33418},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 882, col: 14, offset: 31097},
+								pos:  position{line: 959, col: 14, offset: 33418},
 								name: "InlineWord",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 883, col: 11, offset: 31149},
+								pos:  position{line: 960, col: 11, offset: 33470},
 								name: "LineBreak",
 							},
 							&oneOrMoreExpr{
-								pos: position{line: 884, col: 11, offset: 31195},
+								pos: position{line: 961, col: 11, offset: 33516},
 								expr: &ruleRefExpr{
-									pos:  position{line: 884, col: 11, offset: 31195},
+									pos:  position{line: 961, col: 11, offset: 33516},
 									name: "Space",
 								},
 							},
 							&seqExpr{
-								pos: position{line: 885, col: 11, offset: 31214},
+								pos: position{line: 962, col: 11, offset: 33535},
 								exprs: []interface{}{
 									&notExpr{
-										pos: position{line: 885, col: 11, offset: 31214},
+										pos: position{line: 962, col: 11, offset: 33535},
 										expr: &ruleRefExpr{
-											pos:  position{line: 885, col: 12, offset: 31215},
+											pos:  position{line: 962, col: 12, offset: 33536},
 											name: "EOL",
 										},
 									},
 									&choiceExpr{
-										pos: position{line: 886, col: 13, offset: 31235},
+										pos: position{line: 963, col: 13, offset: 33555},
 										alternatives: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 886, col: 13, offset: 31235},
+												pos:  position{line: 963, col: 13, offset: 33555},
+												name: "QuotedString",
+											},
+											&ruleRefExpr{
+												pos:  position{line: 964, col: 15, offset: 33583},
 												name: "QuotedText",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 887, col: 15, offset: 31261},
+												pos:  position{line: 965, col: 15, offset: 33609},
 												name: "InlineIcon",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 888, col: 15, offset: 31287},
+												pos:  position{line: 966, col: 15, offset: 33635},
 												name: "InlineImage",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 889, col: 15, offset: 31315},
+												pos:  position{line: 967, col: 15, offset: 33663},
 												name: "Link",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 890, col: 15, offset: 31336},
+												pos:  position{line: 968, col: 15, offset: 33684},
 												name: "InlinePassthrough",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 891, col: 15, offset: 31370},
+												pos:  position{line: 969, col: 15, offset: 33718},
 												name: "InlineFootnote",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 892, col: 15, offset: 31401},
+												pos:  position{line: 970, col: 15, offset: 33749},
 												name: "CrossReference",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 893, col: 15, offset: 31432},
+												pos:  position{line: 971, col: 15, offset: 33780},
 												name: "InlineUserMacro",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 894, col: 15, offset: 31464},
+												pos:  position{line: 972, col: 15, offset: 33812},
 												name: "AttributeSubstitution",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 895, col: 15, offset: 31502},
+												pos:  position{line: 973, col: 15, offset: 33850},
 												name: "InlineElementID",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 896, col: 15, offset: 31533},
+												pos:  position{line: 974, col: 15, offset: 33881},
 												name: "ConcealedIndexTerm",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 897, col: 15, offset: 31567},
+												pos:  position{line: 975, col: 15, offset: 33915},
 												name: "IndexTerm",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 898, col: 15, offset: 31592},
+												pos:  position{line: 976, col: 15, offset: 33940},
 												name: "AnyChar",
 											},
 										},
@@ -5896,34 +6307,34 @@ var g = &grammar{
 		},
 		{
 			name: "LineBreak",
-			pos:  position{line: 905, col: 1, offset: 31822},
+			pos:  position{line: 983, col: 1, offset: 34170},
 			expr: &actionExpr{
-				pos: position{line: 905, col: 14, offset: 31835},
+				pos: position{line: 983, col: 14, offset: 34183},
 				run: (*parser).callonLineBreak1,
 				expr: &seqExpr{
-					pos: position{line: 905, col: 14, offset: 31835},
+					pos: position{line: 983, col: 14, offset: 34183},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 905, col: 14, offset: 31835},
+							pos:  position{line: 983, col: 14, offset: 34183},
 							name: "Space",
 						},
 						&litMatcher{
-							pos:        position{line: 905, col: 20, offset: 31841},
+							pos:        position{line: 983, col: 20, offset: 34189},
 							val:        "+",
 							ignoreCase: false,
 							want:       "\"+\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 905, col: 24, offset: 31845},
+							pos: position{line: 983, col: 24, offset: 34193},
 							expr: &ruleRefExpr{
-								pos:  position{line: 905, col: 24, offset: 31845},
+								pos:  position{line: 983, col: 24, offset: 34193},
 								name: "Space",
 							},
 						},
 						&andExpr{
-							pos: position{line: 905, col: 31, offset: 31852},
+							pos: position{line: 983, col: 31, offset: 34200},
 							expr: &ruleRefExpr{
-								pos:  position{line: 905, col: 32, offset: 31853},
+								pos:  position{line: 983, col: 32, offset: 34201},
 								name: "EOL",
 							},
 						},
@@ -5933,20 +6344,20 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedText",
-			pos:  position{line: 912, col: 1, offset: 32144},
+			pos:  position{line: 990, col: 1, offset: 34492},
 			expr: &choiceExpr{
-				pos: position{line: 912, col: 15, offset: 32158},
+				pos: position{line: 990, col: 15, offset: 34506},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 912, col: 15, offset: 32158},
+						pos:  position{line: 990, col: 15, offset: 34506},
 						name: "UnconstrainedQuotedText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 912, col: 41, offset: 32184},
+						pos:  position{line: 990, col: 41, offset: 34532},
 						name: "ConstrainedQuotedText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 912, col: 65, offset: 32208},
+						pos:  position{line: 990, col: 65, offset: 34556},
 						name: "EscapedQuotedText",
 					},
 				},
@@ -5954,23 +6365,23 @@ var g = &grammar{
 		},
 		{
 			name: "ConstrainedQuotedTextMarker",
-			pos:  position{line: 914, col: 1, offset: 32229},
+			pos:  position{line: 992, col: 1, offset: 34577},
 			expr: &choiceExpr{
-				pos: position{line: 914, col: 32, offset: 32260},
+				pos: position{line: 992, col: 32, offset: 34608},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 914, col: 32, offset: 32260},
+						pos: position{line: 992, col: 32, offset: 34608},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 914, col: 32, offset: 32260},
+								pos:        position{line: 992, col: 32, offset: 34608},
 								val:        "*",
 								ignoreCase: false,
 								want:       "\"*\"",
 							},
 							&notExpr{
-								pos: position{line: 914, col: 36, offset: 32264},
+								pos: position{line: 992, col: 36, offset: 34612},
 								expr: &litMatcher{
-									pos:        position{line: 914, col: 37, offset: 32265},
+									pos:        position{line: 992, col: 37, offset: 34613},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
@@ -5979,18 +6390,18 @@ var g = &grammar{
 						},
 					},
 					&seqExpr{
-						pos: position{line: 914, col: 43, offset: 32271},
+						pos: position{line: 992, col: 43, offset: 34619},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 914, col: 43, offset: 32271},
+								pos:        position{line: 992, col: 43, offset: 34619},
 								val:        "_",
 								ignoreCase: false,
 								want:       "\"_\"",
 							},
 							&notExpr{
-								pos: position{line: 914, col: 47, offset: 32275},
+								pos: position{line: 992, col: 47, offset: 34623},
 								expr: &litMatcher{
-									pos:        position{line: 914, col: 48, offset: 32276},
+									pos:        position{line: 992, col: 48, offset: 34624},
 									val:        "_",
 									ignoreCase: false,
 									want:       "\"_\"",
@@ -5999,18 +6410,38 @@ var g = &grammar{
 						},
 					},
 					&seqExpr{
-						pos: position{line: 914, col: 54, offset: 32282},
+						pos: position{line: 992, col: 54, offset: 34630},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 914, col: 54, offset: 32282},
+								pos:        position{line: 992, col: 54, offset: 34630},
+								val:        "#",
+								ignoreCase: false,
+								want:       "\"#\"",
+							},
+							&notExpr{
+								pos: position{line: 992, col: 58, offset: 34634},
+								expr: &litMatcher{
+									pos:        position{line: 992, col: 59, offset: 34635},
+									val:        "#",
+									ignoreCase: false,
+									want:       "\"#\"",
+								},
+							},
+						},
+					},
+					&seqExpr{
+						pos: position{line: 992, col: 65, offset: 34641},
+						exprs: []interface{}{
+							&litMatcher{
+								pos:        position{line: 992, col: 65, offset: 34641},
 								val:        "`",
 								ignoreCase: false,
 								want:       "\"`\"",
 							},
 							&notExpr{
-								pos: position{line: 914, col: 58, offset: 32286},
+								pos: position{line: 992, col: 69, offset: 34645},
 								expr: &litMatcher{
-									pos:        position{line: 914, col: 59, offset: 32287},
+									pos:        position{line: 992, col: 70, offset: 34646},
 									val:        "`",
 									ignoreCase: false,
 									want:       "\"`\"",
@@ -6023,36 +6454,42 @@ var g = &grammar{
 		},
 		{
 			name: "UnconstrainedQuotedTextPrefix",
-			pos:  position{line: 916, col: 1, offset: 32295},
+			pos:  position{line: 994, col: 1, offset: 34653},
 			expr: &choiceExpr{
-				pos: position{line: 916, col: 34, offset: 32328},
+				pos: position{line: 994, col: 34, offset: 34686},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 916, col: 34, offset: 32328},
+						pos:        position{line: 994, col: 34, offset: 34686},
 						val:        "**",
 						ignoreCase: false,
 						want:       "\"**\"",
 					},
 					&litMatcher{
-						pos:        position{line: 916, col: 41, offset: 32335},
+						pos:        position{line: 994, col: 41, offset: 34693},
 						val:        "__",
 						ignoreCase: false,
 						want:       "\"__\"",
 					},
 					&litMatcher{
-						pos:        position{line: 916, col: 48, offset: 32342},
+						pos:        position{line: 994, col: 48, offset: 34700},
 						val:        "``",
 						ignoreCase: false,
 						want:       "\"``\"",
 					},
 					&litMatcher{
-						pos:        position{line: 916, col: 55, offset: 32349},
+						pos:        position{line: 994, col: 55, offset: 34707},
+						val:        "##",
+						ignoreCase: false,
+						want:       "\"##\"",
+					},
+					&litMatcher{
+						pos:        position{line: 994, col: 62, offset: 34714},
 						val:        "^",
 						ignoreCase: false,
 						want:       "\"^\"",
 					},
 					&litMatcher{
-						pos:        position{line: 916, col: 61, offset: 32355},
+						pos:        position{line: 994, col: 68, offset: 34720},
 						val:        "~",
 						ignoreCase: false,
 						want:       "\"~\"",
@@ -6062,42 +6499,42 @@ var g = &grammar{
 		},
 		{
 			name: "ConstrainedQuotedText",
-			pos:  position{line: 918, col: 1, offset: 32362},
+			pos:  position{line: 996, col: 1, offset: 34727},
 			expr: &actionExpr{
-				pos: position{line: 918, col: 26, offset: 32387},
+				pos: position{line: 996, col: 26, offset: 34752},
 				run: (*parser).callonConstrainedQuotedText1,
 				expr: &labeledExpr{
-					pos:   position{line: 918, col: 26, offset: 32387},
+					pos:   position{line: 996, col: 26, offset: 34752},
 					label: "text",
 					expr: &choiceExpr{
-						pos: position{line: 918, col: 32, offset: 32393},
+						pos: position{line: 996, col: 32, offset: 34758},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 918, col: 32, offset: 32393},
+								pos:  position{line: 996, col: 32, offset: 34758},
 								name: "SingleQuoteBoldText",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 919, col: 15, offset: 32429},
+								pos:  position{line: 997, col: 15, offset: 34794},
 								name: "SingleQuoteItalicText",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 920, col: 15, offset: 32466},
+								pos:  position{line: 998, col: 15, offset: 34831},
 								name: "SingleQuoteMarkedText",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 921, col: 15, offset: 32503},
+								pos:  position{line: 999, col: 15, offset: 34868},
 								name: "SingleQuoteMonospaceText",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 922, col: 15, offset: 32544},
+								pos:  position{line: 1000, col: 15, offset: 34909},
 								name: "SubscriptText",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 923, col: 15, offset: 32574},
+								pos:  position{line: 1001, col: 15, offset: 34939},
 								name: "SuperscriptText",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 924, col: 15, offset: 32606},
+								pos:  position{line: 1002, col: 15, offset: 34971},
 								name: "SubscriptOrSuperscriptPrefix",
 							},
 						},
@@ -6107,24 +6544,24 @@ var g = &grammar{
 		},
 		{
 			name: "UnconstrainedQuotedText",
-			pos:  position{line: 928, col: 1, offset: 32764},
+			pos:  position{line: 1006, col: 1, offset: 35129},
 			expr: &choiceExpr{
-				pos: position{line: 928, col: 28, offset: 32791},
+				pos: position{line: 1006, col: 28, offset: 35156},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 928, col: 28, offset: 32791},
+						pos:  position{line: 1006, col: 28, offset: 35156},
 						name: "DoubleQuoteBoldText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 929, col: 15, offset: 32826},
+						pos:  position{line: 1007, col: 15, offset: 35191},
 						name: "DoubleQuoteItalicText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 930, col: 15, offset: 32863},
+						pos:  position{line: 1008, col: 15, offset: 35228},
 						name: "DoubleQuoteMarkedText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 931, col: 15, offset: 32900},
+						pos:  position{line: 1009, col: 15, offset: 35265},
 						name: "DoubleQuoteMonospaceText",
 					},
 				},
@@ -6132,32 +6569,32 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedQuotedText",
-			pos:  position{line: 933, col: 1, offset: 32928},
+			pos:  position{line: 1011, col: 1, offset: 35293},
 			expr: &choiceExpr{
-				pos: position{line: 933, col: 22, offset: 32949},
+				pos: position{line: 1011, col: 22, offset: 35314},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 933, col: 22, offset: 32949},
+						pos:  position{line: 1011, col: 22, offset: 35314},
 						name: "EscapedBoldText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 934, col: 15, offset: 32981},
+						pos:  position{line: 1012, col: 15, offset: 35346},
 						name: "EscapedItalicText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 935, col: 15, offset: 33014},
+						pos:  position{line: 1013, col: 15, offset: 35379},
 						name: "EscapedMarkedText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 936, col: 15, offset: 33047},
+						pos:  position{line: 1014, col: 15, offset: 35412},
 						name: "EscapedMonospaceText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 937, col: 15, offset: 33084},
+						pos:  position{line: 1015, col: 15, offset: 35449},
 						name: "EscapedSubscriptText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 938, col: 15, offset: 33121},
+						pos:  position{line: 1016, col: 15, offset: 35486},
 						name: "EscapedSuperscriptText",
 					},
 				},
@@ -6165,21 +6602,21 @@ var g = &grammar{
 		},
 		{
 			name: "SubscriptOrSuperscriptPrefix",
-			pos:  position{line: 940, col: 1, offset: 33147},
+			pos:  position{line: 1018, col: 1, offset: 35512},
 			expr: &choiceExpr{
-				pos: position{line: 940, col: 33, offset: 33179},
+				pos: position{line: 1018, col: 33, offset: 35544},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 940, col: 33, offset: 33179},
+						pos:        position{line: 1018, col: 33, offset: 35544},
 						val:        "^",
 						ignoreCase: false,
 						want:       "\"^\"",
 					},
 					&actionExpr{
-						pos: position{line: 940, col: 39, offset: 33185},
+						pos: position{line: 1018, col: 39, offset: 35550},
 						run: (*parser).callonSubscriptOrSuperscriptPrefix3,
 						expr: &litMatcher{
-							pos:        position{line: 940, col: 39, offset: 33185},
+							pos:        position{line: 1018, col: 39, offset: 35550},
 							val:        "~",
 							ignoreCase: false,
 							want:       "\"~\"",
@@ -6190,14 +6627,14 @@ var g = &grammar{
 		},
 		{
 			name: "OneOrMoreBackslashes",
-			pos:  position{line: 944, col: 1, offset: 33322},
+			pos:  position{line: 1022, col: 1, offset: 35687},
 			expr: &actionExpr{
-				pos: position{line: 944, col: 25, offset: 33346},
+				pos: position{line: 1022, col: 25, offset: 35711},
 				run: (*parser).callonOneOrMoreBackslashes1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 944, col: 25, offset: 33346},
+					pos: position{line: 1022, col: 25, offset: 35711},
 					expr: &litMatcher{
-						pos:        position{line: 944, col: 25, offset: 33346},
+						pos:        position{line: 1022, col: 25, offset: 35711},
 						val:        "\\",
 						ignoreCase: false,
 						want:       "\"\\\\\"",
@@ -6207,23 +6644,23 @@ var g = &grammar{
 		},
 		{
 			name: "TwoOrMoreBackslashes",
-			pos:  position{line: 948, col: 1, offset: 33391},
+			pos:  position{line: 1026, col: 1, offset: 35756},
 			expr: &actionExpr{
-				pos: position{line: 948, col: 25, offset: 33415},
+				pos: position{line: 1026, col: 25, offset: 35780},
 				run: (*parser).callonTwoOrMoreBackslashes1,
 				expr: &seqExpr{
-					pos: position{line: 948, col: 25, offset: 33415},
+					pos: position{line: 1026, col: 25, offset: 35780},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 948, col: 25, offset: 33415},
+							pos:        position{line: 1026, col: 25, offset: 35780},
 							val:        "\\\\",
 							ignoreCase: false,
 							want:       "\"\\\\\\\\\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 948, col: 30, offset: 33420},
+							pos: position{line: 1026, col: 30, offset: 35785},
 							expr: &litMatcher{
-								pos:        position{line: 948, col: 30, offset: 33420},
+								pos:        position{line: 1026, col: 30, offset: 35785},
 								val:        "\\",
 								ignoreCase: false,
 								want:       "\"\\\\\"",
@@ -6235,16 +6672,16 @@ var g = &grammar{
 		},
 		{
 			name: "BoldText",
-			pos:  position{line: 956, col: 1, offset: 33525},
+			pos:  position{line: 1034, col: 1, offset: 35890},
 			expr: &choiceExpr{
-				pos: position{line: 956, col: 13, offset: 33537},
+				pos: position{line: 1034, col: 13, offset: 35902},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 956, col: 13, offset: 33537},
+						pos:  position{line: 1034, col: 13, offset: 35902},
 						name: "DoubleQuoteBoldText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 956, col: 35, offset: 33559},
+						pos:  position{line: 1034, col: 35, offset: 35924},
 						name: "SingleQuoteBoldText",
 					},
 				},
@@ -6252,49 +6689,49 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteBoldText",
-			pos:  position{line: 958, col: 1, offset: 33628},
+			pos:  position{line: 1036, col: 1, offset: 35993},
 			expr: &actionExpr{
-				pos: position{line: 958, col: 24, offset: 33651},
+				pos: position{line: 1036, col: 24, offset: 36016},
 				run: (*parser).callonDoubleQuoteBoldText1,
 				expr: &seqExpr{
-					pos: position{line: 958, col: 24, offset: 33651},
+					pos: position{line: 1036, col: 24, offset: 36016},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 958, col: 24, offset: 33651},
+							pos:   position{line: 1036, col: 24, offset: 36016},
 							label: "attrs",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 958, col: 30, offset: 33657},
+								pos: position{line: 1036, col: 30, offset: 36022},
 								expr: &ruleRefExpr{
-									pos:  position{line: 958, col: 31, offset: 33658},
+									pos:  position{line: 1036, col: 31, offset: 36023},
 									name: "QuotedTextAttrs",
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 958, col: 49, offset: 33676},
+							pos: position{line: 1036, col: 49, offset: 36041},
 							expr: &litMatcher{
-								pos:        position{line: 958, col: 50, offset: 33677},
+								pos:        position{line: 1036, col: 50, offset: 36042},
 								val:        "\\\\",
 								ignoreCase: false,
 								want:       "\"\\\\\\\\\"",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 958, col: 55, offset: 33682},
+							pos:        position{line: 1036, col: 55, offset: 36047},
 							val:        "**",
 							ignoreCase: false,
 							want:       "\"**\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 958, col: 60, offset: 33687},
+							pos:   position{line: 1036, col: 60, offset: 36052},
 							label: "elements",
 							expr: &ruleRefExpr{
-								pos:  position{line: 958, col: 70, offset: 33697},
+								pos:  position{line: 1036, col: 70, offset: 36062},
 								name: "DoubleQuoteBoldTextElements",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 958, col: 99, offset: 33726},
+							pos:        position{line: 1036, col: 99, offset: 36091},
 							val:        "**",
 							ignoreCase: false,
 							want:       "\"**\"",
@@ -6305,37 +6742,37 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteBoldTextElements",
-			pos:  position{line: 962, col: 1, offset: 33817},
+			pos:  position{line: 1040, col: 1, offset: 36182},
 			expr: &seqExpr{
-				pos: position{line: 962, col: 32, offset: 33848},
+				pos: position{line: 1040, col: 32, offset: 36213},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 962, col: 32, offset: 33848},
+						pos:  position{line: 1040, col: 32, offset: 36213},
 						name: "DoubleQuoteBoldTextElement",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 962, col: 59, offset: 33875},
+						pos: position{line: 1040, col: 59, offset: 36240},
 						expr: &seqExpr{
-							pos: position{line: 962, col: 60, offset: 33876},
+							pos: position{line: 1040, col: 60, offset: 36241},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 962, col: 60, offset: 33876},
+									pos: position{line: 1040, col: 60, offset: 36241},
 									expr: &litMatcher{
-										pos:        position{line: 962, col: 62, offset: 33878},
+										pos:        position{line: 1040, col: 62, offset: 36243},
 										val:        "**",
 										ignoreCase: false,
 										want:       "\"**\"",
 									},
 								},
 								&choiceExpr{
-									pos: position{line: 962, col: 69, offset: 33885},
+									pos: position{line: 1040, col: 69, offset: 36250},
 									alternatives: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 962, col: 69, offset: 33885},
+											pos:  position{line: 1040, col: 69, offset: 36250},
 											name: "Space",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 962, col: 77, offset: 33893},
+											pos:  position{line: 1040, col: 77, offset: 36258},
 											name: "DoubleQuoteBoldTextElement",
 										},
 									},
@@ -6348,64 +6785,68 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteBoldTextElement",
-			pos:  position{line: 964, col: 1, offset: 33960},
+			pos:  position{line: 1042, col: 1, offset: 36325},
 			expr: &choiceExpr{
-				pos: position{line: 964, col: 31, offset: 33990},
+				pos: position{line: 1042, col: 31, offset: 36355},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 964, col: 31, offset: 33990},
+						pos:  position{line: 1042, col: 31, offset: 36355},
 						name: "Word",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 965, col: 11, offset: 34007},
+						pos:  position{line: 1043, col: 11, offset: 36372},
 						name: "SingleQuoteBoldText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 966, col: 11, offset: 34039},
+						pos:  position{line: 1044, col: 11, offset: 36404},
 						name: "ItalicText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 967, col: 11, offset: 34061},
+						pos:  position{line: 1045, col: 11, offset: 36426},
 						name: "MarkedText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 968, col: 11, offset: 34083},
+						pos:  position{line: 1046, col: 11, offset: 36448},
 						name: "MonospaceText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 969, col: 11, offset: 34108},
+						pos:  position{line: 1047, col: 11, offset: 36473},
 						name: "SubscriptText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 970, col: 11, offset: 34133},
+						pos:  position{line: 1048, col: 11, offset: 36498},
 						name: "SuperscriptText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 971, col: 11, offset: 34160},
+						pos:  position{line: 1049, col: 11, offset: 36525},
 						name: "InlineIcon",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 972, col: 11, offset: 34182},
+						pos:  position{line: 1050, col: 11, offset: 36547},
 						name: "InlineImage",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 973, col: 11, offset: 34206},
+						pos:  position{line: 1051, col: 11, offset: 36570},
 						name: "Link",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 974, col: 11, offset: 34223},
+						pos:  position{line: 1052, col: 11, offset: 36586},
 						name: "InlinePassthrough",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 975, col: 11, offset: 34253},
+						pos:  position{line: 1053, col: 11, offset: 36615},
+						name: "QuotedString",
+					},
+					&ruleRefExpr{
+						pos:  position{line: 1054, col: 11, offset: 36639},
 						name: "AttributeSubstitution",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 976, col: 11, offset: 34286},
+						pos:  position{line: 1055, col: 11, offset: 36672},
 						name: "DoubleQuoteBoldTextStringElement",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 977, col: 11, offset: 34330},
+						pos:  position{line: 1056, col: 11, offset: 36716},
 						name: "DoubleQuoteBoldTextFallbackCharacter",
 					},
 				},
@@ -6413,26 +6854,26 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteBoldTextStringElement",
-			pos:  position{line: 980, col: 1, offset: 34372},
+			pos:  position{line: 1059, col: 1, offset: 36758},
 			expr: &actionExpr{
-				pos: position{line: 980, col: 37, offset: 34408},
+				pos: position{line: 1059, col: 37, offset: 36794},
 				run: (*parser).callonDoubleQuoteBoldTextStringElement1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 980, col: 37, offset: 34408},
+					pos: position{line: 1059, col: 37, offset: 36794},
 					expr: &seqExpr{
-						pos: position{line: 980, col: 38, offset: 34409},
+						pos: position{line: 1059, col: 38, offset: 36795},
 						exprs: []interface{}{
 							&notExpr{
-								pos: position{line: 980, col: 38, offset: 34409},
+								pos: position{line: 1059, col: 38, offset: 36795},
 								expr: &litMatcher{
-									pos:        position{line: 980, col: 39, offset: 34410},
+									pos:        position{line: 1059, col: 39, offset: 36796},
 									val:        "**",
 									ignoreCase: false,
 									want:       "\"**\"",
 								},
 							},
 							&charClassMatcher{
-								pos:        position{line: 980, col: 44, offset: 34415},
+								pos:        position{line: 1059, col: 44, offset: 36801},
 								val:        "[^\\r\\n ^~{}]",
 								chars:      []rune{'\r', '\n', ' ', '^', '~', '{', '}'},
 								ignoreCase: false,
@@ -6445,31 +6886,31 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteBoldTextFallbackCharacter",
-			pos:  position{line: 984, col: 1, offset: 34490},
+			pos:  position{line: 1063, col: 1, offset: 36876},
 			expr: &choiceExpr{
-				pos: position{line: 985, col: 5, offset: 34536},
+				pos: position{line: 1064, col: 5, offset: 36922},
 				alternatives: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 985, col: 5, offset: 34536},
+						pos:        position{line: 1064, col: 5, offset: 36922},
 						val:        "[^\\r\\n*]",
 						chars:      []rune{'\r', '\n', '*'},
 						ignoreCase: false,
 						inverted:   true,
 					},
 					&actionExpr{
-						pos: position{line: 986, col: 7, offset: 34634},
+						pos: position{line: 1065, col: 7, offset: 37020},
 						run: (*parser).callonDoubleQuoteBoldTextFallbackCharacter3,
 						expr: &seqExpr{
-							pos: position{line: 986, col: 7, offset: 34634},
+							pos: position{line: 1065, col: 7, offset: 37020},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 986, col: 7, offset: 34634},
+									pos:        position{line: 1065, col: 7, offset: 37020},
 									val:        "**",
 									ignoreCase: false,
 									want:       "\"**\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 986, col: 12, offset: 34639},
+									pos:  position{line: 1065, col: 12, offset: 37025},
 									name: "Alphanums",
 								},
 							},
@@ -6480,49 +6921,49 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteBoldText",
-			pos:  position{line: 990, col: 1, offset: 34806},
+			pos:  position{line: 1069, col: 1, offset: 37192},
 			expr: &choiceExpr{
-				pos: position{line: 990, col: 24, offset: 34829},
+				pos: position{line: 1069, col: 24, offset: 37215},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 990, col: 24, offset: 34829},
+						pos: position{line: 1069, col: 24, offset: 37215},
 						run: (*parser).callonSingleQuoteBoldText2,
 						expr: &seqExpr{
-							pos: position{line: 990, col: 24, offset: 34829},
+							pos: position{line: 1069, col: 24, offset: 37215},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 990, col: 24, offset: 34829},
+									pos:   position{line: 1069, col: 24, offset: 37215},
 									label: "attrs",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 990, col: 30, offset: 34835},
+										pos: position{line: 1069, col: 30, offset: 37221},
 										expr: &ruleRefExpr{
-											pos:  position{line: 990, col: 31, offset: 34836},
+											pos:  position{line: 1069, col: 31, offset: 37222},
 											name: "QuotedTextAttrs",
 										},
 									},
 								},
 								&seqExpr{
-									pos: position{line: 990, col: 50, offset: 34855},
+									pos: position{line: 1069, col: 50, offset: 37241},
 									exprs: []interface{}{
 										&notExpr{
-											pos: position{line: 990, col: 50, offset: 34855},
+											pos: position{line: 1069, col: 50, offset: 37241},
 											expr: &litMatcher{
-												pos:        position{line: 990, col: 51, offset: 34856},
+												pos:        position{line: 1069, col: 51, offset: 37242},
 												val:        "\\",
 												ignoreCase: false,
 												want:       "\"\\\\\"",
 											},
 										},
 										&litMatcher{
-											pos:        position{line: 990, col: 55, offset: 34860},
+											pos:        position{line: 1069, col: 55, offset: 37246},
 											val:        "*",
 											ignoreCase: false,
 											want:       "\"*\"",
 										},
 										&notExpr{
-											pos: position{line: 990, col: 59, offset: 34864},
+											pos: position{line: 1069, col: 59, offset: 37250},
 											expr: &litMatcher{
-												pos:        position{line: 990, col: 60, offset: 34865},
+												pos:        position{line: 1069, col: 60, offset: 37251},
 												val:        "*",
 												ignoreCase: false,
 												want:       "\"*\"",
@@ -6531,25 +6972,25 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 990, col: 65, offset: 34870},
+									pos:   position{line: 1069, col: 65, offset: 37256},
 									label: "elements",
 									expr: &ruleRefExpr{
-										pos:  position{line: 990, col: 75, offset: 34880},
+										pos:  position{line: 1069, col: 75, offset: 37266},
 										name: "SingleQuoteBoldTextElements",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 990, col: 104, offset: 34909},
+									pos:        position{line: 1069, col: 104, offset: 37295},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
 								},
 								&andExpr{
-									pos: position{line: 990, col: 108, offset: 34913},
+									pos: position{line: 1069, col: 108, offset: 37299},
 									expr: &notExpr{
-										pos: position{line: 990, col: 110, offset: 34915},
+										pos: position{line: 1069, col: 110, offset: 37301},
 										expr: &ruleRefExpr{
-											pos:  position{line: 990, col: 111, offset: 34916},
+											pos:  position{line: 1069, col: 111, offset: 37302},
 											name: "Alphanum",
 										},
 									},
@@ -6558,58 +6999,58 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 992, col: 5, offset: 35112},
+						pos: position{line: 1071, col: 5, offset: 37498},
 						run: (*parser).callonSingleQuoteBoldText19,
 						expr: &seqExpr{
-							pos: position{line: 992, col: 5, offset: 35112},
+							pos: position{line: 1071, col: 5, offset: 37498},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 992, col: 5, offset: 35112},
+									pos:   position{line: 1071, col: 5, offset: 37498},
 									label: "attrs",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 992, col: 11, offset: 35118},
+										pos: position{line: 1071, col: 11, offset: 37504},
 										expr: &ruleRefExpr{
-											pos:  position{line: 992, col: 12, offset: 35119},
+											pos:  position{line: 1071, col: 12, offset: 37505},
 											name: "QuotedTextAttrs",
 										},
 									},
 								},
 								&notExpr{
-									pos: position{line: 992, col: 30, offset: 35137},
+									pos: position{line: 1071, col: 30, offset: 37523},
 									expr: &litMatcher{
-										pos:        position{line: 992, col: 31, offset: 35138},
+										pos:        position{line: 1071, col: 31, offset: 37524},
 										val:        "\\\\",
 										ignoreCase: false,
 										want:       "\"\\\\\\\\\"",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 992, col: 36, offset: 35143},
+									pos:        position{line: 1071, col: 36, offset: 37529},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 992, col: 40, offset: 35147},
+									pos:   position{line: 1071, col: 40, offset: 37533},
 									label: "elements",
 									expr: &seqExpr{
-										pos: position{line: 992, col: 50, offset: 35157},
+										pos: position{line: 1071, col: 50, offset: 37543},
 										exprs: []interface{}{
 											&litMatcher{
-												pos:        position{line: 992, col: 50, offset: 35157},
+												pos:        position{line: 1071, col: 50, offset: 37543},
 												val:        "*",
 												ignoreCase: false,
 												want:       "\"*\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 992, col: 54, offset: 35161},
+												pos:  position{line: 1071, col: 54, offset: 37547},
 												name: "SingleQuoteBoldTextElements",
 											},
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 992, col: 83, offset: 35190},
+									pos:        position{line: 1071, col: 83, offset: 37576},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
@@ -6622,21 +7063,21 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteBoldTextElements",
-			pos:  position{line: 996, col: 1, offset: 35400},
+			pos:  position{line: 1075, col: 1, offset: 37786},
 			expr: &seqExpr{
-				pos: position{line: 996, col: 32, offset: 35431},
+				pos: position{line: 1075, col: 32, offset: 37817},
 				exprs: []interface{}{
 					&notExpr{
-						pos: position{line: 996, col: 32, offset: 35431},
+						pos: position{line: 1075, col: 32, offset: 37817},
 						expr: &ruleRefExpr{
-							pos:  position{line: 996, col: 33, offset: 35432},
+							pos:  position{line: 1075, col: 33, offset: 37818},
 							name: "Space",
 						},
 					},
 					&oneOrMoreExpr{
-						pos: position{line: 996, col: 39, offset: 35438},
+						pos: position{line: 1075, col: 39, offset: 37824},
 						expr: &ruleRefExpr{
-							pos:  position{line: 996, col: 39, offset: 35438},
+							pos:  position{line: 1075, col: 39, offset: 37824},
 							name: "SingleQuoteBoldTextElement",
 						},
 					},
@@ -6645,43 +7086,43 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteBoldTextElement",
-			pos:  position{line: 998, col: 1, offset: 35469},
+			pos:  position{line: 1077, col: 1, offset: 37855},
 			expr: &choiceExpr{
-				pos: position{line: 998, col: 31, offset: 35499},
+				pos: position{line: 1077, col: 31, offset: 37885},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 998, col: 31, offset: 35499},
+						pos:  position{line: 1077, col: 31, offset: 37885},
 						name: "Word",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 999, col: 11, offset: 35516},
+						pos:  position{line: 1078, col: 11, offset: 37902},
 						name: "DoubleQuoteBoldText",
 					},
 					&seqExpr{
-						pos: position{line: 1000, col: 11, offset: 35547},
+						pos: position{line: 1079, col: 11, offset: 37933},
 						exprs: []interface{}{
 							&oneOrMoreExpr{
-								pos: position{line: 1000, col: 11, offset: 35547},
+								pos: position{line: 1079, col: 11, offset: 37933},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1000, col: 11, offset: 35547},
+									pos:  position{line: 1079, col: 11, offset: 37933},
 									name: "Space",
 								},
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 1000, col: 18, offset: 35554},
+								pos: position{line: 1079, col: 18, offset: 37940},
 								expr: &seqExpr{
-									pos: position{line: 1000, col: 19, offset: 35555},
+									pos: position{line: 1079, col: 19, offset: 37941},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 1000, col: 19, offset: 35555},
+											pos:        position{line: 1079, col: 19, offset: 37941},
 											val:        "*",
 											ignoreCase: false,
 											want:       "\"*\"",
 										},
 										&notExpr{
-											pos: position{line: 1000, col: 23, offset: 35559},
+											pos: position{line: 1079, col: 23, offset: 37945},
 											expr: &litMatcher{
-												pos:        position{line: 1000, col: 24, offset: 35560},
+												pos:        position{line: 1079, col: 24, offset: 37946},
 												val:        "*",
 												ignoreCase: false,
 												want:       "\"*\"",
@@ -6693,51 +7134,55 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1001, col: 11, offset: 35577},
+						pos:  position{line: 1080, col: 11, offset: 37963},
 						name: "ItalicText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1002, col: 11, offset: 35599},
+						pos:  position{line: 1081, col: 11, offset: 37985},
 						name: "MarkedText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1003, col: 11, offset: 35621},
+						pos:  position{line: 1082, col: 11, offset: 38007},
 						name: "MonospaceText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1004, col: 11, offset: 35646},
+						pos:  position{line: 1083, col: 11, offset: 38032},
 						name: "SubscriptText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1005, col: 11, offset: 35671},
+						pos:  position{line: 1084, col: 11, offset: 38057},
 						name: "SuperscriptText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1006, col: 11, offset: 35698},
+						pos:  position{line: 1085, col: 11, offset: 38084},
 						name: "InlineIcon",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1007, col: 11, offset: 35720},
+						pos:  position{line: 1086, col: 11, offset: 38106},
 						name: "InlineImage",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1008, col: 11, offset: 35744},
+						pos:  position{line: 1087, col: 11, offset: 38130},
 						name: "Link",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1009, col: 11, offset: 35762},
+						pos:  position{line: 1088, col: 11, offset: 38148},
 						name: "InlinePassthrough",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1010, col: 11, offset: 35792},
+						pos:  position{line: 1089, col: 11, offset: 38177},
+						name: "QuotedString",
+					},
+					&ruleRefExpr{
+						pos:  position{line: 1090, col: 11, offset: 38201},
 						name: "AttributeSubstitution",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1011, col: 11, offset: 35825},
+						pos:  position{line: 1091, col: 11, offset: 38234},
 						name: "SingleQuoteBoldTextStringElement",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1012, col: 11, offset: 35869},
+						pos:  position{line: 1092, col: 11, offset: 38278},
 						name: "SingleQuoteBoldTextFallbackCharacter",
 					},
 				},
@@ -6745,14 +7190,14 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteBoldTextStringElement",
-			pos:  position{line: 1014, col: 1, offset: 35909},
+			pos:  position{line: 1094, col: 1, offset: 38318},
 			expr: &actionExpr{
-				pos: position{line: 1014, col: 37, offset: 35945},
+				pos: position{line: 1094, col: 37, offset: 38354},
 				run: (*parser).callonSingleQuoteBoldTextStringElement1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1014, col: 37, offset: 35945},
+					pos: position{line: 1094, col: 37, offset: 38354},
 					expr: &charClassMatcher{
-						pos:        position{line: 1014, col: 37, offset: 35945},
+						pos:        position{line: 1094, col: 37, offset: 38354},
 						val:        "[^\\r\\n{} *^~]",
 						chars:      []rune{'\r', '\n', '{', '}', ' ', '*', '^', '~'},
 						ignoreCase: false,
@@ -6763,31 +7208,31 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteBoldTextFallbackCharacter",
-			pos:  position{line: 1018, col: 1, offset: 36175},
+			pos:  position{line: 1098, col: 1, offset: 38584},
 			expr: &choiceExpr{
-				pos: position{line: 1019, col: 5, offset: 36221},
+				pos: position{line: 1099, col: 5, offset: 38630},
 				alternatives: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 1019, col: 5, offset: 36221},
+						pos:        position{line: 1099, col: 5, offset: 38630},
 						val:        "[^\\r\\n*]",
 						chars:      []rune{'\r', '\n', '*'},
 						ignoreCase: false,
 						inverted:   true,
 					},
 					&actionExpr{
-						pos: position{line: 1020, col: 7, offset: 36319},
+						pos: position{line: 1100, col: 7, offset: 38728},
 						run: (*parser).callonSingleQuoteBoldTextFallbackCharacter3,
 						expr: &seqExpr{
-							pos: position{line: 1020, col: 7, offset: 36319},
+							pos: position{line: 1100, col: 7, offset: 38728},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1020, col: 7, offset: 36319},
+									pos:        position{line: 1100, col: 7, offset: 38728},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1020, col: 11, offset: 36323},
+									pos:  position{line: 1100, col: 11, offset: 38732},
 									name: "Alphanums",
 								},
 							},
@@ -6798,40 +7243,40 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedBoldText",
-			pos:  position{line: 1024, col: 1, offset: 36490},
+			pos:  position{line: 1104, col: 1, offset: 38899},
 			expr: &choiceExpr{
-				pos: position{line: 1025, col: 5, offset: 36515},
+				pos: position{line: 1105, col: 5, offset: 38924},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1025, col: 5, offset: 36515},
+						pos: position{line: 1105, col: 5, offset: 38924},
 						run: (*parser).callonEscapedBoldText2,
 						expr: &seqExpr{
-							pos: position{line: 1025, col: 5, offset: 36515},
+							pos: position{line: 1105, col: 5, offset: 38924},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1025, col: 5, offset: 36515},
+									pos:   position{line: 1105, col: 5, offset: 38924},
 									label: "backslashes",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1025, col: 18, offset: 36528},
+										pos:  position{line: 1105, col: 18, offset: 38937},
 										name: "TwoOrMoreBackslashes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1025, col: 40, offset: 36550},
+									pos:        position{line: 1105, col: 40, offset: 38959},
 									val:        "**",
 									ignoreCase: false,
 									want:       "\"**\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1025, col: 45, offset: 36555},
+									pos:   position{line: 1105, col: 45, offset: 38964},
 									label: "elements",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1025, col: 55, offset: 36565},
+										pos:  position{line: 1105, col: 55, offset: 38974},
 										name: "DoubleQuoteBoldTextElements",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1025, col: 84, offset: 36594},
+									pos:        position{line: 1105, col: 84, offset: 39003},
 									val:        "**",
 									ignoreCase: false,
 									want:       "\"**\"",
@@ -6840,35 +7285,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1027, col: 9, offset: 36753},
+						pos: position{line: 1107, col: 9, offset: 39162},
 						run: (*parser).callonEscapedBoldText10,
 						expr: &seqExpr{
-							pos: position{line: 1027, col: 9, offset: 36753},
+							pos: position{line: 1107, col: 9, offset: 39162},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1027, col: 9, offset: 36753},
+									pos:   position{line: 1107, col: 9, offset: 39162},
 									label: "backslashes",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1027, col: 22, offset: 36766},
+										pos:  position{line: 1107, col: 22, offset: 39175},
 										name: "OneOrMoreBackslashes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1027, col: 44, offset: 36788},
+									pos:        position{line: 1107, col: 44, offset: 39197},
 									val:        "**",
 									ignoreCase: false,
 									want:       "\"**\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1027, col: 49, offset: 36793},
+									pos:   position{line: 1107, col: 49, offset: 39202},
 									label: "elements",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1027, col: 59, offset: 36803},
+										pos:  position{line: 1107, col: 59, offset: 39212},
 										name: "SingleQuoteBoldTextElements",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1027, col: 88, offset: 36832},
+									pos:        position{line: 1107, col: 88, offset: 39241},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
@@ -6877,35 +7322,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1030, col: 9, offset: 37035},
+						pos: position{line: 1110, col: 9, offset: 39444},
 						run: (*parser).callonEscapedBoldText18,
 						expr: &seqExpr{
-							pos: position{line: 1030, col: 9, offset: 37035},
+							pos: position{line: 1110, col: 9, offset: 39444},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1030, col: 9, offset: 37035},
+									pos:   position{line: 1110, col: 9, offset: 39444},
 									label: "backslashes",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1030, col: 22, offset: 37048},
+										pos:  position{line: 1110, col: 22, offset: 39457},
 										name: "OneOrMoreBackslashes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1030, col: 44, offset: 37070},
+									pos:        position{line: 1110, col: 44, offset: 39479},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1030, col: 48, offset: 37074},
+									pos:   position{line: 1110, col: 48, offset: 39483},
 									label: "elements",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1030, col: 58, offset: 37084},
+										pos:  position{line: 1110, col: 58, offset: 39493},
 										name: "SingleQuoteBoldTextElements",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1030, col: 87, offset: 37113},
+									pos:        position{line: 1110, col: 87, offset: 39522},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
@@ -6918,16 +7363,16 @@ var g = &grammar{
 		},
 		{
 			name: "ItalicText",
-			pos:  position{line: 1038, col: 1, offset: 37329},
+			pos:  position{line: 1118, col: 1, offset: 39738},
 			expr: &choiceExpr{
-				pos: position{line: 1038, col: 15, offset: 37343},
+				pos: position{line: 1118, col: 15, offset: 39752},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1038, col: 15, offset: 37343},
+						pos:  position{line: 1118, col: 15, offset: 39752},
 						name: "DoubleQuoteItalicText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1038, col: 39, offset: 37367},
+						pos:  position{line: 1118, col: 39, offset: 39776},
 						name: "SingleQuoteItalicText",
 					},
 				},
@@ -6935,49 +7380,49 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteItalicText",
-			pos:  position{line: 1040, col: 1, offset: 37392},
+			pos:  position{line: 1120, col: 1, offset: 39801},
 			expr: &actionExpr{
-				pos: position{line: 1040, col: 26, offset: 37417},
+				pos: position{line: 1120, col: 26, offset: 39826},
 				run: (*parser).callonDoubleQuoteItalicText1,
 				expr: &seqExpr{
-					pos: position{line: 1040, col: 26, offset: 37417},
+					pos: position{line: 1120, col: 26, offset: 39826},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1040, col: 26, offset: 37417},
+							pos:   position{line: 1120, col: 26, offset: 39826},
 							label: "attrs",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1040, col: 32, offset: 37423},
+								pos: position{line: 1120, col: 32, offset: 39832},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1040, col: 33, offset: 37424},
+									pos:  position{line: 1120, col: 33, offset: 39833},
 									name: "QuotedTextAttrs",
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 1040, col: 51, offset: 37442},
+							pos: position{line: 1120, col: 51, offset: 39851},
 							expr: &litMatcher{
-								pos:        position{line: 1040, col: 52, offset: 37443},
+								pos:        position{line: 1120, col: 52, offset: 39852},
 								val:        "\\\\",
 								ignoreCase: false,
 								want:       "\"\\\\\\\\\"",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1040, col: 57, offset: 37448},
+							pos:        position{line: 1120, col: 57, offset: 39857},
 							val:        "__",
 							ignoreCase: false,
 							want:       "\"__\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1040, col: 62, offset: 37453},
+							pos:   position{line: 1120, col: 62, offset: 39862},
 							label: "elements",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1040, col: 72, offset: 37463},
+								pos:  position{line: 1120, col: 72, offset: 39872},
 								name: "DoubleQuoteItalicTextElements",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1040, col: 103, offset: 37494},
+							pos:        position{line: 1120, col: 103, offset: 39903},
 							val:        "__",
 							ignoreCase: false,
 							want:       "\"__\"",
@@ -6988,37 +7433,37 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteItalicTextElements",
-			pos:  position{line: 1044, col: 1, offset: 37632},
+			pos:  position{line: 1124, col: 1, offset: 40041},
 			expr: &seqExpr{
-				pos: position{line: 1044, col: 34, offset: 37665},
+				pos: position{line: 1124, col: 34, offset: 40074},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1044, col: 34, offset: 37665},
+						pos:  position{line: 1124, col: 34, offset: 40074},
 						name: "DoubleQuoteItalicTextElement",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1044, col: 63, offset: 37694},
+						pos: position{line: 1124, col: 63, offset: 40103},
 						expr: &seqExpr{
-							pos: position{line: 1044, col: 64, offset: 37695},
+							pos: position{line: 1124, col: 64, offset: 40104},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1044, col: 64, offset: 37695},
+									pos: position{line: 1124, col: 64, offset: 40104},
 									expr: &litMatcher{
-										pos:        position{line: 1044, col: 66, offset: 37697},
+										pos:        position{line: 1124, col: 66, offset: 40106},
 										val:        "__",
 										ignoreCase: false,
 										want:       "\"__\"",
 									},
 								},
 								&choiceExpr{
-									pos: position{line: 1044, col: 73, offset: 37704},
+									pos: position{line: 1124, col: 73, offset: 40113},
 									alternatives: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 1044, col: 73, offset: 37704},
+											pos:  position{line: 1124, col: 73, offset: 40113},
 											name: "Space",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1044, col: 81, offset: 37712},
+											pos:  position{line: 1124, col: 81, offset: 40121},
 											name: "DoubleQuoteItalicTextElement",
 										},
 									},
@@ -7031,60 +7476,64 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteItalicTextElement",
-			pos:  position{line: 1046, col: 1, offset: 37781},
+			pos:  position{line: 1126, col: 1, offset: 40190},
 			expr: &choiceExpr{
-				pos: position{line: 1046, col: 33, offset: 37813},
+				pos: position{line: 1126, col: 33, offset: 40222},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1046, col: 33, offset: 37813},
+						pos:  position{line: 1126, col: 33, offset: 40222},
 						name: "Word",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1047, col: 11, offset: 37830},
+						pos:  position{line: 1127, col: 11, offset: 40239},
 						name: "SingleQuoteItalicText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1048, col: 11, offset: 37864},
+						pos:  position{line: 1128, col: 11, offset: 40273},
 						name: "BoldText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1049, col: 11, offset: 37884},
+						pos:  position{line: 1129, col: 11, offset: 40293},
 						name: "MarkedText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1050, col: 11, offset: 37906},
+						pos:  position{line: 1130, col: 11, offset: 40315},
 						name: "MonospaceText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1051, col: 11, offset: 37931},
+						pos:  position{line: 1131, col: 11, offset: 40340},
 						name: "SubscriptText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1052, col: 11, offset: 37956},
+						pos:  position{line: 1132, col: 11, offset: 40365},
 						name: "SuperscriptText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1053, col: 11, offset: 37983},
+						pos:  position{line: 1133, col: 11, offset: 40392},
 						name: "InlineIcon",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1054, col: 11, offset: 38005},
+						pos:  position{line: 1134, col: 11, offset: 40414},
 						name: "InlineImage",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1055, col: 11, offset: 38029},
+						pos:  position{line: 1135, col: 11, offset: 40438},
 						name: "Link",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1056, col: 11, offset: 38046},
+						pos:  position{line: 1136, col: 11, offset: 40455},
 						name: "InlinePassthrough",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1057, col: 11, offset: 38076},
+						pos:  position{line: 1137, col: 11, offset: 40484},
+						name: "QuotedString",
+					},
+					&ruleRefExpr{
+						pos:  position{line: 1138, col: 11, offset: 40508},
 						name: "DoubleQuoteItalicTextStringElement",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1058, col: 11, offset: 38122},
+						pos:  position{line: 1139, col: 11, offset: 40554},
 						name: "DoubleQuoteItalicTextFallbackCharacter",
 					},
 				},
@@ -7092,26 +7541,26 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteItalicTextStringElement",
-			pos:  position{line: 1060, col: 1, offset: 38164},
+			pos:  position{line: 1141, col: 1, offset: 40596},
 			expr: &actionExpr{
-				pos: position{line: 1060, col: 39, offset: 38202},
+				pos: position{line: 1141, col: 39, offset: 40634},
 				run: (*parser).callonDoubleQuoteItalicTextStringElement1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1060, col: 39, offset: 38202},
+					pos: position{line: 1141, col: 39, offset: 40634},
 					expr: &seqExpr{
-						pos: position{line: 1060, col: 40, offset: 38203},
+						pos: position{line: 1141, col: 40, offset: 40635},
 						exprs: []interface{}{
 							&notExpr{
-								pos: position{line: 1060, col: 40, offset: 38203},
+								pos: position{line: 1141, col: 40, offset: 40635},
 								expr: &litMatcher{
-									pos:        position{line: 1060, col: 41, offset: 38204},
+									pos:        position{line: 1141, col: 41, offset: 40636},
 									val:        "__",
 									ignoreCase: false,
 									want:       "\"__\"",
 								},
 							},
 							&charClassMatcher{
-								pos:        position{line: 1060, col: 46, offset: 38209},
+								pos:        position{line: 1141, col: 46, offset: 40641},
 								val:        "[^\\r\\n ^~{}]",
 								chars:      []rune{'\r', '\n', ' ', '^', '~', '{', '}'},
 								ignoreCase: false,
@@ -7124,31 +7573,31 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteItalicTextFallbackCharacter",
-			pos:  position{line: 1064, col: 1, offset: 38284},
+			pos:  position{line: 1145, col: 1, offset: 40716},
 			expr: &choiceExpr{
-				pos: position{line: 1065, col: 5, offset: 38332},
+				pos: position{line: 1146, col: 5, offset: 40764},
 				alternatives: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 1065, col: 5, offset: 38332},
+						pos:        position{line: 1146, col: 5, offset: 40764},
 						val:        "[^\\r\\n_]",
 						chars:      []rune{'\r', '\n', '_'},
 						ignoreCase: false,
 						inverted:   true,
 					},
 					&actionExpr{
-						pos: position{line: 1066, col: 7, offset: 38432},
+						pos: position{line: 1147, col: 7, offset: 40864},
 						run: (*parser).callonDoubleQuoteItalicTextFallbackCharacter3,
 						expr: &seqExpr{
-							pos: position{line: 1066, col: 7, offset: 38432},
+							pos: position{line: 1147, col: 7, offset: 40864},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1066, col: 7, offset: 38432},
+									pos:        position{line: 1147, col: 7, offset: 40864},
 									val:        "__",
 									ignoreCase: false,
 									want:       "\"__\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1066, col: 12, offset: 38437},
+									pos:  position{line: 1147, col: 12, offset: 40869},
 									name: "Alphanums",
 								},
 							},
@@ -7159,49 +7608,49 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteItalicText",
-			pos:  position{line: 1070, col: 1, offset: 38606},
+			pos:  position{line: 1151, col: 1, offset: 41038},
 			expr: &choiceExpr{
-				pos: position{line: 1070, col: 26, offset: 38631},
+				pos: position{line: 1151, col: 26, offset: 41063},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1070, col: 26, offset: 38631},
+						pos: position{line: 1151, col: 26, offset: 41063},
 						run: (*parser).callonSingleQuoteItalicText2,
 						expr: &seqExpr{
-							pos: position{line: 1070, col: 26, offset: 38631},
+							pos: position{line: 1151, col: 26, offset: 41063},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1070, col: 26, offset: 38631},
+									pos:   position{line: 1151, col: 26, offset: 41063},
 									label: "attrs",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1070, col: 32, offset: 38637},
+										pos: position{line: 1151, col: 32, offset: 41069},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1070, col: 33, offset: 38638},
+											pos:  position{line: 1151, col: 33, offset: 41070},
 											name: "QuotedTextAttrs",
 										},
 									},
 								},
 								&seqExpr{
-									pos: position{line: 1070, col: 52, offset: 38657},
+									pos: position{line: 1151, col: 52, offset: 41089},
 									exprs: []interface{}{
 										&notExpr{
-											pos: position{line: 1070, col: 52, offset: 38657},
+											pos: position{line: 1151, col: 52, offset: 41089},
 											expr: &litMatcher{
-												pos:        position{line: 1070, col: 53, offset: 38658},
+												pos:        position{line: 1151, col: 53, offset: 41090},
 												val:        "\\",
 												ignoreCase: false,
 												want:       "\"\\\\\"",
 											},
 										},
 										&litMatcher{
-											pos:        position{line: 1070, col: 57, offset: 38662},
+											pos:        position{line: 1151, col: 57, offset: 41094},
 											val:        "_",
 											ignoreCase: false,
 											want:       "\"_\"",
 										},
 										&notExpr{
-											pos: position{line: 1070, col: 61, offset: 38666},
+											pos: position{line: 1151, col: 61, offset: 41098},
 											expr: &litMatcher{
-												pos:        position{line: 1070, col: 62, offset: 38667},
+												pos:        position{line: 1151, col: 62, offset: 41099},
 												val:        "_",
 												ignoreCase: false,
 												want:       "\"_\"",
@@ -7210,15 +7659,15 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1070, col: 67, offset: 38672},
+									pos:   position{line: 1151, col: 67, offset: 41104},
 									label: "elements",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1070, col: 77, offset: 38682},
+										pos:  position{line: 1151, col: 77, offset: 41114},
 										name: "SingleQuoteItalicTextElements",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1070, col: 108, offset: 38713},
+									pos:        position{line: 1151, col: 108, offset: 41145},
 									val:        "_",
 									ignoreCase: false,
 									want:       "\"_\"",
@@ -7227,58 +7676,58 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1072, col: 5, offset: 38905},
+						pos: position{line: 1153, col: 5, offset: 41337},
 						run: (*parser).callonSingleQuoteItalicText16,
 						expr: &seqExpr{
-							pos: position{line: 1072, col: 5, offset: 38905},
+							pos: position{line: 1153, col: 5, offset: 41337},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1072, col: 5, offset: 38905},
+									pos:   position{line: 1153, col: 5, offset: 41337},
 									label: "attrs",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1072, col: 11, offset: 38911},
+										pos: position{line: 1153, col: 11, offset: 41343},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1072, col: 12, offset: 38912},
+											pos:  position{line: 1153, col: 12, offset: 41344},
 											name: "QuotedTextAttrs",
 										},
 									},
 								},
 								&notExpr{
-									pos: position{line: 1072, col: 30, offset: 38930},
+									pos: position{line: 1153, col: 30, offset: 41362},
 									expr: &litMatcher{
-										pos:        position{line: 1072, col: 31, offset: 38931},
+										pos:        position{line: 1153, col: 31, offset: 41363},
 										val:        "\\\\",
 										ignoreCase: false,
 										want:       "\"\\\\\\\\\"",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1072, col: 36, offset: 38936},
+									pos:        position{line: 1153, col: 36, offset: 41368},
 									val:        "_",
 									ignoreCase: false,
 									want:       "\"_\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1072, col: 40, offset: 38940},
+									pos:   position{line: 1153, col: 40, offset: 41372},
 									label: "elements",
 									expr: &seqExpr{
-										pos: position{line: 1072, col: 50, offset: 38950},
+										pos: position{line: 1153, col: 50, offset: 41382},
 										exprs: []interface{}{
 											&litMatcher{
-												pos:        position{line: 1072, col: 50, offset: 38950},
+												pos:        position{line: 1153, col: 50, offset: 41382},
 												val:        "_",
 												ignoreCase: false,
 												want:       "\"_\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1072, col: 54, offset: 38954},
+												pos:  position{line: 1153, col: 54, offset: 41386},
 												name: "SingleQuoteItalicTextElements",
 											},
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1072, col: 85, offset: 38985},
+									pos:        position{line: 1153, col: 85, offset: 41417},
 									val:        "_",
 									ignoreCase: false,
 									want:       "\"_\"",
@@ -7291,21 +7740,21 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteItalicTextElements",
-			pos:  position{line: 1076, col: 1, offset: 39199},
+			pos:  position{line: 1157, col: 1, offset: 41631},
 			expr: &seqExpr{
-				pos: position{line: 1076, col: 34, offset: 39232},
+				pos: position{line: 1157, col: 34, offset: 41664},
 				exprs: []interface{}{
 					&notExpr{
-						pos: position{line: 1076, col: 34, offset: 39232},
+						pos: position{line: 1157, col: 34, offset: 41664},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1076, col: 35, offset: 39233},
+							pos:  position{line: 1157, col: 35, offset: 41665},
 							name: "Space",
 						},
 					},
 					&oneOrMoreExpr{
-						pos: position{line: 1076, col: 41, offset: 39239},
+						pos: position{line: 1157, col: 41, offset: 41671},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1076, col: 41, offset: 39239},
+							pos:  position{line: 1157, col: 41, offset: 41671},
 							name: "SingleQuoteItalicTextElement",
 						},
 					},
@@ -7314,43 +7763,43 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteItalicTextElement",
-			pos:  position{line: 1078, col: 1, offset: 39272},
+			pos:  position{line: 1159, col: 1, offset: 41704},
 			expr: &choiceExpr{
-				pos: position{line: 1078, col: 33, offset: 39304},
+				pos: position{line: 1159, col: 33, offset: 41736},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1078, col: 33, offset: 39304},
+						pos:  position{line: 1159, col: 33, offset: 41736},
 						name: "Word",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1079, col: 11, offset: 39321},
+						pos:  position{line: 1160, col: 11, offset: 41753},
 						name: "DoubleQuoteItalicText",
 					},
 					&seqExpr{
-						pos: position{line: 1080, col: 11, offset: 39354},
+						pos: position{line: 1161, col: 11, offset: 41786},
 						exprs: []interface{}{
 							&oneOrMoreExpr{
-								pos: position{line: 1080, col: 11, offset: 39354},
+								pos: position{line: 1161, col: 11, offset: 41786},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1080, col: 11, offset: 39354},
+									pos:  position{line: 1161, col: 11, offset: 41786},
 									name: "Space",
 								},
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 1080, col: 18, offset: 39361},
+								pos: position{line: 1161, col: 18, offset: 41793},
 								expr: &seqExpr{
-									pos: position{line: 1080, col: 19, offset: 39362},
+									pos: position{line: 1161, col: 19, offset: 41794},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 1080, col: 19, offset: 39362},
+											pos:        position{line: 1161, col: 19, offset: 41794},
 											val:        "_",
 											ignoreCase: false,
 											want:       "\"_\"",
 										},
 										&notExpr{
-											pos: position{line: 1080, col: 23, offset: 39366},
+											pos: position{line: 1161, col: 23, offset: 41798},
 											expr: &litMatcher{
-												pos:        position{line: 1080, col: 24, offset: 39367},
+												pos:        position{line: 1161, col: 24, offset: 41799},
 												val:        "_",
 												ignoreCase: false,
 												want:       "\"_\"",
@@ -7362,51 +7811,55 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1081, col: 11, offset: 39384},
+						pos:  position{line: 1162, col: 11, offset: 41816},
 						name: "BoldText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1082, col: 11, offset: 39404},
+						pos:  position{line: 1163, col: 11, offset: 41836},
 						name: "MarkedText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1083, col: 11, offset: 39426},
+						pos:  position{line: 1164, col: 11, offset: 41858},
 						name: "MonospaceText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1084, col: 11, offset: 39451},
+						pos:  position{line: 1165, col: 11, offset: 41883},
 						name: "SubscriptText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1085, col: 11, offset: 39476},
+						pos:  position{line: 1166, col: 11, offset: 41908},
 						name: "SuperscriptText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1086, col: 11, offset: 39503},
+						pos:  position{line: 1167, col: 11, offset: 41935},
 						name: "InlineIcon",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1087, col: 11, offset: 39525},
+						pos:  position{line: 1168, col: 11, offset: 41957},
 						name: "InlineImage",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1088, col: 11, offset: 39549},
+						pos:  position{line: 1169, col: 11, offset: 41981},
 						name: "Link",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1089, col: 11, offset: 39567},
+						pos:  position{line: 1170, col: 11, offset: 41999},
 						name: "InlinePassthrough",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1090, col: 11, offset: 39597},
+						pos:  position{line: 1171, col: 11, offset: 42029},
+						name: "QuotedString",
+					},
+					&ruleRefExpr{
+						pos:  position{line: 1172, col: 11, offset: 42053},
 						name: "AttributeSubstitution",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1091, col: 11, offset: 39630},
+						pos:  position{line: 1173, col: 11, offset: 42086},
 						name: "SingleQuoteItalicTextStringElement",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1092, col: 11, offset: 39676},
+						pos:  position{line: 1174, col: 11, offset: 42132},
 						name: "SingleQuoteItalicTextFallbackCharacter",
 					},
 				},
@@ -7414,14 +7867,14 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteItalicTextStringElement",
-			pos:  position{line: 1094, col: 1, offset: 39718},
+			pos:  position{line: 1176, col: 1, offset: 42174},
 			expr: &actionExpr{
-				pos: position{line: 1094, col: 39, offset: 39756},
+				pos: position{line: 1176, col: 39, offset: 42212},
 				run: (*parser).callonSingleQuoteItalicTextStringElement1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1094, col: 39, offset: 39756},
+					pos: position{line: 1176, col: 39, offset: 42212},
 					expr: &charClassMatcher{
-						pos:        position{line: 1094, col: 39, offset: 39756},
+						pos:        position{line: 1176, col: 39, offset: 42212},
 						val:        "[^\\r\\n{} _^~]",
 						chars:      []rune{'\r', '\n', '{', '}', ' ', '_', '^', '~'},
 						ignoreCase: false,
@@ -7432,31 +7885,31 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteItalicTextFallbackCharacter",
-			pos:  position{line: 1098, col: 1, offset: 39986},
+			pos:  position{line: 1180, col: 1, offset: 42442},
 			expr: &choiceExpr{
-				pos: position{line: 1099, col: 5, offset: 40034},
+				pos: position{line: 1181, col: 5, offset: 42490},
 				alternatives: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 1099, col: 5, offset: 40034},
+						pos:        position{line: 1181, col: 5, offset: 42490},
 						val:        "[^\\r\\n_]",
 						chars:      []rune{'\r', '\n', '_'},
 						ignoreCase: false,
 						inverted:   true,
 					},
 					&actionExpr{
-						pos: position{line: 1100, col: 7, offset: 40134},
+						pos: position{line: 1182, col: 7, offset: 42590},
 						run: (*parser).callonSingleQuoteItalicTextFallbackCharacter3,
 						expr: &seqExpr{
-							pos: position{line: 1100, col: 7, offset: 40134},
+							pos: position{line: 1182, col: 7, offset: 42590},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1100, col: 7, offset: 40134},
+									pos:        position{line: 1182, col: 7, offset: 42590},
 									val:        "_",
 									ignoreCase: false,
 									want:       "\"_\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1100, col: 11, offset: 40138},
+									pos:  position{line: 1182, col: 11, offset: 42594},
 									name: "Alphanums",
 								},
 							},
@@ -7467,40 +7920,40 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedItalicText",
-			pos:  position{line: 1104, col: 1, offset: 40308},
+			pos:  position{line: 1186, col: 1, offset: 42764},
 			expr: &choiceExpr{
-				pos: position{line: 1105, col: 5, offset: 40335},
+				pos: position{line: 1187, col: 5, offset: 42791},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1105, col: 5, offset: 40335},
+						pos: position{line: 1187, col: 5, offset: 42791},
 						run: (*parser).callonEscapedItalicText2,
 						expr: &seqExpr{
-							pos: position{line: 1105, col: 5, offset: 40335},
+							pos: position{line: 1187, col: 5, offset: 42791},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1105, col: 5, offset: 40335},
+									pos:   position{line: 1187, col: 5, offset: 42791},
 									label: "backslashes",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1105, col: 18, offset: 40348},
+										pos:  position{line: 1187, col: 18, offset: 42804},
 										name: "TwoOrMoreBackslashes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1105, col: 40, offset: 40370},
+									pos:        position{line: 1187, col: 40, offset: 42826},
 									val:        "__",
 									ignoreCase: false,
 									want:       "\"__\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1105, col: 45, offset: 40375},
+									pos:   position{line: 1187, col: 45, offset: 42831},
 									label: "elements",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1105, col: 55, offset: 40385},
+										pos:  position{line: 1187, col: 55, offset: 42841},
 										name: "DoubleQuoteItalicTextElements",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1105, col: 86, offset: 40416},
+									pos:        position{line: 1187, col: 86, offset: 42872},
 									val:        "__",
 									ignoreCase: false,
 									want:       "\"__\"",
@@ -7509,35 +7962,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1107, col: 9, offset: 40575},
+						pos: position{line: 1189, col: 9, offset: 43031},
 						run: (*parser).callonEscapedItalicText10,
 						expr: &seqExpr{
-							pos: position{line: 1107, col: 9, offset: 40575},
+							pos: position{line: 1189, col: 9, offset: 43031},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1107, col: 9, offset: 40575},
+									pos:   position{line: 1189, col: 9, offset: 43031},
 									label: "backslashes",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1107, col: 22, offset: 40588},
+										pos:  position{line: 1189, col: 22, offset: 43044},
 										name: "OneOrMoreBackslashes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1107, col: 44, offset: 40610},
+									pos:        position{line: 1189, col: 44, offset: 43066},
 									val:        "__",
 									ignoreCase: false,
 									want:       "\"__\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1107, col: 49, offset: 40615},
+									pos:   position{line: 1189, col: 49, offset: 43071},
 									label: "elements",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1107, col: 59, offset: 40625},
+										pos:  position{line: 1189, col: 59, offset: 43081},
 										name: "SingleQuoteItalicTextElements",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1107, col: 90, offset: 40656},
+									pos:        position{line: 1189, col: 90, offset: 43112},
 									val:        "_",
 									ignoreCase: false,
 									want:       "\"_\"",
@@ -7546,35 +7999,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1110, col: 9, offset: 40859},
+						pos: position{line: 1192, col: 9, offset: 43315},
 						run: (*parser).callonEscapedItalicText18,
 						expr: &seqExpr{
-							pos: position{line: 1110, col: 9, offset: 40859},
+							pos: position{line: 1192, col: 9, offset: 43315},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1110, col: 9, offset: 40859},
+									pos:   position{line: 1192, col: 9, offset: 43315},
 									label: "backslashes",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1110, col: 22, offset: 40872},
+										pos:  position{line: 1192, col: 22, offset: 43328},
 										name: "OneOrMoreBackslashes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1110, col: 44, offset: 40894},
+									pos:        position{line: 1192, col: 44, offset: 43350},
 									val:        "_",
 									ignoreCase: false,
 									want:       "\"_\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1110, col: 48, offset: 40898},
+									pos:   position{line: 1192, col: 48, offset: 43354},
 									label: "elements",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1110, col: 58, offset: 40908},
+										pos:  position{line: 1192, col: 58, offset: 43364},
 										name: "SingleQuoteItalicTextElements",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1110, col: 89, offset: 40939},
+									pos:        position{line: 1192, col: 89, offset: 43395},
 									val:        "_",
 									ignoreCase: false,
 									want:       "\"_\"",
@@ -7587,16 +8040,16 @@ var g = &grammar{
 		},
 		{
 			name: "MonospaceText",
-			pos:  position{line: 1117, col: 1, offset: 41156},
+			pos:  position{line: 1199, col: 1, offset: 43612},
 			expr: &choiceExpr{
-				pos: position{line: 1117, col: 18, offset: 41173},
+				pos: position{line: 1199, col: 18, offset: 43629},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1117, col: 18, offset: 41173},
+						pos:  position{line: 1199, col: 18, offset: 43629},
 						name: "DoubleQuoteMonospaceText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1117, col: 45, offset: 41200},
+						pos:  position{line: 1199, col: 45, offset: 43656},
 						name: "SingleQuoteMonospaceText",
 					},
 				},
@@ -7604,49 +8057,49 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteMonospaceText",
-			pos:  position{line: 1119, col: 1, offset: 41228},
+			pos:  position{line: 1201, col: 1, offset: 43684},
 			expr: &actionExpr{
-				pos: position{line: 1119, col: 29, offset: 41256},
+				pos: position{line: 1201, col: 29, offset: 43712},
 				run: (*parser).callonDoubleQuoteMonospaceText1,
 				expr: &seqExpr{
-					pos: position{line: 1119, col: 29, offset: 41256},
+					pos: position{line: 1201, col: 29, offset: 43712},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1119, col: 29, offset: 41256},
+							pos:   position{line: 1201, col: 29, offset: 43712},
 							label: "attrs",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1119, col: 35, offset: 41262},
+								pos: position{line: 1201, col: 35, offset: 43718},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1119, col: 36, offset: 41263},
+									pos:  position{line: 1201, col: 36, offset: 43719},
 									name: "QuotedTextAttrs",
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 1119, col: 54, offset: 41281},
+							pos: position{line: 1201, col: 54, offset: 43737},
 							expr: &litMatcher{
-								pos:        position{line: 1119, col: 55, offset: 41282},
+								pos:        position{line: 1201, col: 55, offset: 43738},
 								val:        "\\\\",
 								ignoreCase: false,
 								want:       "\"\\\\\\\\\"",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1119, col: 60, offset: 41287},
+							pos:        position{line: 1201, col: 60, offset: 43743},
 							val:        "``",
 							ignoreCase: false,
 							want:       "\"``\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1119, col: 65, offset: 41292},
+							pos:   position{line: 1201, col: 65, offset: 43748},
 							label: "elements",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1119, col: 75, offset: 41302},
+								pos:  position{line: 1201, col: 75, offset: 43758},
 								name: "DoubleQuoteMonospaceTextElements",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1119, col: 109, offset: 41336},
+							pos:        position{line: 1201, col: 109, offset: 43792},
 							val:        "``",
 							ignoreCase: false,
 							want:       "\"``\"",
@@ -7657,37 +8110,37 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteMonospaceTextElements",
-			pos:  position{line: 1123, col: 1, offset: 41477},
+			pos:  position{line: 1205, col: 1, offset: 43933},
 			expr: &seqExpr{
-				pos: position{line: 1123, col: 37, offset: 41513},
+				pos: position{line: 1205, col: 37, offset: 43969},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1123, col: 37, offset: 41513},
+						pos:  position{line: 1205, col: 37, offset: 43969},
 						name: "DoubleQuoteMonospaceTextElement",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1123, col: 69, offset: 41545},
+						pos: position{line: 1205, col: 69, offset: 44001},
 						expr: &seqExpr{
-							pos: position{line: 1123, col: 70, offset: 41546},
+							pos: position{line: 1205, col: 70, offset: 44002},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1123, col: 70, offset: 41546},
+									pos: position{line: 1205, col: 70, offset: 44002},
 									expr: &litMatcher{
-										pos:        position{line: 1123, col: 72, offset: 41548},
+										pos:        position{line: 1205, col: 72, offset: 44004},
 										val:        "``",
 										ignoreCase: false,
 										want:       "\"``\"",
 									},
 								},
 								&choiceExpr{
-									pos: position{line: 1123, col: 79, offset: 41555},
+									pos: position{line: 1205, col: 79, offset: 44011},
 									alternatives: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 1123, col: 79, offset: 41555},
+											pos:  position{line: 1205, col: 79, offset: 44011},
 											name: "Space",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1123, col: 87, offset: 41563},
+											pos:  position{line: 1205, col: 87, offset: 44019},
 											name: "DoubleQuoteMonospaceTextElement",
 										},
 									},
@@ -7700,60 +8153,64 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteMonospaceTextElement",
-			pos:  position{line: 1125, col: 1, offset: 41634},
+			pos:  position{line: 1207, col: 1, offset: 44090},
 			expr: &choiceExpr{
-				pos: position{line: 1125, col: 36, offset: 41669},
+				pos: position{line: 1207, col: 36, offset: 44125},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1125, col: 36, offset: 41669},
+						pos:  position{line: 1207, col: 36, offset: 44125},
 						name: "Word",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1126, col: 11, offset: 41686},
+						pos:  position{line: 1208, col: 11, offset: 44142},
 						name: "SingleQuoteMonospaceText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1127, col: 11, offset: 41723},
+						pos:  position{line: 1209, col: 11, offset: 44179},
 						name: "BoldText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1128, col: 11, offset: 41743},
+						pos:  position{line: 1210, col: 11, offset: 44199},
 						name: "ItalicText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1129, col: 11, offset: 41765},
+						pos:  position{line: 1211, col: 11, offset: 44221},
 						name: "MarkedText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1130, col: 11, offset: 41787},
+						pos:  position{line: 1212, col: 11, offset: 44243},
 						name: "SubscriptText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1131, col: 11, offset: 41812},
+						pos:  position{line: 1213, col: 11, offset: 44268},
 						name: "SuperscriptText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1132, col: 11, offset: 41839},
+						pos:  position{line: 1214, col: 11, offset: 44295},
 						name: "InlineIcon",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1133, col: 11, offset: 41861},
+						pos:  position{line: 1215, col: 11, offset: 44317},
 						name: "InlineImage",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1134, col: 11, offset: 41884},
+						pos:  position{line: 1216, col: 11, offset: 44340},
 						name: "Link",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1135, col: 11, offset: 41900},
+						pos:  position{line: 1217, col: 11, offset: 44356},
 						name: "InlinePassthrough",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1136, col: 11, offset: 41930},
+						pos:  position{line: 1218, col: 11, offset: 44386},
+						name: "QuotedString",
+					},
+					&ruleRefExpr{
+						pos:  position{line: 1219, col: 11, offset: 44410},
 						name: "DoubleQuoteMonospaceTextStringElement",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1137, col: 11, offset: 41979},
+						pos:  position{line: 1220, col: 11, offset: 44459},
 						name: "DoubleQuoteMonospaceTextFallbackCharacter",
 					},
 				},
@@ -7761,26 +8218,26 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteMonospaceTextStringElement",
-			pos:  position{line: 1139, col: 1, offset: 42024},
+			pos:  position{line: 1222, col: 1, offset: 44504},
 			expr: &actionExpr{
-				pos: position{line: 1139, col: 42, offset: 42065},
+				pos: position{line: 1222, col: 42, offset: 44545},
 				run: (*parser).callonDoubleQuoteMonospaceTextStringElement1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1139, col: 42, offset: 42065},
+					pos: position{line: 1222, col: 42, offset: 44545},
 					expr: &seqExpr{
-						pos: position{line: 1139, col: 43, offset: 42066},
+						pos: position{line: 1222, col: 43, offset: 44546},
 						exprs: []interface{}{
 							&notExpr{
-								pos: position{line: 1139, col: 43, offset: 42066},
+								pos: position{line: 1222, col: 43, offset: 44546},
 								expr: &litMatcher{
-									pos:        position{line: 1139, col: 44, offset: 42067},
+									pos:        position{line: 1222, col: 44, offset: 44547},
 									val:        "``",
 									ignoreCase: false,
 									want:       "\"``\"",
 								},
 							},
 							&charClassMatcher{
-								pos:        position{line: 1139, col: 49, offset: 42072},
+								pos:        position{line: 1222, col: 49, offset: 44552},
 								val:        "[^\\r\\n ^~{}]",
 								chars:      []rune{'\r', '\n', ' ', '^', '~', '{', '}'},
 								ignoreCase: false,
@@ -7793,31 +8250,31 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteMonospaceTextFallbackCharacter",
-			pos:  position{line: 1143, col: 1, offset: 42147},
+			pos:  position{line: 1226, col: 1, offset: 44627},
 			expr: &choiceExpr{
-				pos: position{line: 1144, col: 5, offset: 42198},
+				pos: position{line: 1227, col: 5, offset: 44678},
 				alternatives: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 1144, col: 5, offset: 42198},
+						pos:        position{line: 1227, col: 5, offset: 44678},
 						val:        "[^\\r\\n`]",
 						chars:      []rune{'\r', '\n', '`'},
 						ignoreCase: false,
 						inverted:   true,
 					},
 					&actionExpr{
-						pos: position{line: 1145, col: 7, offset: 42301},
+						pos: position{line: 1228, col: 7, offset: 44781},
 						run: (*parser).callonDoubleQuoteMonospaceTextFallbackCharacter3,
 						expr: &seqExpr{
-							pos: position{line: 1145, col: 7, offset: 42301},
+							pos: position{line: 1228, col: 7, offset: 44781},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1145, col: 7, offset: 42301},
+									pos:        position{line: 1228, col: 7, offset: 44781},
 									val:        "``",
 									ignoreCase: false,
 									want:       "\"``\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1145, col: 12, offset: 42306},
+									pos:  position{line: 1228, col: 12, offset: 44786},
 									name: "Alphanums",
 								},
 							},
@@ -7828,49 +8285,49 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteMonospaceText",
-			pos:  position{line: 1149, col: 1, offset: 42478},
+			pos:  position{line: 1232, col: 1, offset: 44958},
 			expr: &choiceExpr{
-				pos: position{line: 1149, col: 29, offset: 42506},
+				pos: position{line: 1232, col: 29, offset: 44986},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1149, col: 29, offset: 42506},
+						pos: position{line: 1232, col: 29, offset: 44986},
 						run: (*parser).callonSingleQuoteMonospaceText2,
 						expr: &seqExpr{
-							pos: position{line: 1149, col: 29, offset: 42506},
+							pos: position{line: 1232, col: 29, offset: 44986},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1149, col: 29, offset: 42506},
+									pos:   position{line: 1232, col: 29, offset: 44986},
 									label: "attrs",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1149, col: 35, offset: 42512},
+										pos: position{line: 1232, col: 35, offset: 44992},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1149, col: 36, offset: 42513},
+											pos:  position{line: 1232, col: 36, offset: 44993},
 											name: "QuotedTextAttrs",
 										},
 									},
 								},
 								&seqExpr{
-									pos: position{line: 1149, col: 55, offset: 42532},
+									pos: position{line: 1232, col: 55, offset: 45012},
 									exprs: []interface{}{
 										&notExpr{
-											pos: position{line: 1149, col: 55, offset: 42532},
+											pos: position{line: 1232, col: 55, offset: 45012},
 											expr: &litMatcher{
-												pos:        position{line: 1149, col: 56, offset: 42533},
+												pos:        position{line: 1232, col: 56, offset: 45013},
 												val:        "\\",
 												ignoreCase: false,
 												want:       "\"\\\\\"",
 											},
 										},
 										&litMatcher{
-											pos:        position{line: 1149, col: 60, offset: 42537},
+											pos:        position{line: 1232, col: 60, offset: 45017},
 											val:        "`",
 											ignoreCase: false,
 											want:       "\"`\"",
 										},
 										&notExpr{
-											pos: position{line: 1149, col: 64, offset: 42541},
+											pos: position{line: 1232, col: 64, offset: 45021},
 											expr: &litMatcher{
-												pos:        position{line: 1149, col: 65, offset: 42542},
+												pos:        position{line: 1232, col: 65, offset: 45022},
 												val:        "`",
 												ignoreCase: false,
 												want:       "\"`\"",
@@ -7879,15 +8336,15 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1149, col: 70, offset: 42547},
+									pos:   position{line: 1232, col: 70, offset: 45027},
 									label: "elements",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1149, col: 80, offset: 42557},
+										pos:  position{line: 1232, col: 80, offset: 45037},
 										name: "SingleQuoteMonospaceTextElements",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1149, col: 114, offset: 42591},
+									pos:        position{line: 1232, col: 114, offset: 45071},
 									val:        "`",
 									ignoreCase: false,
 									want:       "\"`\"",
@@ -7896,58 +8353,58 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1151, col: 5, offset: 42786},
+						pos: position{line: 1234, col: 5, offset: 45266},
 						run: (*parser).callonSingleQuoteMonospaceText16,
 						expr: &seqExpr{
-							pos: position{line: 1151, col: 5, offset: 42786},
+							pos: position{line: 1234, col: 5, offset: 45266},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1151, col: 5, offset: 42786},
+									pos:   position{line: 1234, col: 5, offset: 45266},
 									label: "attrs",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1151, col: 11, offset: 42792},
+										pos: position{line: 1234, col: 11, offset: 45272},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1151, col: 12, offset: 42793},
+											pos:  position{line: 1234, col: 12, offset: 45273},
 											name: "QuotedTextAttrs",
 										},
 									},
 								},
 								&notExpr{
-									pos: position{line: 1151, col: 30, offset: 42811},
+									pos: position{line: 1234, col: 30, offset: 45291},
 									expr: &litMatcher{
-										pos:        position{line: 1151, col: 31, offset: 42812},
+										pos:        position{line: 1234, col: 31, offset: 45292},
 										val:        "\\\\",
 										ignoreCase: false,
 										want:       "\"\\\\\\\\\"",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1151, col: 36, offset: 42817},
+									pos:        position{line: 1234, col: 36, offset: 45297},
 									val:        "`",
 									ignoreCase: false,
 									want:       "\"`\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1151, col: 40, offset: 42821},
+									pos:   position{line: 1234, col: 40, offset: 45301},
 									label: "elements",
 									expr: &seqExpr{
-										pos: position{line: 1151, col: 50, offset: 42831},
+										pos: position{line: 1234, col: 50, offset: 45311},
 										exprs: []interface{}{
 											&litMatcher{
-												pos:        position{line: 1151, col: 50, offset: 42831},
+												pos:        position{line: 1234, col: 50, offset: 45311},
 												val:        "`",
 												ignoreCase: false,
 												want:       "\"`\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1151, col: 54, offset: 42835},
+												pos:  position{line: 1234, col: 54, offset: 45315},
 												name: "SingleQuoteMonospaceTextElements",
 											},
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1151, col: 88, offset: 42869},
+									pos:        position{line: 1234, col: 88, offset: 45349},
 									val:        "`",
 									ignoreCase: false,
 									want:       "\"`\"",
@@ -7960,21 +8417,21 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteMonospaceTextElements",
-			pos:  position{line: 1155, col: 1, offset: 43089},
+			pos:  position{line: 1238, col: 1, offset: 45569},
 			expr: &seqExpr{
-				pos: position{line: 1155, col: 37, offset: 43125},
+				pos: position{line: 1238, col: 37, offset: 45605},
 				exprs: []interface{}{
 					&notExpr{
-						pos: position{line: 1155, col: 37, offset: 43125},
+						pos: position{line: 1238, col: 37, offset: 45605},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1155, col: 38, offset: 43126},
+							pos:  position{line: 1238, col: 38, offset: 45606},
 							name: "Space",
 						},
 					},
 					&oneOrMoreExpr{
-						pos: position{line: 1155, col: 44, offset: 43132},
+						pos: position{line: 1238, col: 44, offset: 45612},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1155, col: 44, offset: 43132},
+							pos:  position{line: 1238, col: 44, offset: 45612},
 							name: "SingleQuoteMonospaceTextElement",
 						},
 					},
@@ -7983,43 +8440,43 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteMonospaceTextElement",
-			pos:  position{line: 1157, col: 1, offset: 43168},
+			pos:  position{line: 1240, col: 1, offset: 45648},
 			expr: &choiceExpr{
-				pos: position{line: 1157, col: 37, offset: 43204},
+				pos: position{line: 1240, col: 37, offset: 45684},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1157, col: 37, offset: 43204},
+						pos:  position{line: 1240, col: 37, offset: 45684},
 						name: "Word",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1158, col: 11, offset: 43221},
+						pos:  position{line: 1241, col: 11, offset: 45701},
 						name: "DoubleQuoteMonospaceText",
 					},
 					&seqExpr{
-						pos: position{line: 1159, col: 11, offset: 43258},
+						pos: position{line: 1242, col: 11, offset: 45738},
 						exprs: []interface{}{
 							&oneOrMoreExpr{
-								pos: position{line: 1159, col: 11, offset: 43258},
+								pos: position{line: 1242, col: 11, offset: 45738},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1159, col: 11, offset: 43258},
+									pos:  position{line: 1242, col: 11, offset: 45738},
 									name: "Space",
 								},
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 1159, col: 18, offset: 43265},
+								pos: position{line: 1242, col: 18, offset: 45745},
 								expr: &seqExpr{
-									pos: position{line: 1159, col: 19, offset: 43266},
+									pos: position{line: 1242, col: 19, offset: 45746},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 1159, col: 19, offset: 43266},
+											pos:        position{line: 1242, col: 19, offset: 45746},
 											val:        "`",
 											ignoreCase: false,
 											want:       "\"`\"",
 										},
 										&notExpr{
-											pos: position{line: 1159, col: 23, offset: 43270},
+											pos: position{line: 1242, col: 23, offset: 45750},
 											expr: &litMatcher{
-												pos:        position{line: 1159, col: 24, offset: 43271},
+												pos:        position{line: 1242, col: 24, offset: 45751},
 												val:        "`",
 												ignoreCase: false,
 												want:       "\"`\"",
@@ -8031,55 +8488,59 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1160, col: 11, offset: 43400},
+						pos:  position{line: 1243, col: 11, offset: 45880},
 						name: "Newline",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1161, col: 11, offset: 43439},
+						pos:  position{line: 1244, col: 11, offset: 45919},
 						name: "BoldText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1162, col: 11, offset: 43459},
+						pos:  position{line: 1245, col: 11, offset: 45939},
 						name: "ItalicText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1163, col: 11, offset: 43481},
+						pos:  position{line: 1246, col: 11, offset: 45961},
 						name: "MarkedText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1164, col: 11, offset: 43503},
+						pos:  position{line: 1247, col: 11, offset: 45983},
 						name: "SubscriptText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1165, col: 11, offset: 43528},
+						pos:  position{line: 1248, col: 11, offset: 46008},
 						name: "SuperscriptText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1166, col: 11, offset: 43555},
+						pos:  position{line: 1249, col: 11, offset: 46035},
 						name: "InlineIcon",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1167, col: 11, offset: 43577},
+						pos:  position{line: 1250, col: 11, offset: 46057},
 						name: "InlineImage",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1168, col: 11, offset: 43601},
+						pos:  position{line: 1251, col: 11, offset: 46081},
 						name: "Link",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1169, col: 11, offset: 43618},
+						pos:  position{line: 1252, col: 11, offset: 46098},
 						name: "InlinePassthrough",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1170, col: 11, offset: 43648},
+						pos:  position{line: 1253, col: 11, offset: 46128},
+						name: "QuotedString",
+					},
+					&ruleRefExpr{
+						pos:  position{line: 1254, col: 11, offset: 46152},
 						name: "AttributeSubstitution",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1171, col: 11, offset: 43681},
+						pos:  position{line: 1255, col: 11, offset: 46185},
 						name: "SingleQuoteMonospaceTextStringElement",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1172, col: 11, offset: 43730},
+						pos:  position{line: 1256, col: 11, offset: 46234},
 						name: "SingleQuoteMonospaceTextFallbackCharacter",
 					},
 				},
@@ -8087,14 +8548,14 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteMonospaceTextStringElement",
-			pos:  position{line: 1174, col: 1, offset: 43775},
+			pos:  position{line: 1258, col: 1, offset: 46279},
 			expr: &actionExpr{
-				pos: position{line: 1174, col: 42, offset: 43816},
+				pos: position{line: 1258, col: 42, offset: 46320},
 				run: (*parser).callonSingleQuoteMonospaceTextStringElement1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1174, col: 42, offset: 43816},
+					pos: position{line: 1258, col: 42, offset: 46320},
 					expr: &charClassMatcher{
-						pos:        position{line: 1174, col: 42, offset: 43816},
+						pos:        position{line: 1258, col: 42, offset: 46320},
 						val:        "[^\\r\\n {}`^~]",
 						chars:      []rune{'\r', '\n', ' ', '{', '}', '`', '^', '~'},
 						ignoreCase: false,
@@ -8105,31 +8566,31 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteMonospaceTextFallbackCharacter",
-			pos:  position{line: 1178, col: 1, offset: 44038},
+			pos:  position{line: 1262, col: 1, offset: 46542},
 			expr: &choiceExpr{
-				pos: position{line: 1179, col: 5, offset: 44089},
+				pos: position{line: 1263, col: 5, offset: 46593},
 				alternatives: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 1179, col: 5, offset: 44089},
+						pos:        position{line: 1263, col: 5, offset: 46593},
 						val:        "[^\\r\\n`]",
 						chars:      []rune{'\r', '\n', '`'},
 						ignoreCase: false,
 						inverted:   true,
 					},
 					&actionExpr{
-						pos: position{line: 1180, col: 7, offset: 44192},
+						pos: position{line: 1264, col: 7, offset: 46696},
 						run: (*parser).callonSingleQuoteMonospaceTextFallbackCharacter3,
 						expr: &seqExpr{
-							pos: position{line: 1180, col: 7, offset: 44192},
+							pos: position{line: 1264, col: 7, offset: 46696},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1180, col: 7, offset: 44192},
+									pos:        position{line: 1264, col: 7, offset: 46696},
 									val:        "`",
 									ignoreCase: false,
 									want:       "\"`\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1180, col: 11, offset: 44196},
+									pos:  position{line: 1264, col: 11, offset: 46700},
 									name: "Alphanums",
 								},
 							},
@@ -8140,40 +8601,40 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedMonospaceText",
-			pos:  position{line: 1184, col: 1, offset: 44369},
+			pos:  position{line: 1268, col: 1, offset: 46873},
 			expr: &choiceExpr{
-				pos: position{line: 1185, col: 5, offset: 44399},
+				pos: position{line: 1269, col: 5, offset: 46903},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1185, col: 5, offset: 44399},
+						pos: position{line: 1269, col: 5, offset: 46903},
 						run: (*parser).callonEscapedMonospaceText2,
 						expr: &seqExpr{
-							pos: position{line: 1185, col: 5, offset: 44399},
+							pos: position{line: 1269, col: 5, offset: 46903},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1185, col: 5, offset: 44399},
+									pos:   position{line: 1269, col: 5, offset: 46903},
 									label: "backslashes",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1185, col: 18, offset: 44412},
+										pos:  position{line: 1269, col: 18, offset: 46916},
 										name: "TwoOrMoreBackslashes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1185, col: 40, offset: 44434},
+									pos:        position{line: 1269, col: 40, offset: 46938},
 									val:        "``",
 									ignoreCase: false,
 									want:       "\"``\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1185, col: 45, offset: 44439},
+									pos:   position{line: 1269, col: 45, offset: 46943},
 									label: "elements",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1185, col: 55, offset: 44449},
+										pos:  position{line: 1269, col: 55, offset: 46953},
 										name: "DoubleQuoteMonospaceTextElements",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1185, col: 89, offset: 44483},
+									pos:        position{line: 1269, col: 89, offset: 46987},
 									val:        "``",
 									ignoreCase: false,
 									want:       "\"``\"",
@@ -8182,35 +8643,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1187, col: 9, offset: 44642},
+						pos: position{line: 1271, col: 9, offset: 47146},
 						run: (*parser).callonEscapedMonospaceText10,
 						expr: &seqExpr{
-							pos: position{line: 1187, col: 9, offset: 44642},
+							pos: position{line: 1271, col: 9, offset: 47146},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1187, col: 9, offset: 44642},
+									pos:   position{line: 1271, col: 9, offset: 47146},
 									label: "backslashes",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1187, col: 22, offset: 44655},
+										pos:  position{line: 1271, col: 22, offset: 47159},
 										name: "OneOrMoreBackslashes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1187, col: 44, offset: 44677},
+									pos:        position{line: 1271, col: 44, offset: 47181},
 									val:        "``",
 									ignoreCase: false,
 									want:       "\"``\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1187, col: 49, offset: 44682},
+									pos:   position{line: 1271, col: 49, offset: 47186},
 									label: "elements",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1187, col: 59, offset: 44692},
+										pos:  position{line: 1271, col: 59, offset: 47196},
 										name: "SingleQuoteMonospaceTextElements",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1187, col: 93, offset: 44726},
+									pos:        position{line: 1271, col: 93, offset: 47230},
 									val:        "`",
 									ignoreCase: false,
 									want:       "\"`\"",
@@ -8219,35 +8680,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1190, col: 9, offset: 44929},
+						pos: position{line: 1274, col: 9, offset: 47433},
 						run: (*parser).callonEscapedMonospaceText18,
 						expr: &seqExpr{
-							pos: position{line: 1190, col: 9, offset: 44929},
+							pos: position{line: 1274, col: 9, offset: 47433},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1190, col: 9, offset: 44929},
+									pos:   position{line: 1274, col: 9, offset: 47433},
 									label: "backslashes",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1190, col: 22, offset: 44942},
+										pos:  position{line: 1274, col: 22, offset: 47446},
 										name: "OneOrMoreBackslashes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1190, col: 44, offset: 44964},
+									pos:        position{line: 1274, col: 44, offset: 47468},
 									val:        "`",
 									ignoreCase: false,
 									want:       "\"`\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1190, col: 48, offset: 44968},
+									pos:   position{line: 1274, col: 48, offset: 47472},
 									label: "elements",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1190, col: 58, offset: 44978},
+										pos:  position{line: 1274, col: 58, offset: 47482},
 										name: "SingleQuoteMonospaceTextElements",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1190, col: 92, offset: 45012},
+									pos:        position{line: 1274, col: 92, offset: 47516},
 									val:        "`",
 									ignoreCase: false,
 									want:       "\"`\"",
@@ -8260,16 +8721,16 @@ var g = &grammar{
 		},
 		{
 			name: "MarkedText",
-			pos:  position{line: 1198, col: 1, offset: 45228},
+			pos:  position{line: 1282, col: 1, offset: 47732},
 			expr: &choiceExpr{
-				pos: position{line: 1198, col: 15, offset: 45242},
+				pos: position{line: 1282, col: 15, offset: 47746},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1198, col: 15, offset: 45242},
+						pos:  position{line: 1282, col: 15, offset: 47746},
 						name: "DoubleQuoteMarkedText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1198, col: 39, offset: 45266},
+						pos:  position{line: 1282, col: 39, offset: 47770},
 						name: "SingleQuoteMarkedText",
 					},
 				},
@@ -8277,49 +8738,49 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteMarkedText",
-			pos:  position{line: 1200, col: 1, offset: 45291},
+			pos:  position{line: 1284, col: 1, offset: 47795},
 			expr: &actionExpr{
-				pos: position{line: 1200, col: 26, offset: 45316},
+				pos: position{line: 1284, col: 26, offset: 47820},
 				run: (*parser).callonDoubleQuoteMarkedText1,
 				expr: &seqExpr{
-					pos: position{line: 1200, col: 26, offset: 45316},
+					pos: position{line: 1284, col: 26, offset: 47820},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1200, col: 26, offset: 45316},
+							pos:   position{line: 1284, col: 26, offset: 47820},
 							label: "attrs",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1200, col: 32, offset: 45322},
+								pos: position{line: 1284, col: 32, offset: 47826},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1200, col: 33, offset: 45323},
+									pos:  position{line: 1284, col: 33, offset: 47827},
 									name: "QuotedTextAttrs",
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 1200, col: 51, offset: 45341},
+							pos: position{line: 1284, col: 51, offset: 47845},
 							expr: &litMatcher{
-								pos:        position{line: 1200, col: 52, offset: 45342},
+								pos:        position{line: 1284, col: 52, offset: 47846},
 								val:        "\\\\",
 								ignoreCase: false,
 								want:       "\"\\\\\\\\\"",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1200, col: 57, offset: 45347},
+							pos:        position{line: 1284, col: 57, offset: 47851},
 							val:        "##",
 							ignoreCase: false,
 							want:       "\"##\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1200, col: 62, offset: 45352},
+							pos:   position{line: 1284, col: 62, offset: 47856},
 							label: "elements",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1200, col: 72, offset: 45362},
+								pos:  position{line: 1284, col: 72, offset: 47866},
 								name: "DoubleQuoteMarkedTextElements",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1200, col: 103, offset: 45393},
+							pos:        position{line: 1284, col: 103, offset: 47897},
 							val:        "##",
 							ignoreCase: false,
 							want:       "\"##\"",
@@ -8330,37 +8791,37 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteMarkedTextElements",
-			pos:  position{line: 1204, col: 1, offset: 45531},
+			pos:  position{line: 1288, col: 1, offset: 48035},
 			expr: &seqExpr{
-				pos: position{line: 1204, col: 34, offset: 45564},
+				pos: position{line: 1288, col: 34, offset: 48068},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1204, col: 34, offset: 45564},
+						pos:  position{line: 1288, col: 34, offset: 48068},
 						name: "DoubleQuoteMarkedTextElement",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1204, col: 63, offset: 45593},
+						pos: position{line: 1288, col: 63, offset: 48097},
 						expr: &seqExpr{
-							pos: position{line: 1204, col: 64, offset: 45594},
+							pos: position{line: 1288, col: 64, offset: 48098},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1204, col: 64, offset: 45594},
+									pos: position{line: 1288, col: 64, offset: 48098},
 									expr: &litMatcher{
-										pos:        position{line: 1204, col: 66, offset: 45596},
+										pos:        position{line: 1288, col: 66, offset: 48100},
 										val:        "##",
 										ignoreCase: false,
 										want:       "\"##\"",
 									},
 								},
 								&choiceExpr{
-									pos: position{line: 1204, col: 73, offset: 45603},
+									pos: position{line: 1288, col: 73, offset: 48107},
 									alternatives: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 1204, col: 73, offset: 45603},
+											pos:  position{line: 1288, col: 73, offset: 48107},
 											name: "Space",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1204, col: 81, offset: 45611},
+											pos:  position{line: 1288, col: 81, offset: 48115},
 											name: "DoubleQuoteMarkedTextElement",
 										},
 									},
@@ -8373,60 +8834,64 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteMarkedTextElement",
-			pos:  position{line: 1206, col: 1, offset: 45680},
+			pos:  position{line: 1290, col: 1, offset: 48184},
 			expr: &choiceExpr{
-				pos: position{line: 1206, col: 33, offset: 45712},
+				pos: position{line: 1290, col: 33, offset: 48216},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1206, col: 33, offset: 45712},
+						pos:  position{line: 1290, col: 33, offset: 48216},
 						name: "Word",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1207, col: 11, offset: 45728},
+						pos:  position{line: 1291, col: 11, offset: 48232},
 						name: "SingleQuoteMarkedText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1208, col: 11, offset: 45761},
+						pos:  position{line: 1292, col: 11, offset: 48265},
 						name: "BoldText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1209, col: 11, offset: 45781},
+						pos:  position{line: 1293, col: 11, offset: 48285},
 						name: "ItalicText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1210, col: 11, offset: 45803},
+						pos:  position{line: 1294, col: 11, offset: 48307},
 						name: "MonospaceText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1211, col: 11, offset: 45828},
+						pos:  position{line: 1295, col: 11, offset: 48332},
 						name: "SubscriptText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1212, col: 11, offset: 45853},
+						pos:  position{line: 1296, col: 11, offset: 48357},
 						name: "SuperscriptText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1213, col: 11, offset: 45880},
+						pos:  position{line: 1297, col: 11, offset: 48384},
 						name: "InlineIcon",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1214, col: 11, offset: 45902},
+						pos:  position{line: 1298, col: 11, offset: 48406},
 						name: "InlineImage",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1215, col: 11, offset: 45925},
+						pos:  position{line: 1299, col: 11, offset: 48429},
 						name: "Link",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1216, col: 11, offset: 45941},
+						pos:  position{line: 1300, col: 11, offset: 48445},
 						name: "InlinePassthrough",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1217, col: 11, offset: 45970},
+						pos:  position{line: 1301, col: 11, offset: 48474},
+						name: "QuotedString",
+					},
+					&ruleRefExpr{
+						pos:  position{line: 1302, col: 11, offset: 48498},
 						name: "DoubleQuoteMarkedTextStringElement",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1218, col: 11, offset: 46016},
+						pos:  position{line: 1303, col: 11, offset: 48544},
 						name: "DoubleQuoteMarkedTextFallbackCharacter",
 					},
 				},
@@ -8434,26 +8899,26 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteMarkedTextStringElement",
-			pos:  position{line: 1220, col: 1, offset: 46058},
+			pos:  position{line: 1305, col: 1, offset: 48586},
 			expr: &actionExpr{
-				pos: position{line: 1220, col: 39, offset: 46096},
+				pos: position{line: 1305, col: 39, offset: 48624},
 				run: (*parser).callonDoubleQuoteMarkedTextStringElement1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1220, col: 39, offset: 46096},
+					pos: position{line: 1305, col: 39, offset: 48624},
 					expr: &seqExpr{
-						pos: position{line: 1220, col: 40, offset: 46097},
+						pos: position{line: 1305, col: 40, offset: 48625},
 						exprs: []interface{}{
 							&notExpr{
-								pos: position{line: 1220, col: 40, offset: 46097},
+								pos: position{line: 1305, col: 40, offset: 48625},
 								expr: &litMatcher{
-									pos:        position{line: 1220, col: 41, offset: 46098},
+									pos:        position{line: 1305, col: 41, offset: 48626},
 									val:        "##",
 									ignoreCase: false,
 									want:       "\"##\"",
 								},
 							},
 							&charClassMatcher{
-								pos:        position{line: 1220, col: 46, offset: 46103},
+								pos:        position{line: 1305, col: 46, offset: 48631},
 								val:        "[^\\r\\n ^~{}]",
 								chars:      []rune{'\r', '\n', ' ', '^', '~', '{', '}'},
 								ignoreCase: false,
@@ -8466,31 +8931,31 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteMarkedTextFallbackCharacter",
-			pos:  position{line: 1224, col: 1, offset: 46177},
+			pos:  position{line: 1309, col: 1, offset: 48705},
 			expr: &choiceExpr{
-				pos: position{line: 1225, col: 5, offset: 46224},
+				pos: position{line: 1310, col: 5, offset: 48752},
 				alternatives: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 1225, col: 5, offset: 46224},
+						pos:        position{line: 1310, col: 5, offset: 48752},
 						val:        "[^\\r\\n#]",
 						chars:      []rune{'\r', '\n', '#'},
 						ignoreCase: false,
 						inverted:   true,
 					},
 					&actionExpr{
-						pos: position{line: 1226, col: 7, offset: 46324},
+						pos: position{line: 1311, col: 7, offset: 48852},
 						run: (*parser).callonDoubleQuoteMarkedTextFallbackCharacter3,
 						expr: &seqExpr{
-							pos: position{line: 1226, col: 7, offset: 46324},
+							pos: position{line: 1311, col: 7, offset: 48852},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1226, col: 7, offset: 46324},
+									pos:        position{line: 1311, col: 7, offset: 48852},
 									val:        "##",
 									ignoreCase: false,
 									want:       "\"##\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1226, col: 12, offset: 46329},
+									pos:  position{line: 1311, col: 12, offset: 48857},
 									name: "Alphanums",
 								},
 							},
@@ -8501,49 +8966,49 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteMarkedText",
-			pos:  position{line: 1230, col: 1, offset: 46498},
+			pos:  position{line: 1315, col: 1, offset: 49026},
 			expr: &choiceExpr{
-				pos: position{line: 1230, col: 26, offset: 46523},
+				pos: position{line: 1315, col: 26, offset: 49051},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1230, col: 26, offset: 46523},
+						pos: position{line: 1315, col: 26, offset: 49051},
 						run: (*parser).callonSingleQuoteMarkedText2,
 						expr: &seqExpr{
-							pos: position{line: 1230, col: 26, offset: 46523},
+							pos: position{line: 1315, col: 26, offset: 49051},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1230, col: 26, offset: 46523},
+									pos:   position{line: 1315, col: 26, offset: 49051},
 									label: "attrs",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1230, col: 32, offset: 46529},
+										pos: position{line: 1315, col: 32, offset: 49057},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1230, col: 33, offset: 46530},
+											pos:  position{line: 1315, col: 33, offset: 49058},
 											name: "QuotedTextAttrs",
 										},
 									},
 								},
 								&seqExpr{
-									pos: position{line: 1230, col: 52, offset: 46549},
+									pos: position{line: 1315, col: 52, offset: 49077},
 									exprs: []interface{}{
 										&notExpr{
-											pos: position{line: 1230, col: 52, offset: 46549},
+											pos: position{line: 1315, col: 52, offset: 49077},
 											expr: &litMatcher{
-												pos:        position{line: 1230, col: 53, offset: 46550},
+												pos:        position{line: 1315, col: 53, offset: 49078},
 												val:        "\\",
 												ignoreCase: false,
 												want:       "\"\\\\\"",
 											},
 										},
 										&litMatcher{
-											pos:        position{line: 1230, col: 57, offset: 46554},
+											pos:        position{line: 1315, col: 57, offset: 49082},
 											val:        "#",
 											ignoreCase: false,
 											want:       "\"#\"",
 										},
 										&notExpr{
-											pos: position{line: 1230, col: 61, offset: 46558},
+											pos: position{line: 1315, col: 61, offset: 49086},
 											expr: &litMatcher{
-												pos:        position{line: 1230, col: 62, offset: 46559},
+												pos:        position{line: 1315, col: 62, offset: 49087},
 												val:        "#",
 												ignoreCase: false,
 												want:       "\"#\"",
@@ -8552,15 +9017,15 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1230, col: 67, offset: 46564},
+									pos:   position{line: 1315, col: 67, offset: 49092},
 									label: "elements",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1230, col: 77, offset: 46574},
+										pos:  position{line: 1315, col: 77, offset: 49102},
 										name: "SingleQuoteMarkedTextElements",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1230, col: 108, offset: 46605},
+									pos:        position{line: 1315, col: 108, offset: 49133},
 									val:        "#",
 									ignoreCase: false,
 									want:       "\"#\"",
@@ -8569,58 +9034,58 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1232, col: 5, offset: 46797},
+						pos: position{line: 1317, col: 5, offset: 49325},
 						run: (*parser).callonSingleQuoteMarkedText16,
 						expr: &seqExpr{
-							pos: position{line: 1232, col: 5, offset: 46797},
+							pos: position{line: 1317, col: 5, offset: 49325},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1232, col: 5, offset: 46797},
+									pos:   position{line: 1317, col: 5, offset: 49325},
 									label: "attrs",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1232, col: 11, offset: 46803},
+										pos: position{line: 1317, col: 11, offset: 49331},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1232, col: 12, offset: 46804},
+											pos:  position{line: 1317, col: 12, offset: 49332},
 											name: "QuotedTextAttrs",
 										},
 									},
 								},
 								&notExpr{
-									pos: position{line: 1232, col: 30, offset: 46822},
+									pos: position{line: 1317, col: 30, offset: 49350},
 									expr: &litMatcher{
-										pos:        position{line: 1232, col: 31, offset: 46823},
+										pos:        position{line: 1317, col: 31, offset: 49351},
 										val:        "\\\\",
 										ignoreCase: false,
 										want:       "\"\\\\\\\\\"",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1232, col: 36, offset: 46828},
+									pos:        position{line: 1317, col: 36, offset: 49356},
 									val:        "#",
 									ignoreCase: false,
 									want:       "\"#\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1232, col: 40, offset: 46832},
+									pos:   position{line: 1317, col: 40, offset: 49360},
 									label: "elements",
 									expr: &seqExpr{
-										pos: position{line: 1232, col: 50, offset: 46842},
+										pos: position{line: 1317, col: 50, offset: 49370},
 										exprs: []interface{}{
 											&litMatcher{
-												pos:        position{line: 1232, col: 50, offset: 46842},
+												pos:        position{line: 1317, col: 50, offset: 49370},
 												val:        "#",
 												ignoreCase: false,
 												want:       "\"#\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1232, col: 54, offset: 46846},
+												pos:  position{line: 1317, col: 54, offset: 49374},
 												name: "SingleQuoteMarkedTextElements",
 											},
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1232, col: 85, offset: 46877},
+									pos:        position{line: 1317, col: 85, offset: 49405},
 									val:        "#",
 									ignoreCase: false,
 									want:       "\"#\"",
@@ -8633,21 +9098,21 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteMarkedTextElements",
-			pos:  position{line: 1236, col: 1, offset: 47090},
+			pos:  position{line: 1321, col: 1, offset: 49618},
 			expr: &seqExpr{
-				pos: position{line: 1236, col: 34, offset: 47123},
+				pos: position{line: 1321, col: 34, offset: 49651},
 				exprs: []interface{}{
 					&notExpr{
-						pos: position{line: 1236, col: 34, offset: 47123},
+						pos: position{line: 1321, col: 34, offset: 49651},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1236, col: 35, offset: 47124},
+							pos:  position{line: 1321, col: 35, offset: 49652},
 							name: "Space",
 						},
 					},
 					&oneOrMoreExpr{
-						pos: position{line: 1236, col: 41, offset: 47130},
+						pos: position{line: 1321, col: 41, offset: 49658},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1236, col: 41, offset: 47130},
+							pos:  position{line: 1321, col: 41, offset: 49658},
 							name: "SingleQuoteMarkedTextElement",
 						},
 					},
@@ -8656,43 +9121,43 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteMarkedTextElement",
-			pos:  position{line: 1238, col: 1, offset: 47163},
+			pos:  position{line: 1323, col: 1, offset: 49691},
 			expr: &choiceExpr{
-				pos: position{line: 1238, col: 33, offset: 47195},
+				pos: position{line: 1323, col: 33, offset: 49723},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1238, col: 33, offset: 47195},
+						pos:  position{line: 1323, col: 33, offset: 49723},
 						name: "Word",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1239, col: 11, offset: 47211},
+						pos:  position{line: 1324, col: 11, offset: 49739},
 						name: "DoubleQuoteMarkedText",
 					},
 					&seqExpr{
-						pos: position{line: 1240, col: 11, offset: 47244},
+						pos: position{line: 1325, col: 11, offset: 49772},
 						exprs: []interface{}{
 							&oneOrMoreExpr{
-								pos: position{line: 1240, col: 11, offset: 47244},
+								pos: position{line: 1325, col: 11, offset: 49772},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1240, col: 11, offset: 47244},
+									pos:  position{line: 1325, col: 11, offset: 49772},
 									name: "Space",
 								},
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 1240, col: 18, offset: 47251},
+								pos: position{line: 1325, col: 18, offset: 49779},
 								expr: &seqExpr{
-									pos: position{line: 1240, col: 19, offset: 47252},
+									pos: position{line: 1325, col: 19, offset: 49780},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 1240, col: 19, offset: 47252},
+											pos:        position{line: 1325, col: 19, offset: 49780},
 											val:        "#",
 											ignoreCase: false,
 											want:       "\"#\"",
 										},
 										&notExpr{
-											pos: position{line: 1240, col: 23, offset: 47256},
+											pos: position{line: 1325, col: 23, offset: 49784},
 											expr: &litMatcher{
-												pos:        position{line: 1240, col: 24, offset: 47257},
+												pos:        position{line: 1325, col: 24, offset: 49785},
 												val:        "#",
 												ignoreCase: false,
 												want:       "\"#\"",
@@ -8704,51 +9169,55 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1241, col: 11, offset: 47274},
+						pos:  position{line: 1326, col: 11, offset: 49802},
 						name: "BoldText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1242, col: 11, offset: 47294},
+						pos:  position{line: 1327, col: 11, offset: 49822},
 						name: "ItalicText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1243, col: 11, offset: 47316},
+						pos:  position{line: 1328, col: 11, offset: 49844},
 						name: "MonospaceText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1244, col: 11, offset: 47341},
+						pos:  position{line: 1329, col: 11, offset: 49869},
 						name: "SubscriptText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1245, col: 11, offset: 47366},
+						pos:  position{line: 1330, col: 11, offset: 49894},
 						name: "SuperscriptText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1246, col: 11, offset: 47393},
+						pos:  position{line: 1331, col: 11, offset: 49921},
 						name: "InlineIcon",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1247, col: 11, offset: 47415},
+						pos:  position{line: 1332, col: 11, offset: 49943},
 						name: "InlineImage",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1248, col: 11, offset: 47438},
+						pos:  position{line: 1333, col: 11, offset: 49966},
 						name: "Link",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1249, col: 11, offset: 47454},
+						pos:  position{line: 1334, col: 11, offset: 49982},
 						name: "InlinePassthrough",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1250, col: 11, offset: 47483},
+						pos:  position{line: 1335, col: 11, offset: 50011},
+						name: "QuotedString",
+					},
+					&ruleRefExpr{
+						pos:  position{line: 1336, col: 11, offset: 50035},
 						name: "AttributeSubstitution",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1251, col: 11, offset: 47516},
+						pos:  position{line: 1337, col: 11, offset: 50068},
 						name: "SingleQuoteMarkedTextStringElement",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1252, col: 11, offset: 47562},
+						pos:  position{line: 1338, col: 11, offset: 50114},
 						name: "SingleQuoteMarkedTextFallbackCharacter",
 					},
 				},
@@ -8756,14 +9225,14 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteMarkedTextStringElement",
-			pos:  position{line: 1254, col: 1, offset: 47604},
+			pos:  position{line: 1340, col: 1, offset: 50156},
 			expr: &actionExpr{
-				pos: position{line: 1254, col: 39, offset: 47642},
+				pos: position{line: 1340, col: 39, offset: 50194},
 				run: (*parser).callonSingleQuoteMarkedTextStringElement1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1254, col: 39, offset: 47642},
+					pos: position{line: 1340, col: 39, offset: 50194},
 					expr: &charClassMatcher{
-						pos:        position{line: 1254, col: 39, offset: 47642},
+						pos:        position{line: 1340, col: 39, offset: 50194},
 						val:        "[^\\r\\n{} #^~]",
 						chars:      []rune{'\r', '\n', '{', '}', ' ', '#', '^', '~'},
 						ignoreCase: false,
@@ -8774,31 +9243,31 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteMarkedTextFallbackCharacter",
-			pos:  position{line: 1258, col: 1, offset: 47872},
+			pos:  position{line: 1344, col: 1, offset: 50424},
 			expr: &choiceExpr{
-				pos: position{line: 1259, col: 5, offset: 47919},
+				pos: position{line: 1345, col: 5, offset: 50471},
 				alternatives: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 1259, col: 5, offset: 47919},
+						pos:        position{line: 1345, col: 5, offset: 50471},
 						val:        "[^\\r\\n#]",
 						chars:      []rune{'\r', '\n', '#'},
 						ignoreCase: false,
 						inverted:   true,
 					},
 					&actionExpr{
-						pos: position{line: 1260, col: 7, offset: 48017},
+						pos: position{line: 1346, col: 7, offset: 50569},
 						run: (*parser).callonSingleQuoteMarkedTextFallbackCharacter3,
 						expr: &seqExpr{
-							pos: position{line: 1260, col: 7, offset: 48017},
+							pos: position{line: 1346, col: 7, offset: 50569},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1260, col: 7, offset: 48017},
+									pos:        position{line: 1346, col: 7, offset: 50569},
 									val:        "#",
 									ignoreCase: false,
 									want:       "\"#\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1260, col: 11, offset: 48021},
+									pos:  position{line: 1346, col: 11, offset: 50573},
 									name: "Alphanums",
 								},
 							},
@@ -8809,40 +9278,40 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedMarkedText",
-			pos:  position{line: 1264, col: 1, offset: 48188},
+			pos:  position{line: 1350, col: 1, offset: 50740},
 			expr: &choiceExpr{
-				pos: position{line: 1265, col: 5, offset: 48214},
+				pos: position{line: 1351, col: 5, offset: 50766},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1265, col: 5, offset: 48214},
+						pos: position{line: 1351, col: 5, offset: 50766},
 						run: (*parser).callonEscapedMarkedText2,
 						expr: &seqExpr{
-							pos: position{line: 1265, col: 5, offset: 48214},
+							pos: position{line: 1351, col: 5, offset: 50766},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1265, col: 5, offset: 48214},
+									pos:   position{line: 1351, col: 5, offset: 50766},
 									label: "backslashes",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1265, col: 18, offset: 48227},
+										pos:  position{line: 1351, col: 18, offset: 50779},
 										name: "TwoOrMoreBackslashes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1265, col: 40, offset: 48249},
+									pos:        position{line: 1351, col: 40, offset: 50801},
 									val:        "##",
 									ignoreCase: false,
 									want:       "\"##\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1265, col: 45, offset: 48254},
+									pos:   position{line: 1351, col: 45, offset: 50806},
 									label: "elements",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1265, col: 55, offset: 48264},
+										pos:  position{line: 1351, col: 55, offset: 50816},
 										name: "DoubleQuoteMarkedTextElements",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1265, col: 86, offset: 48295},
+									pos:        position{line: 1351, col: 86, offset: 50847},
 									val:        "##",
 									ignoreCase: false,
 									want:       "\"##\"",
@@ -8851,35 +9320,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1267, col: 9, offset: 48454},
+						pos: position{line: 1353, col: 9, offset: 51006},
 						run: (*parser).callonEscapedMarkedText10,
 						expr: &seqExpr{
-							pos: position{line: 1267, col: 9, offset: 48454},
+							pos: position{line: 1353, col: 9, offset: 51006},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1267, col: 9, offset: 48454},
+									pos:   position{line: 1353, col: 9, offset: 51006},
 									label: "backslashes",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1267, col: 22, offset: 48467},
+										pos:  position{line: 1353, col: 22, offset: 51019},
 										name: "OneOrMoreBackslashes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1267, col: 44, offset: 48489},
+									pos:        position{line: 1353, col: 44, offset: 51041},
 									val:        "##",
 									ignoreCase: false,
 									want:       "\"##\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1267, col: 49, offset: 48494},
+									pos:   position{line: 1353, col: 49, offset: 51046},
 									label: "elements",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1267, col: 59, offset: 48504},
+										pos:  position{line: 1353, col: 59, offset: 51056},
 										name: "SingleQuoteMarkedTextElements",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1267, col: 90, offset: 48535},
+									pos:        position{line: 1353, col: 90, offset: 51087},
 									val:        "#",
 									ignoreCase: false,
 									want:       "\"#\"",
@@ -8888,35 +9357,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1270, col: 9, offset: 48738},
+						pos: position{line: 1356, col: 9, offset: 51290},
 						run: (*parser).callonEscapedMarkedText18,
 						expr: &seqExpr{
-							pos: position{line: 1270, col: 9, offset: 48738},
+							pos: position{line: 1356, col: 9, offset: 51290},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1270, col: 9, offset: 48738},
+									pos:   position{line: 1356, col: 9, offset: 51290},
 									label: "backslashes",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1270, col: 22, offset: 48751},
+										pos:  position{line: 1356, col: 22, offset: 51303},
 										name: "OneOrMoreBackslashes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1270, col: 44, offset: 48773},
+									pos:        position{line: 1356, col: 44, offset: 51325},
 									val:        "#",
 									ignoreCase: false,
 									want:       "\"#\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1270, col: 48, offset: 48777},
+									pos:   position{line: 1356, col: 48, offset: 51329},
 									label: "elements",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1270, col: 58, offset: 48787},
+										pos:  position{line: 1356, col: 58, offset: 51339},
 										name: "SingleQuoteMarkedTextElements",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1270, col: 89, offset: 48818},
+									pos:        position{line: 1356, col: 89, offset: 51370},
 									val:        "#",
 									ignoreCase: false,
 									want:       "\"#\"",
@@ -8929,49 +9398,49 @@ var g = &grammar{
 		},
 		{
 			name: "SubscriptText",
-			pos:  position{line: 1275, col: 1, offset: 48973},
+			pos:  position{line: 1361, col: 1, offset: 51525},
 			expr: &actionExpr{
-				pos: position{line: 1275, col: 18, offset: 48990},
+				pos: position{line: 1361, col: 18, offset: 51542},
 				run: (*parser).callonSubscriptText1,
 				expr: &seqExpr{
-					pos: position{line: 1275, col: 18, offset: 48990},
+					pos: position{line: 1361, col: 18, offset: 51542},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1275, col: 18, offset: 48990},
+							pos:   position{line: 1361, col: 18, offset: 51542},
 							label: "attrs",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1275, col: 24, offset: 48996},
+								pos: position{line: 1361, col: 24, offset: 51548},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1275, col: 25, offset: 48997},
+									pos:  position{line: 1361, col: 25, offset: 51549},
 									name: "QuotedTextAttrs",
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 1275, col: 43, offset: 49015},
+							pos: position{line: 1361, col: 43, offset: 51567},
 							expr: &litMatcher{
-								pos:        position{line: 1275, col: 44, offset: 49016},
+								pos:        position{line: 1361, col: 44, offset: 51568},
 								val:        "\\",
 								ignoreCase: false,
 								want:       "\"\\\\\"",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1275, col: 48, offset: 49020},
+							pos:        position{line: 1361, col: 48, offset: 51572},
 							val:        "~",
 							ignoreCase: false,
 							want:       "\"~\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1275, col: 52, offset: 49024},
+							pos:   position{line: 1361, col: 52, offset: 51576},
 							label: "element",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1275, col: 61, offset: 49033},
+								pos:  position{line: 1361, col: 61, offset: 51585},
 								name: "SubscriptTextElement",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1275, col: 83, offset: 49055},
+							pos:        position{line: 1361, col: 83, offset: 51607},
 							val:        "~",
 							ignoreCase: false,
 							want:       "\"~\"",
@@ -8982,16 +9451,16 @@ var g = &grammar{
 		},
 		{
 			name: "SubscriptTextElement",
-			pos:  position{line: 1279, col: 1, offset: 49155},
+			pos:  position{line: 1365, col: 1, offset: 51707},
 			expr: &choiceExpr{
-				pos: position{line: 1279, col: 25, offset: 49179},
+				pos: position{line: 1365, col: 25, offset: 51731},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1279, col: 25, offset: 49179},
+						pos:  position{line: 1365, col: 25, offset: 51731},
 						name: "QuotedText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1279, col: 38, offset: 49192},
+						pos:  position{line: 1365, col: 38, offset: 51744},
 						name: "NonSubscriptText",
 					},
 				},
@@ -8999,14 +9468,14 @@ var g = &grammar{
 		},
 		{
 			name: "NonSubscriptText",
-			pos:  position{line: 1281, col: 1, offset: 49213},
+			pos:  position{line: 1367, col: 1, offset: 51765},
 			expr: &actionExpr{
-				pos: position{line: 1281, col: 21, offset: 49233},
+				pos: position{line: 1367, col: 21, offset: 51785},
 				run: (*parser).callonNonSubscriptText1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1281, col: 21, offset: 49233},
+					pos: position{line: 1367, col: 21, offset: 51785},
 					expr: &charClassMatcher{
-						pos:        position{line: 1281, col: 21, offset: 49233},
+						pos:        position{line: 1367, col: 21, offset: 51785},
 						val:        "[^\\r\\n ~]",
 						chars:      []rune{'\r', '\n', ' ', '~'},
 						ignoreCase: false,
@@ -9017,37 +9486,37 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedSubscriptText",
-			pos:  position{line: 1285, col: 1, offset: 49314},
+			pos:  position{line: 1371, col: 1, offset: 51866},
 			expr: &actionExpr{
-				pos: position{line: 1285, col: 25, offset: 49338},
+				pos: position{line: 1371, col: 25, offset: 51890},
 				run: (*parser).callonEscapedSubscriptText1,
 				expr: &seqExpr{
-					pos: position{line: 1285, col: 25, offset: 49338},
+					pos: position{line: 1371, col: 25, offset: 51890},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1285, col: 25, offset: 49338},
+							pos:   position{line: 1371, col: 25, offset: 51890},
 							label: "backslashes",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1285, col: 38, offset: 49351},
+								pos:  position{line: 1371, col: 38, offset: 51903},
 								name: "OneOrMoreBackslashes",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1285, col: 60, offset: 49373},
+							pos:        position{line: 1371, col: 60, offset: 51925},
 							val:        "~",
 							ignoreCase: false,
 							want:       "\"~\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1285, col: 64, offset: 49377},
+							pos:   position{line: 1371, col: 64, offset: 51929},
 							label: "element",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1285, col: 73, offset: 49386},
+								pos:  position{line: 1371, col: 73, offset: 51938},
 								name: "SubscriptTextElement",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1285, col: 95, offset: 49408},
+							pos:        position{line: 1371, col: 95, offset: 51960},
 							val:        "~",
 							ignoreCase: false,
 							want:       "\"~\"",
@@ -9058,49 +9527,49 @@ var g = &grammar{
 		},
 		{
 			name: "SuperscriptText",
-			pos:  position{line: 1289, col: 1, offset: 49541},
+			pos:  position{line: 1375, col: 1, offset: 52093},
 			expr: &actionExpr{
-				pos: position{line: 1289, col: 20, offset: 49560},
+				pos: position{line: 1375, col: 20, offset: 52112},
 				run: (*parser).callonSuperscriptText1,
 				expr: &seqExpr{
-					pos: position{line: 1289, col: 20, offset: 49560},
+					pos: position{line: 1375, col: 20, offset: 52112},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1289, col: 20, offset: 49560},
+							pos:   position{line: 1375, col: 20, offset: 52112},
 							label: "attrs",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1289, col: 26, offset: 49566},
+								pos: position{line: 1375, col: 26, offset: 52118},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1289, col: 27, offset: 49567},
+									pos:  position{line: 1375, col: 27, offset: 52119},
 									name: "QuotedTextAttrs",
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 1289, col: 45, offset: 49585},
+							pos: position{line: 1375, col: 45, offset: 52137},
 							expr: &litMatcher{
-								pos:        position{line: 1289, col: 46, offset: 49586},
+								pos:        position{line: 1375, col: 46, offset: 52138},
 								val:        "\\",
 								ignoreCase: false,
 								want:       "\"\\\\\"",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1289, col: 50, offset: 49590},
+							pos:        position{line: 1375, col: 50, offset: 52142},
 							val:        "^",
 							ignoreCase: false,
 							want:       "\"^\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1289, col: 54, offset: 49594},
+							pos:   position{line: 1375, col: 54, offset: 52146},
 							label: "element",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1289, col: 63, offset: 49603},
+								pos:  position{line: 1375, col: 63, offset: 52155},
 								name: "SuperscriptTextElement",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1289, col: 87, offset: 49627},
+							pos:        position{line: 1375, col: 87, offset: 52179},
 							val:        "^",
 							ignoreCase: false,
 							want:       "\"^\"",
@@ -9111,16 +9580,16 @@ var g = &grammar{
 		},
 		{
 			name: "SuperscriptTextElement",
-			pos:  position{line: 1293, col: 1, offset: 49729},
+			pos:  position{line: 1379, col: 1, offset: 52281},
 			expr: &choiceExpr{
-				pos: position{line: 1293, col: 27, offset: 49755},
+				pos: position{line: 1379, col: 27, offset: 52307},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1293, col: 27, offset: 49755},
+						pos:  position{line: 1379, col: 27, offset: 52307},
 						name: "QuotedText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1293, col: 40, offset: 49768},
+						pos:  position{line: 1379, col: 40, offset: 52320},
 						name: "NonSuperscriptText",
 					},
 				},
@@ -9128,14 +9597,14 @@ var g = &grammar{
 		},
 		{
 			name: "NonSuperscriptText",
-			pos:  position{line: 1295, col: 1, offset: 49791},
+			pos:  position{line: 1381, col: 1, offset: 52343},
 			expr: &actionExpr{
-				pos: position{line: 1295, col: 23, offset: 49813},
+				pos: position{line: 1381, col: 23, offset: 52365},
 				run: (*parser).callonNonSuperscriptText1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1295, col: 23, offset: 49813},
+					pos: position{line: 1381, col: 23, offset: 52365},
 					expr: &charClassMatcher{
-						pos:        position{line: 1295, col: 23, offset: 49813},
+						pos:        position{line: 1381, col: 23, offset: 52365},
 						val:        "[^\\r\\n ^]",
 						chars:      []rune{'\r', '\n', ' ', '^'},
 						ignoreCase: false,
@@ -9146,37 +9615,37 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedSuperscriptText",
-			pos:  position{line: 1299, col: 1, offset: 49894},
+			pos:  position{line: 1385, col: 1, offset: 52446},
 			expr: &actionExpr{
-				pos: position{line: 1299, col: 27, offset: 49920},
+				pos: position{line: 1385, col: 27, offset: 52472},
 				run: (*parser).callonEscapedSuperscriptText1,
 				expr: &seqExpr{
-					pos: position{line: 1299, col: 27, offset: 49920},
+					pos: position{line: 1385, col: 27, offset: 52472},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1299, col: 27, offset: 49920},
+							pos:   position{line: 1385, col: 27, offset: 52472},
 							label: "backslashes",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1299, col: 40, offset: 49933},
+								pos:  position{line: 1385, col: 40, offset: 52485},
 								name: "OneOrMoreBackslashes",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1299, col: 62, offset: 49955},
+							pos:        position{line: 1385, col: 62, offset: 52507},
 							val:        "^",
 							ignoreCase: false,
 							want:       "\"^\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1299, col: 66, offset: 49959},
+							pos:   position{line: 1385, col: 66, offset: 52511},
 							label: "element",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1299, col: 75, offset: 49968},
+								pos:  position{line: 1385, col: 75, offset: 52520},
 								name: "SuperscriptTextElement",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1299, col: 99, offset: 49992},
+							pos:        position{line: 1385, col: 99, offset: 52544},
 							val:        "^",
 							ignoreCase: false,
 							want:       "\"^\"",
@@ -9187,20 +9656,20 @@ var g = &grammar{
 		},
 		{
 			name: "InlinePassthrough",
-			pos:  position{line: 1306, col: 1, offset: 50241},
+			pos:  position{line: 1392, col: 1, offset: 52793},
 			expr: &choiceExpr{
-				pos: position{line: 1306, col: 22, offset: 50262},
+				pos: position{line: 1392, col: 22, offset: 52814},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1306, col: 22, offset: 50262},
+						pos:  position{line: 1392, col: 22, offset: 52814},
 						name: "TriplePlusPassthrough",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1306, col: 46, offset: 50286},
+						pos:  position{line: 1392, col: 46, offset: 52838},
 						name: "SinglePlusPassthrough",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1306, col: 70, offset: 50310},
+						pos:  position{line: 1392, col: 70, offset: 52862},
 						name: "PassthroughMacro",
 					},
 				},
@@ -9208,9 +9677,9 @@ var g = &grammar{
 		},
 		{
 			name: "SinglePlusPassthroughPrefix",
-			pos:  position{line: 1308, col: 1, offset: 50330},
+			pos:  position{line: 1394, col: 1, offset: 52882},
 			expr: &litMatcher{
-				pos:        position{line: 1308, col: 32, offset: 50361},
+				pos:        position{line: 1394, col: 32, offset: 52913},
 				val:        "+",
 				ignoreCase: false,
 				want:       "\"+\"",
@@ -9218,33 +9687,33 @@ var g = &grammar{
 		},
 		{
 			name: "SinglePlusPassthrough",
-			pos:  position{line: 1310, col: 1, offset: 50368},
+			pos:  position{line: 1396, col: 1, offset: 52920},
 			expr: &actionExpr{
-				pos: position{line: 1310, col: 26, offset: 50393},
+				pos: position{line: 1396, col: 26, offset: 52945},
 				run: (*parser).callonSinglePlusPassthrough1,
 				expr: &seqExpr{
-					pos: position{line: 1310, col: 26, offset: 50393},
+					pos: position{line: 1396, col: 26, offset: 52945},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1310, col: 26, offset: 50393},
+							pos:  position{line: 1396, col: 26, offset: 52945},
 							name: "SinglePlusPassthroughPrefix",
 						},
 						&labeledExpr{
-							pos:   position{line: 1310, col: 54, offset: 50421},
+							pos:   position{line: 1396, col: 54, offset: 52973},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1310, col: 63, offset: 50430},
+								pos:  position{line: 1396, col: 63, offset: 52982},
 								name: "SinglePlusPassthroughContent",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1310, col: 93, offset: 50460},
+							pos:  position{line: 1396, col: 93, offset: 53012},
 							name: "SinglePlusPassthroughPrefix",
 						},
 						&notExpr{
-							pos: position{line: 1310, col: 121, offset: 50488},
+							pos: position{line: 1396, col: 121, offset: 53040},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1310, col: 122, offset: 50489},
+								pos:  position{line: 1396, col: 122, offset: 53041},
 								name: "Alphanum",
 							},
 						},
@@ -9254,85 +9723,85 @@ var g = &grammar{
 		},
 		{
 			name: "SinglePlusPassthroughContent",
-			pos:  position{line: 1314, col: 1, offset: 50598},
+			pos:  position{line: 1400, col: 1, offset: 53150},
 			expr: &choiceExpr{
-				pos: position{line: 1314, col: 33, offset: 50630},
+				pos: position{line: 1400, col: 33, offset: 53182},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1314, col: 34, offset: 50631},
+						pos: position{line: 1400, col: 34, offset: 53183},
 						run: (*parser).callonSinglePlusPassthroughContent2,
 						expr: &seqExpr{
-							pos: position{line: 1314, col: 34, offset: 50631},
+							pos: position{line: 1400, col: 34, offset: 53183},
 							exprs: []interface{}{
 								&seqExpr{
-									pos: position{line: 1314, col: 35, offset: 50632},
+									pos: position{line: 1400, col: 35, offset: 53184},
 									exprs: []interface{}{
 										&notExpr{
-											pos: position{line: 1314, col: 35, offset: 50632},
+											pos: position{line: 1400, col: 35, offset: 53184},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1314, col: 36, offset: 50633},
+												pos:  position{line: 1400, col: 36, offset: 53185},
 												name: "SinglePlusPassthroughPrefix",
 											},
 										},
 										&notExpr{
-											pos: position{line: 1314, col: 64, offset: 50661},
+											pos: position{line: 1400, col: 64, offset: 53213},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1314, col: 65, offset: 50662},
+												pos:  position{line: 1400, col: 65, offset: 53214},
 												name: "Space",
 											},
 										},
 										&notExpr{
-											pos: position{line: 1314, col: 71, offset: 50668},
+											pos: position{line: 1400, col: 71, offset: 53220},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1314, col: 72, offset: 50669},
+												pos:  position{line: 1400, col: 72, offset: 53221},
 												name: "Newline",
 											},
 										},
 										&anyMatcher{
-											line: 1314, col: 80, offset: 50677,
+											line: 1400, col: 80, offset: 53229,
 										},
 									},
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1314, col: 83, offset: 50680},
+									pos: position{line: 1400, col: 83, offset: 53232},
 									expr: &seqExpr{
-										pos: position{line: 1314, col: 84, offset: 50681},
+										pos: position{line: 1400, col: 84, offset: 53233},
 										exprs: []interface{}{
 											&notExpr{
-												pos: position{line: 1314, col: 84, offset: 50681},
+												pos: position{line: 1400, col: 84, offset: 53233},
 												expr: &seqExpr{
-													pos: position{line: 1314, col: 86, offset: 50683},
+													pos: position{line: 1400, col: 86, offset: 53235},
 													exprs: []interface{}{
 														&oneOrMoreExpr{
-															pos: position{line: 1314, col: 86, offset: 50683},
+															pos: position{line: 1400, col: 86, offset: 53235},
 															expr: &ruleRefExpr{
-																pos:  position{line: 1314, col: 86, offset: 50683},
+																pos:  position{line: 1400, col: 86, offset: 53235},
 																name: "Space",
 															},
 														},
 														&ruleRefExpr{
-															pos:  position{line: 1314, col: 93, offset: 50690},
+															pos:  position{line: 1400, col: 93, offset: 53242},
 															name: "SinglePlusPassthroughPrefix",
 														},
 													},
 												},
 											},
 											&notExpr{
-												pos: position{line: 1314, col: 122, offset: 50719},
+												pos: position{line: 1400, col: 122, offset: 53271},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1314, col: 123, offset: 50720},
+													pos:  position{line: 1400, col: 123, offset: 53272},
 													name: "SinglePlusPassthroughPrefix",
 												},
 											},
 											&notExpr{
-												pos: position{line: 1314, col: 151, offset: 50748},
+												pos: position{line: 1400, col: 151, offset: 53300},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1314, col: 152, offset: 50749},
+													pos:  position{line: 1400, col: 152, offset: 53301},
 													name: "Newline",
 												},
 											},
 											&anyMatcher{
-												line: 1314, col: 160, offset: 50757,
+												line: 1400, col: 160, offset: 53309,
 											},
 										},
 									},
@@ -9341,34 +9810,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1316, col: 7, offset: 50901},
+						pos: position{line: 1402, col: 7, offset: 53453},
 						run: (*parser).callonSinglePlusPassthroughContent24,
 						expr: &seqExpr{
-							pos: position{line: 1316, col: 8, offset: 50902},
+							pos: position{line: 1402, col: 8, offset: 53454},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1316, col: 8, offset: 50902},
+									pos: position{line: 1402, col: 8, offset: 53454},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1316, col: 9, offset: 50903},
+										pos:  position{line: 1402, col: 9, offset: 53455},
 										name: "Space",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1316, col: 15, offset: 50909},
+									pos: position{line: 1402, col: 15, offset: 53461},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1316, col: 16, offset: 50910},
+										pos:  position{line: 1402, col: 16, offset: 53462},
 										name: "Newline",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1316, col: 24, offset: 50918},
+									pos: position{line: 1402, col: 24, offset: 53470},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1316, col: 25, offset: 50919},
+										pos:  position{line: 1402, col: 25, offset: 53471},
 										name: "SinglePlusPassthroughPrefix",
 									},
 								},
 								&anyMatcher{
-									line: 1316, col: 53, offset: 50947,
+									line: 1402, col: 53, offset: 53499,
 								},
 							},
 						},
@@ -9378,9 +9847,9 @@ var g = &grammar{
 		},
 		{
 			name: "TriplePlusPassthroughPrefix",
-			pos:  position{line: 1320, col: 1, offset: 51033},
+			pos:  position{line: 1406, col: 1, offset: 53585},
 			expr: &litMatcher{
-				pos:        position{line: 1320, col: 32, offset: 51064},
+				pos:        position{line: 1406, col: 32, offset: 53616},
 				val:        "+++",
 				ignoreCase: false,
 				want:       "\"+++\"",
@@ -9388,33 +9857,33 @@ var g = &grammar{
 		},
 		{
 			name: "TriplePlusPassthrough",
-			pos:  position{line: 1322, col: 1, offset: 51073},
+			pos:  position{line: 1408, col: 1, offset: 53625},
 			expr: &actionExpr{
-				pos: position{line: 1322, col: 26, offset: 51098},
+				pos: position{line: 1408, col: 26, offset: 53650},
 				run: (*parser).callonTriplePlusPassthrough1,
 				expr: &seqExpr{
-					pos: position{line: 1322, col: 26, offset: 51098},
+					pos: position{line: 1408, col: 26, offset: 53650},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1322, col: 26, offset: 51098},
+							pos:  position{line: 1408, col: 26, offset: 53650},
 							name: "TriplePlusPassthroughPrefix",
 						},
 						&labeledExpr{
-							pos:   position{line: 1322, col: 54, offset: 51126},
+							pos:   position{line: 1408, col: 54, offset: 53678},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1322, col: 63, offset: 51135},
+								pos:  position{line: 1408, col: 63, offset: 53687},
 								name: "TriplePlusPassthroughContent",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1322, col: 93, offset: 51165},
+							pos:  position{line: 1408, col: 93, offset: 53717},
 							name: "TriplePlusPassthroughPrefix",
 						},
 						&notExpr{
-							pos: position{line: 1322, col: 121, offset: 51193},
+							pos: position{line: 1408, col: 121, offset: 53745},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1322, col: 122, offset: 51194},
+								pos:  position{line: 1408, col: 122, offset: 53746},
 								name: "Alphanum",
 							},
 						},
@@ -9424,63 +9893,63 @@ var g = &grammar{
 		},
 		{
 			name: "TriplePlusPassthroughContent",
-			pos:  position{line: 1326, col: 1, offset: 51303},
+			pos:  position{line: 1412, col: 1, offset: 53855},
 			expr: &choiceExpr{
-				pos: position{line: 1326, col: 33, offset: 51335},
+				pos: position{line: 1412, col: 33, offset: 53887},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1326, col: 34, offset: 51336},
+						pos: position{line: 1412, col: 34, offset: 53888},
 						run: (*parser).callonTriplePlusPassthroughContent2,
 						expr: &zeroOrMoreExpr{
-							pos: position{line: 1326, col: 34, offset: 51336},
+							pos: position{line: 1412, col: 34, offset: 53888},
 							expr: &seqExpr{
-								pos: position{line: 1326, col: 35, offset: 51337},
+								pos: position{line: 1412, col: 35, offset: 53889},
 								exprs: []interface{}{
 									&notExpr{
-										pos: position{line: 1326, col: 35, offset: 51337},
+										pos: position{line: 1412, col: 35, offset: 53889},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1326, col: 36, offset: 51338},
+											pos:  position{line: 1412, col: 36, offset: 53890},
 											name: "TriplePlusPassthroughPrefix",
 										},
 									},
 									&anyMatcher{
-										line: 1326, col: 64, offset: 51366,
+										line: 1412, col: 64, offset: 53918,
 									},
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1328, col: 7, offset: 51533},
+						pos: position{line: 1414, col: 7, offset: 54085},
 						run: (*parser).callonTriplePlusPassthroughContent8,
 						expr: &zeroOrOneExpr{
-							pos: position{line: 1328, col: 7, offset: 51533},
+							pos: position{line: 1414, col: 7, offset: 54085},
 							expr: &seqExpr{
-								pos: position{line: 1328, col: 8, offset: 51534},
+								pos: position{line: 1414, col: 8, offset: 54086},
 								exprs: []interface{}{
 									&notExpr{
-										pos: position{line: 1328, col: 8, offset: 51534},
+										pos: position{line: 1414, col: 8, offset: 54086},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1328, col: 9, offset: 51535},
+											pos:  position{line: 1414, col: 9, offset: 54087},
 											name: "Space",
 										},
 									},
 									&notExpr{
-										pos: position{line: 1328, col: 15, offset: 51541},
+										pos: position{line: 1414, col: 15, offset: 54093},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1328, col: 16, offset: 51542},
+											pos:  position{line: 1414, col: 16, offset: 54094},
 											name: "Newline",
 										},
 									},
 									&notExpr{
-										pos: position{line: 1328, col: 24, offset: 51550},
+										pos: position{line: 1414, col: 24, offset: 54102},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1328, col: 25, offset: 51551},
+											pos:  position{line: 1414, col: 25, offset: 54103},
 											name: "TriplePlusPassthroughPrefix",
 										},
 									},
 									&anyMatcher{
-										line: 1328, col: 53, offset: 51579,
+										line: 1414, col: 53, offset: 54131,
 									},
 								},
 							},
@@ -9491,35 +9960,35 @@ var g = &grammar{
 		},
 		{
 			name: "PassthroughMacro",
-			pos:  position{line: 1332, col: 1, offset: 51666},
+			pos:  position{line: 1418, col: 1, offset: 54218},
 			expr: &choiceExpr{
-				pos: position{line: 1332, col: 21, offset: 51686},
+				pos: position{line: 1418, col: 21, offset: 54238},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1332, col: 21, offset: 51686},
+						pos: position{line: 1418, col: 21, offset: 54238},
 						run: (*parser).callonPassthroughMacro2,
 						expr: &seqExpr{
-							pos: position{line: 1332, col: 21, offset: 51686},
+							pos: position{line: 1418, col: 21, offset: 54238},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1332, col: 21, offset: 51686},
+									pos:        position{line: 1418, col: 21, offset: 54238},
 									val:        "pass:[",
 									ignoreCase: false,
 									want:       "\"pass:[\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1332, col: 30, offset: 51695},
+									pos:   position{line: 1418, col: 30, offset: 54247},
 									label: "content",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1332, col: 38, offset: 51703},
+										pos: position{line: 1418, col: 38, offset: 54255},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1332, col: 39, offset: 51704},
+											pos:  position{line: 1418, col: 39, offset: 54256},
 											name: "PassthroughMacroCharacter",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1332, col: 67, offset: 51732},
+									pos:        position{line: 1418, col: 67, offset: 54284},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -9528,31 +9997,31 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1334, col: 5, offset: 51830},
+						pos: position{line: 1420, col: 5, offset: 54382},
 						run: (*parser).callonPassthroughMacro9,
 						expr: &seqExpr{
-							pos: position{line: 1334, col: 5, offset: 51830},
+							pos: position{line: 1420, col: 5, offset: 54382},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1334, col: 5, offset: 51830},
+									pos:        position{line: 1420, col: 5, offset: 54382},
 									val:        "pass:q[",
 									ignoreCase: false,
 									want:       "\"pass:q[\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1334, col: 15, offset: 51840},
+									pos:   position{line: 1420, col: 15, offset: 54392},
 									label: "content",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1334, col: 23, offset: 51848},
+										pos: position{line: 1420, col: 23, offset: 54400},
 										expr: &choiceExpr{
-											pos: position{line: 1334, col: 24, offset: 51849},
+											pos: position{line: 1420, col: 24, offset: 54401},
 											alternatives: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 1334, col: 24, offset: 51849},
+													pos:  position{line: 1420, col: 24, offset: 54401},
 													name: "QuotedText",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1334, col: 37, offset: 51862},
+													pos:  position{line: 1420, col: 37, offset: 54414},
 													name: "PassthroughMacroCharacter",
 												},
 											},
@@ -9560,7 +10029,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1334, col: 65, offset: 51890},
+									pos:        position{line: 1420, col: 65, offset: 54442},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -9573,12 +10042,12 @@ var g = &grammar{
 		},
 		{
 			name: "PassthroughMacroCharacter",
-			pos:  position{line: 1338, col: 1, offset: 51990},
+			pos:  position{line: 1424, col: 1, offset: 54542},
 			expr: &actionExpr{
-				pos: position{line: 1338, col: 30, offset: 52019},
+				pos: position{line: 1424, col: 30, offset: 54571},
 				run: (*parser).callonPassthroughMacroCharacter1,
 				expr: &charClassMatcher{
-					pos:        position{line: 1338, col: 30, offset: 52019},
+					pos:        position{line: 1424, col: 30, offset: 54571},
 					val:        "[^\\]]",
 					chars:      []rune{']'},
 					ignoreCase: false,
@@ -9588,16 +10057,16 @@ var g = &grammar{
 		},
 		{
 			name: "CrossReference",
-			pos:  position{line: 1345, col: 1, offset: 52199},
+			pos:  position{line: 1431, col: 1, offset: 54751},
 			expr: &choiceExpr{
-				pos: position{line: 1345, col: 19, offset: 52217},
+				pos: position{line: 1431, col: 19, offset: 54769},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1345, col: 19, offset: 52217},
+						pos:  position{line: 1431, col: 19, offset: 54769},
 						name: "InternalCrossReference",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1345, col: 44, offset: 52242},
+						pos:  position{line: 1431, col: 44, offset: 54794},
 						name: "ExternalCrossReference",
 					},
 				},
@@ -9605,53 +10074,53 @@ var g = &grammar{
 		},
 		{
 			name: "InternalCrossReference",
-			pos:  position{line: 1347, col: 1, offset: 52269},
+			pos:  position{line: 1433, col: 1, offset: 54821},
 			expr: &choiceExpr{
-				pos: position{line: 1347, col: 27, offset: 52295},
+				pos: position{line: 1433, col: 27, offset: 54847},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1347, col: 27, offset: 52295},
+						pos: position{line: 1433, col: 27, offset: 54847},
 						run: (*parser).callonInternalCrossReference2,
 						expr: &seqExpr{
-							pos: position{line: 1347, col: 27, offset: 52295},
+							pos: position{line: 1433, col: 27, offset: 54847},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1347, col: 27, offset: 52295},
+									pos:        position{line: 1433, col: 27, offset: 54847},
 									val:        "<<",
 									ignoreCase: false,
 									want:       "\"<<\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1347, col: 32, offset: 52300},
+									pos:   position{line: 1433, col: 32, offset: 54852},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1347, col: 36, offset: 52304},
+										pos:  position{line: 1433, col: 36, offset: 54856},
 										name: "ID",
 									},
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1347, col: 40, offset: 52308},
+									pos: position{line: 1433, col: 40, offset: 54860},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1347, col: 40, offset: 52308},
+										pos:  position{line: 1433, col: 40, offset: 54860},
 										name: "Space",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1347, col: 47, offset: 52315},
+									pos:        position{line: 1433, col: 47, offset: 54867},
 									val:        ",",
 									ignoreCase: false,
 									want:       "\",\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1347, col: 51, offset: 52319},
+									pos:   position{line: 1433, col: 51, offset: 54871},
 									label: "label",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1347, col: 58, offset: 52326},
+										pos:  position{line: 1433, col: 58, offset: 54878},
 										name: "CrossReferenceLabel",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1347, col: 79, offset: 52347},
+									pos:        position{line: 1433, col: 79, offset: 54899},
 									val:        ">>",
 									ignoreCase: false,
 									want:       "\">>\"",
@@ -9660,27 +10129,27 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1349, col: 5, offset: 52432},
+						pos: position{line: 1435, col: 5, offset: 54984},
 						run: (*parser).callonInternalCrossReference13,
 						expr: &seqExpr{
-							pos: position{line: 1349, col: 5, offset: 52432},
+							pos: position{line: 1435, col: 5, offset: 54984},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1349, col: 5, offset: 52432},
+									pos:        position{line: 1435, col: 5, offset: 54984},
 									val:        "<<",
 									ignoreCase: false,
 									want:       "\"<<\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1349, col: 10, offset: 52437},
+									pos:   position{line: 1435, col: 10, offset: 54989},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1349, col: 14, offset: 52441},
+										pos:  position{line: 1435, col: 14, offset: 54993},
 										name: "ID",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1349, col: 18, offset: 52445},
+									pos:        position{line: 1435, col: 18, offset: 54997},
 									val:        ">>",
 									ignoreCase: false,
 									want:       "\">>\"",
@@ -9693,32 +10162,32 @@ var g = &grammar{
 		},
 		{
 			name: "ExternalCrossReference",
-			pos:  position{line: 1353, col: 1, offset: 52521},
+			pos:  position{line: 1439, col: 1, offset: 55073},
 			expr: &actionExpr{
-				pos: position{line: 1353, col: 27, offset: 52547},
+				pos: position{line: 1439, col: 27, offset: 55099},
 				run: (*parser).callonExternalCrossReference1,
 				expr: &seqExpr{
-					pos: position{line: 1353, col: 27, offset: 52547},
+					pos: position{line: 1439, col: 27, offset: 55099},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1353, col: 27, offset: 52547},
+							pos:        position{line: 1439, col: 27, offset: 55099},
 							val:        "xref:",
 							ignoreCase: false,
 							want:       "\"xref:\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1353, col: 35, offset: 52555},
+							pos:   position{line: 1439, col: 35, offset: 55107},
 							label: "url",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1353, col: 40, offset: 52560},
+								pos:  position{line: 1439, col: 40, offset: 55112},
 								name: "FileLocation",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1353, col: 54, offset: 52574},
+							pos:   position{line: 1439, col: 54, offset: 55126},
 							label: "inlineAttributes",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1353, col: 72, offset: 52592},
+								pos:  position{line: 1439, col: 72, offset: 55144},
 								name: "LinkAttributes",
 							},
 						},
@@ -9728,24 +10197,24 @@ var g = &grammar{
 		},
 		{
 			name: "CrossReferenceLabel",
-			pos:  position{line: 1357, col: 1, offset: 52719},
+			pos:  position{line: 1443, col: 1, offset: 55271},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1357, col: 24, offset: 52742},
+				pos:  position{line: 1443, col: 24, offset: 55294},
 				name: "ElementTitleContent",
 			},
 		},
 		{
 			name: "Link",
-			pos:  position{line: 1362, col: 1, offset: 52869},
+			pos:  position{line: 1448, col: 1, offset: 55421},
 			expr: &choiceExpr{
-				pos: position{line: 1362, col: 9, offset: 52877},
+				pos: position{line: 1448, col: 9, offset: 55429},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1362, col: 9, offset: 52877},
+						pos:  position{line: 1448, col: 9, offset: 55429},
 						name: "RelativeLink",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1362, col: 24, offset: 52892},
+						pos:  position{line: 1448, col: 24, offset: 55444},
 						name: "ExternalLink",
 					},
 				},
@@ -9753,32 +10222,32 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeLink",
-			pos:  position{line: 1365, col: 1, offset: 52976},
+			pos:  position{line: 1451, col: 1, offset: 55528},
 			expr: &actionExpr{
-				pos: position{line: 1365, col: 17, offset: 52992},
+				pos: position{line: 1451, col: 17, offset: 55544},
 				run: (*parser).callonRelativeLink1,
 				expr: &seqExpr{
-					pos: position{line: 1365, col: 17, offset: 52992},
+					pos: position{line: 1451, col: 17, offset: 55544},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1365, col: 17, offset: 52992},
+							pos:        position{line: 1451, col: 17, offset: 55544},
 							val:        "link:",
 							ignoreCase: false,
 							want:       "\"link:\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1365, col: 25, offset: 53000},
+							pos:   position{line: 1451, col: 25, offset: 55552},
 							label: "url",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1365, col: 30, offset: 53005},
+								pos:  position{line: 1451, col: 30, offset: 55557},
 								name: "Location",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1365, col: 40, offset: 53015},
+							pos:   position{line: 1451, col: 40, offset: 55567},
 							label: "inlineAttributes",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1365, col: 58, offset: 53033},
+								pos:  position{line: 1451, col: 58, offset: 55585},
 								name: "LinkAttributes",
 							},
 						},
@@ -9788,28 +10257,28 @@ var g = &grammar{
 		},
 		{
 			name: "ExternalLink",
-			pos:  position{line: 1369, col: 1, offset: 53148},
+			pos:  position{line: 1455, col: 1, offset: 55700},
 			expr: &actionExpr{
-				pos: position{line: 1369, col: 17, offset: 53164},
+				pos: position{line: 1455, col: 17, offset: 55716},
 				run: (*parser).callonExternalLink1,
 				expr: &seqExpr{
-					pos: position{line: 1369, col: 17, offset: 53164},
+					pos: position{line: 1455, col: 17, offset: 55716},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1369, col: 17, offset: 53164},
+							pos:   position{line: 1455, col: 17, offset: 55716},
 							label: "url",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1369, col: 22, offset: 53169},
+								pos:  position{line: 1455, col: 22, offset: 55721},
 								name: "LocationWithScheme",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1369, col: 42, offset: 53189},
+							pos:   position{line: 1455, col: 42, offset: 55741},
 							label: "inlineAttributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1369, col: 59, offset: 53206},
+								pos: position{line: 1455, col: 59, offset: 55758},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1369, col: 60, offset: 53207},
+									pos:  position{line: 1455, col: 60, offset: 55759},
 									name: "LinkAttributes",
 								},
 							},
@@ -9820,50 +10289,50 @@ var g = &grammar{
 		},
 		{
 			name: "LinkAttributes",
-			pos:  position{line: 1373, col: 1, offset: 53304},
+			pos:  position{line: 1459, col: 1, offset: 55856},
 			expr: &actionExpr{
-				pos: position{line: 1373, col: 19, offset: 53322},
+				pos: position{line: 1459, col: 19, offset: 55874},
 				run: (*parser).callonLinkAttributes1,
 				expr: &seqExpr{
-					pos: position{line: 1373, col: 19, offset: 53322},
+					pos: position{line: 1459, col: 19, offset: 55874},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1373, col: 19, offset: 53322},
+							pos:        position{line: 1459, col: 19, offset: 55874},
 							val:        "[",
 							ignoreCase: false,
 							want:       "\"[\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1373, col: 23, offset: 53326},
+							pos:   position{line: 1459, col: 23, offset: 55878},
 							label: "firstAttr",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1373, col: 33, offset: 53336},
+								pos: position{line: 1459, col: 33, offset: 55888},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1373, col: 34, offset: 53337},
+									pos:  position{line: 1459, col: 34, offset: 55889},
 									name: "FirstLinkAttributeElement",
 								},
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1374, col: 5, offset: 53370},
+							pos: position{line: 1460, col: 5, offset: 55922},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1374, col: 5, offset: 53370},
+								pos:  position{line: 1460, col: 5, offset: 55922},
 								name: "Space",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1374, col: 12, offset: 53377},
+							pos:   position{line: 1460, col: 12, offset: 55929},
 							label: "otherattrs",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1374, col: 23, offset: 53388},
+								pos: position{line: 1460, col: 23, offset: 55940},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1374, col: 24, offset: 53389},
+									pos:  position{line: 1460, col: 24, offset: 55941},
 									name: "GenericAttribute",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1374, col: 43, offset: 53408},
+							pos:        position{line: 1460, col: 43, offset: 55960},
 							val:        "]",
 							ignoreCase: false,
 							want:       "\"]\"",
@@ -9874,42 +10343,46 @@ var g = &grammar{
 		},
 		{
 			name: "FirstLinkAttributeElement",
-			pos:  position{line: 1378, col: 1, offset: 53529},
+			pos:  position{line: 1464, col: 1, offset: 56081},
 			expr: &actionExpr{
-				pos: position{line: 1378, col: 30, offset: 53558},
+				pos: position{line: 1464, col: 30, offset: 56110},
 				run: (*parser).callonFirstLinkAttributeElement1,
 				expr: &labeledExpr{
-					pos:   position{line: 1378, col: 30, offset: 53558},
+					pos:   position{line: 1464, col: 30, offset: 56110},
 					label: "element",
 					expr: &choiceExpr{
-						pos: position{line: 1380, col: 5, offset: 53611},
+						pos: position{line: 1466, col: 5, offset: 56163},
 						alternatives: []interface{}{
 							&actionExpr{
-								pos: position{line: 1380, col: 6, offset: 53612},
+								pos: position{line: 1466, col: 6, offset: 56164},
 								run: (*parser).callonFirstLinkAttributeElement4,
 								expr: &seqExpr{
-									pos: position{line: 1380, col: 6, offset: 53612},
+									pos: position{line: 1466, col: 6, offset: 56164},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 1380, col: 6, offset: 53612},
+											pos:        position{line: 1466, col: 6, offset: 56164},
 											val:        "\"",
 											ignoreCase: false,
 											want:       "\"\\\"\"",
 										},
 										&labeledExpr{
-											pos:   position{line: 1380, col: 11, offset: 53617},
+											pos:   position{line: 1466, col: 11, offset: 56169},
 											label: "elements",
 											expr: &oneOrMoreExpr{
-												pos: position{line: 1380, col: 20, offset: 53626},
+												pos: position{line: 1466, col: 20, offset: 56178},
 												expr: &choiceExpr{
-													pos: position{line: 1380, col: 21, offset: 53627},
+													pos: position{line: 1466, col: 21, offset: 56179},
 													alternatives: []interface{}{
 														&ruleRefExpr{
-															pos:  position{line: 1380, col: 21, offset: 53627},
+															pos:  position{line: 1466, col: 21, offset: 56179},
+															name: "QuotedString",
+														},
+														&ruleRefExpr{
+															pos:  position{line: 1466, col: 36, offset: 56194},
 															name: "QuotedText",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 1380, col: 34, offset: 53640},
+															pos:  position{line: 1466, col: 49, offset: 56207},
 															name: "QuotedAttributeChar",
 														},
 													},
@@ -9917,17 +10390,17 @@ var g = &grammar{
 											},
 										},
 										&litMatcher{
-											pos:        position{line: 1380, col: 56, offset: 53662},
+											pos:        position{line: 1466, col: 71, offset: 56229},
 											val:        "\"",
 											ignoreCase: false,
 											want:       "\"\\\"\"",
 										},
 										&andExpr{
-											pos: position{line: 1380, col: 61, offset: 53667},
+											pos: position{line: 1466, col: 76, offset: 56234},
 											expr: &notExpr{
-												pos: position{line: 1380, col: 63, offset: 53669},
+												pos: position{line: 1466, col: 78, offset: 56236},
 												expr: &litMatcher{
-													pos:        position{line: 1380, col: 64, offset: 53670},
+													pos:        position{line: 1466, col: 79, offset: 56237},
 													val:        "=",
 													ignoreCase: false,
 													want:       "\"=\"",
@@ -9935,9 +10408,9 @@ var g = &grammar{
 											},
 										},
 										&zeroOrOneExpr{
-											pos: position{line: 1380, col: 69, offset: 53675},
+											pos: position{line: 1466, col: 84, offset: 56242},
 											expr: &litMatcher{
-												pos:        position{line: 1380, col: 69, offset: 53675},
+												pos:        position{line: 1466, col: 84, offset: 56242},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
@@ -9947,25 +10420,29 @@ var g = &grammar{
 								},
 							},
 							&actionExpr{
-								pos: position{line: 1384, col: 6, offset: 53806},
-								run: (*parser).callonFirstLinkAttributeElement18,
+								pos: position{line: 1470, col: 6, offset: 56373},
+								run: (*parser).callonFirstLinkAttributeElement19,
 								expr: &seqExpr{
-									pos: position{line: 1384, col: 6, offset: 53806},
+									pos: position{line: 1470, col: 6, offset: 56373},
 									exprs: []interface{}{
 										&labeledExpr{
-											pos:   position{line: 1384, col: 6, offset: 53806},
+											pos:   position{line: 1470, col: 6, offset: 56373},
 											label: "elements",
 											expr: &oneOrMoreExpr{
-												pos: position{line: 1384, col: 15, offset: 53815},
+												pos: position{line: 1470, col: 15, offset: 56382},
 												expr: &choiceExpr{
-													pos: position{line: 1384, col: 16, offset: 53816},
+													pos: position{line: 1470, col: 16, offset: 56383},
 													alternatives: []interface{}{
 														&ruleRefExpr{
-															pos:  position{line: 1384, col: 16, offset: 53816},
+															pos:  position{line: 1470, col: 16, offset: 56383},
+															name: "QuotedString",
+														},
+														&ruleRefExpr{
+															pos:  position{line: 1470, col: 31, offset: 56398},
 															name: "QuotedText",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 1384, col: 29, offset: 53829},
+															pos:  position{line: 1470, col: 44, offset: 56411},
 															name: "UnquotedAttributeChar",
 														},
 													},
@@ -9973,11 +10450,11 @@ var g = &grammar{
 											},
 										},
 										&andExpr{
-											pos: position{line: 1384, col: 53, offset: 53853},
+											pos: position{line: 1470, col: 68, offset: 56435},
 											expr: &notExpr{
-												pos: position{line: 1384, col: 55, offset: 53855},
+												pos: position{line: 1470, col: 70, offset: 56437},
 												expr: &litMatcher{
-													pos:        position{line: 1384, col: 56, offset: 53856},
+													pos:        position{line: 1470, col: 71, offset: 56438},
 													val:        "=",
 													ignoreCase: false,
 													want:       "\"=\"",
@@ -9985,9 +10462,9 @@ var g = &grammar{
 											},
 										},
 										&zeroOrOneExpr{
-											pos: position{line: 1384, col: 61, offset: 53861},
+											pos: position{line: 1470, col: 76, offset: 56443},
 											expr: &litMatcher{
-												pos:        position{line: 1384, col: 61, offset: 53861},
+												pos:        position{line: 1470, col: 76, offset: 56443},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
@@ -10003,12 +10480,12 @@ var g = &grammar{
 		},
 		{
 			name: "AttributeChar",
-			pos:  position{line: 1390, col: 1, offset: 53981},
+			pos:  position{line: 1476, col: 1, offset: 56563},
 			expr: &actionExpr{
-				pos: position{line: 1390, col: 18, offset: 53998},
+				pos: position{line: 1476, col: 18, offset: 56580},
 				run: (*parser).callonAttributeChar1,
 				expr: &charClassMatcher{
-					pos:        position{line: 1390, col: 18, offset: 53998},
+					pos:        position{line: 1476, col: 18, offset: 56580},
 					val:        "[^\\r\\n\"=\\],]",
 					chars:      []rune{'\r', '\n', '"', '=', ']', ','},
 					ignoreCase: false,
@@ -10018,12 +10495,12 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedAttributeChar",
-			pos:  position{line: 1394, col: 1, offset: 54088},
+			pos:  position{line: 1480, col: 1, offset: 56670},
 			expr: &actionExpr{
-				pos: position{line: 1394, col: 24, offset: 54111},
+				pos: position{line: 1480, col: 24, offset: 56693},
 				run: (*parser).callonQuotedAttributeChar1,
 				expr: &charClassMatcher{
-					pos:        position{line: 1394, col: 24, offset: 54111},
+					pos:        position{line: 1480, col: 24, offset: 56693},
 					val:        "[^\\r\\n\"=\\]]",
 					chars:      []rune{'\r', '\n', '"', '=', ']'},
 					ignoreCase: false,
@@ -10033,12 +10510,12 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedAttributeChar",
-			pos:  position{line: 1398, col: 1, offset: 54208},
+			pos:  position{line: 1484, col: 1, offset: 56790},
 			expr: &actionExpr{
-				pos: position{line: 1398, col: 26, offset: 54233},
+				pos: position{line: 1484, col: 26, offset: 56815},
 				run: (*parser).callonUnquotedAttributeChar1,
 				expr: &charClassMatcher{
-					pos:        position{line: 1398, col: 26, offset: 54233},
+					pos:        position{line: 1484, col: 26, offset: 56815},
 					val:        "[^\\r\\n\"=\\],]",
 					chars:      []rune{'\r', '\n', '"', '=', ']', ','},
 					ignoreCase: false,
@@ -10048,46 +10525,46 @@ var g = &grammar{
 		},
 		{
 			name: "InlineLinks",
-			pos:  position{line: 1403, col: 1, offset: 54395},
+			pos:  position{line: 1489, col: 1, offset: 56977},
 			expr: &actionExpr{
-				pos: position{line: 1404, col: 5, offset: 54416},
+				pos: position{line: 1490, col: 5, offset: 56998},
 				run: (*parser).callonInlineLinks1,
 				expr: &seqExpr{
-					pos: position{line: 1404, col: 5, offset: 54416},
+					pos: position{line: 1490, col: 5, offset: 56998},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1404, col: 5, offset: 54416},
+							pos:   position{line: 1490, col: 5, offset: 56998},
 							label: "elements",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1404, col: 14, offset: 54425},
+								pos: position{line: 1490, col: 14, offset: 57007},
 								expr: &choiceExpr{
-									pos: position{line: 1404, col: 15, offset: 54426},
+									pos: position{line: 1490, col: 15, offset: 57008},
 									alternatives: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 1404, col: 15, offset: 54426},
+											pos:  position{line: 1490, col: 15, offset: 57008},
 											name: "Word",
 										},
 										&oneOrMoreExpr{
-											pos: position{line: 1405, col: 11, offset: 54442},
+											pos: position{line: 1491, col: 11, offset: 57024},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1405, col: 11, offset: 54442},
+												pos:  position{line: 1491, col: 11, offset: 57024},
 												name: "Space",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1406, col: 11, offset: 54461},
+											pos:  position{line: 1492, col: 11, offset: 57043},
 											name: "ResolvedLink",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1407, col: 11, offset: 54486},
+											pos:  position{line: 1493, col: 11, offset: 57068},
 											name: "Parenthesis",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1408, col: 11, offset: 54509},
+											pos:  position{line: 1494, col: 11, offset: 57091},
 											name: "AnyChar",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1409, col: 11, offset: 54528},
+											pos:  position{line: 1495, col: 11, offset: 57110},
 											name: "Newline",
 										},
 									},
@@ -10095,7 +10572,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1409, col: 21, offset: 54538},
+							pos:  position{line: 1495, col: 21, offset: 57120},
 							name: "EOF",
 						},
 					},
@@ -10104,16 +10581,16 @@ var g = &grammar{
 		},
 		{
 			name: "ResolvedLink",
-			pos:  position{line: 1413, col: 1, offset: 54612},
+			pos:  position{line: 1499, col: 1, offset: 57194},
 			expr: &choiceExpr{
-				pos: position{line: 1413, col: 17, offset: 54628},
+				pos: position{line: 1499, col: 17, offset: 57210},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1413, col: 17, offset: 54628},
+						pos:  position{line: 1499, col: 17, offset: 57210},
 						name: "ResolvedRelativeLink",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1413, col: 40, offset: 54651},
+						pos:  position{line: 1499, col: 40, offset: 57233},
 						name: "ResolvedExternalLink",
 					},
 				},
@@ -10121,41 +10598,41 @@ var g = &grammar{
 		},
 		{
 			name: "ResolvedRelativeLink",
-			pos:  position{line: 1416, col: 1, offset: 54782},
+			pos:  position{line: 1502, col: 1, offset: 57364},
 			expr: &actionExpr{
-				pos: position{line: 1416, col: 25, offset: 54806},
+				pos: position{line: 1502, col: 25, offset: 57388},
 				run: (*parser).callonResolvedRelativeLink1,
 				expr: &seqExpr{
-					pos: position{line: 1416, col: 25, offset: 54806},
+					pos: position{line: 1502, col: 25, offset: 57388},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1416, col: 25, offset: 54806},
+							pos:        position{line: 1502, col: 25, offset: 57388},
 							val:        "link:",
 							ignoreCase: false,
 							want:       "\"link:\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1416, col: 33, offset: 54814},
+							pos:   position{line: 1502, col: 33, offset: 57396},
 							label: "url",
 							expr: &choiceExpr{
-								pos: position{line: 1416, col: 38, offset: 54819},
+								pos: position{line: 1502, col: 38, offset: 57401},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1416, col: 38, offset: 54819},
+										pos:  position{line: 1502, col: 38, offset: 57401},
 										name: "ResolvedLocation",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1416, col: 57, offset: 54838},
+										pos:  position{line: 1502, col: 57, offset: 57420},
 										name: "ResolvedFileLocation",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1416, col: 79, offset: 54860},
+							pos:   position{line: 1502, col: 79, offset: 57442},
 							label: "inlineAttributes",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1416, col: 97, offset: 54878},
+								pos:  position{line: 1502, col: 97, offset: 57460},
 								name: "LinkAttributes",
 							},
 						},
@@ -10165,28 +10642,28 @@ var g = &grammar{
 		},
 		{
 			name: "ResolvedExternalLink",
-			pos:  position{line: 1420, col: 1, offset: 54993},
+			pos:  position{line: 1506, col: 1, offset: 57575},
 			expr: &actionExpr{
-				pos: position{line: 1420, col: 25, offset: 55017},
+				pos: position{line: 1506, col: 25, offset: 57599},
 				run: (*parser).callonResolvedExternalLink1,
 				expr: &seqExpr{
-					pos: position{line: 1420, col: 25, offset: 55017},
+					pos: position{line: 1506, col: 25, offset: 57599},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1420, col: 25, offset: 55017},
+							pos:   position{line: 1506, col: 25, offset: 57599},
 							label: "url",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1420, col: 30, offset: 55022},
+								pos:  position{line: 1506, col: 30, offset: 57604},
 								name: "ResolvedLocation",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1420, col: 48, offset: 55040},
+							pos:   position{line: 1506, col: 48, offset: 57622},
 							label: "inlineAttributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1420, col: 65, offset: 55057},
+								pos: position{line: 1506, col: 65, offset: 57639},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1420, col: 66, offset: 55058},
+									pos:  position{line: 1506, col: 66, offset: 57640},
 									name: "LinkAttributes",
 								},
 							},
@@ -10197,55 +10674,55 @@ var g = &grammar{
 		},
 		{
 			name: "ImageBlock",
-			pos:  position{line: 1427, col: 1, offset: 55260},
+			pos:  position{line: 1513, col: 1, offset: 57842},
 			expr: &actionExpr{
-				pos: position{line: 1427, col: 15, offset: 55274},
+				pos: position{line: 1513, col: 15, offset: 57856},
 				run: (*parser).callonImageBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1427, col: 15, offset: 55274},
+					pos: position{line: 1513, col: 15, offset: 57856},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1427, col: 15, offset: 55274},
+							pos:   position{line: 1513, col: 15, offset: 57856},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1427, col: 26, offset: 55285},
+								pos: position{line: 1513, col: 26, offset: 57867},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1427, col: 27, offset: 55286},
+									pos:  position{line: 1513, col: 27, offset: 57868},
 									name: "Attributes",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1427, col: 40, offset: 55299},
+							pos:        position{line: 1513, col: 40, offset: 57881},
 							val:        "image::",
 							ignoreCase: false,
 							want:       "\"image::\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1427, col: 50, offset: 55309},
+							pos:   position{line: 1513, col: 50, offset: 57891},
 							label: "path",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1427, col: 56, offset: 55315},
+								pos:  position{line: 1513, col: 56, offset: 57897},
 								name: "Location",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1427, col: 66, offset: 55325},
+							pos:   position{line: 1513, col: 66, offset: 57907},
 							label: "inlineAttributes",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1427, col: 84, offset: 55343},
+								pos:  position{line: 1513, col: 84, offset: 57925},
 								name: "ImageAttributes",
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1427, col: 101, offset: 55360},
+							pos: position{line: 1513, col: 101, offset: 57942},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1427, col: 101, offset: 55360},
+								pos:  position{line: 1513, col: 101, offset: 57942},
 								name: "Space",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1427, col: 108, offset: 55367},
+							pos:  position{line: 1513, col: 108, offset: 57949},
 							name: "EOL",
 						},
 					},
@@ -10254,41 +10731,41 @@ var g = &grammar{
 		},
 		{
 			name: "InlineImage",
-			pos:  position{line: 1431, col: 1, offset: 55483},
+			pos:  position{line: 1517, col: 1, offset: 58065},
 			expr: &actionExpr{
-				pos: position{line: 1431, col: 16, offset: 55498},
+				pos: position{line: 1517, col: 16, offset: 58080},
 				run: (*parser).callonInlineImage1,
 				expr: &seqExpr{
-					pos: position{line: 1431, col: 16, offset: 55498},
+					pos: position{line: 1517, col: 16, offset: 58080},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1431, col: 16, offset: 55498},
+							pos:        position{line: 1517, col: 16, offset: 58080},
 							val:        "image:",
 							ignoreCase: false,
 							want:       "\"image:\"",
 						},
 						&notExpr{
-							pos: position{line: 1431, col: 25, offset: 55507},
+							pos: position{line: 1517, col: 25, offset: 58089},
 							expr: &litMatcher{
-								pos:        position{line: 1431, col: 26, offset: 55508},
+								pos:        position{line: 1517, col: 26, offset: 58090},
 								val:        ":",
 								ignoreCase: false,
 								want:       "\":\"",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1431, col: 30, offset: 55512},
+							pos:   position{line: 1517, col: 30, offset: 58094},
 							label: "path",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1431, col: 36, offset: 55518},
+								pos:  position{line: 1517, col: 36, offset: 58100},
 								name: "Location",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1431, col: 46, offset: 55528},
+							pos:   position{line: 1517, col: 46, offset: 58110},
 							label: "inlineAttributes",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1431, col: 64, offset: 55546},
+								pos:  position{line: 1517, col: 64, offset: 58128},
 								name: "ImageAttributes",
 							},
 						},
@@ -10298,99 +10775,99 @@ var g = &grammar{
 		},
 		{
 			name: "ImageAttributes",
-			pos:  position{line: 1435, col: 1, offset: 55664},
+			pos:  position{line: 1521, col: 1, offset: 58246},
 			expr: &actionExpr{
-				pos: position{line: 1435, col: 20, offset: 55683},
+				pos: position{line: 1521, col: 20, offset: 58265},
 				run: (*parser).callonImageAttributes1,
 				expr: &seqExpr{
-					pos: position{line: 1435, col: 20, offset: 55683},
+					pos: position{line: 1521, col: 20, offset: 58265},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1435, col: 20, offset: 55683},
+							pos:        position{line: 1521, col: 20, offset: 58265},
 							val:        "[",
 							ignoreCase: false,
 							want:       "\"[\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1435, col: 24, offset: 55687},
+							pos:   position{line: 1521, col: 24, offset: 58269},
 							label: "alt",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1435, col: 28, offset: 55691},
+								pos: position{line: 1521, col: 28, offset: 58273},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1435, col: 29, offset: 55692},
+									pos:  position{line: 1521, col: 29, offset: 58274},
 									name: "StandaloneAttributeValue",
 								},
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 1435, col: 56, offset: 55719},
+							pos: position{line: 1521, col: 56, offset: 58301},
 							expr: &litMatcher{
-								pos:        position{line: 1435, col: 56, offset: 55719},
+								pos:        position{line: 1521, col: 56, offset: 58301},
 								val:        ",",
 								ignoreCase: false,
 								want:       "\",\"",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1435, col: 61, offset: 55724},
+							pos:   position{line: 1521, col: 61, offset: 58306},
 							label: "width",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1435, col: 67, offset: 55730},
+								pos: position{line: 1521, col: 67, offset: 58312},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1435, col: 68, offset: 55731},
+									pos:  position{line: 1521, col: 68, offset: 58313},
 									name: "StandaloneAttributeValue",
 								},
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 1435, col: 95, offset: 55758},
+							pos: position{line: 1521, col: 95, offset: 58340},
 							expr: &litMatcher{
-								pos:        position{line: 1435, col: 95, offset: 55758},
+								pos:        position{line: 1521, col: 95, offset: 58340},
 								val:        ",",
 								ignoreCase: false,
 								want:       "\",\"",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1435, col: 100, offset: 55763},
+							pos:   position{line: 1521, col: 100, offset: 58345},
 							label: "height",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1435, col: 107, offset: 55770},
+								pos: position{line: 1521, col: 107, offset: 58352},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1435, col: 108, offset: 55771},
+									pos:  position{line: 1521, col: 108, offset: 58353},
 									name: "StandaloneAttributeValue",
 								},
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 1435, col: 135, offset: 55798},
+							pos: position{line: 1521, col: 135, offset: 58380},
 							expr: &litMatcher{
-								pos:        position{line: 1435, col: 135, offset: 55798},
+								pos:        position{line: 1521, col: 135, offset: 58380},
 								val:        ",",
 								ignoreCase: false,
 								want:       "\",\"",
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1435, col: 140, offset: 55803},
+							pos: position{line: 1521, col: 140, offset: 58385},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1435, col: 140, offset: 55803},
+								pos:  position{line: 1521, col: 140, offset: 58385},
 								name: "Space",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1435, col: 147, offset: 55810},
+							pos:   position{line: 1521, col: 147, offset: 58392},
 							label: "otherattrs",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1435, col: 158, offset: 55821},
+								pos: position{line: 1521, col: 158, offset: 58403},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1435, col: 159, offset: 55822},
+									pos:  position{line: 1521, col: 159, offset: 58404},
 									name: "GenericAttribute",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1435, col: 178, offset: 55841},
+							pos:        position{line: 1521, col: 178, offset: 58423},
 							val:        "]",
 							ignoreCase: false,
 							want:       "\"]\"",
@@ -10401,29 +10878,29 @@ var g = &grammar{
 		},
 		{
 			name: "InlineIcon",
-			pos:  position{line: 1442, col: 1, offset: 56133},
+			pos:  position{line: 1528, col: 1, offset: 58715},
 			expr: &actionExpr{
-				pos: position{line: 1442, col: 15, offset: 56147},
+				pos: position{line: 1528, col: 15, offset: 58729},
 				run: (*parser).callonInlineIcon1,
 				expr: &seqExpr{
-					pos: position{line: 1442, col: 15, offset: 56147},
+					pos: position{line: 1528, col: 15, offset: 58729},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1442, col: 15, offset: 56147},
+							pos:        position{line: 1528, col: 15, offset: 58729},
 							val:        "icon:",
 							ignoreCase: false,
 							want:       "\"icon:\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1442, col: 23, offset: 56155},
+							pos:   position{line: 1528, col: 23, offset: 58737},
 							label: "iconClass",
 							expr: &actionExpr{
-								pos: position{line: 1442, col: 34, offset: 56166},
+								pos: position{line: 1528, col: 34, offset: 58748},
 								run: (*parser).callonInlineIcon5,
 								expr: &oneOrMoreExpr{
-									pos: position{line: 1442, col: 34, offset: 56166},
+									pos: position{line: 1528, col: 34, offset: 58748},
 									expr: &charClassMatcher{
-										pos:        position{line: 1442, col: 34, offset: 56166},
+										pos:        position{line: 1528, col: 34, offset: 58748},
 										val:        "[\\pL0-9_-]",
 										chars:      []rune{'_', '-'},
 										ranges:     []rune{'0', '9'},
@@ -10435,10 +10912,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1442, col: 78, offset: 56210},
+							pos:   position{line: 1528, col: 78, offset: 58792},
 							label: "inlineAttributes",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1442, col: 96, offset: 56228},
+								pos:  position{line: 1528, col: 96, offset: 58810},
 								name: "IconAttributes",
 							},
 						},
@@ -10448,59 +10925,59 @@ var g = &grammar{
 		},
 		{
 			name: "IconAttributes",
-			pos:  position{line: 1446, col: 1, offset: 56335},
+			pos:  position{line: 1532, col: 1, offset: 58917},
 			expr: &actionExpr{
-				pos: position{line: 1446, col: 19, offset: 56353},
+				pos: position{line: 1532, col: 19, offset: 58935},
 				run: (*parser).callonIconAttributes1,
 				expr: &seqExpr{
-					pos: position{line: 1446, col: 19, offset: 56353},
+					pos: position{line: 1532, col: 19, offset: 58935},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1446, col: 19, offset: 56353},
+							pos:        position{line: 1532, col: 19, offset: 58935},
 							val:        "[",
 							ignoreCase: false,
 							want:       "\"[\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1446, col: 23, offset: 56357},
+							pos:   position{line: 1532, col: 23, offset: 58939},
 							label: "size",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1446, col: 28, offset: 56362},
+								pos: position{line: 1532, col: 28, offset: 58944},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1446, col: 29, offset: 56363},
+									pos:  position{line: 1532, col: 29, offset: 58945},
 									name: "StandaloneAttributeValue",
 								},
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 1446, col: 56, offset: 56390},
+							pos: position{line: 1532, col: 56, offset: 58972},
 							expr: &litMatcher{
-								pos:        position{line: 1446, col: 56, offset: 56390},
+								pos:        position{line: 1532, col: 56, offset: 58972},
 								val:        ",",
 								ignoreCase: false,
 								want:       "\",\"",
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1446, col: 61, offset: 56395},
+							pos: position{line: 1532, col: 61, offset: 58977},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1446, col: 61, offset: 56395},
+								pos:  position{line: 1532, col: 61, offset: 58977},
 								name: "Space",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1446, col: 68, offset: 56402},
+							pos:   position{line: 1532, col: 68, offset: 58984},
 							label: "others",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1446, col: 75, offset: 56409},
+								pos: position{line: 1532, col: 75, offset: 58991},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1446, col: 76, offset: 56410},
+									pos:  position{line: 1532, col: 76, offset: 58992},
 									name: "GenericAttribute",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1446, col: 95, offset: 56429},
+							pos:        position{line: 1532, col: 95, offset: 59011},
 							val:        "]",
 							ignoreCase: false,
 							want:       "\"]\"",
@@ -10511,32 +10988,32 @@ var g = &grammar{
 		},
 		{
 			name: "InlineFootnote",
-			pos:  position{line: 1453, col: 1, offset: 56707},
+			pos:  position{line: 1539, col: 1, offset: 59289},
 			expr: &choiceExpr{
-				pos: position{line: 1453, col: 19, offset: 56725},
+				pos: position{line: 1539, col: 19, offset: 59307},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1453, col: 19, offset: 56725},
+						pos: position{line: 1539, col: 19, offset: 59307},
 						run: (*parser).callonInlineFootnote2,
 						expr: &seqExpr{
-							pos: position{line: 1453, col: 19, offset: 56725},
+							pos: position{line: 1539, col: 19, offset: 59307},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1453, col: 19, offset: 56725},
+									pos:        position{line: 1539, col: 19, offset: 59307},
 									val:        "footnote:[",
 									ignoreCase: false,
 									want:       "\"footnote:[\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1453, col: 32, offset: 56738},
+									pos:   position{line: 1539, col: 32, offset: 59320},
 									label: "content",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1453, col: 41, offset: 56747},
+										pos:  position{line: 1539, col: 41, offset: 59329},
 										name: "FootnoteContent",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1453, col: 58, offset: 56764},
+									pos:        position{line: 1539, col: 58, offset: 59346},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -10545,44 +11022,44 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1455, col: 5, offset: 56834},
+						pos: position{line: 1541, col: 5, offset: 59416},
 						run: (*parser).callonInlineFootnote8,
 						expr: &seqExpr{
-							pos: position{line: 1455, col: 5, offset: 56834},
+							pos: position{line: 1541, col: 5, offset: 59416},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1455, col: 5, offset: 56834},
+									pos:        position{line: 1541, col: 5, offset: 59416},
 									val:        "footnote:",
 									ignoreCase: false,
 									want:       "\"footnote:\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1455, col: 17, offset: 56846},
+									pos:   position{line: 1541, col: 17, offset: 59428},
 									label: "ref",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1455, col: 22, offset: 56851},
+										pos:  position{line: 1541, col: 22, offset: 59433},
 										name: "FootnoteRef",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1455, col: 35, offset: 56864},
+									pos:        position{line: 1541, col: 35, offset: 59446},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1455, col: 39, offset: 56868},
+									pos:   position{line: 1541, col: 39, offset: 59450},
 									label: "content",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1455, col: 47, offset: 56876},
+										pos: position{line: 1541, col: 47, offset: 59458},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1455, col: 48, offset: 56877},
+											pos:  position{line: 1541, col: 48, offset: 59459},
 											name: "FootnoteContent",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1455, col: 66, offset: 56895},
+									pos:        position{line: 1541, col: 66, offset: 59477},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -10595,37 +11072,37 @@ var g = &grammar{
 		},
 		{
 			name: "FootnoteRef",
-			pos:  position{line: 1459, col: 1, offset: 56960},
+			pos:  position{line: 1545, col: 1, offset: 59542},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1459, col: 16, offset: 56975},
+				pos:  position{line: 1545, col: 16, offset: 59557},
 				name: "Alphanums",
 			},
 		},
 		{
 			name: "FootnoteContent",
-			pos:  position{line: 1461, col: 1, offset: 56988},
+			pos:  position{line: 1547, col: 1, offset: 59570},
 			expr: &actionExpr{
-				pos: position{line: 1461, col: 20, offset: 57007},
+				pos: position{line: 1547, col: 20, offset: 59589},
 				run: (*parser).callonFootnoteContent1,
 				expr: &labeledExpr{
-					pos:   position{line: 1461, col: 20, offset: 57007},
+					pos:   position{line: 1547, col: 20, offset: 59589},
 					label: "elements",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 1461, col: 29, offset: 57016},
+						pos: position{line: 1547, col: 29, offset: 59598},
 						expr: &seqExpr{
-							pos: position{line: 1461, col: 30, offset: 57017},
+							pos: position{line: 1547, col: 30, offset: 59599},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1461, col: 30, offset: 57017},
+									pos: position{line: 1547, col: 30, offset: 59599},
 									expr: &litMatcher{
-										pos:        position{line: 1461, col: 31, offset: 57018},
+										pos:        position{line: 1547, col: 31, offset: 59600},
 										val:        "]",
 										ignoreCase: false,
 										want:       "\"]\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1461, col: 35, offset: 57022},
+									pos:  position{line: 1547, col: 35, offset: 59604},
 									name: "InlineElement",
 								},
 							},
@@ -10636,64 +11113,64 @@ var g = &grammar{
 		},
 		{
 			name: "DelimitedBlock",
-			pos:  position{line: 1468, col: 1, offset: 57353},
+			pos:  position{line: 1554, col: 1, offset: 59935},
 			expr: &actionExpr{
-				pos: position{line: 1468, col: 19, offset: 57371},
+				pos: position{line: 1554, col: 19, offset: 59953},
 				run: (*parser).callonDelimitedBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1468, col: 19, offset: 57371},
+					pos: position{line: 1554, col: 19, offset: 59953},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1468, col: 19, offset: 57371},
+							pos: position{line: 1554, col: 19, offset: 59953},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1468, col: 20, offset: 57372},
+								pos:  position{line: 1554, col: 20, offset: 59954},
 								name: "Alphanum",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1469, col: 5, offset: 57461},
+							pos:   position{line: 1555, col: 5, offset: 60043},
 							label: "block",
 							expr: &choiceExpr{
-								pos: position{line: 1469, col: 12, offset: 57468},
+								pos: position{line: 1555, col: 12, offset: 60050},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1469, col: 12, offset: 57468},
+										pos:  position{line: 1555, col: 12, offset: 60050},
 										name: "FencedBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1470, col: 11, offset: 57492},
+										pos:  position{line: 1556, col: 11, offset: 60074},
 										name: "ListingBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1471, col: 11, offset: 57517},
+										pos:  position{line: 1557, col: 11, offset: 60099},
 										name: "ExampleBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1472, col: 11, offset: 57542},
+										pos:  position{line: 1558, col: 11, offset: 60124},
 										name: "VerseBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1473, col: 11, offset: 57565},
+										pos:  position{line: 1559, col: 11, offset: 60147},
 										name: "QuoteBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1474, col: 11, offset: 57588},
+										pos:  position{line: 1560, col: 11, offset: 60170},
 										name: "SidebarBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1475, col: 11, offset: 57612},
+										pos:  position{line: 1561, col: 11, offset: 60194},
 										name: "SingleLineComment",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1476, col: 11, offset: 57641},
+										pos:  position{line: 1562, col: 11, offset: 60223},
 										name: "PassthroughBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1477, col: 11, offset: 57669},
+										pos:  position{line: 1563, col: 11, offset: 60251},
 										name: "Table",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1478, col: 11, offset: 57686},
+										pos:  position{line: 1564, col: 11, offset: 60268},
 										name: "CommentBlock",
 									},
 								},
@@ -10705,52 +11182,52 @@ var g = &grammar{
 		},
 		{
 			name: "BlockDelimiter",
-			pos:  position{line: 1482, col: 1, offset: 57731},
+			pos:  position{line: 1568, col: 1, offset: 60313},
 			expr: &choiceExpr{
-				pos: position{line: 1482, col: 19, offset: 57749},
+				pos: position{line: 1568, col: 19, offset: 60331},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 1482, col: 19, offset: 57749},
+						pos: position{line: 1568, col: 19, offset: 60331},
 						exprs: []interface{}{
 							&notExpr{
-								pos: position{line: 1482, col: 19, offset: 57749},
+								pos: position{line: 1568, col: 19, offset: 60331},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1482, col: 21, offset: 57751},
+									pos:  position{line: 1568, col: 21, offset: 60333},
 									name: "Alphanum",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1482, col: 31, offset: 57761},
+								pos:  position{line: 1568, col: 31, offset: 60343},
 								name: "LiteralBlockDelimiter",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1483, col: 19, offset: 57833},
+						pos:  position{line: 1569, col: 19, offset: 60415},
 						name: "FencedBlockDelimiter",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1484, col: 19, offset: 57874},
+						pos:  position{line: 1570, col: 19, offset: 60456},
 						name: "ListingBlockDelimiter",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1485, col: 19, offset: 57916},
+						pos:  position{line: 1571, col: 19, offset: 60498},
 						name: "ExampleBlockDelimiter",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1486, col: 19, offset: 57958},
+						pos:  position{line: 1572, col: 19, offset: 60540},
 						name: "CommentBlockDelimiter",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1487, col: 19, offset: 58000},
+						pos:  position{line: 1573, col: 19, offset: 60582},
 						name: "QuoteBlockDelimiter",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1488, col: 19, offset: 58039},
+						pos:  position{line: 1574, col: 19, offset: 60621},
 						name: "SidebarBlockDelimiter",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1489, col: 19, offset: 58080},
+						pos:  position{line: 1575, col: 19, offset: 60662},
 						name: "PassthroughBlockDelimiter",
 					},
 				},
@@ -10758,16 +11235,16 @@ var g = &grammar{
 		},
 		{
 			name: "VerbatimContent",
-			pos:  position{line: 1491, col: 1, offset: 58109},
+			pos:  position{line: 1577, col: 1, offset: 60691},
 			expr: &choiceExpr{
-				pos: position{line: 1491, col: 20, offset: 58128},
+				pos: position{line: 1577, col: 20, offset: 60710},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1491, col: 20, offset: 58128},
+						pos:  position{line: 1577, col: 20, offset: 60710},
 						name: "FileInclusion",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1491, col: 36, offset: 58144},
+						pos:  position{line: 1577, col: 36, offset: 60726},
 						name: "VerbatimLine",
 					},
 				},
@@ -10775,41 +11252,41 @@ var g = &grammar{
 		},
 		{
 			name: "VerbatimLine",
-			pos:  position{line: 1493, col: 1, offset: 58160},
+			pos:  position{line: 1579, col: 1, offset: 60742},
 			expr: &actionExpr{
-				pos: position{line: 1493, col: 17, offset: 58176},
+				pos: position{line: 1579, col: 17, offset: 60758},
 				run: (*parser).callonVerbatimLine1,
 				expr: &seqExpr{
-					pos: position{line: 1493, col: 17, offset: 58176},
+					pos: position{line: 1579, col: 17, offset: 60758},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1493, col: 17, offset: 58176},
+							pos: position{line: 1579, col: 17, offset: 60758},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1493, col: 18, offset: 58177},
+								pos:  position{line: 1579, col: 18, offset: 60759},
 								name: "EOF",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1493, col: 22, offset: 58181},
+							pos:   position{line: 1579, col: 22, offset: 60763},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1493, col: 31, offset: 58190},
+								pos:  position{line: 1579, col: 31, offset: 60772},
 								name: "VerbatimLineContent",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1493, col: 52, offset: 58211},
+							pos:   position{line: 1579, col: 52, offset: 60793},
 							label: "callouts",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1493, col: 61, offset: 58220},
+								pos: position{line: 1579, col: 61, offset: 60802},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1493, col: 62, offset: 58221},
+									pos:  position{line: 1579, col: 62, offset: 60803},
 									name: "Callouts",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1493, col: 73, offset: 58232},
+							pos:  position{line: 1579, col: 73, offset: 60814},
 							name: "EOL",
 						},
 					},
@@ -10818,36 +11295,36 @@ var g = &grammar{
 		},
 		{
 			name: "VerbatimLineContent",
-			pos:  position{line: 1497, col: 1, offset: 58306},
+			pos:  position{line: 1583, col: 1, offset: 60888},
 			expr: &actionExpr{
-				pos: position{line: 1497, col: 24, offset: 58329},
+				pos: position{line: 1583, col: 24, offset: 60911},
 				run: (*parser).callonVerbatimLineContent1,
 				expr: &zeroOrMoreExpr{
-					pos: position{line: 1497, col: 24, offset: 58329},
+					pos: position{line: 1583, col: 24, offset: 60911},
 					expr: &seqExpr{
-						pos: position{line: 1497, col: 25, offset: 58330},
+						pos: position{line: 1583, col: 25, offset: 60912},
 						exprs: []interface{}{
 							&notExpr{
-								pos: position{line: 1497, col: 25, offset: 58330},
+								pos: position{line: 1583, col: 25, offset: 60912},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1497, col: 26, offset: 58331},
+									pos:  position{line: 1583, col: 26, offset: 60913},
 									name: "Callouts",
 								},
 							},
 							&choiceExpr{
-								pos: position{line: 1497, col: 36, offset: 58341},
+								pos: position{line: 1583, col: 36, offset: 60923},
 								alternatives: []interface{}{
 									&oneOrMoreExpr{
-										pos: position{line: 1497, col: 36, offset: 58341},
+										pos: position{line: 1583, col: 36, offset: 60923},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1497, col: 36, offset: 58341},
+											pos:  position{line: 1583, col: 36, offset: 60923},
 											name: "Space",
 										},
 									},
 									&oneOrMoreExpr{
-										pos: position{line: 1497, col: 45, offset: 58350},
+										pos: position{line: 1583, col: 45, offset: 60932},
 										expr: &charClassMatcher{
-											pos:        position{line: 1497, col: 45, offset: 58350},
+											pos:        position{line: 1583, col: 45, offset: 60932},
 											val:        "[^ \\r\\n]",
 											chars:      []rune{' ', '\r', '\n'},
 											ignoreCase: false,
@@ -10863,40 +11340,40 @@ var g = &grammar{
 		},
 		{
 			name: "Callouts",
-			pos:  position{line: 1501, col: 1, offset: 58404},
+			pos:  position{line: 1587, col: 1, offset: 60986},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 1501, col: 13, offset: 58416},
+				pos: position{line: 1587, col: 13, offset: 60998},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1501, col: 13, offset: 58416},
+					pos:  position{line: 1587, col: 13, offset: 60998},
 					name: "Callout",
 				},
 			},
 		},
 		{
 			name: "Callout",
-			pos:  position{line: 1503, col: 1, offset: 58428},
+			pos:  position{line: 1589, col: 1, offset: 61010},
 			expr: &actionExpr{
-				pos: position{line: 1503, col: 12, offset: 58439},
+				pos: position{line: 1589, col: 12, offset: 61021},
 				run: (*parser).callonCallout1,
 				expr: &seqExpr{
-					pos: position{line: 1503, col: 12, offset: 58439},
+					pos: position{line: 1589, col: 12, offset: 61021},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1503, col: 12, offset: 58439},
+							pos:        position{line: 1589, col: 12, offset: 61021},
 							val:        "<",
 							ignoreCase: false,
 							want:       "\"<\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1503, col: 16, offset: 58443},
+							pos:   position{line: 1589, col: 16, offset: 61025},
 							label: "ref",
 							expr: &actionExpr{
-								pos: position{line: 1503, col: 21, offset: 58448},
+								pos: position{line: 1589, col: 21, offset: 61030},
 								run: (*parser).callonCallout5,
 								expr: &oneOrMoreExpr{
-									pos: position{line: 1503, col: 21, offset: 58448},
+									pos: position{line: 1589, col: 21, offset: 61030},
 									expr: &charClassMatcher{
-										pos:        position{line: 1503, col: 21, offset: 58448},
+										pos:        position{line: 1589, col: 21, offset: 61030},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10906,29 +11383,29 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1503, col: 69, offset: 58496},
+							pos:        position{line: 1589, col: 69, offset: 61078},
 							val:        ">",
 							ignoreCase: false,
 							want:       "\">\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1503, col: 73, offset: 58500},
+							pos: position{line: 1589, col: 73, offset: 61082},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1503, col: 73, offset: 58500},
+								pos:  position{line: 1589, col: 73, offset: 61082},
 								name: "Space",
 							},
 						},
 						&andExpr{
-							pos: position{line: 1503, col: 80, offset: 58507},
+							pos: position{line: 1589, col: 80, offset: 61089},
 							expr: &choiceExpr{
-								pos: position{line: 1503, col: 82, offset: 58509},
+								pos: position{line: 1589, col: 82, offset: 61091},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1503, col: 82, offset: 58509},
+										pos:  position{line: 1589, col: 82, offset: 61091},
 										name: "EOL",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1503, col: 88, offset: 58515},
+										pos:  position{line: 1589, col: 88, offset: 61097},
 										name: "Callout",
 									},
 								},
@@ -10940,28 +11417,28 @@ var g = &grammar{
 		},
 		{
 			name: "CalloutListItem",
-			pos:  position{line: 1507, col: 1, offset: 58572},
+			pos:  position{line: 1593, col: 1, offset: 61154},
 			expr: &actionExpr{
-				pos: position{line: 1507, col: 20, offset: 58591},
+				pos: position{line: 1593, col: 20, offset: 61173},
 				run: (*parser).callonCalloutListItem1,
 				expr: &seqExpr{
-					pos: position{line: 1507, col: 20, offset: 58591},
+					pos: position{line: 1593, col: 20, offset: 61173},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1507, col: 20, offset: 58591},
+							pos:   position{line: 1593, col: 20, offset: 61173},
 							label: "ref",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1507, col: 25, offset: 58596},
+								pos:  position{line: 1593, col: 25, offset: 61178},
 								name: "CalloutListItemPrefix",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1507, col: 48, offset: 58619},
+							pos:   position{line: 1593, col: 48, offset: 61201},
 							label: "description",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1507, col: 61, offset: 58632},
+								pos: position{line: 1593, col: 61, offset: 61214},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1507, col: 61, offset: 58632},
+									pos:  position{line: 1593, col: 61, offset: 61214},
 									name: "ListParagraph",
 								},
 							},
@@ -10972,29 +11449,29 @@ var g = &grammar{
 		},
 		{
 			name: "CalloutListItemPrefix",
-			pos:  position{line: 1511, col: 1, offset: 58733},
+			pos:  position{line: 1597, col: 1, offset: 61315},
 			expr: &actionExpr{
-				pos: position{line: 1511, col: 26, offset: 58758},
+				pos: position{line: 1597, col: 26, offset: 61340},
 				run: (*parser).callonCalloutListItemPrefix1,
 				expr: &seqExpr{
-					pos: position{line: 1511, col: 26, offset: 58758},
+					pos: position{line: 1597, col: 26, offset: 61340},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1511, col: 26, offset: 58758},
+							pos:        position{line: 1597, col: 26, offset: 61340},
 							val:        "<",
 							ignoreCase: false,
 							want:       "\"<\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1511, col: 30, offset: 58762},
+							pos:   position{line: 1597, col: 30, offset: 61344},
 							label: "ref",
 							expr: &actionExpr{
-								pos: position{line: 1511, col: 35, offset: 58767},
+								pos: position{line: 1597, col: 35, offset: 61349},
 								run: (*parser).callonCalloutListItemPrefix5,
 								expr: &oneOrMoreExpr{
-									pos: position{line: 1511, col: 35, offset: 58767},
+									pos: position{line: 1597, col: 35, offset: 61349},
 									expr: &charClassMatcher{
-										pos:        position{line: 1511, col: 35, offset: 58767},
+										pos:        position{line: 1597, col: 35, offset: 61349},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -11004,15 +11481,15 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1511, col: 83, offset: 58815},
+							pos:        position{line: 1597, col: 83, offset: 61397},
 							val:        ">",
 							ignoreCase: false,
 							want:       "\">\"",
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 1511, col: 87, offset: 58819},
+							pos: position{line: 1597, col: 87, offset: 61401},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1511, col: 87, offset: 58819},
+								pos:  position{line: 1597, col: 87, offset: 61401},
 								name: "Space",
 							},
 						},
@@ -11022,25 +11499,25 @@ var g = &grammar{
 		},
 		{
 			name: "FencedBlockDelimiter",
-			pos:  position{line: 1518, col: 1, offset: 59053},
+			pos:  position{line: 1604, col: 1, offset: 61635},
 			expr: &seqExpr{
-				pos: position{line: 1518, col: 25, offset: 59077},
+				pos: position{line: 1604, col: 25, offset: 61659},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1518, col: 25, offset: 59077},
+						pos:        position{line: 1604, col: 25, offset: 61659},
 						val:        "```",
 						ignoreCase: false,
 						want:       "\"```\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1518, col: 31, offset: 59083},
+						pos: position{line: 1604, col: 31, offset: 61665},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1518, col: 31, offset: 59083},
+							pos:  position{line: 1604, col: 31, offset: 61665},
 							name: "Space",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1518, col: 38, offset: 59090},
+						pos:  position{line: 1604, col: 38, offset: 61672},
 						name: "EOL",
 					},
 				},
@@ -11048,25 +11525,25 @@ var g = &grammar{
 		},
 		{
 			name: "FencedBlockStartDelimiter",
-			pos:  position{line: 1520, col: 1, offset: 59152},
+			pos:  position{line: 1606, col: 1, offset: 61734},
 			expr: &seqExpr{
-				pos: position{line: 1520, col: 30, offset: 59181},
+				pos: position{line: 1606, col: 30, offset: 61763},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1520, col: 30, offset: 59181},
+						pos:        position{line: 1606, col: 30, offset: 61763},
 						val:        "```",
 						ignoreCase: false,
 						want:       "\"```\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1520, col: 36, offset: 59187},
+						pos: position{line: 1606, col: 36, offset: 61769},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1520, col: 36, offset: 59187},
+							pos:  position{line: 1606, col: 36, offset: 61769},
 							name: "Space",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1520, col: 43, offset: 59194},
+						pos:  position{line: 1606, col: 43, offset: 61776},
 						name: "EOL",
 					},
 				},
@@ -11074,34 +11551,34 @@ var g = &grammar{
 		},
 		{
 			name: "FencedBlockEndDelimiter",
-			pos:  position{line: 1522, col: 1, offset: 59201},
+			pos:  position{line: 1608, col: 1, offset: 61783},
 			expr: &choiceExpr{
-				pos: position{line: 1522, col: 28, offset: 59228},
+				pos: position{line: 1608, col: 28, offset: 61810},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 1522, col: 29, offset: 59229},
+						pos: position{line: 1608, col: 29, offset: 61811},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 1522, col: 29, offset: 59229},
+								pos:        position{line: 1608, col: 29, offset: 61811},
 								val:        "```",
 								ignoreCase: false,
 								want:       "\"```\"",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 1522, col: 35, offset: 59235},
+								pos: position{line: 1608, col: 35, offset: 61817},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1522, col: 35, offset: 59235},
+									pos:  position{line: 1608, col: 35, offset: 61817},
 									name: "Space",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1522, col: 42, offset: 59242},
+								pos:  position{line: 1608, col: 42, offset: 61824},
 								name: "EOL",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1522, col: 49, offset: 59249},
+						pos:  position{line: 1608, col: 49, offset: 61831},
 						name: "EOF",
 					},
 				},
@@ -11109,38 +11586,38 @@ var g = &grammar{
 		},
 		{
 			name: "FencedBlock",
-			pos:  position{line: 1524, col: 1, offset: 59256},
+			pos:  position{line: 1610, col: 1, offset: 61838},
 			expr: &actionExpr{
-				pos: position{line: 1524, col: 16, offset: 59271},
+				pos: position{line: 1610, col: 16, offset: 61853},
 				run: (*parser).callonFencedBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1524, col: 16, offset: 59271},
+					pos: position{line: 1610, col: 16, offset: 61853},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1524, col: 16, offset: 59271},
+							pos:   position{line: 1610, col: 16, offset: 61853},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1524, col: 27, offset: 59282},
+								pos: position{line: 1610, col: 27, offset: 61864},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1524, col: 28, offset: 59283},
+									pos:  position{line: 1610, col: 28, offset: 61865},
 									name: "Attributes",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1524, col: 41, offset: 59296},
+							pos:  position{line: 1610, col: 41, offset: 61878},
 							name: "FencedBlockStartDelimiter",
 						},
 						&labeledExpr{
-							pos:   position{line: 1524, col: 67, offset: 59322},
+							pos:   position{line: 1610, col: 67, offset: 61904},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1524, col: 76, offset: 59331},
+								pos:  position{line: 1610, col: 76, offset: 61913},
 								name: "FencedBlockVerbatimContent",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1524, col: 104, offset: 59359},
+							pos:  position{line: 1610, col: 104, offset: 61941},
 							name: "FencedBlockEndDelimiter",
 						},
 					},
@@ -11149,27 +11626,27 @@ var g = &grammar{
 		},
 		{
 			name: "FencedBlockVerbatimContent",
-			pos:  position{line: 1528, col: 1, offset: 59478},
+			pos:  position{line: 1614, col: 1, offset: 62060},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1528, col: 31, offset: 59508},
+				pos: position{line: 1614, col: 31, offset: 62090},
 				expr: &actionExpr{
-					pos: position{line: 1528, col: 32, offset: 59509},
+					pos: position{line: 1614, col: 32, offset: 62091},
 					run: (*parser).callonFencedBlockVerbatimContent2,
 					expr: &seqExpr{
-						pos: position{line: 1528, col: 32, offset: 59509},
+						pos: position{line: 1614, col: 32, offset: 62091},
 						exprs: []interface{}{
 							&notExpr{
-								pos: position{line: 1528, col: 32, offset: 59509},
+								pos: position{line: 1614, col: 32, offset: 62091},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1528, col: 33, offset: 59510},
+									pos:  position{line: 1614, col: 33, offset: 62092},
 									name: "FencedBlockEndDelimiter",
 								},
 							},
 							&labeledExpr{
-								pos:   position{line: 1528, col: 57, offset: 59534},
+								pos:   position{line: 1614, col: 57, offset: 62116},
 								label: "content",
 								expr: &ruleRefExpr{
-									pos:  position{line: 1528, col: 66, offset: 59543},
+									pos:  position{line: 1614, col: 66, offset: 62125},
 									name: "VerbatimContent",
 								},
 							},
@@ -11180,25 +11657,25 @@ var g = &grammar{
 		},
 		{
 			name: "ListingBlockDelimiter",
-			pos:  position{line: 1535, col: 1, offset: 59887},
+			pos:  position{line: 1621, col: 1, offset: 62469},
 			expr: &seqExpr{
-				pos: position{line: 1535, col: 26, offset: 59912},
+				pos: position{line: 1621, col: 26, offset: 62494},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1535, col: 26, offset: 59912},
+						pos:        position{line: 1621, col: 26, offset: 62494},
 						val:        "----",
 						ignoreCase: false,
 						want:       "\"----\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1535, col: 33, offset: 59919},
+						pos: position{line: 1621, col: 33, offset: 62501},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1535, col: 33, offset: 59919},
+							pos:  position{line: 1621, col: 33, offset: 62501},
 							name: "Space",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1535, col: 40, offset: 59926},
+						pos:  position{line: 1621, col: 40, offset: 62508},
 						name: "EOL",
 					},
 				},
@@ -11206,25 +11683,25 @@ var g = &grammar{
 		},
 		{
 			name: "ListingBlockStartDelimiter",
-			pos:  position{line: 1537, col: 1, offset: 59933},
+			pos:  position{line: 1623, col: 1, offset: 62515},
 			expr: &seqExpr{
-				pos: position{line: 1537, col: 31, offset: 59963},
+				pos: position{line: 1623, col: 31, offset: 62545},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1537, col: 31, offset: 59963},
+						pos:        position{line: 1623, col: 31, offset: 62545},
 						val:        "----",
 						ignoreCase: false,
 						want:       "\"----\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1537, col: 38, offset: 59970},
+						pos: position{line: 1623, col: 38, offset: 62552},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1537, col: 38, offset: 59970},
+							pos:  position{line: 1623, col: 38, offset: 62552},
 							name: "Space",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1537, col: 45, offset: 59977},
+						pos:  position{line: 1623, col: 45, offset: 62559},
 						name: "EOL",
 					},
 				},
@@ -11232,34 +11709,34 @@ var g = &grammar{
 		},
 		{
 			name: "ListingBlockEndDelimiter",
-			pos:  position{line: 1539, col: 1, offset: 59984},
+			pos:  position{line: 1625, col: 1, offset: 62566},
 			expr: &choiceExpr{
-				pos: position{line: 1539, col: 29, offset: 60012},
+				pos: position{line: 1625, col: 29, offset: 62594},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 1539, col: 30, offset: 60013},
+						pos: position{line: 1625, col: 30, offset: 62595},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 1539, col: 30, offset: 60013},
+								pos:        position{line: 1625, col: 30, offset: 62595},
 								val:        "----",
 								ignoreCase: false,
 								want:       "\"----\"",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 1539, col: 37, offset: 60020},
+								pos: position{line: 1625, col: 37, offset: 62602},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1539, col: 37, offset: 60020},
+									pos:  position{line: 1625, col: 37, offset: 62602},
 									name: "Space",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1539, col: 44, offset: 60027},
+								pos:  position{line: 1625, col: 44, offset: 62609},
 								name: "EOL",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1539, col: 51, offset: 60034},
+						pos:  position{line: 1625, col: 51, offset: 62616},
 						name: "EOF",
 					},
 				},
@@ -11267,38 +11744,38 @@ var g = &grammar{
 		},
 		{
 			name: "ListingBlock",
-			pos:  position{line: 1541, col: 1, offset: 60041},
+			pos:  position{line: 1627, col: 1, offset: 62623},
 			expr: &actionExpr{
-				pos: position{line: 1541, col: 17, offset: 60057},
+				pos: position{line: 1627, col: 17, offset: 62639},
 				run: (*parser).callonListingBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1541, col: 17, offset: 60057},
+					pos: position{line: 1627, col: 17, offset: 62639},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1541, col: 17, offset: 60057},
+							pos:   position{line: 1627, col: 17, offset: 62639},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1541, col: 28, offset: 60068},
+								pos: position{line: 1627, col: 28, offset: 62650},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1541, col: 29, offset: 60069},
+									pos:  position{line: 1627, col: 29, offset: 62651},
 									name: "Attributes",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1541, col: 42, offset: 60082},
+							pos:  position{line: 1627, col: 42, offset: 62664},
 							name: "ListingBlockStartDelimiter",
 						},
 						&labeledExpr{
-							pos:   position{line: 1541, col: 69, offset: 60109},
+							pos:   position{line: 1627, col: 69, offset: 62691},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1541, col: 78, offset: 60118},
+								pos:  position{line: 1627, col: 78, offset: 62700},
 								name: "ListingBlockVerbatimContent",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1541, col: 107, offset: 60147},
+							pos:  position{line: 1627, col: 107, offset: 62729},
 							name: "ListingBlockEndDelimiter",
 						},
 					},
@@ -11307,27 +11784,27 @@ var g = &grammar{
 		},
 		{
 			name: "ListingBlockVerbatimContent",
-			pos:  position{line: 1545, col: 1, offset: 60268},
+			pos:  position{line: 1631, col: 1, offset: 62850},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1545, col: 32, offset: 60299},
+				pos: position{line: 1631, col: 32, offset: 62881},
 				expr: &actionExpr{
-					pos: position{line: 1545, col: 33, offset: 60300},
+					pos: position{line: 1631, col: 33, offset: 62882},
 					run: (*parser).callonListingBlockVerbatimContent2,
 					expr: &seqExpr{
-						pos: position{line: 1545, col: 33, offset: 60300},
+						pos: position{line: 1631, col: 33, offset: 62882},
 						exprs: []interface{}{
 							&notExpr{
-								pos: position{line: 1545, col: 33, offset: 60300},
+								pos: position{line: 1631, col: 33, offset: 62882},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1545, col: 34, offset: 60301},
+									pos:  position{line: 1631, col: 34, offset: 62883},
 									name: "ListingBlockEndDelimiter",
 								},
 							},
 							&labeledExpr{
-								pos:   position{line: 1545, col: 59, offset: 60326},
+								pos:   position{line: 1631, col: 59, offset: 62908},
 								label: "content",
 								expr: &ruleRefExpr{
-									pos:  position{line: 1545, col: 68, offset: 60335},
+									pos:  position{line: 1631, col: 68, offset: 62917},
 									name: "VerbatimContent",
 								},
 							},
@@ -11338,25 +11815,25 @@ var g = &grammar{
 		},
 		{
 			name: "ExampleBlockDelimiter",
-			pos:  position{line: 1552, col: 1, offset: 60679},
+			pos:  position{line: 1638, col: 1, offset: 63261},
 			expr: &seqExpr{
-				pos: position{line: 1552, col: 26, offset: 60704},
+				pos: position{line: 1638, col: 26, offset: 63286},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1552, col: 26, offset: 60704},
+						pos:        position{line: 1638, col: 26, offset: 63286},
 						val:        "====",
 						ignoreCase: false,
 						want:       "\"====\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1552, col: 33, offset: 60711},
+						pos: position{line: 1638, col: 33, offset: 63293},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1552, col: 33, offset: 60711},
+							pos:  position{line: 1638, col: 33, offset: 63293},
 							name: "Space",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1552, col: 40, offset: 60718},
+						pos:  position{line: 1638, col: 40, offset: 63300},
 						name: "EOL",
 					},
 				},
@@ -11364,25 +11841,25 @@ var g = &grammar{
 		},
 		{
 			name: "ExampleBlockStartDelimiter",
-			pos:  position{line: 1554, col: 1, offset: 60725},
+			pos:  position{line: 1640, col: 1, offset: 63307},
 			expr: &seqExpr{
-				pos: position{line: 1554, col: 31, offset: 60755},
+				pos: position{line: 1640, col: 31, offset: 63337},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1554, col: 31, offset: 60755},
+						pos:        position{line: 1640, col: 31, offset: 63337},
 						val:        "====",
 						ignoreCase: false,
 						want:       "\"====\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1554, col: 38, offset: 60762},
+						pos: position{line: 1640, col: 38, offset: 63344},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1554, col: 38, offset: 60762},
+							pos:  position{line: 1640, col: 38, offset: 63344},
 							name: "Space",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1554, col: 45, offset: 60769},
+						pos:  position{line: 1640, col: 45, offset: 63351},
 						name: "EOL",
 					},
 				},
@@ -11390,34 +11867,34 @@ var g = &grammar{
 		},
 		{
 			name: "ExampleBlockEndDelimiter",
-			pos:  position{line: 1556, col: 1, offset: 60776},
+			pos:  position{line: 1642, col: 1, offset: 63358},
 			expr: &choiceExpr{
-				pos: position{line: 1556, col: 29, offset: 60804},
+				pos: position{line: 1642, col: 29, offset: 63386},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 1556, col: 30, offset: 60805},
+						pos: position{line: 1642, col: 30, offset: 63387},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 1556, col: 30, offset: 60805},
+								pos:        position{line: 1642, col: 30, offset: 63387},
 								val:        "====",
 								ignoreCase: false,
 								want:       "\"====\"",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 1556, col: 37, offset: 60812},
+								pos: position{line: 1642, col: 37, offset: 63394},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1556, col: 37, offset: 60812},
+									pos:  position{line: 1642, col: 37, offset: 63394},
 									name: "Space",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1556, col: 44, offset: 60819},
+								pos:  position{line: 1642, col: 44, offset: 63401},
 								name: "EOL",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1556, col: 51, offset: 60826},
+						pos:  position{line: 1642, col: 51, offset: 63408},
 						name: "EOF",
 					},
 				},
@@ -11425,38 +11902,38 @@ var g = &grammar{
 		},
 		{
 			name: "ExampleBlock",
-			pos:  position{line: 1558, col: 1, offset: 60833},
+			pos:  position{line: 1644, col: 1, offset: 63415},
 			expr: &actionExpr{
-				pos: position{line: 1558, col: 17, offset: 60849},
+				pos: position{line: 1644, col: 17, offset: 63431},
 				run: (*parser).callonExampleBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1558, col: 17, offset: 60849},
+					pos: position{line: 1644, col: 17, offset: 63431},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1558, col: 17, offset: 60849},
+							pos:   position{line: 1644, col: 17, offset: 63431},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1558, col: 28, offset: 60860},
+								pos: position{line: 1644, col: 28, offset: 63442},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1558, col: 29, offset: 60861},
+									pos:  position{line: 1644, col: 29, offset: 63443},
 									name: "Attributes",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1558, col: 42, offset: 60874},
+							pos:  position{line: 1644, col: 42, offset: 63456},
 							name: "ExampleBlockStartDelimiter",
 						},
 						&labeledExpr{
-							pos:   position{line: 1558, col: 69, offset: 60901},
+							pos:   position{line: 1644, col: 69, offset: 63483},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1558, col: 78, offset: 60910},
+								pos:  position{line: 1644, col: 78, offset: 63492},
 								name: "ExampleBlockVerbatimContent",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1558, col: 107, offset: 60939},
+							pos:  position{line: 1644, col: 107, offset: 63521},
 							name: "ExampleBlockEndDelimiter",
 						},
 					},
@@ -11465,27 +11942,27 @@ var g = &grammar{
 		},
 		{
 			name: "ExampleBlockVerbatimContent",
-			pos:  position{line: 1562, col: 1, offset: 61060},
+			pos:  position{line: 1648, col: 1, offset: 63642},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1562, col: 32, offset: 61091},
+				pos: position{line: 1648, col: 32, offset: 63673},
 				expr: &actionExpr{
-					pos: position{line: 1562, col: 33, offset: 61092},
+					pos: position{line: 1648, col: 33, offset: 63674},
 					run: (*parser).callonExampleBlockVerbatimContent2,
 					expr: &seqExpr{
-						pos: position{line: 1562, col: 33, offset: 61092},
+						pos: position{line: 1648, col: 33, offset: 63674},
 						exprs: []interface{}{
 							&notExpr{
-								pos: position{line: 1562, col: 33, offset: 61092},
+								pos: position{line: 1648, col: 33, offset: 63674},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1562, col: 34, offset: 61093},
+									pos:  position{line: 1648, col: 34, offset: 63675},
 									name: "ExampleBlockEndDelimiter",
 								},
 							},
 							&labeledExpr{
-								pos:   position{line: 1562, col: 59, offset: 61118},
+								pos:   position{line: 1648, col: 59, offset: 63700},
 								label: "content",
 								expr: &ruleRefExpr{
-									pos:  position{line: 1562, col: 68, offset: 61127},
+									pos:  position{line: 1648, col: 68, offset: 63709},
 									name: "VerbatimContent",
 								},
 							},
@@ -11496,25 +11973,25 @@ var g = &grammar{
 		},
 		{
 			name: "QuoteBlockDelimiter",
-			pos:  position{line: 1569, col: 1, offset: 61469},
+			pos:  position{line: 1655, col: 1, offset: 64051},
 			expr: &seqExpr{
-				pos: position{line: 1569, col: 24, offset: 61492},
+				pos: position{line: 1655, col: 24, offset: 64074},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1569, col: 24, offset: 61492},
+						pos:        position{line: 1655, col: 24, offset: 64074},
 						val:        "____",
 						ignoreCase: false,
 						want:       "\"____\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1569, col: 31, offset: 61499},
+						pos: position{line: 1655, col: 31, offset: 64081},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1569, col: 31, offset: 61499},
+							pos:  position{line: 1655, col: 31, offset: 64081},
 							name: "Space",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1569, col: 38, offset: 61506},
+						pos:  position{line: 1655, col: 38, offset: 64088},
 						name: "EOL",
 					},
 				},
@@ -11522,25 +11999,25 @@ var g = &grammar{
 		},
 		{
 			name: "QuoteBlockStartDelimiter",
-			pos:  position{line: 1571, col: 1, offset: 61538},
+			pos:  position{line: 1657, col: 1, offset: 64120},
 			expr: &seqExpr{
-				pos: position{line: 1571, col: 29, offset: 61566},
+				pos: position{line: 1657, col: 29, offset: 64148},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1571, col: 29, offset: 61566},
+						pos:        position{line: 1657, col: 29, offset: 64148},
 						val:        "____",
 						ignoreCase: false,
 						want:       "\"____\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1571, col: 36, offset: 61573},
+						pos: position{line: 1657, col: 36, offset: 64155},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1571, col: 36, offset: 61573},
+							pos:  position{line: 1657, col: 36, offset: 64155},
 							name: "Space",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1571, col: 43, offset: 61580},
+						pos:  position{line: 1657, col: 43, offset: 64162},
 						name: "EOL",
 					},
 				},
@@ -11548,34 +12025,34 @@ var g = &grammar{
 		},
 		{
 			name: "QuoteBlockEndDelimiter",
-			pos:  position{line: 1573, col: 1, offset: 61612},
+			pos:  position{line: 1659, col: 1, offset: 64194},
 			expr: &choiceExpr{
-				pos: position{line: 1573, col: 27, offset: 61638},
+				pos: position{line: 1659, col: 27, offset: 64220},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 1573, col: 28, offset: 61639},
+						pos: position{line: 1659, col: 28, offset: 64221},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 1573, col: 28, offset: 61639},
+								pos:        position{line: 1659, col: 28, offset: 64221},
 								val:        "____",
 								ignoreCase: false,
 								want:       "\"____\"",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 1573, col: 35, offset: 61646},
+								pos: position{line: 1659, col: 35, offset: 64228},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1573, col: 35, offset: 61646},
+									pos:  position{line: 1659, col: 35, offset: 64228},
 									name: "Space",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1573, col: 42, offset: 61653},
+								pos:  position{line: 1659, col: 42, offset: 64235},
 								name: "EOL",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1573, col: 49, offset: 61660},
+						pos:  position{line: 1659, col: 49, offset: 64242},
 						name: "EOF",
 					},
 				},
@@ -11583,38 +12060,38 @@ var g = &grammar{
 		},
 		{
 			name: "QuoteBlock",
-			pos:  position{line: 1575, col: 1, offset: 61692},
+			pos:  position{line: 1661, col: 1, offset: 64274},
 			expr: &actionExpr{
-				pos: position{line: 1575, col: 15, offset: 61706},
+				pos: position{line: 1661, col: 15, offset: 64288},
 				run: (*parser).callonQuoteBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1575, col: 15, offset: 61706},
+					pos: position{line: 1661, col: 15, offset: 64288},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1575, col: 15, offset: 61706},
+							pos:   position{line: 1661, col: 15, offset: 64288},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1575, col: 26, offset: 61717},
+								pos: position{line: 1661, col: 26, offset: 64299},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1575, col: 27, offset: 61718},
+									pos:  position{line: 1661, col: 27, offset: 64300},
 									name: "Attributes",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1575, col: 40, offset: 61731},
+							pos:  position{line: 1661, col: 40, offset: 64313},
 							name: "QuoteBlockStartDelimiter",
 						},
 						&labeledExpr{
-							pos:   position{line: 1575, col: 65, offset: 61756},
+							pos:   position{line: 1661, col: 65, offset: 64338},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1575, col: 74, offset: 61765},
+								pos:  position{line: 1661, col: 74, offset: 64347},
 								name: "QuoteBlockVerbatimElement",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1575, col: 101, offset: 61792},
+							pos:  position{line: 1661, col: 101, offset: 64374},
 							name: "QuoteBlockEndDelimiter",
 						},
 					},
@@ -11623,27 +12100,27 @@ var g = &grammar{
 		},
 		{
 			name: "QuoteBlockVerbatimElement",
-			pos:  position{line: 1579, col: 1, offset: 61909},
+			pos:  position{line: 1665, col: 1, offset: 64491},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1579, col: 30, offset: 61938},
+				pos: position{line: 1665, col: 30, offset: 64520},
 				expr: &actionExpr{
-					pos: position{line: 1579, col: 31, offset: 61939},
+					pos: position{line: 1665, col: 31, offset: 64521},
 					run: (*parser).callonQuoteBlockVerbatimElement2,
 					expr: &seqExpr{
-						pos: position{line: 1579, col: 31, offset: 61939},
+						pos: position{line: 1665, col: 31, offset: 64521},
 						exprs: []interface{}{
 							&notExpr{
-								pos: position{line: 1579, col: 31, offset: 61939},
+								pos: position{line: 1665, col: 31, offset: 64521},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1579, col: 32, offset: 61940},
+									pos:  position{line: 1665, col: 32, offset: 64522},
 									name: "QuoteBlockEndDelimiter",
 								},
 							},
 							&labeledExpr{
-								pos:   position{line: 1579, col: 55, offset: 61963},
+								pos:   position{line: 1665, col: 55, offset: 64545},
 								label: "content",
 								expr: &ruleRefExpr{
-									pos:  position{line: 1579, col: 64, offset: 61972},
+									pos:  position{line: 1665, col: 64, offset: 64554},
 									name: "VerbatimContent",
 								},
 							},
@@ -11654,39 +12131,39 @@ var g = &grammar{
 		},
 		{
 			name: "VerseBlock",
-			pos:  position{line: 1588, col: 1, offset: 62365},
+			pos:  position{line: 1674, col: 1, offset: 64947},
 			expr: &actionExpr{
-				pos: position{line: 1588, col: 15, offset: 62379},
+				pos: position{line: 1674, col: 15, offset: 64961},
 				run: (*parser).callonVerseBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1588, col: 15, offset: 62379},
+					pos: position{line: 1674, col: 15, offset: 64961},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1588, col: 15, offset: 62379},
+							pos:   position{line: 1674, col: 15, offset: 64961},
 							label: "attributes",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1588, col: 27, offset: 62391},
+								pos:  position{line: 1674, col: 27, offset: 64973},
 								name: "Attributes",
 							},
 						},
 						&andCodeExpr{
-							pos: position{line: 1589, col: 5, offset: 62409},
+							pos: position{line: 1675, col: 5, offset: 64991},
 							run: (*parser).callonVerseBlock5,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1593, col: 5, offset: 62608},
+							pos:  position{line: 1679, col: 5, offset: 65190},
 							name: "QuoteBlockStartDelimiter",
 						},
 						&labeledExpr{
-							pos:   position{line: 1593, col: 30, offset: 62633},
+							pos:   position{line: 1679, col: 30, offset: 65215},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1593, col: 39, offset: 62642},
+								pos:  position{line: 1679, col: 39, offset: 65224},
 								name: "VerseBlockVerbatimContent",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1593, col: 66, offset: 62669},
+							pos:  position{line: 1679, col: 66, offset: 65251},
 							name: "QuoteBlockEndDelimiter",
 						},
 					},
@@ -11695,27 +12172,27 @@ var g = &grammar{
 		},
 		{
 			name: "VerseBlockVerbatimContent",
-			pos:  position{line: 1597, col: 1, offset: 62794},
+			pos:  position{line: 1683, col: 1, offset: 65376},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1597, col: 30, offset: 62823},
+				pos: position{line: 1683, col: 30, offset: 65405},
 				expr: &actionExpr{
-					pos: position{line: 1597, col: 31, offset: 62824},
+					pos: position{line: 1683, col: 31, offset: 65406},
 					run: (*parser).callonVerseBlockVerbatimContent2,
 					expr: &seqExpr{
-						pos: position{line: 1597, col: 31, offset: 62824},
+						pos: position{line: 1683, col: 31, offset: 65406},
 						exprs: []interface{}{
 							&notExpr{
-								pos: position{line: 1597, col: 31, offset: 62824},
+								pos: position{line: 1683, col: 31, offset: 65406},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1597, col: 32, offset: 62825},
+									pos:  position{line: 1683, col: 32, offset: 65407},
 									name: "QuoteBlockEndDelimiter",
 								},
 							},
 							&labeledExpr{
-								pos:   position{line: 1597, col: 55, offset: 62848},
+								pos:   position{line: 1683, col: 55, offset: 65430},
 								label: "content",
 								expr: &ruleRefExpr{
-									pos:  position{line: 1597, col: 64, offset: 62857},
+									pos:  position{line: 1683, col: 64, offset: 65439},
 									name: "VerbatimContent",
 								},
 							},
@@ -11726,25 +12203,25 @@ var g = &grammar{
 		},
 		{
 			name: "SidebarBlockDelimiter",
-			pos:  position{line: 1604, col: 1, offset: 63201},
+			pos:  position{line: 1690, col: 1, offset: 65783},
 			expr: &seqExpr{
-				pos: position{line: 1604, col: 26, offset: 63226},
+				pos: position{line: 1690, col: 26, offset: 65808},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1604, col: 26, offset: 63226},
+						pos:        position{line: 1690, col: 26, offset: 65808},
 						val:        "****",
 						ignoreCase: false,
 						want:       "\"****\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1604, col: 33, offset: 63233},
+						pos: position{line: 1690, col: 33, offset: 65815},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1604, col: 33, offset: 63233},
+							pos:  position{line: 1690, col: 33, offset: 65815},
 							name: "Space",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1604, col: 40, offset: 63240},
+						pos:  position{line: 1690, col: 40, offset: 65822},
 						name: "EOL",
 					},
 				},
@@ -11752,25 +12229,25 @@ var g = &grammar{
 		},
 		{
 			name: "SidebarBlockStartDelimiter",
-			pos:  position{line: 1606, col: 1, offset: 63247},
+			pos:  position{line: 1692, col: 1, offset: 65829},
 			expr: &seqExpr{
-				pos: position{line: 1606, col: 31, offset: 63277},
+				pos: position{line: 1692, col: 31, offset: 65859},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1606, col: 31, offset: 63277},
+						pos:        position{line: 1692, col: 31, offset: 65859},
 						val:        "****",
 						ignoreCase: false,
 						want:       "\"****\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1606, col: 38, offset: 63284},
+						pos: position{line: 1692, col: 38, offset: 65866},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1606, col: 38, offset: 63284},
+							pos:  position{line: 1692, col: 38, offset: 65866},
 							name: "Space",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1606, col: 45, offset: 63291},
+						pos:  position{line: 1692, col: 45, offset: 65873},
 						name: "EOL",
 					},
 				},
@@ -11778,34 +12255,34 @@ var g = &grammar{
 		},
 		{
 			name: "SidebarBlockEndDelimiter",
-			pos:  position{line: 1608, col: 1, offset: 63298},
+			pos:  position{line: 1694, col: 1, offset: 65880},
 			expr: &choiceExpr{
-				pos: position{line: 1608, col: 29, offset: 63326},
+				pos: position{line: 1694, col: 29, offset: 65908},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 1608, col: 30, offset: 63327},
+						pos: position{line: 1694, col: 30, offset: 65909},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 1608, col: 30, offset: 63327},
+								pos:        position{line: 1694, col: 30, offset: 65909},
 								val:        "****",
 								ignoreCase: false,
 								want:       "\"****\"",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 1608, col: 37, offset: 63334},
+								pos: position{line: 1694, col: 37, offset: 65916},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1608, col: 37, offset: 63334},
+									pos:  position{line: 1694, col: 37, offset: 65916},
 									name: "Space",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1608, col: 44, offset: 63341},
+								pos:  position{line: 1694, col: 44, offset: 65923},
 								name: "EOL",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1608, col: 51, offset: 63348},
+						pos:  position{line: 1694, col: 51, offset: 65930},
 						name: "EOF",
 					},
 				},
@@ -11813,38 +12290,38 @@ var g = &grammar{
 		},
 		{
 			name: "SidebarBlock",
-			pos:  position{line: 1610, col: 1, offset: 63355},
+			pos:  position{line: 1696, col: 1, offset: 65937},
 			expr: &actionExpr{
-				pos: position{line: 1610, col: 17, offset: 63371},
+				pos: position{line: 1696, col: 17, offset: 65953},
 				run: (*parser).callonSidebarBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1610, col: 17, offset: 63371},
+					pos: position{line: 1696, col: 17, offset: 65953},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1610, col: 17, offset: 63371},
+							pos:   position{line: 1696, col: 17, offset: 65953},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1610, col: 28, offset: 63382},
+								pos: position{line: 1696, col: 28, offset: 65964},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1610, col: 29, offset: 63383},
+									pos:  position{line: 1696, col: 29, offset: 65965},
 									name: "Attributes",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1610, col: 42, offset: 63396},
+							pos:  position{line: 1696, col: 42, offset: 65978},
 							name: "SidebarBlockStartDelimiter",
 						},
 						&labeledExpr{
-							pos:   position{line: 1610, col: 69, offset: 63423},
+							pos:   position{line: 1696, col: 69, offset: 66005},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1610, col: 78, offset: 63432},
+								pos:  position{line: 1696, col: 78, offset: 66014},
 								name: "SidebarBlockVerbatimContent",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1610, col: 107, offset: 63461},
+							pos:  position{line: 1696, col: 107, offset: 66043},
 							name: "SidebarBlockEndDelimiter",
 						},
 					},
@@ -11853,27 +12330,27 @@ var g = &grammar{
 		},
 		{
 			name: "SidebarBlockVerbatimContent",
-			pos:  position{line: 1614, col: 1, offset: 63582},
+			pos:  position{line: 1700, col: 1, offset: 66164},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1614, col: 32, offset: 63613},
+				pos: position{line: 1700, col: 32, offset: 66195},
 				expr: &actionExpr{
-					pos: position{line: 1614, col: 33, offset: 63614},
+					pos: position{line: 1700, col: 33, offset: 66196},
 					run: (*parser).callonSidebarBlockVerbatimContent2,
 					expr: &seqExpr{
-						pos: position{line: 1614, col: 33, offset: 63614},
+						pos: position{line: 1700, col: 33, offset: 66196},
 						exprs: []interface{}{
 							&notExpr{
-								pos: position{line: 1614, col: 33, offset: 63614},
+								pos: position{line: 1700, col: 33, offset: 66196},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1614, col: 34, offset: 63615},
+									pos:  position{line: 1700, col: 34, offset: 66197},
 									name: "SidebarBlockEndDelimiter",
 								},
 							},
 							&labeledExpr{
-								pos:   position{line: 1614, col: 59, offset: 63640},
+								pos:   position{line: 1700, col: 59, offset: 66222},
 								label: "content",
 								expr: &ruleRefExpr{
-									pos:  position{line: 1614, col: 68, offset: 63649},
+									pos:  position{line: 1700, col: 68, offset: 66231},
 									name: "VerbatimContent",
 								},
 							},
@@ -11884,25 +12361,25 @@ var g = &grammar{
 		},
 		{
 			name: "PassthroughBlockDelimiter",
-			pos:  position{line: 1621, col: 1, offset: 63997},
+			pos:  position{line: 1707, col: 1, offset: 66579},
 			expr: &seqExpr{
-				pos: position{line: 1621, col: 30, offset: 64026},
+				pos: position{line: 1707, col: 30, offset: 66608},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1621, col: 30, offset: 64026},
+						pos:        position{line: 1707, col: 30, offset: 66608},
 						val:        "++++",
 						ignoreCase: false,
 						want:       "\"++++\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1621, col: 37, offset: 64033},
+						pos: position{line: 1707, col: 37, offset: 66615},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1621, col: 37, offset: 64033},
+							pos:  position{line: 1707, col: 37, offset: 66615},
 							name: "Space",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1621, col: 44, offset: 64040},
+						pos:  position{line: 1707, col: 44, offset: 66622},
 						name: "EOL",
 					},
 				},
@@ -11910,25 +12387,25 @@ var g = &grammar{
 		},
 		{
 			name: "PassthroughBlockStartDelimiter",
-			pos:  position{line: 1623, col: 1, offset: 64047},
+			pos:  position{line: 1709, col: 1, offset: 66629},
 			expr: &seqExpr{
-				pos: position{line: 1623, col: 35, offset: 64081},
+				pos: position{line: 1709, col: 35, offset: 66663},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1623, col: 35, offset: 64081},
+						pos:        position{line: 1709, col: 35, offset: 66663},
 						val:        "++++",
 						ignoreCase: false,
 						want:       "\"++++\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1623, col: 42, offset: 64088},
+						pos: position{line: 1709, col: 42, offset: 66670},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1623, col: 42, offset: 64088},
+							pos:  position{line: 1709, col: 42, offset: 66670},
 							name: "Space",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1623, col: 49, offset: 64095},
+						pos:  position{line: 1709, col: 49, offset: 66677},
 						name: "EOL",
 					},
 				},
@@ -11936,34 +12413,34 @@ var g = &grammar{
 		},
 		{
 			name: "PassthroughBlockEndDelimiter",
-			pos:  position{line: 1625, col: 1, offset: 64102},
+			pos:  position{line: 1711, col: 1, offset: 66684},
 			expr: &choiceExpr{
-				pos: position{line: 1625, col: 33, offset: 64134},
+				pos: position{line: 1711, col: 33, offset: 66716},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 1625, col: 34, offset: 64135},
+						pos: position{line: 1711, col: 34, offset: 66717},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 1625, col: 34, offset: 64135},
+								pos:        position{line: 1711, col: 34, offset: 66717},
 								val:        "++++",
 								ignoreCase: false,
 								want:       "\"++++\"",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 1625, col: 41, offset: 64142},
+								pos: position{line: 1711, col: 41, offset: 66724},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1625, col: 41, offset: 64142},
+									pos:  position{line: 1711, col: 41, offset: 66724},
 									name: "Space",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1625, col: 48, offset: 64149},
+								pos:  position{line: 1711, col: 48, offset: 66731},
 								name: "EOL",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1625, col: 55, offset: 64156},
+						pos:  position{line: 1711, col: 55, offset: 66738},
 						name: "EOF",
 					},
 				},
@@ -11971,38 +12448,38 @@ var g = &grammar{
 		},
 		{
 			name: "PassthroughBlock",
-			pos:  position{line: 1627, col: 1, offset: 64163},
+			pos:  position{line: 1713, col: 1, offset: 66745},
 			expr: &actionExpr{
-				pos: position{line: 1627, col: 21, offset: 64183},
+				pos: position{line: 1713, col: 21, offset: 66765},
 				run: (*parser).callonPassthroughBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1627, col: 21, offset: 64183},
+					pos: position{line: 1713, col: 21, offset: 66765},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1627, col: 21, offset: 64183},
+							pos:   position{line: 1713, col: 21, offset: 66765},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1627, col: 32, offset: 64194},
+								pos: position{line: 1713, col: 32, offset: 66776},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1627, col: 33, offset: 64195},
+									pos:  position{line: 1713, col: 33, offset: 66777},
 									name: "Attributes",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1627, col: 46, offset: 64208},
+							pos:  position{line: 1713, col: 46, offset: 66790},
 							name: "PassthroughBlockStartDelimiter",
 						},
 						&labeledExpr{
-							pos:   position{line: 1627, col: 77, offset: 64239},
+							pos:   position{line: 1713, col: 77, offset: 66821},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1627, col: 86, offset: 64248},
+								pos:  position{line: 1713, col: 86, offset: 66830},
 								name: "PassthroughBlockVerbatimContent",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1627, col: 119, offset: 64281},
+							pos:  position{line: 1713, col: 119, offset: 66863},
 							name: "PassthroughBlockEndDelimiter",
 						},
 					},
@@ -12011,27 +12488,27 @@ var g = &grammar{
 		},
 		{
 			name: "PassthroughBlockVerbatimContent",
-			pos:  position{line: 1631, col: 1, offset: 64410},
+			pos:  position{line: 1717, col: 1, offset: 66992},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1631, col: 36, offset: 64445},
+				pos: position{line: 1717, col: 36, offset: 67027},
 				expr: &actionExpr{
-					pos: position{line: 1631, col: 37, offset: 64446},
+					pos: position{line: 1717, col: 37, offset: 67028},
 					run: (*parser).callonPassthroughBlockVerbatimContent2,
 					expr: &seqExpr{
-						pos: position{line: 1631, col: 37, offset: 64446},
+						pos: position{line: 1717, col: 37, offset: 67028},
 						exprs: []interface{}{
 							&notExpr{
-								pos: position{line: 1631, col: 37, offset: 64446},
+								pos: position{line: 1717, col: 37, offset: 67028},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1631, col: 38, offset: 64447},
+									pos:  position{line: 1717, col: 38, offset: 67029},
 									name: "PassthroughBlockEndDelimiter",
 								},
 							},
 							&labeledExpr{
-								pos:   position{line: 1631, col: 67, offset: 64476},
+								pos:   position{line: 1717, col: 67, offset: 67058},
 								label: "content",
 								expr: &ruleRefExpr{
-									pos:  position{line: 1631, col: 76, offset: 64485},
+									pos:  position{line: 1717, col: 76, offset: 67067},
 									name: "VerbatimContent",
 								},
 							},
@@ -12042,87 +12519,87 @@ var g = &grammar{
 		},
 		{
 			name: "NormalBlockContent",
-			pos:  position{line: 1639, col: 1, offset: 64839},
+			pos:  position{line: 1725, col: 1, offset: 67421},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1639, col: 23, offset: 64861},
+				pos: position{line: 1725, col: 23, offset: 67443},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1639, col: 23, offset: 64861},
+					pos:  position{line: 1725, col: 23, offset: 67443},
 					name: "NormalBlockElement",
 				},
 			},
 		},
 		{
 			name: "NormalBlockElement",
-			pos:  position{line: 1641, col: 1, offset: 64884},
+			pos:  position{line: 1727, col: 1, offset: 67466},
 			expr: &actionExpr{
-				pos: position{line: 1642, col: 5, offset: 64912},
+				pos: position{line: 1728, col: 5, offset: 67494},
 				run: (*parser).callonNormalBlockElement1,
 				expr: &seqExpr{
-					pos: position{line: 1642, col: 5, offset: 64912},
+					pos: position{line: 1728, col: 5, offset: 67494},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1642, col: 5, offset: 64912},
+							pos: position{line: 1728, col: 5, offset: 67494},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1642, col: 6, offset: 64913},
+								pos:  position{line: 1728, col: 6, offset: 67495},
 								name: "EOF",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1642, col: 10, offset: 64917},
+							pos:   position{line: 1728, col: 10, offset: 67499},
 							label: "element",
 							expr: &choiceExpr{
-								pos: position{line: 1642, col: 19, offset: 64926},
+								pos: position{line: 1728, col: 19, offset: 67508},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1642, col: 19, offset: 64926},
+										pos:  position{line: 1728, col: 19, offset: 67508},
 										name: "BlankLine",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1643, col: 15, offset: 64952},
+										pos:  position{line: 1729, col: 15, offset: 67534},
 										name: "FileInclusion",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1644, col: 15, offset: 64981},
+										pos:  position{line: 1730, col: 15, offset: 67563},
 										name: "ImageBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1645, col: 15, offset: 65008},
+										pos:  position{line: 1731, col: 15, offset: 67590},
 										name: "OrderedListItem",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1646, col: 15, offset: 65040},
+										pos:  position{line: 1732, col: 15, offset: 67622},
 										name: "UnorderedListItem",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1647, col: 15, offset: 65074},
+										pos:  position{line: 1733, col: 15, offset: 67656},
 										name: "LabeledListItem",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1648, col: 15, offset: 65106},
+										pos:  position{line: 1734, col: 15, offset: 67688},
 										name: "ContinuedListItemElement",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1649, col: 15, offset: 65146},
+										pos:  position{line: 1735, col: 15, offset: 67728},
 										name: "DelimitedBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1650, col: 15, offset: 65176},
+										pos:  position{line: 1736, col: 15, offset: 67758},
 										name: "LiteralBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1651, col: 15, offset: 65205},
+										pos:  position{line: 1737, col: 15, offset: 67787},
 										name: "AttributeDeclaration",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1652, col: 15, offset: 65242},
+										pos:  position{line: 1738, col: 15, offset: 67824},
 										name: "AttributeReset",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1653, col: 15, offset: 65273},
+										pos:  position{line: 1739, col: 15, offset: 67855},
 										name: "TableOfContentsPlaceHolder",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1654, col: 15, offset: 65315},
+										pos:  position{line: 1740, col: 15, offset: 67897},
 										name: "Paragraph",
 									},
 								},
@@ -12134,43 +12611,43 @@ var g = &grammar{
 		},
 		{
 			name: "VerseBlockContent",
-			pos:  position{line: 1658, col: 1, offset: 65368},
+			pos:  position{line: 1744, col: 1, offset: 67950},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1658, col: 22, offset: 65389},
+				pos: position{line: 1744, col: 22, offset: 67971},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1658, col: 22, offset: 65389},
+					pos:  position{line: 1744, col: 22, offset: 67971},
 					name: "VerseBlockElement",
 				},
 			},
 		},
 		{
 			name: "VerseBlockElement",
-			pos:  position{line: 1660, col: 1, offset: 65411},
+			pos:  position{line: 1746, col: 1, offset: 67993},
 			expr: &actionExpr{
-				pos: position{line: 1660, col: 22, offset: 65432},
+				pos: position{line: 1746, col: 22, offset: 68014},
 				run: (*parser).callonVerseBlockElement1,
 				expr: &seqExpr{
-					pos: position{line: 1660, col: 22, offset: 65432},
+					pos: position{line: 1746, col: 22, offset: 68014},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1660, col: 22, offset: 65432},
+							pos: position{line: 1746, col: 22, offset: 68014},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1660, col: 23, offset: 65433},
+								pos:  position{line: 1746, col: 23, offset: 68015},
 								name: "EOF",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1660, col: 27, offset: 65437},
+							pos:   position{line: 1746, col: 27, offset: 68019},
 							label: "element",
 							expr: &choiceExpr{
-								pos: position{line: 1660, col: 36, offset: 65446},
+								pos: position{line: 1746, col: 36, offset: 68028},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1660, col: 36, offset: 65446},
+										pos:  position{line: 1746, col: 36, offset: 68028},
 										name: "BlankLine",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1660, col: 48, offset: 65458},
+										pos:  position{line: 1746, col: 48, offset: 68040},
 										name: "VerseBlockParagraph",
 									},
 								},
@@ -12182,17 +12659,17 @@ var g = &grammar{
 		},
 		{
 			name: "VerseBlockParagraph",
-			pos:  position{line: 1664, col: 1, offset: 65512},
+			pos:  position{line: 1750, col: 1, offset: 68094},
 			expr: &actionExpr{
-				pos: position{line: 1664, col: 24, offset: 65535},
+				pos: position{line: 1750, col: 24, offset: 68117},
 				run: (*parser).callonVerseBlockParagraph1,
 				expr: &labeledExpr{
-					pos:   position{line: 1664, col: 24, offset: 65535},
+					pos:   position{line: 1750, col: 24, offset: 68117},
 					label: "lines",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 1664, col: 30, offset: 65541},
+						pos: position{line: 1750, col: 30, offset: 68123},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1664, col: 31, offset: 65542},
+							pos:  position{line: 1750, col: 31, offset: 68124},
 							name: "VerseBlockParagraphLine",
 						},
 					},
@@ -12201,26 +12678,26 @@ var g = &grammar{
 		},
 		{
 			name: "VerseBlockParagraphLine",
-			pos:  position{line: 1668, col: 1, offset: 65636},
+			pos:  position{line: 1754, col: 1, offset: 68218},
 			expr: &actionExpr{
-				pos: position{line: 1668, col: 28, offset: 65663},
+				pos: position{line: 1754, col: 28, offset: 68245},
 				run: (*parser).callonVerseBlockParagraphLine1,
 				expr: &seqExpr{
-					pos: position{line: 1668, col: 28, offset: 65663},
+					pos: position{line: 1754, col: 28, offset: 68245},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1668, col: 28, offset: 65663},
+							pos:   position{line: 1754, col: 28, offset: 68245},
 							label: "elements",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1668, col: 37, offset: 65672},
+								pos: position{line: 1754, col: 37, offset: 68254},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1668, col: 38, offset: 65673},
+									pos:  position{line: 1754, col: 38, offset: 68255},
 									name: "InlineElement",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1668, col: 54, offset: 65689},
+							pos:  position{line: 1754, col: 54, offset: 68271},
 							name: "EOL",
 						},
 					},
@@ -12229,59 +12706,59 @@ var g = &grammar{
 		},
 		{
 			name: "Table",
-			pos:  position{line: 1675, col: 1, offset: 65938},
+			pos:  position{line: 1761, col: 1, offset: 68520},
 			expr: &actionExpr{
-				pos: position{line: 1675, col: 10, offset: 65947},
+				pos: position{line: 1761, col: 10, offset: 68529},
 				run: (*parser).callonTable1,
 				expr: &seqExpr{
-					pos: position{line: 1675, col: 10, offset: 65947},
+					pos: position{line: 1761, col: 10, offset: 68529},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1675, col: 10, offset: 65947},
+							pos:   position{line: 1761, col: 10, offset: 68529},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1675, col: 21, offset: 65958},
+								pos: position{line: 1761, col: 21, offset: 68540},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1675, col: 22, offset: 65959},
+									pos:  position{line: 1761, col: 22, offset: 68541},
 									name: "Attributes",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1675, col: 35, offset: 65972},
+							pos:  position{line: 1761, col: 35, offset: 68554},
 							name: "TableDelimiter",
 						},
 						&labeledExpr{
-							pos:   position{line: 1676, col: 5, offset: 65992},
+							pos:   position{line: 1762, col: 5, offset: 68574},
 							label: "header",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1676, col: 12, offset: 65999},
+								pos: position{line: 1762, col: 12, offset: 68581},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1676, col: 13, offset: 66000},
+									pos:  position{line: 1762, col: 13, offset: 68582},
 									name: "TableLineHeader",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1677, col: 5, offset: 66023},
+							pos:   position{line: 1763, col: 5, offset: 68605},
 							label: "lines",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1677, col: 11, offset: 66029},
+								pos: position{line: 1763, col: 11, offset: 68611},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1677, col: 12, offset: 66030},
+									pos:  position{line: 1763, col: 12, offset: 68612},
 									name: "TableLine",
 								},
 							},
 						},
 						&choiceExpr{
-							pos: position{line: 1678, col: 6, offset: 66048},
+							pos: position{line: 1764, col: 6, offset: 68630},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 1678, col: 6, offset: 66048},
+									pos:  position{line: 1764, col: 6, offset: 68630},
 									name: "TableDelimiter",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1678, col: 23, offset: 66065},
+									pos:  position{line: 1764, col: 23, offset: 68647},
 									name: "EOF",
 								},
 							},
@@ -12292,20 +12769,20 @@ var g = &grammar{
 		},
 		{
 			name: "TableCellSeparator",
-			pos:  position{line: 1682, col: 1, offset: 66184},
+			pos:  position{line: 1768, col: 1, offset: 68766},
 			expr: &seqExpr{
-				pos: position{line: 1682, col: 23, offset: 66206},
+				pos: position{line: 1768, col: 23, offset: 68788},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1682, col: 23, offset: 66206},
+						pos:        position{line: 1768, col: 23, offset: 68788},
 						val:        "|",
 						ignoreCase: false,
 						want:       "\"|\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1682, col: 27, offset: 66210},
+						pos: position{line: 1768, col: 27, offset: 68792},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1682, col: 27, offset: 66210},
+							pos:  position{line: 1768, col: 27, offset: 68792},
 							name: "Space",
 						},
 					},
@@ -12314,25 +12791,25 @@ var g = &grammar{
 		},
 		{
 			name: "TableDelimiter",
-			pos:  position{line: 1684, col: 1, offset: 66220},
+			pos:  position{line: 1770, col: 1, offset: 68802},
 			expr: &seqExpr{
-				pos: position{line: 1684, col: 19, offset: 66238},
+				pos: position{line: 1770, col: 19, offset: 68820},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1684, col: 19, offset: 66238},
+						pos:        position{line: 1770, col: 19, offset: 68820},
 						val:        "|===",
 						ignoreCase: false,
 						want:       "\"|===\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1684, col: 26, offset: 66245},
+						pos: position{line: 1770, col: 26, offset: 68827},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1684, col: 26, offset: 66245},
+							pos:  position{line: 1770, col: 26, offset: 68827},
 							name: "Space",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1684, col: 33, offset: 66252},
+						pos:  position{line: 1770, col: 33, offset: 68834},
 						name: "EOL",
 					},
 				},
@@ -12340,37 +12817,37 @@ var g = &grammar{
 		},
 		{
 			name: "TableLineHeader",
-			pos:  position{line: 1687, col: 1, offset: 66323},
+			pos:  position{line: 1773, col: 1, offset: 68905},
 			expr: &actionExpr{
-				pos: position{line: 1687, col: 20, offset: 66342},
+				pos: position{line: 1773, col: 20, offset: 68924},
 				run: (*parser).callonTableLineHeader1,
 				expr: &seqExpr{
-					pos: position{line: 1687, col: 20, offset: 66342},
+					pos: position{line: 1773, col: 20, offset: 68924},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1687, col: 20, offset: 66342},
+							pos: position{line: 1773, col: 20, offset: 68924},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1687, col: 21, offset: 66343},
+								pos:  position{line: 1773, col: 21, offset: 68925},
 								name: "TableDelimiter",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1687, col: 36, offset: 66358},
+							pos:   position{line: 1773, col: 36, offset: 68940},
 							label: "cells",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1687, col: 42, offset: 66364},
+								pos: position{line: 1773, col: 42, offset: 68946},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1687, col: 43, offset: 66365},
+									pos:  position{line: 1773, col: 43, offset: 68947},
 									name: "TableCell",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1687, col: 55, offset: 66377},
+							pos:  position{line: 1773, col: 55, offset: 68959},
 							name: "EOL",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1687, col: 59, offset: 66381},
+							pos:  position{line: 1773, col: 59, offset: 68963},
 							name: "BlankLine",
 						},
 					},
@@ -12379,39 +12856,39 @@ var g = &grammar{
 		},
 		{
 			name: "TableLine",
-			pos:  position{line: 1691, col: 1, offset: 66453},
+			pos:  position{line: 1777, col: 1, offset: 69035},
 			expr: &actionExpr{
-				pos: position{line: 1691, col: 14, offset: 66466},
+				pos: position{line: 1777, col: 14, offset: 69048},
 				run: (*parser).callonTableLine1,
 				expr: &seqExpr{
-					pos: position{line: 1691, col: 14, offset: 66466},
+					pos: position{line: 1777, col: 14, offset: 69048},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1691, col: 14, offset: 66466},
+							pos: position{line: 1777, col: 14, offset: 69048},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1691, col: 15, offset: 66467},
+								pos:  position{line: 1777, col: 15, offset: 69049},
 								name: "TableDelimiter",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1691, col: 30, offset: 66482},
+							pos:   position{line: 1777, col: 30, offset: 69064},
 							label: "cells",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1691, col: 36, offset: 66488},
+								pos: position{line: 1777, col: 36, offset: 69070},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1691, col: 37, offset: 66489},
+									pos:  position{line: 1777, col: 37, offset: 69071},
 									name: "TableCell",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1691, col: 49, offset: 66501},
+							pos:  position{line: 1777, col: 49, offset: 69083},
 							name: "EOL",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1691, col: 53, offset: 66505},
+							pos: position{line: 1777, col: 53, offset: 69087},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1691, col: 53, offset: 66505},
+								pos:  position{line: 1777, col: 53, offset: 69087},
 								name: "BlankLine",
 							},
 						},
@@ -12421,54 +12898,54 @@ var g = &grammar{
 		},
 		{
 			name: "TableCell",
-			pos:  position{line: 1695, col: 1, offset: 66578},
+			pos:  position{line: 1781, col: 1, offset: 69160},
 			expr: &actionExpr{
-				pos: position{line: 1695, col: 14, offset: 66591},
+				pos: position{line: 1781, col: 14, offset: 69173},
 				run: (*parser).callonTableCell1,
 				expr: &seqExpr{
-					pos: position{line: 1695, col: 14, offset: 66591},
+					pos: position{line: 1781, col: 14, offset: 69173},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1695, col: 14, offset: 66591},
+							pos:  position{line: 1781, col: 14, offset: 69173},
 							name: "TableCellSeparator",
 						},
 						&labeledExpr{
-							pos:   position{line: 1695, col: 33, offset: 66610},
+							pos:   position{line: 1781, col: 33, offset: 69192},
 							label: "elements",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1695, col: 42, offset: 66619},
+								pos: position{line: 1781, col: 42, offset: 69201},
 								expr: &seqExpr{
-									pos: position{line: 1695, col: 43, offset: 66620},
+									pos: position{line: 1781, col: 43, offset: 69202},
 									exprs: []interface{}{
 										&notExpr{
-											pos: position{line: 1695, col: 43, offset: 66620},
+											pos: position{line: 1781, col: 43, offset: 69202},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1695, col: 44, offset: 66621},
+												pos:  position{line: 1781, col: 44, offset: 69203},
 												name: "TableCellSeparator",
 											},
 										},
 										&notExpr{
-											pos: position{line: 1695, col: 63, offset: 66640},
+											pos: position{line: 1781, col: 63, offset: 69222},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1695, col: 64, offset: 66641},
+												pos:  position{line: 1781, col: 64, offset: 69223},
 												name: "EOL",
 											},
 										},
 										&zeroOrMoreExpr{
-											pos: position{line: 1695, col: 68, offset: 66645},
+											pos: position{line: 1781, col: 68, offset: 69227},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1695, col: 68, offset: 66645},
+												pos:  position{line: 1781, col: 68, offset: 69227},
 												name: "Space",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1695, col: 75, offset: 66652},
+											pos:  position{line: 1781, col: 75, offset: 69234},
 											name: "InlineElement",
 										},
 										&zeroOrMoreExpr{
-											pos: position{line: 1695, col: 89, offset: 66666},
+											pos: position{line: 1781, col: 89, offset: 69248},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1695, col: 89, offset: 66666},
+												pos:  position{line: 1781, col: 89, offset: 69248},
 												name: "Space",
 											},
 										},
@@ -12482,25 +12959,25 @@ var g = &grammar{
 		},
 		{
 			name: "CommentBlockDelimiter",
-			pos:  position{line: 1702, col: 1, offset: 66922},
+			pos:  position{line: 1788, col: 1, offset: 69504},
 			expr: &seqExpr{
-				pos: position{line: 1702, col: 26, offset: 66947},
+				pos: position{line: 1788, col: 26, offset: 69529},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1702, col: 26, offset: 66947},
+						pos:        position{line: 1788, col: 26, offset: 69529},
 						val:        "////",
 						ignoreCase: false,
 						want:       "\"////\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1702, col: 33, offset: 66954},
+						pos: position{line: 1788, col: 33, offset: 69536},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1702, col: 33, offset: 66954},
+							pos:  position{line: 1788, col: 33, offset: 69536},
 							name: "Space",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1702, col: 40, offset: 66961},
+						pos:  position{line: 1788, col: 40, offset: 69543},
 						name: "EOL",
 					},
 				},
@@ -12508,25 +12985,25 @@ var g = &grammar{
 		},
 		{
 			name: "CommentBlockStartDelimiter",
-			pos:  position{line: 1704, col: 1, offset: 66968},
+			pos:  position{line: 1790, col: 1, offset: 69550},
 			expr: &seqExpr{
-				pos: position{line: 1704, col: 31, offset: 66998},
+				pos: position{line: 1790, col: 31, offset: 69580},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1704, col: 31, offset: 66998},
+						pos:        position{line: 1790, col: 31, offset: 69580},
 						val:        "////",
 						ignoreCase: false,
 						want:       "\"////\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1704, col: 38, offset: 67005},
+						pos: position{line: 1790, col: 38, offset: 69587},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1704, col: 38, offset: 67005},
+							pos:  position{line: 1790, col: 38, offset: 69587},
 							name: "Space",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1704, col: 45, offset: 67012},
+						pos:  position{line: 1790, col: 45, offset: 69594},
 						name: "EOL",
 					},
 				},
@@ -12534,34 +13011,34 @@ var g = &grammar{
 		},
 		{
 			name: "CommentBlockEndDelimiter",
-			pos:  position{line: 1706, col: 1, offset: 67019},
+			pos:  position{line: 1792, col: 1, offset: 69601},
 			expr: &choiceExpr{
-				pos: position{line: 1706, col: 29, offset: 67047},
+				pos: position{line: 1792, col: 29, offset: 69629},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 1706, col: 30, offset: 67048},
+						pos: position{line: 1792, col: 30, offset: 69630},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 1706, col: 30, offset: 67048},
+								pos:        position{line: 1792, col: 30, offset: 69630},
 								val:        "////",
 								ignoreCase: false,
 								want:       "\"////\"",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 1706, col: 37, offset: 67055},
+								pos: position{line: 1792, col: 37, offset: 69637},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1706, col: 37, offset: 67055},
+									pos:  position{line: 1792, col: 37, offset: 69637},
 									name: "Space",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1706, col: 44, offset: 67062},
+								pos:  position{line: 1792, col: 44, offset: 69644},
 								name: "EOL",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1706, col: 51, offset: 67069},
+						pos:  position{line: 1792, col: 51, offset: 69651},
 						name: "EOF",
 					},
 				},
@@ -12569,27 +13046,27 @@ var g = &grammar{
 		},
 		{
 			name: "CommentBlock",
-			pos:  position{line: 1708, col: 1, offset: 67076},
+			pos:  position{line: 1794, col: 1, offset: 69658},
 			expr: &actionExpr{
-				pos: position{line: 1708, col: 17, offset: 67092},
+				pos: position{line: 1794, col: 17, offset: 69674},
 				run: (*parser).callonCommentBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1708, col: 17, offset: 67092},
+					pos: position{line: 1794, col: 17, offset: 69674},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1708, col: 17, offset: 67092},
+							pos:  position{line: 1794, col: 17, offset: 69674},
 							name: "CommentBlockStartDelimiter",
 						},
 						&labeledExpr{
-							pos:   position{line: 1708, col: 44, offset: 67119},
+							pos:   position{line: 1794, col: 44, offset: 69701},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1708, col: 53, offset: 67128},
+								pos:  position{line: 1794, col: 53, offset: 69710},
 								name: "CommentBlockVerbatimContent",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1708, col: 83, offset: 67158},
+							pos:  position{line: 1794, col: 83, offset: 69740},
 							name: "CommentBlockEndDelimiter",
 						},
 					},
@@ -12598,27 +13075,27 @@ var g = &grammar{
 		},
 		{
 			name: "CommentBlockVerbatimContent",
-			pos:  position{line: 1712, col: 1, offset: 67272},
+			pos:  position{line: 1798, col: 1, offset: 69854},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1712, col: 32, offset: 67303},
+				pos: position{line: 1798, col: 32, offset: 69885},
 				expr: &actionExpr{
-					pos: position{line: 1712, col: 33, offset: 67304},
+					pos: position{line: 1798, col: 33, offset: 69886},
 					run: (*parser).callonCommentBlockVerbatimContent2,
 					expr: &seqExpr{
-						pos: position{line: 1712, col: 33, offset: 67304},
+						pos: position{line: 1798, col: 33, offset: 69886},
 						exprs: []interface{}{
 							&notExpr{
-								pos: position{line: 1712, col: 33, offset: 67304},
+								pos: position{line: 1798, col: 33, offset: 69886},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1712, col: 34, offset: 67305},
+									pos:  position{line: 1798, col: 34, offset: 69887},
 									name: "CommentBlockEndDelimiter",
 								},
 							},
 							&labeledExpr{
-								pos:   position{line: 1712, col: 59, offset: 67330},
+								pos:   position{line: 1798, col: 59, offset: 69912},
 								label: "content",
 								expr: &ruleRefExpr{
-									pos:  position{line: 1712, col: 68, offset: 67339},
+									pos:  position{line: 1798, col: 68, offset: 69921},
 									name: "VerbatimContent",
 								},
 							},
@@ -12629,43 +13106,43 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineComment",
-			pos:  position{line: 1716, col: 1, offset: 67484},
+			pos:  position{line: 1802, col: 1, offset: 70066},
 			expr: &actionExpr{
-				pos: position{line: 1716, col: 22, offset: 67505},
+				pos: position{line: 1802, col: 22, offset: 70087},
 				run: (*parser).callonSingleLineComment1,
 				expr: &seqExpr{
-					pos: position{line: 1716, col: 22, offset: 67505},
+					pos: position{line: 1802, col: 22, offset: 70087},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1716, col: 22, offset: 67505},
+							pos: position{line: 1802, col: 22, offset: 70087},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1716, col: 23, offset: 67506},
+								pos:  position{line: 1802, col: 23, offset: 70088},
 								name: "CommentBlockDelimiter",
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1716, col: 45, offset: 67528},
+							pos: position{line: 1802, col: 45, offset: 70110},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1716, col: 45, offset: 67528},
+								pos:  position{line: 1802, col: 45, offset: 70110},
 								name: "Space",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1716, col: 52, offset: 67535},
+							pos:        position{line: 1802, col: 52, offset: 70117},
 							val:        "//",
 							ignoreCase: false,
 							want:       "\"//\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1716, col: 57, offset: 67540},
+							pos:   position{line: 1802, col: 57, offset: 70122},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1716, col: 66, offset: 67549},
+								pos:  position{line: 1802, col: 66, offset: 70131},
 								name: "SingleLineCommentContent",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1716, col: 92, offset: 67575},
+							pos:  position{line: 1802, col: 92, offset: 70157},
 							name: "EOL",
 						},
 					},
@@ -12674,14 +13151,14 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineCommentContent",
-			pos:  position{line: 1720, col: 1, offset: 67644},
+			pos:  position{line: 1806, col: 1, offset: 70226},
 			expr: &actionExpr{
-				pos: position{line: 1720, col: 29, offset: 67672},
+				pos: position{line: 1806, col: 29, offset: 70254},
 				run: (*parser).callonSingleLineCommentContent1,
 				expr: &zeroOrMoreExpr{
-					pos: position{line: 1720, col: 29, offset: 67672},
+					pos: position{line: 1806, col: 29, offset: 70254},
 					expr: &charClassMatcher{
-						pos:        position{line: 1720, col: 29, offset: 67672},
+						pos:        position{line: 1806, col: 29, offset: 70254},
 						val:        "[^\\r\\n]",
 						chars:      []rune{'\r', '\n'},
 						ignoreCase: false,
@@ -12692,20 +13169,20 @@ var g = &grammar{
 		},
 		{
 			name: "LiteralBlock",
-			pos:  position{line: 1728, col: 1, offset: 67993},
+			pos:  position{line: 1814, col: 1, offset: 70575},
 			expr: &choiceExpr{
-				pos: position{line: 1728, col: 17, offset: 68009},
+				pos: position{line: 1814, col: 17, offset: 70591},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1728, col: 17, offset: 68009},
+						pos:  position{line: 1814, col: 17, offset: 70591},
 						name: "ParagraphWithLiteralAttribute",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1728, col: 49, offset: 68041},
+						pos:  position{line: 1814, col: 49, offset: 70623},
 						name: "ParagraphWithHeadingSpaces",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1728, col: 78, offset: 68070},
+						pos:  position{line: 1814, col: 78, offset: 70652},
 						name: "ParagraphWithLiteralBlockDelimiter",
 					},
 				},
@@ -12713,9 +13190,9 @@ var g = &grammar{
 		},
 		{
 			name: "LiteralBlockDelimiter",
-			pos:  position{line: 1730, col: 1, offset: 68108},
+			pos:  position{line: 1816, col: 1, offset: 70690},
 			expr: &litMatcher{
-				pos:        position{line: 1730, col: 26, offset: 68133},
+				pos:        position{line: 1816, col: 26, offset: 70715},
 				val:        "....",
 				ignoreCase: false,
 				want:       "\"....\"",
@@ -12723,29 +13200,29 @@ var g = &grammar{
 		},
 		{
 			name: "ParagraphWithHeadingSpaces",
-			pos:  position{line: 1733, col: 1, offset: 68208},
+			pos:  position{line: 1819, col: 1, offset: 70790},
 			expr: &actionExpr{
-				pos: position{line: 1733, col: 31, offset: 68238},
+				pos: position{line: 1819, col: 31, offset: 70820},
 				run: (*parser).callonParagraphWithHeadingSpaces1,
 				expr: &seqExpr{
-					pos: position{line: 1733, col: 31, offset: 68238},
+					pos: position{line: 1819, col: 31, offset: 70820},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1733, col: 31, offset: 68238},
+							pos:   position{line: 1819, col: 31, offset: 70820},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1733, col: 42, offset: 68249},
+								pos: position{line: 1819, col: 42, offset: 70831},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1733, col: 43, offset: 68250},
+									pos:  position{line: 1819, col: 43, offset: 70832},
 									name: "Attributes",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1733, col: 56, offset: 68263},
+							pos:   position{line: 1819, col: 56, offset: 70845},
 							label: "lines",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1733, col: 63, offset: 68270},
+								pos:  position{line: 1819, col: 63, offset: 70852},
 								name: "ParagraphWithHeadingSpacesLines",
 							},
 						},
@@ -12755,33 +13232,33 @@ var g = &grammar{
 		},
 		{
 			name: "ParagraphWithHeadingSpacesLines",
-			pos:  position{line: 1738, col: 1, offset: 68505},
+			pos:  position{line: 1824, col: 1, offset: 71087},
 			expr: &actionExpr{
-				pos: position{line: 1739, col: 5, offset: 68546},
+				pos: position{line: 1825, col: 5, offset: 71128},
 				run: (*parser).callonParagraphWithHeadingSpacesLines1,
 				expr: &seqExpr{
-					pos: position{line: 1739, col: 5, offset: 68546},
+					pos: position{line: 1825, col: 5, offset: 71128},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1739, col: 5, offset: 68546},
+							pos:   position{line: 1825, col: 5, offset: 71128},
 							label: "firstLine",
 							expr: &actionExpr{
-								pos: position{line: 1739, col: 16, offset: 68557},
+								pos: position{line: 1825, col: 16, offset: 71139},
 								run: (*parser).callonParagraphWithHeadingSpacesLines4,
 								expr: &seqExpr{
-									pos: position{line: 1739, col: 16, offset: 68557},
+									pos: position{line: 1825, col: 16, offset: 71139},
 									exprs: []interface{}{
 										&oneOrMoreExpr{
-											pos: position{line: 1739, col: 16, offset: 68557},
+											pos: position{line: 1825, col: 16, offset: 71139},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1739, col: 16, offset: 68557},
+												pos:  position{line: 1825, col: 16, offset: 71139},
 												name: "Space",
 											},
 										},
 										&oneOrMoreExpr{
-											pos: position{line: 1739, col: 23, offset: 68564},
+											pos: position{line: 1825, col: 23, offset: 71146},
 											expr: &charClassMatcher{
-												pos:        position{line: 1739, col: 23, offset: 68564},
+												pos:        position{line: 1825, col: 23, offset: 71146},
 												val:        "[^\\r\\n]",
 												chars:      []rune{'\r', '\n'},
 												ignoreCase: false,
@@ -12793,37 +13270,37 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1741, col: 8, offset: 68619},
+							pos:  position{line: 1827, col: 8, offset: 71201},
 							name: "EOL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1742, col: 5, offset: 68683},
+							pos:   position{line: 1828, col: 5, offset: 71265},
 							label: "otherLines",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1742, col: 16, offset: 68694},
+								pos: position{line: 1828, col: 16, offset: 71276},
 								expr: &actionExpr{
-									pos: position{line: 1743, col: 9, offset: 68705},
+									pos: position{line: 1829, col: 9, offset: 71287},
 									run: (*parser).callonParagraphWithHeadingSpacesLines13,
 									expr: &seqExpr{
-										pos: position{line: 1743, col: 9, offset: 68705},
+										pos: position{line: 1829, col: 9, offset: 71287},
 										exprs: []interface{}{
 											&notExpr{
-												pos: position{line: 1743, col: 9, offset: 68705},
+												pos: position{line: 1829, col: 9, offset: 71287},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1743, col: 10, offset: 68706},
+													pos:  position{line: 1829, col: 10, offset: 71288},
 													name: "BlankLine",
 												},
 											},
 											&labeledExpr{
-												pos:   position{line: 1744, col: 9, offset: 68726},
+												pos:   position{line: 1830, col: 9, offset: 71308},
 												label: "otherLine",
 												expr: &actionExpr{
-													pos: position{line: 1744, col: 20, offset: 68737},
+													pos: position{line: 1830, col: 20, offset: 71319},
 													run: (*parser).callonParagraphWithHeadingSpacesLines18,
 													expr: &oneOrMoreExpr{
-														pos: position{line: 1744, col: 20, offset: 68737},
+														pos: position{line: 1830, col: 20, offset: 71319},
 														expr: &charClassMatcher{
-															pos:        position{line: 1744, col: 20, offset: 68737},
+															pos:        position{line: 1830, col: 20, offset: 71319},
 															val:        "[^\\r\\n]",
 															chars:      []rune{'\r', '\n'},
 															ignoreCase: false,
@@ -12833,7 +13310,7 @@ var g = &grammar{
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1746, col: 12, offset: 68800},
+												pos:  position{line: 1832, col: 12, offset: 71382},
 												name: "EOL",
 											},
 										},
@@ -12847,72 +13324,72 @@ var g = &grammar{
 		},
 		{
 			name: "ParagraphWithLiteralBlockDelimiter",
-			pos:  position{line: 1753, col: 1, offset: 69037},
+			pos:  position{line: 1839, col: 1, offset: 71619},
 			expr: &actionExpr{
-				pos: position{line: 1753, col: 39, offset: 69075},
+				pos: position{line: 1839, col: 39, offset: 71657},
 				run: (*parser).callonParagraphWithLiteralBlockDelimiter1,
 				expr: &seqExpr{
-					pos: position{line: 1753, col: 39, offset: 69075},
+					pos: position{line: 1839, col: 39, offset: 71657},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1753, col: 39, offset: 69075},
+							pos:   position{line: 1839, col: 39, offset: 71657},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1753, col: 50, offset: 69086},
+								pos: position{line: 1839, col: 50, offset: 71668},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1753, col: 51, offset: 69087},
+									pos:  position{line: 1839, col: 51, offset: 71669},
 									name: "Attributes",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1754, col: 9, offset: 69109},
+							pos:  position{line: 1840, col: 9, offset: 71691},
 							name: "LiteralBlockDelimiter",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1754, col: 31, offset: 69131},
+							pos: position{line: 1840, col: 31, offset: 71713},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1754, col: 31, offset: 69131},
+								pos:  position{line: 1840, col: 31, offset: 71713},
 								name: "Space",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1754, col: 38, offset: 69138},
+							pos:  position{line: 1840, col: 38, offset: 71720},
 							name: "Newline",
 						},
 						&labeledExpr{
-							pos:   position{line: 1754, col: 46, offset: 69146},
+							pos:   position{line: 1840, col: 46, offset: 71728},
 							label: "lines",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1754, col: 53, offset: 69153},
+								pos:  position{line: 1840, col: 53, offset: 71735},
 								name: "ParagraphWithLiteralBlockDelimiterLines",
 							},
 						},
 						&choiceExpr{
-							pos: position{line: 1754, col: 95, offset: 69195},
+							pos: position{line: 1840, col: 95, offset: 71777},
 							alternatives: []interface{}{
 								&seqExpr{
-									pos: position{line: 1754, col: 96, offset: 69196},
+									pos: position{line: 1840, col: 96, offset: 71778},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 1754, col: 96, offset: 69196},
+											pos:  position{line: 1840, col: 96, offset: 71778},
 											name: "LiteralBlockDelimiter",
 										},
 										&zeroOrMoreExpr{
-											pos: position{line: 1754, col: 118, offset: 69218},
+											pos: position{line: 1840, col: 118, offset: 71800},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1754, col: 118, offset: 69218},
+												pos:  position{line: 1840, col: 118, offset: 71800},
 												name: "Space",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1754, col: 125, offset: 69225},
+											pos:  position{line: 1840, col: 125, offset: 71807},
 											name: "EOL",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1754, col: 132, offset: 69232},
+									pos:  position{line: 1840, col: 132, offset: 71814},
 									name: "EOF",
 								},
 							},
@@ -12923,17 +13400,17 @@ var g = &grammar{
 		},
 		{
 			name: "ParagraphWithLiteralBlockDelimiterLines",
-			pos:  position{line: 1759, col: 1, offset: 69396},
+			pos:  position{line: 1845, col: 1, offset: 71978},
 			expr: &actionExpr{
-				pos: position{line: 1759, col: 44, offset: 69439},
+				pos: position{line: 1845, col: 44, offset: 72021},
 				run: (*parser).callonParagraphWithLiteralBlockDelimiterLines1,
 				expr: &labeledExpr{
-					pos:   position{line: 1759, col: 44, offset: 69439},
+					pos:   position{line: 1845, col: 44, offset: 72021},
 					label: "lines",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 1759, col: 50, offset: 69445},
+						pos: position{line: 1845, col: 50, offset: 72027},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1759, col: 51, offset: 69446},
+							pos:  position{line: 1845, col: 51, offset: 72028},
 							name: "ParagraphWithLiteralBlockDelimiterLine",
 						},
 					},
@@ -12942,33 +13419,33 @@ var g = &grammar{
 		},
 		{
 			name: "ParagraphWithLiteralBlockDelimiterLine",
-			pos:  position{line: 1763, col: 1, offset: 69534},
+			pos:  position{line: 1849, col: 1, offset: 72116},
 			expr: &actionExpr{
-				pos: position{line: 1764, col: 5, offset: 69590},
+				pos: position{line: 1850, col: 5, offset: 72172},
 				run: (*parser).callonParagraphWithLiteralBlockDelimiterLine1,
 				expr: &seqExpr{
-					pos: position{line: 1764, col: 5, offset: 69590},
+					pos: position{line: 1850, col: 5, offset: 72172},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1764, col: 5, offset: 69590},
+							pos:   position{line: 1850, col: 5, offset: 72172},
 							label: "line",
 							expr: &actionExpr{
-								pos: position{line: 1764, col: 11, offset: 69596},
+								pos: position{line: 1850, col: 11, offset: 72178},
 								run: (*parser).callonParagraphWithLiteralBlockDelimiterLine4,
 								expr: &seqExpr{
-									pos: position{line: 1764, col: 11, offset: 69596},
+									pos: position{line: 1850, col: 11, offset: 72178},
 									exprs: []interface{}{
 										&notExpr{
-											pos: position{line: 1764, col: 11, offset: 69596},
+											pos: position{line: 1850, col: 11, offset: 72178},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1764, col: 12, offset: 69597},
+												pos:  position{line: 1850, col: 12, offset: 72179},
 												name: "LiteralBlockDelimiter",
 											},
 										},
 										&zeroOrMoreExpr{
-											pos: position{line: 1764, col: 34, offset: 69619},
+											pos: position{line: 1850, col: 34, offset: 72201},
 											expr: &charClassMatcher{
-												pos:        position{line: 1764, col: 34, offset: 69619},
+												pos:        position{line: 1850, col: 34, offset: 72201},
 												val:        "[^\\r\\n]",
 												chars:      []rune{'\r', '\n'},
 												ignoreCase: false,
@@ -12980,7 +13457,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1766, col: 8, offset: 69674},
+							pos:  position{line: 1852, col: 8, offset: 72256},
 							name: "EOL",
 						},
 					},
@@ -12989,33 +13466,33 @@ var g = &grammar{
 		},
 		{
 			name: "ParagraphWithLiteralAttribute",
-			pos:  position{line: 1771, col: 1, offset: 69805},
+			pos:  position{line: 1857, col: 1, offset: 72387},
 			expr: &actionExpr{
-				pos: position{line: 1772, col: 5, offset: 69844},
+				pos: position{line: 1858, col: 5, offset: 72426},
 				run: (*parser).callonParagraphWithLiteralAttribute1,
 				expr: &seqExpr{
-					pos: position{line: 1772, col: 5, offset: 69844},
+					pos: position{line: 1858, col: 5, offset: 72426},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1772, col: 5, offset: 69844},
+							pos:   position{line: 1858, col: 5, offset: 72426},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1772, col: 16, offset: 69855},
+								pos: position{line: 1858, col: 16, offset: 72437},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1772, col: 17, offset: 69856},
+									pos:  position{line: 1858, col: 17, offset: 72438},
 									name: "Attributes",
 								},
 							},
 						},
 						&andCodeExpr{
-							pos: position{line: 1773, col: 5, offset: 69874},
+							pos: position{line: 1859, col: 5, offset: 72456},
 							run: (*parser).callonParagraphWithLiteralAttribute6,
 						},
 						&labeledExpr{
-							pos:   position{line: 1780, col: 5, offset: 70088},
+							pos:   position{line: 1866, col: 5, offset: 72670},
 							label: "lines",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1780, col: 12, offset: 70095},
+								pos:  position{line: 1866, col: 12, offset: 72677},
 								name: "ParagraphWithLiteralAttributeLines",
 							},
 						},
@@ -13025,12 +13502,12 @@ var g = &grammar{
 		},
 		{
 			name: "LiteralKind",
-			pos:  position{line: 1784, col: 1, offset: 70249},
+			pos:  position{line: 1870, col: 1, offset: 72831},
 			expr: &actionExpr{
-				pos: position{line: 1784, col: 16, offset: 70264},
+				pos: position{line: 1870, col: 16, offset: 72846},
 				run: (*parser).callonLiteralKind1,
 				expr: &litMatcher{
-					pos:        position{line: 1784, col: 16, offset: 70264},
+					pos:        position{line: 1870, col: 16, offset: 72846},
 					val:        "literal",
 					ignoreCase: false,
 					want:       "\"literal\"",
@@ -13039,17 +13516,17 @@ var g = &grammar{
 		},
 		{
 			name: "ParagraphWithLiteralAttributeLines",
-			pos:  position{line: 1789, col: 1, offset: 70352},
+			pos:  position{line: 1875, col: 1, offset: 72934},
 			expr: &actionExpr{
-				pos: position{line: 1789, col: 39, offset: 70390},
+				pos: position{line: 1875, col: 39, offset: 72972},
 				run: (*parser).callonParagraphWithLiteralAttributeLines1,
 				expr: &labeledExpr{
-					pos:   position{line: 1789, col: 39, offset: 70390},
+					pos:   position{line: 1875, col: 39, offset: 72972},
 					label: "lines",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 1789, col: 45, offset: 70396},
+						pos: position{line: 1875, col: 45, offset: 72978},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1789, col: 46, offset: 70397},
+							pos:  position{line: 1875, col: 46, offset: 72979},
 							name: "ParagraphWithLiteralAttributeLine",
 						},
 					},
@@ -13058,30 +13535,30 @@ var g = &grammar{
 		},
 		{
 			name: "ParagraphWithLiteralAttributeLine",
-			pos:  position{line: 1793, col: 1, offset: 70481},
+			pos:  position{line: 1879, col: 1, offset: 73063},
 			expr: &actionExpr{
-				pos: position{line: 1793, col: 38, offset: 70518},
+				pos: position{line: 1879, col: 38, offset: 73100},
 				run: (*parser).callonParagraphWithLiteralAttributeLine1,
 				expr: &seqExpr{
-					pos: position{line: 1793, col: 38, offset: 70518},
+					pos: position{line: 1879, col: 38, offset: 73100},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1793, col: 38, offset: 70518},
+							pos: position{line: 1879, col: 38, offset: 73100},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1793, col: 39, offset: 70519},
+								pos:  position{line: 1879, col: 39, offset: 73101},
 								name: "BlankLine",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1793, col: 49, offset: 70529},
+							pos:   position{line: 1879, col: 49, offset: 73111},
 							label: "content",
 							expr: &actionExpr{
-								pos: position{line: 1793, col: 58, offset: 70538},
+								pos: position{line: 1879, col: 58, offset: 73120},
 								run: (*parser).callonParagraphWithLiteralAttributeLine6,
 								expr: &oneOrMoreExpr{
-									pos: position{line: 1793, col: 58, offset: 70538},
+									pos: position{line: 1879, col: 58, offset: 73120},
 									expr: &charClassMatcher{
-										pos:        position{line: 1793, col: 58, offset: 70538},
+										pos:        position{line: 1879, col: 58, offset: 73120},
 										val:        "[^\\r\\n]",
 										chars:      []rune{'\r', '\n'},
 										ignoreCase: false,
@@ -13091,7 +13568,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1795, col: 4, offset: 70585},
+							pos:  position{line: 1881, col: 4, offset: 73167},
 							name: "EOL",
 						},
 					},
@@ -13100,29 +13577,29 @@ var g = &grammar{
 		},
 		{
 			name: "IndexTerm",
-			pos:  position{line: 1802, col: 1, offset: 70778},
+			pos:  position{line: 1888, col: 1, offset: 73360},
 			expr: &actionExpr{
-				pos: position{line: 1802, col: 14, offset: 70791},
+				pos: position{line: 1888, col: 14, offset: 73373},
 				run: (*parser).callonIndexTerm1,
 				expr: &seqExpr{
-					pos: position{line: 1802, col: 14, offset: 70791},
+					pos: position{line: 1888, col: 14, offset: 73373},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1802, col: 14, offset: 70791},
+							pos:        position{line: 1888, col: 14, offset: 73373},
 							val:        "((",
 							ignoreCase: false,
 							want:       "\"((\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1802, col: 19, offset: 70796},
+							pos:   position{line: 1888, col: 19, offset: 73378},
 							label: "term",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1802, col: 25, offset: 70802},
+								pos:  position{line: 1888, col: 25, offset: 73384},
 								name: "IndexTermContent",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1802, col: 43, offset: 70820},
+							pos:        position{line: 1888, col: 43, offset: 73402},
 							val:        "))",
 							ignoreCase: false,
 							want:       "\"))\"",
@@ -13133,47 +13610,51 @@ var g = &grammar{
 		},
 		{
 			name: "IndexTermContent",
-			pos:  position{line: 1806, col: 1, offset: 70889},
+			pos:  position{line: 1892, col: 1, offset: 73471},
 			expr: &actionExpr{
-				pos: position{line: 1806, col: 21, offset: 70909},
+				pos: position{line: 1892, col: 21, offset: 73491},
 				run: (*parser).callonIndexTermContent1,
 				expr: &labeledExpr{
-					pos:   position{line: 1806, col: 21, offset: 70909},
+					pos:   position{line: 1892, col: 21, offset: 73491},
 					label: "elements",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 1806, col: 30, offset: 70918},
+						pos: position{line: 1892, col: 30, offset: 73500},
 						expr: &choiceExpr{
-							pos: position{line: 1806, col: 31, offset: 70919},
+							pos: position{line: 1892, col: 31, offset: 73501},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 1806, col: 31, offset: 70919},
+									pos:  position{line: 1892, col: 31, offset: 73501},
 									name: "Word",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1806, col: 38, offset: 70926},
+									pos:  position{line: 1892, col: 38, offset: 73508},
 									name: "QuotedText",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1806, col: 51, offset: 70939},
+									pos:  position{line: 1892, col: 51, offset: 73521},
+									name: "QuotedString",
+								},
+								&ruleRefExpr{
+									pos:  position{line: 1892, col: 66, offset: 73536},
 									name: "Space",
 								},
 								&actionExpr{
-									pos: position{line: 1806, col: 59, offset: 70947},
-									run: (*parser).callonIndexTermContent8,
+									pos: position{line: 1892, col: 74, offset: 73544},
+									run: (*parser).callonIndexTermContent9,
 									expr: &seqExpr{
-										pos: position{line: 1806, col: 60, offset: 70948},
+										pos: position{line: 1892, col: 75, offset: 73545},
 										exprs: []interface{}{
 											&notExpr{
-												pos: position{line: 1806, col: 60, offset: 70948},
+												pos: position{line: 1892, col: 75, offset: 73545},
 												expr: &litMatcher{
-													pos:        position{line: 1806, col: 61, offset: 70949},
+													pos:        position{line: 1892, col: 76, offset: 73546},
 													val:        "))",
 													ignoreCase: false,
 													want:       "\"))\"",
 												},
 											},
 											&anyMatcher{
-												line: 1806, col: 66, offset: 70954,
+												line: 1892, col: 81, offset: 73551,
 											},
 										},
 									},
@@ -13186,63 +13667,63 @@ var g = &grammar{
 		},
 		{
 			name: "ConcealedIndexTerm",
-			pos:  position{line: 1812, col: 1, offset: 71066},
+			pos:  position{line: 1898, col: 1, offset: 73663},
 			expr: &actionExpr{
-				pos: position{line: 1812, col: 23, offset: 71088},
+				pos: position{line: 1898, col: 23, offset: 73685},
 				run: (*parser).callonConcealedIndexTerm1,
 				expr: &seqExpr{
-					pos: position{line: 1812, col: 23, offset: 71088},
+					pos: position{line: 1898, col: 23, offset: 73685},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1812, col: 23, offset: 71088},
+							pos:        position{line: 1898, col: 23, offset: 73685},
 							val:        "(((",
 							ignoreCase: false,
 							want:       "\"(((\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1812, col: 29, offset: 71094},
+							pos:   position{line: 1898, col: 29, offset: 73691},
 							label: "term1",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1812, col: 36, offset: 71101},
+								pos:  position{line: 1898, col: 36, offset: 73698},
 								name: "ConcealedIndexTermContent",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1813, col: 5, offset: 71134},
+							pos:   position{line: 1899, col: 5, offset: 73731},
 							label: "term2",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1813, col: 11, offset: 71140},
+								pos: position{line: 1899, col: 11, offset: 73737},
 								expr: &actionExpr{
-									pos: position{line: 1813, col: 12, offset: 71141},
+									pos: position{line: 1899, col: 12, offset: 73738},
 									run: (*parser).callonConcealedIndexTerm8,
 									expr: &seqExpr{
-										pos: position{line: 1813, col: 12, offset: 71141},
+										pos: position{line: 1899, col: 12, offset: 73738},
 										exprs: []interface{}{
 											&zeroOrMoreExpr{
-												pos: position{line: 1813, col: 12, offset: 71141},
+												pos: position{line: 1899, col: 12, offset: 73738},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1813, col: 12, offset: 71141},
+													pos:  position{line: 1899, col: 12, offset: 73738},
 													name: "Space",
 												},
 											},
 											&litMatcher{
-												pos:        position{line: 1813, col: 19, offset: 71148},
+												pos:        position{line: 1899, col: 19, offset: 73745},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&zeroOrMoreExpr{
-												pos: position{line: 1813, col: 23, offset: 71152},
+												pos: position{line: 1899, col: 23, offset: 73749},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1813, col: 23, offset: 71152},
+													pos:  position{line: 1899, col: 23, offset: 73749},
 													name: "Space",
 												},
 											},
 											&labeledExpr{
-												pos:   position{line: 1813, col: 30, offset: 71159},
+												pos:   position{line: 1899, col: 30, offset: 73756},
 												label: "content",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1813, col: 39, offset: 71168},
+													pos:  position{line: 1899, col: 39, offset: 73765},
 													name: "ConcealedIndexTermContent",
 												},
 											},
@@ -13252,41 +13733,41 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1814, col: 5, offset: 71227},
+							pos:   position{line: 1900, col: 5, offset: 73824},
 							label: "term3",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1814, col: 11, offset: 71233},
+								pos: position{line: 1900, col: 11, offset: 73830},
 								expr: &actionExpr{
-									pos: position{line: 1814, col: 12, offset: 71234},
+									pos: position{line: 1900, col: 12, offset: 73831},
 									run: (*parser).callonConcealedIndexTerm19,
 									expr: &seqExpr{
-										pos: position{line: 1814, col: 12, offset: 71234},
+										pos: position{line: 1900, col: 12, offset: 73831},
 										exprs: []interface{}{
 											&zeroOrMoreExpr{
-												pos: position{line: 1814, col: 12, offset: 71234},
+												pos: position{line: 1900, col: 12, offset: 73831},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1814, col: 12, offset: 71234},
+													pos:  position{line: 1900, col: 12, offset: 73831},
 													name: "Space",
 												},
 											},
 											&litMatcher{
-												pos:        position{line: 1814, col: 19, offset: 71241},
+												pos:        position{line: 1900, col: 19, offset: 73838},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&zeroOrMoreExpr{
-												pos: position{line: 1814, col: 23, offset: 71245},
+												pos: position{line: 1900, col: 23, offset: 73842},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1814, col: 23, offset: 71245},
+													pos:  position{line: 1900, col: 23, offset: 73842},
 													name: "Space",
 												},
 											},
 											&labeledExpr{
-												pos:   position{line: 1814, col: 30, offset: 71252},
+												pos:   position{line: 1900, col: 30, offset: 73849},
 												label: "content",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1814, col: 39, offset: 71261},
+													pos:  position{line: 1900, col: 39, offset: 73858},
 													name: "ConcealedIndexTermContent",
 												},
 											},
@@ -13296,7 +13777,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1815, col: 5, offset: 71320},
+							pos:        position{line: 1901, col: 5, offset: 73917},
 							val:        ")))",
 							ignoreCase: false,
 							want:       "\")))\"",
@@ -13307,21 +13788,21 @@ var g = &grammar{
 		},
 		{
 			name: "ConcealedIndexTermContent",
-			pos:  position{line: 1819, col: 1, offset: 71403},
+			pos:  position{line: 1905, col: 1, offset: 74000},
 			expr: &actionExpr{
-				pos: position{line: 1819, col: 30, offset: 71432},
+				pos: position{line: 1905, col: 30, offset: 74029},
 				run: (*parser).callonConcealedIndexTermContent1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1819, col: 30, offset: 71432},
+					pos: position{line: 1905, col: 30, offset: 74029},
 					expr: &choiceExpr{
-						pos: position{line: 1819, col: 31, offset: 71433},
+						pos: position{line: 1905, col: 31, offset: 74030},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 1819, col: 31, offset: 71433},
+								pos:  position{line: 1905, col: 31, offset: 74030},
 								name: "Alphanum",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1819, col: 42, offset: 71444},
+								pos:  position{line: 1905, col: 42, offset: 74041},
 								name: "Space",
 							},
 						},
@@ -13331,29 +13812,29 @@ var g = &grammar{
 		},
 		{
 			name: "BlankLine",
-			pos:  position{line: 1826, col: 1, offset: 71600},
+			pos:  position{line: 1912, col: 1, offset: 74197},
 			expr: &actionExpr{
-				pos: position{line: 1826, col: 14, offset: 71613},
+				pos: position{line: 1912, col: 14, offset: 74210},
 				run: (*parser).callonBlankLine1,
 				expr: &seqExpr{
-					pos: position{line: 1826, col: 14, offset: 71613},
+					pos: position{line: 1912, col: 14, offset: 74210},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1826, col: 14, offset: 71613},
+							pos: position{line: 1912, col: 14, offset: 74210},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1826, col: 15, offset: 71614},
+								pos:  position{line: 1912, col: 15, offset: 74211},
 								name: "EOF",
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1826, col: 19, offset: 71618},
+							pos: position{line: 1912, col: 19, offset: 74215},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1826, col: 19, offset: 71618},
+								pos:  position{line: 1912, col: 19, offset: 74215},
 								name: "Space",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1826, col: 26, offset: 71625},
+							pos:  position{line: 1912, col: 26, offset: 74222},
 							name: "EOL",
 						},
 					},
@@ -13362,9 +13843,9 @@ var g = &grammar{
 		},
 		{
 			name: "Alphanum",
-			pos:  position{line: 1833, col: 1, offset: 71779},
+			pos:  position{line: 1919, col: 1, offset: 74376},
 			expr: &charClassMatcher{
-				pos:        position{line: 1833, col: 13, offset: 71791},
+				pos:        position{line: 1919, col: 13, offset: 74388},
 				val:        "[\\pL0-9]",
 				ranges:     []rune{'0', '9'},
 				classes:    []*unicode.RangeTable{rangeTable("L")},
@@ -13374,42 +13855,42 @@ var g = &grammar{
 		},
 		{
 			name: "Parenthesis",
-			pos:  position{line: 1835, col: 1, offset: 71803},
+			pos:  position{line: 1921, col: 1, offset: 74400},
 			expr: &choiceExpr{
-				pos: position{line: 1835, col: 16, offset: 71818},
+				pos: position{line: 1921, col: 16, offset: 74415},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1835, col: 16, offset: 71818},
+						pos:        position{line: 1921, col: 16, offset: 74415},
 						val:        "(",
 						ignoreCase: false,
 						want:       "\"(\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1835, col: 22, offset: 71824},
+						pos:        position{line: 1921, col: 22, offset: 74421},
 						val:        ")",
 						ignoreCase: false,
 						want:       "\")\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1835, col: 28, offset: 71830},
+						pos:        position{line: 1921, col: 28, offset: 74427},
 						val:        "[",
 						ignoreCase: false,
 						want:       "\"[\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1835, col: 34, offset: 71836},
+						pos:        position{line: 1921, col: 34, offset: 74433},
 						val:        "]",
 						ignoreCase: false,
 						want:       "\"]\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1835, col: 40, offset: 71842},
+						pos:        position{line: 1921, col: 40, offset: 74439},
 						val:        "{",
 						ignoreCase: false,
 						want:       "\"{\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1835, col: 46, offset: 71848},
+						pos:        position{line: 1921, col: 46, offset: 74445},
 						val:        "}",
 						ignoreCase: false,
 						want:       "\"}\"",
@@ -13419,14 +13900,14 @@ var g = &grammar{
 		},
 		{
 			name: "Alphanums",
-			pos:  position{line: 1837, col: 1, offset: 71856},
+			pos:  position{line: 1923, col: 1, offset: 74453},
 			expr: &actionExpr{
-				pos: position{line: 1837, col: 14, offset: 71869},
+				pos: position{line: 1923, col: 14, offset: 74466},
 				run: (*parser).callonAlphanums1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1837, col: 14, offset: 71869},
+					pos: position{line: 1923, col: 14, offset: 74466},
 					expr: &charClassMatcher{
-						pos:        position{line: 1837, col: 14, offset: 71869},
+						pos:        position{line: 1923, col: 14, offset: 74466},
 						val:        "[\\pL0-9]",
 						ranges:     []rune{'0', '9'},
 						classes:    []*unicode.RangeTable{rangeTable("L")},
@@ -13438,20 +13919,20 @@ var g = &grammar{
 		},
 		{
 			name: "Word",
-			pos:  position{line: 1841, col: 1, offset: 71919},
+			pos:  position{line: 1927, col: 1, offset: 74516},
 			expr: &choiceExpr{
-				pos: position{line: 1845, col: 5, offset: 72250},
+				pos: position{line: 1931, col: 5, offset: 74847},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1845, col: 5, offset: 72250},
+						pos: position{line: 1931, col: 5, offset: 74847},
 						run: (*parser).callonWord2,
 						expr: &seqExpr{
-							pos: position{line: 1845, col: 5, offset: 72250},
+							pos: position{line: 1931, col: 5, offset: 74847},
 							exprs: []interface{}{
 								&oneOrMoreExpr{
-									pos: position{line: 1845, col: 5, offset: 72250},
+									pos: position{line: 1931, col: 5, offset: 74847},
 									expr: &charClassMatcher{
-										pos:        position{line: 1845, col: 5, offset: 72250},
+										pos:        position{line: 1931, col: 5, offset: 74847},
 										val:        "[\\pL0-9]",
 										ranges:     []rune{'0', '9'},
 										classes:    []*unicode.RangeTable{rangeTable("L")},
@@ -13460,19 +13941,19 @@ var g = &grammar{
 									},
 								},
 								&andExpr{
-									pos: position{line: 1845, col: 15, offset: 72260},
+									pos: position{line: 1931, col: 15, offset: 74857},
 									expr: &choiceExpr{
-										pos: position{line: 1845, col: 17, offset: 72262},
+										pos: position{line: 1931, col: 17, offset: 74859},
 										alternatives: []interface{}{
 											&charClassMatcher{
-												pos:        position{line: 1845, col: 17, offset: 72262},
+												pos:        position{line: 1931, col: 17, offset: 74859},
 												val:        "[\\r\\n ,\\]]",
 												chars:      []rune{'\r', '\n', ' ', ',', ']'},
 												ignoreCase: false,
 												inverted:   false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1845, col: 30, offset: 72275},
+												pos:  position{line: 1931, col: 30, offset: 74872},
 												name: "EOF",
 											},
 										},
@@ -13482,15 +13963,15 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1847, col: 9, offset: 72347},
+						pos: position{line: 1933, col: 9, offset: 74944},
 						run: (*parser).callonWord10,
 						expr: &seqExpr{
-							pos: position{line: 1847, col: 9, offset: 72347},
+							pos: position{line: 1933, col: 9, offset: 74944},
 							exprs: []interface{}{
 								&oneOrMoreExpr{
-									pos: position{line: 1847, col: 9, offset: 72347},
+									pos: position{line: 1933, col: 9, offset: 74944},
 									expr: &charClassMatcher{
-										pos:        position{line: 1847, col: 9, offset: 72347},
+										pos:        position{line: 1933, col: 9, offset: 74944},
 										val:        "[\\pL0-9]",
 										ranges:     []rune{'0', '9'},
 										classes:    []*unicode.RangeTable{rangeTable("L")},
@@ -13499,21 +13980,21 @@ var g = &grammar{
 									},
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1847, col: 19, offset: 72357},
+									pos: position{line: 1933, col: 19, offset: 74954},
 									expr: &seqExpr{
-										pos: position{line: 1847, col: 20, offset: 72358},
+										pos: position{line: 1933, col: 20, offset: 74955},
 										exprs: []interface{}{
 											&charClassMatcher{
-												pos:        position{line: 1847, col: 20, offset: 72358},
+												pos:        position{line: 1933, col: 20, offset: 74955},
 												val:        "[=*_`]",
 												chars:      []rune{'=', '*', '_', '`'},
 												ignoreCase: false,
 												inverted:   false,
 											},
 											&oneOrMoreExpr{
-												pos: position{line: 1847, col: 27, offset: 72365},
+												pos: position{line: 1933, col: 27, offset: 74962},
 												expr: &charClassMatcher{
-													pos:        position{line: 1847, col: 27, offset: 72365},
+													pos:        position{line: 1933, col: 27, offset: 74962},
 													val:        "[\\pL0-9]",
 													ranges:     []rune{'0', '9'},
 													classes:    []*unicode.RangeTable{rangeTable("L")},
@@ -13532,20 +14013,20 @@ var g = &grammar{
 		},
 		{
 			name: "InlineWord",
-			pos:  position{line: 1851, col: 1, offset: 72445},
+			pos:  position{line: 1937, col: 1, offset: 75042},
 			expr: &choiceExpr{
-				pos: position{line: 1852, col: 5, offset: 72527},
+				pos: position{line: 1938, col: 5, offset: 75124},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1852, col: 5, offset: 72527},
+						pos: position{line: 1938, col: 5, offset: 75124},
 						run: (*parser).callonInlineWord2,
 						expr: &seqExpr{
-							pos: position{line: 1852, col: 5, offset: 72527},
+							pos: position{line: 1938, col: 5, offset: 75124},
 							exprs: []interface{}{
 								&oneOrMoreExpr{
-									pos: position{line: 1852, col: 5, offset: 72527},
+									pos: position{line: 1938, col: 5, offset: 75124},
 									expr: &charClassMatcher{
-										pos:        position{line: 1852, col: 5, offset: 72527},
+										pos:        position{line: 1938, col: 5, offset: 75124},
 										val:        "[\\pL0-9,.?!;]",
 										chars:      []rune{',', '.', '?', '!', ';'},
 										ranges:     []rune{'0', '9'},
@@ -13555,19 +14036,19 @@ var g = &grammar{
 									},
 								},
 								&andExpr{
-									pos: position{line: 1852, col: 20, offset: 72542},
+									pos: position{line: 1938, col: 20, offset: 75139},
 									expr: &choiceExpr{
-										pos: position{line: 1852, col: 22, offset: 72544},
+										pos: position{line: 1938, col: 22, offset: 75141},
 										alternatives: []interface{}{
 											&charClassMatcher{
-												pos:        position{line: 1852, col: 22, offset: 72544},
+												pos:        position{line: 1938, col: 22, offset: 75141},
 												val:        "[\\r\\n ]",
 												chars:      []rune{'\r', '\n', ' '},
 												ignoreCase: false,
 												inverted:   false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1852, col: 32, offset: 72554},
+												pos:  position{line: 1938, col: 32, offset: 75151},
 												name: "EOF",
 											},
 										},
@@ -13577,7 +14058,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1854, col: 9, offset: 72626},
+						pos:  position{line: 1940, col: 9, offset: 75223},
 						name: "Word",
 					},
 				},
@@ -13585,12 +14066,12 @@ var g = &grammar{
 		},
 		{
 			name: "AnyChar",
-			pos:  position{line: 1857, col: 1, offset: 72729},
+			pos:  position{line: 1943, col: 1, offset: 75326},
 			expr: &actionExpr{
-				pos: position{line: 1857, col: 12, offset: 72740},
+				pos: position{line: 1943, col: 12, offset: 75337},
 				run: (*parser).callonAnyChar1,
 				expr: &charClassMatcher{
-					pos:        position{line: 1857, col: 12, offset: 72740},
+					pos:        position{line: 1943, col: 12, offset: 75337},
 					val:        "[^\\r\\n]",
 					chars:      []rune{'\r', '\n'},
 					ignoreCase: false,
@@ -13600,24 +14081,24 @@ var g = &grammar{
 		},
 		{
 			name: "FileLocation",
-			pos:  position{line: 1861, col: 1, offset: 72809},
+			pos:  position{line: 1947, col: 1, offset: 75406},
 			expr: &actionExpr{
-				pos: position{line: 1861, col: 17, offset: 72825},
+				pos: position{line: 1947, col: 17, offset: 75422},
 				run: (*parser).callonFileLocation1,
 				expr: &labeledExpr{
-					pos:   position{line: 1861, col: 17, offset: 72825},
+					pos:   position{line: 1947, col: 17, offset: 75422},
 					label: "path",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 1861, col: 22, offset: 72830},
+						pos: position{line: 1947, col: 22, offset: 75427},
 						expr: &choiceExpr{
-							pos: position{line: 1861, col: 23, offset: 72831},
+							pos: position{line: 1947, col: 23, offset: 75428},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 1861, col: 23, offset: 72831},
+									pos:  position{line: 1947, col: 23, offset: 75428},
 									name: "FILENAME",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1861, col: 34, offset: 72842},
+									pos:  position{line: 1947, col: 34, offset: 75439},
 									name: "AttributeSubstitution",
 								},
 							},
@@ -13628,17 +14109,17 @@ var g = &grammar{
 		},
 		{
 			name: "ResolvedFileLocation",
-			pos:  position{line: 1865, col: 1, offset: 72930},
+			pos:  position{line: 1951, col: 1, offset: 75527},
 			expr: &actionExpr{
-				pos: position{line: 1865, col: 25, offset: 72954},
+				pos: position{line: 1951, col: 25, offset: 75551},
 				run: (*parser).callonResolvedFileLocation1,
 				expr: &labeledExpr{
-					pos:   position{line: 1865, col: 25, offset: 72954},
+					pos:   position{line: 1951, col: 25, offset: 75551},
 					label: "path",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 1865, col: 30, offset: 72959},
+						pos: position{line: 1951, col: 30, offset: 75556},
 						expr: &charClassMatcher{
-							pos:        position{line: 1865, col: 31, offset: 72960},
+							pos:        position{line: 1951, col: 31, offset: 75557},
 							val:        "[^\\r\\n []",
 							chars:      []rune{'\r', '\n', ' ', '['},
 							ignoreCase: false,
@@ -13650,38 +14131,38 @@ var g = &grammar{
 		},
 		{
 			name: "Location",
-			pos:  position{line: 1869, col: 1, offset: 73036},
+			pos:  position{line: 1955, col: 1, offset: 75633},
 			expr: &actionExpr{
-				pos: position{line: 1869, col: 13, offset: 73048},
+				pos: position{line: 1955, col: 13, offset: 75645},
 				run: (*parser).callonLocation1,
 				expr: &seqExpr{
-					pos: position{line: 1869, col: 13, offset: 73048},
+					pos: position{line: 1955, col: 13, offset: 75645},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1869, col: 13, offset: 73048},
+							pos:   position{line: 1955, col: 13, offset: 75645},
 							label: "scheme",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1869, col: 20, offset: 73055},
+								pos: position{line: 1955, col: 20, offset: 75652},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1869, col: 21, offset: 73056},
+									pos:  position{line: 1955, col: 21, offset: 75653},
 									name: "URL_SCHEME",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1869, col: 34, offset: 73069},
+							pos:   position{line: 1955, col: 34, offset: 75666},
 							label: "path",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1869, col: 39, offset: 73074},
+								pos: position{line: 1955, col: 39, offset: 75671},
 								expr: &choiceExpr{
-									pos: position{line: 1869, col: 40, offset: 73075},
+									pos: position{line: 1955, col: 40, offset: 75672},
 									alternatives: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 1869, col: 40, offset: 73075},
+											pos:  position{line: 1955, col: 40, offset: 75672},
 											name: "FILENAME",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1869, col: 51, offset: 73086},
+											pos:  position{line: 1955, col: 51, offset: 75683},
 											name: "AttributeSubstitution",
 										},
 									},
@@ -13694,35 +14175,35 @@ var g = &grammar{
 		},
 		{
 			name: "LocationWithScheme",
-			pos:  position{line: 1873, col: 1, offset: 73178},
+			pos:  position{line: 1959, col: 1, offset: 75775},
 			expr: &actionExpr{
-				pos: position{line: 1873, col: 23, offset: 73200},
+				pos: position{line: 1959, col: 23, offset: 75797},
 				run: (*parser).callonLocationWithScheme1,
 				expr: &seqExpr{
-					pos: position{line: 1873, col: 23, offset: 73200},
+					pos: position{line: 1959, col: 23, offset: 75797},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1873, col: 23, offset: 73200},
+							pos:   position{line: 1959, col: 23, offset: 75797},
 							label: "scheme",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1873, col: 31, offset: 73208},
+								pos:  position{line: 1959, col: 31, offset: 75805},
 								name: "URL_SCHEME",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1873, col: 43, offset: 73220},
+							pos:   position{line: 1959, col: 43, offset: 75817},
 							label: "path",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1873, col: 48, offset: 73225},
+								pos: position{line: 1959, col: 48, offset: 75822},
 								expr: &choiceExpr{
-									pos: position{line: 1873, col: 49, offset: 73226},
+									pos: position{line: 1959, col: 49, offset: 75823},
 									alternatives: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 1873, col: 49, offset: 73226},
+											pos:  position{line: 1959, col: 49, offset: 75823},
 											name: "FILENAME",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1873, col: 60, offset: 73237},
+											pos:  position{line: 1959, col: 60, offset: 75834},
 											name: "AttributeSubstitution",
 										},
 									},
@@ -13735,11 +14216,11 @@ var g = &grammar{
 		},
 		{
 			name: "FILENAME",
-			pos:  position{line: 1877, col: 1, offset: 73329},
+			pos:  position{line: 1963, col: 1, offset: 75926},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 1877, col: 13, offset: 73341},
+				pos: position{line: 1963, col: 13, offset: 75938},
 				expr: &charClassMatcher{
-					pos:        position{line: 1877, col: 14, offset: 73342},
+					pos:        position{line: 1963, col: 14, offset: 75939},
 					val:        "[^\\r\\n{}[\\] ]",
 					chars:      []rune{'\r', '\n', '{', '}', '[', ']', ' '},
 					ignoreCase: false,
@@ -13749,26 +14230,26 @@ var g = &grammar{
 		},
 		{
 			name: "ResolvedLocation",
-			pos:  position{line: 1879, col: 1, offset: 73478},
+			pos:  position{line: 1965, col: 1, offset: 76075},
 			expr: &actionExpr{
-				pos: position{line: 1879, col: 21, offset: 73498},
+				pos: position{line: 1965, col: 21, offset: 76095},
 				run: (*parser).callonResolvedLocation1,
 				expr: &seqExpr{
-					pos: position{line: 1879, col: 21, offset: 73498},
+					pos: position{line: 1965, col: 21, offset: 76095},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1879, col: 21, offset: 73498},
+							pos:   position{line: 1965, col: 21, offset: 76095},
 							label: "scheme",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1879, col: 29, offset: 73506},
+								pos:  position{line: 1965, col: 29, offset: 76103},
 								name: "URL_SCHEME",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1879, col: 41, offset: 73518},
+							pos:   position{line: 1965, col: 41, offset: 76115},
 							label: "path",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1879, col: 47, offset: 73524},
+								pos:  position{line: 1965, col: 47, offset: 76121},
 								name: "RESOLVED_FILENAME",
 							},
 						},
@@ -13778,11 +14259,11 @@ var g = &grammar{
 		},
 		{
 			name: "RESOLVED_FILENAME",
-			pos:  position{line: 1884, col: 1, offset: 73777},
+			pos:  position{line: 1970, col: 1, offset: 76374},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 1884, col: 22, offset: 73798},
+				pos: position{line: 1970, col: 22, offset: 76395},
 				expr: &charClassMatcher{
-					pos:        position{line: 1884, col: 23, offset: 73799},
+					pos:        position{line: 1970, col: 23, offset: 76396},
 					val:        "[^\\r\\n[\\] ]",
 					chars:      []rune{'\r', '\n', '[', ']', ' '},
 					ignoreCase: false,
@@ -13792,14 +14273,14 @@ var g = &grammar{
 		},
 		{
 			name: "URL",
-			pos:  position{line: 1886, col: 1, offset: 73933},
+			pos:  position{line: 1972, col: 1, offset: 76530},
 			expr: &actionExpr{
-				pos: position{line: 1886, col: 9, offset: 73941},
+				pos: position{line: 1972, col: 9, offset: 76538},
 				run: (*parser).callonURL1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1886, col: 9, offset: 73941},
+					pos: position{line: 1972, col: 9, offset: 76538},
 					expr: &charClassMatcher{
-						pos:        position{line: 1886, col: 9, offset: 73941},
+						pos:        position{line: 1972, col: 9, offset: 76538},
 						val:        "[^\\r\\n[\\]]",
 						chars:      []rune{'\r', '\n', '[', ']'},
 						ignoreCase: false,
@@ -13810,36 +14291,36 @@ var g = &grammar{
 		},
 		{
 			name: "URL_SCHEME",
-			pos:  position{line: 1890, col: 1, offset: 73993},
+			pos:  position{line: 1976, col: 1, offset: 76590},
 			expr: &choiceExpr{
-				pos: position{line: 1890, col: 15, offset: 74007},
+				pos: position{line: 1976, col: 15, offset: 76604},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1890, col: 15, offset: 74007},
+						pos:        position{line: 1976, col: 15, offset: 76604},
 						val:        "http://",
 						ignoreCase: false,
 						want:       "\"http://\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1890, col: 27, offset: 74019},
+						pos:        position{line: 1976, col: 27, offset: 76616},
 						val:        "https://",
 						ignoreCase: false,
 						want:       "\"https://\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1890, col: 40, offset: 74032},
+						pos:        position{line: 1976, col: 40, offset: 76629},
 						val:        "ftp://",
 						ignoreCase: false,
 						want:       "\"ftp://\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1890, col: 51, offset: 74043},
+						pos:        position{line: 1976, col: 51, offset: 76640},
 						val:        "irc://",
 						ignoreCase: false,
 						want:       "\"irc://\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1890, col: 62, offset: 74054},
+						pos:        position{line: 1976, col: 62, offset: 76651},
 						val:        "mailto:",
 						ignoreCase: false,
 						want:       "\"mailto:\"",
@@ -13849,14 +14330,14 @@ var g = &grammar{
 		},
 		{
 			name: "ID",
-			pos:  position{line: 1892, col: 1, offset: 74067},
+			pos:  position{line: 1978, col: 1, offset: 76664},
 			expr: &actionExpr{
-				pos: position{line: 1892, col: 7, offset: 74073},
+				pos: position{line: 1978, col: 7, offset: 76670},
 				run: (*parser).callonID1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1892, col: 7, offset: 74073},
+					pos: position{line: 1978, col: 7, offset: 76670},
 					expr: &charClassMatcher{
-						pos:        position{line: 1892, col: 7, offset: 74073},
+						pos:        position{line: 1978, col: 7, offset: 76670},
 						val:        "[^[\\]<>,]",
 						chars:      []rune{'[', ']', '<', '>', ','},
 						ignoreCase: false,
@@ -13867,12 +14348,12 @@ var g = &grammar{
 		},
 		{
 			name: "DIGIT",
-			pos:  position{line: 1896, col: 1, offset: 74202},
+			pos:  position{line: 1982, col: 1, offset: 76799},
 			expr: &actionExpr{
-				pos: position{line: 1896, col: 10, offset: 74211},
+				pos: position{line: 1982, col: 10, offset: 76808},
 				run: (*parser).callonDIGIT1,
 				expr: &charClassMatcher{
-					pos:        position{line: 1896, col: 10, offset: 74211},
+					pos:        position{line: 1982, col: 10, offset: 76808},
 					val:        "[0-9]",
 					ranges:     []rune{'0', '9'},
 					ignoreCase: false,
@@ -13882,26 +14363,26 @@ var g = &grammar{
 		},
 		{
 			name: "NUMBER",
-			pos:  position{line: 1900, col: 1, offset: 74257},
+			pos:  position{line: 1986, col: 1, offset: 76854},
 			expr: &actionExpr{
-				pos: position{line: 1900, col: 11, offset: 74267},
+				pos: position{line: 1986, col: 11, offset: 76864},
 				run: (*parser).callonNUMBER1,
 				expr: &seqExpr{
-					pos: position{line: 1900, col: 11, offset: 74267},
+					pos: position{line: 1986, col: 11, offset: 76864},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 1900, col: 11, offset: 74267},
+							pos: position{line: 1986, col: 11, offset: 76864},
 							expr: &litMatcher{
-								pos:        position{line: 1900, col: 11, offset: 74267},
+								pos:        position{line: 1986, col: 11, offset: 76864},
 								val:        "-",
 								ignoreCase: false,
 								want:       "\"-\"",
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 1900, col: 16, offset: 74272},
+							pos: position{line: 1986, col: 16, offset: 76869},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1900, col: 16, offset: 74272},
+								pos:  position{line: 1986, col: 16, offset: 76869},
 								name: "DIGIT",
 							},
 						},
@@ -13911,21 +14392,21 @@ var g = &grammar{
 		},
 		{
 			name: "Space",
-			pos:  position{line: 1904, col: 1, offset: 74328},
+			pos:  position{line: 1990, col: 1, offset: 76925},
 			expr: &choiceExpr{
-				pos: position{line: 1904, col: 10, offset: 74337},
+				pos: position{line: 1990, col: 10, offset: 76934},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1904, col: 10, offset: 74337},
+						pos:        position{line: 1990, col: 10, offset: 76934},
 						val:        " ",
 						ignoreCase: false,
 						want:       "\" \"",
 					},
 					&actionExpr{
-						pos: position{line: 1904, col: 16, offset: 74343},
+						pos: position{line: 1990, col: 16, offset: 76940},
 						run: (*parser).callonSpace3,
 						expr: &litMatcher{
-							pos:        position{line: 1904, col: 16, offset: 74343},
+							pos:        position{line: 1990, col: 16, offset: 76940},
 							val:        "\t",
 							ignoreCase: false,
 							want:       "\"\\t\"",
@@ -13936,24 +14417,24 @@ var g = &grammar{
 		},
 		{
 			name: "Newline",
-			pos:  position{line: 1908, col: 1, offset: 74388},
+			pos:  position{line: 1994, col: 1, offset: 76985},
 			expr: &choiceExpr{
-				pos: position{line: 1908, col: 12, offset: 74399},
+				pos: position{line: 1994, col: 12, offset: 76996},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1908, col: 12, offset: 74399},
+						pos:        position{line: 1994, col: 12, offset: 76996},
 						val:        "\r\n",
 						ignoreCase: false,
 						want:       "\"\\r\\n\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1908, col: 21, offset: 74408},
+						pos:        position{line: 1994, col: 21, offset: 77005},
 						val:        "\r",
 						ignoreCase: false,
 						want:       "\"\\r\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1908, col: 28, offset: 74415},
+						pos:        position{line: 1994, col: 28, offset: 77012},
 						val:        "\n",
 						ignoreCase: false,
 						want:       "\"\\n\"",
@@ -13963,26 +14444,26 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 1910, col: 1, offset: 74423},
+			pos:  position{line: 1996, col: 1, offset: 77020},
 			expr: &notExpr{
-				pos: position{line: 1910, col: 8, offset: 74430},
+				pos: position{line: 1996, col: 8, offset: 77027},
 				expr: &anyMatcher{
-					line: 1910, col: 9, offset: 74431,
+					line: 1996, col: 9, offset: 77028,
 				},
 			},
 		},
 		{
 			name: "EOL",
-			pos:  position{line: 1912, col: 1, offset: 74436},
+			pos:  position{line: 1998, col: 1, offset: 77033},
 			expr: &choiceExpr{
-				pos: position{line: 1912, col: 8, offset: 74443},
+				pos: position{line: 1998, col: 8, offset: 77040},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1912, col: 8, offset: 74443},
+						pos:  position{line: 1998, col: 8, offset: 77040},
 						name: "Newline",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1912, col: 18, offset: 74453},
+						pos:  position{line: 1998, col: 18, offset: 77050},
 						name: "EOF",
 					},
 				},
@@ -14712,6 +15193,105 @@ func (p *parser) callonStandaloneAttributes1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStandaloneAttributes1(stack["attributes"])
+}
+
+func (c *current) onQuotedString1(qs interface{}) (interface{}, error) {
+
+	return qs, nil
+}
+
+func (p *parser) callonQuotedString1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onQuotedString1(stack["qs"])
+}
+
+func (c *current) onSingleQuotedString1(elements interface{}) (interface{}, error) {
+
+	return types.QuotedString{Kind: types.SingleQuote, Elements: elements.([]interface{})}, nil
+}
+
+func (p *parser) callonSingleQuotedString1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onSingleQuotedString1(stack["elements"])
+}
+
+func (c *current) onSingleQuotedStringElements1(elements interface{}) (interface{}, error) {
+
+	return types.NewInlineElements(elements)
+}
+
+func (p *parser) callonSingleQuotedStringElements1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onSingleQuotedStringElements1(stack["elements"])
+}
+
+func (c *current) onSingleQuotedStringElement1(element interface{}) (interface{}, error) {
+
+	return element, nil
+}
+
+func (p *parser) callonSingleQuotedStringElement1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onSingleQuotedStringElement1(stack["element"])
+}
+
+func (c *current) onSingleQuotedStringFallbackCharacter3() (interface{}, error) {
+
+	return types.NewStringElement(string(c.text))
+}
+
+func (p *parser) callonSingleQuotedStringFallbackCharacter3() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onSingleQuotedStringFallbackCharacter3()
+}
+
+func (c *current) onDoubleQuotedString1(elements interface{}) (interface{}, error) {
+
+	return types.QuotedString{Kind: types.DoubleQuote, Elements: elements.([]interface{})}, nil
+}
+
+func (p *parser) callonDoubleQuotedString1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onDoubleQuotedString1(stack["elements"])
+}
+
+func (c *current) onDoubleQuotedStringElements1(elements interface{}) (interface{}, error) {
+
+	return types.NewInlineElements(elements)
+}
+
+func (p *parser) callonDoubleQuotedStringElements1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onDoubleQuotedStringElements1(stack["elements"])
+}
+
+func (c *current) onDoubleQuotedStringElement1(element interface{}) (interface{}, error) {
+
+	return element, nil
+}
+
+func (p *parser) callonDoubleQuotedStringElement1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onDoubleQuotedStringElement1(stack["element"])
+}
+
+func (c *current) onDoubleQuotedStringFallbackCharacter1() (interface{}, error) {
+
+	return types.NewStringElement(string(c.text))
+}
+
+func (p *parser) callonDoubleQuotedStringFallbackCharacter1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onDoubleQuotedStringFallbackCharacter1()
 }
 
 func (c *current) onSection7() (interface{}, error) {
@@ -16733,16 +17313,16 @@ func (p *parser) callonFirstLinkAttributeElement4() (interface{}, error) {
 	return p.cur.onFirstLinkAttributeElement4(stack["elements"])
 }
 
-func (c *current) onFirstLinkAttributeElement18(elements interface{}) (interface{}, error) {
+func (c *current) onFirstLinkAttributeElement19(elements interface{}) (interface{}, error) {
 
 	return types.NewInlineElements(elements.([]interface{}))
 
 }
 
-func (p *parser) callonFirstLinkAttributeElement18() (interface{}, error) {
+func (p *parser) callonFirstLinkAttributeElement19() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onFirstLinkAttributeElement18(stack["elements"])
+	return p.cur.onFirstLinkAttributeElement19(stack["elements"])
 }
 
 func (c *current) onFirstLinkAttributeElement1(element interface{}) (interface{}, error) {
@@ -17493,15 +18073,15 @@ func (p *parser) callonIndexTerm1() (interface{}, error) {
 	return p.cur.onIndexTerm1(stack["term"])
 }
 
-func (c *current) onIndexTermContent8() (interface{}, error) {
+func (c *current) onIndexTermContent9() (interface{}, error) {
 
 	return string(c.text), nil
 }
 
-func (p *parser) callonIndexTermContent8() (interface{}, error) {
+func (p *parser) callonIndexTermContent9() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onIndexTermContent8()
+	return p.cur.onIndexTermContent9()
 }
 
 func (c *current) onIndexTermContent1(elements interface{}) (interface{}, error) {
@@ -17789,6 +18369,63 @@ func Entrypoint(ruleName string) Option {
 	}
 }
 
+// Statistics adds a user provided Stats struct to the parser to allow
+// the user to process the results after the parsing has finished.
+// Also the key for the "no match" counter is set.
+//
+// Example usage:
+//
+//     input := "input"
+//     stats := Stats{}
+//     _, err := Parse("input-file", []byte(input), Statistics(&stats, "no match"))
+//     if err != nil {
+//         log.Panicln(err)
+//     }
+//     b, err := json.MarshalIndent(stats.ChoiceAltCnt, "", "  ")
+//     if err != nil {
+//         log.Panicln(err)
+//     }
+//     fmt.Println(string(b))
+//
+func Statistics(stats *Stats, choiceNoMatch string) Option {
+	return func(p *parser) Option {
+		oldStats := p.Stats
+		p.Stats = stats
+		oldChoiceNoMatch := p.choiceNoMatch
+		p.choiceNoMatch = choiceNoMatch
+		if p.Stats.ChoiceAltCnt == nil {
+			p.Stats.ChoiceAltCnt = make(map[string]map[string]int)
+		}
+		return Statistics(oldStats, oldChoiceNoMatch)
+	}
+}
+
+// Debug creates an Option to set the debug flag to b. When set to true,
+// debugging information is printed to stdout while parsing.
+//
+// The default is false.
+func Debug(b bool) Option {
+	return func(p *parser) Option {
+		old := p.debug
+		p.debug = b
+		return Debug(old)
+	}
+}
+
+// Memoize creates an Option to set the memoize flag to b. When set to true,
+// the parser will cache all results so each expression is evaluated only
+// once. This guarantees linear parsing time even for pathological cases,
+// at the expense of more memory and slower times for typical cases.
+//
+// The default is false.
+func Memoize(b bool) Option {
+	return func(p *parser) Option {
+		old := p.memoize
+		p.memoize = b
+		return Memoize(old)
+	}
+}
+
 // AllowInvalidUTF8 creates an Option to allow invalid UTF-8 bytes.
 // Every invalid UTF-8 byte is treated as a utf8.RuneError (U+FFFD)
 // by character class matchers and is matched by the any matcher.
@@ -17824,6 +18461,16 @@ func GlobalStore(key string, value interface{}) Option {
 		old := p.cur.globalStore[key]
 		p.cur.globalStore[key] = value
 		return GlobalStore(key, old)
+	}
+}
+
+// InitState creates an Option to set a key to a certain value in
+// the global "state" store.
+func InitState(key string, value interface{}) Option {
+	return func(p *parser) Option {
+		old := p.cur.state[key]
+		p.cur.state[key] = value
+		return InitState(key, old)
 	}
 }
 
@@ -17878,6 +18525,11 @@ type savepoint struct {
 type current struct {
 	pos  position // start position of the match
 	text []byte   // raw text of the match
+
+	// state is a store for arbitrary key,value pairs that the user wants to be
+	// tied to the backtracking of the parser.
+	// This is always rolled back if a parsing rule fails.
+	state storeDict
 
 	// globalStore is a general store for the user to store arbitrary key-value
 	// pairs that they need to manage and that they do not want tied to the
@@ -17951,6 +18603,11 @@ type oneOrMoreExpr expr
 type ruleRefExpr struct {
 	pos  position
 	name string
+}
+
+type stateCodeExpr struct {
+	pos position
+	run func(*parser) error
 }
 
 type andCodeExpr struct {
@@ -18056,6 +18713,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		pt:       savepoint{position: position{line: 1}},
 		recover:  true,
 		cur: current{
+			state:       make(storeDict),
 			globalStore: make(storeDict),
 		},
 		maxFailPos:      position{col: 1, line: 1},
@@ -18120,6 +18778,12 @@ type parser struct {
 
 	depth   int
 	recover bool
+	debug   bool
+
+	memoize bool
+	// memoization table for the packrat algorithm:
+	// map[offset in source] map[expression or rule] {value, match}
+	memo map[int]map[interface{}]resultTuple
 
 	// rules table, maps the rule identifier to the rule node
 	rules map[string]*rule
@@ -18204,6 +18868,26 @@ func (p *parser) popRecovery() {
 	p.recoveryStack = p.recoveryStack[:len(p.recoveryStack)-1]
 }
 
+func (p *parser) print(prefix, s string) string {
+	if !p.debug {
+		return s
+	}
+
+	fmt.Printf("%s %d:%d:%d: %s [%#U]\n",
+		prefix, p.pt.line, p.pt.col, p.pt.offset, s, p.pt.rn)
+	return s
+}
+
+func (p *parser) in(s string) string {
+	p.depth++
+	return p.print(strings.Repeat(" ", p.depth)+">", s)
+}
+
+func (p *parser) out(s string) string {
+	p.depth--
+	return p.print(strings.Repeat(" ", p.depth)+"<", s)
+}
+
 func (p *parser) addErr(err error) {
 	p.addErrAt(err, p.pt.position, []string{})
 }
@@ -18272,15 +18956,91 @@ func (p *parser) read() {
 
 // restore parser position to the savepoint pt.
 func (p *parser) restore(pt savepoint) {
+	if p.debug {
+		defer p.out(p.in("restore"))
+	}
 	if pt.offset == p.pt.offset {
 		return
 	}
 	p.pt = pt
 }
 
+// Cloner is implemented by any value that has a Clone method, which returns a
+// copy of the value. This is mainly used for types which are not passed by
+// value (e.g map, slice, chan) or structs that contain such types.
+//
+// This is used in conjunction with the global state feature to create proper
+// copies of the state to allow the parser to properly restore the state in
+// the case of backtracking.
+type Cloner interface {
+	Clone() interface{}
+}
+
+var statePool = &sync.Pool{
+	New: func() interface{} { return make(storeDict) },
+}
+
+func (sd storeDict) Discard() {
+	for k := range sd {
+		delete(sd, k)
+	}
+	statePool.Put(sd)
+}
+
+// clone and return parser current state.
+func (p *parser) cloneState() storeDict {
+	if p.debug {
+		defer p.out(p.in("cloneState"))
+	}
+
+	state := statePool.Get().(storeDict)
+	for k, v := range p.cur.state {
+		if c, ok := v.(Cloner); ok {
+			state[k] = c.Clone()
+		} else {
+			state[k] = v
+		}
+	}
+	return state
+}
+
+// restore parser current state to the state storeDict.
+// every restoreState should applied only one time for every cloned state
+func (p *parser) restoreState(state storeDict) {
+	if p.debug {
+		defer p.out(p.in("restoreState"))
+	}
+	p.cur.state.Discard()
+	p.cur.state = state
+}
+
 // get the slice of bytes from the savepoint start to the current position.
 func (p *parser) sliceFrom(start savepoint) []byte {
 	return p.data[start.position.offset:p.pt.position.offset]
+}
+
+func (p *parser) getMemoized(node interface{}) (resultTuple, bool) {
+	if len(p.memo) == 0 {
+		return resultTuple{}, false
+	}
+	m := p.memo[p.pt.offset]
+	if len(m) == 0 {
+		return resultTuple{}, false
+	}
+	res, ok := m[node]
+	return res, ok
+}
+
+func (p *parser) setMemoized(pt savepoint, node interface{}, tuple resultTuple) {
+	if p.memo == nil {
+		p.memo = make(map[int]map[interface{}]resultTuple)
+	}
+	m := p.memo[pt.offset]
+	if m == nil {
+		m = make(map[interface{}]resultTuple)
+		p.memo[pt.offset] = m
+	}
+	m[node] = tuple
 }
 
 func (p *parser) buildRulesTable(g *grammar) {
@@ -18304,6 +19064,9 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 		// and return the panic as an error.
 		defer func() {
 			if e := recover(); e != nil {
+				if p.debug {
+					defer p.out(p.in("panic handler"))
+				}
 				val = nil
 				switch e := e.(type) {
 				case error:
@@ -18365,15 +19128,45 @@ func listJoin(list []string, sep string, lastSep string) string {
 }
 
 func (p *parser) parseRule(rule *rule) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseRule " + rule.name))
+	}
+
+	if p.memoize {
+		res, ok := p.getMemoized(rule)
+		if ok {
+			p.restore(res.end)
+			return res.v, res.b
+		}
+	}
+
+	start := p.pt
 	p.rstack = append(p.rstack, rule)
 	p.pushV()
 	val, ok := p.parseExpr(rule.expr)
 	p.popV()
 	p.rstack = p.rstack[:len(p.rstack)-1]
+	if ok && p.debug {
+		p.print(strings.Repeat(" ", p.depth)+"MATCH", string(p.sliceFrom(start)))
+	}
+
+	if p.memoize {
+		p.setMemoized(start, rule, resultTuple{val, ok, p.pt})
+	}
 	return val, ok
 }
 
 func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
+	var pt savepoint
+
+	if p.memoize {
+		res, ok := p.getMemoized(expr)
+		if ok {
+			p.restore(res.end)
+			return res.v, res.b
+		}
+		pt = p.pt
+	}
 
 	p.ExprCnt++
 	if p.ExprCnt > p.maxExprCnt {
@@ -18411,6 +19204,8 @@ func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
 		val, ok = p.parseRuleRefExpr(expr)
 	case *seqExpr:
 		val, ok = p.parseSeqExpr(expr)
+	case *stateCodeExpr:
+		val, ok = p.parseStateCodeExpr(expr)
 	case *throwExpr:
 		val, ok = p.parseThrowExpr(expr)
 	case *zeroOrMoreExpr:
@@ -18420,46 +19215,74 @@ func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
 	default:
 		panic(fmt.Sprintf("unknown expression type %T", expr))
 	}
+	if p.memoize {
+		p.setMemoized(pt, expr, resultTuple{val, ok, p.pt})
+	}
 	return val, ok
 }
 
 func (p *parser) parseActionExpr(act *actionExpr) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseActionExpr"))
+	}
+
 	start := p.pt
 	val, ok := p.parseExpr(act.expr)
 	if ok {
 		p.cur.pos = start.position
 		p.cur.text = p.sliceFrom(start)
+		state := p.cloneState()
 		actVal, err := act.run(p)
 		if err != nil {
 			p.addErrAt(err, start.position, []string{})
 		}
+		p.restoreState(state)
 
 		val = actVal
+	}
+	if ok && p.debug {
+		p.print(strings.Repeat(" ", p.depth)+"MATCH", string(p.sliceFrom(start)))
 	}
 	return val, ok
 }
 
 func (p *parser) parseAndCodeExpr(and *andCodeExpr) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseAndCodeExpr"))
+	}
+
+	state := p.cloneState()
 
 	ok, err := and.run(p)
 	if err != nil {
 		p.addErr(err)
 	}
+	p.restoreState(state)
 
 	return nil, ok
 }
 
 func (p *parser) parseAndExpr(and *andExpr) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseAndExpr"))
+	}
+
 	pt := p.pt
+	state := p.cloneState()
 	p.pushV()
 	_, ok := p.parseExpr(and.expr)
 	p.popV()
+	p.restoreState(state)
 	p.restore(pt)
 
 	return nil, ok
 }
 
 func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseAnyMatcher"))
+	}
+
 	if p.pt.rn == utf8.RuneError && p.pt.w == 0 {
 		// EOF - see utf8.DecodeRune
 		p.failAt(false, p.pt.position, ".")
@@ -18472,6 +19295,10 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 }
 
 func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseCharClassMatcher"))
+	}
+
 	cur := p.pt.rn
 	start := p.pt
 
@@ -18533,22 +19360,50 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	return nil, false
 }
 
+func (p *parser) incChoiceAltCnt(ch *choiceExpr, altI int) {
+	choiceIdent := fmt.Sprintf("%s %d:%d", p.rstack[len(p.rstack)-1].name, ch.pos.line, ch.pos.col)
+	m := p.ChoiceAltCnt[choiceIdent]
+	if m == nil {
+		m = make(map[string]int)
+		p.ChoiceAltCnt[choiceIdent] = m
+	}
+	// We increment altI by 1, so the keys do not start at 0
+	alt := strconv.Itoa(altI + 1)
+	if altI == choiceNoMatch {
+		alt = p.choiceNoMatch
+	}
+	m[alt]++
+}
+
 func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseChoiceExpr"))
+	}
+
 	for altI, alt := range ch.alternatives {
 		// dummy assignment to prevent compile error if optimized
 		_ = altI
+
+		state := p.cloneState()
 
 		p.pushV()
 		val, ok := p.parseExpr(alt)
 		p.popV()
 		if ok {
+			p.incChoiceAltCnt(ch, altI)
 			return val, ok
 		}
+		p.restoreState(state)
 	}
+	p.incChoiceAltCnt(ch, choiceNoMatch)
 	return nil, false
 }
 
 func (p *parser) parseLabeledExpr(lab *labeledExpr) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseLabeledExpr"))
+	}
+
 	p.pushV()
 	val, ok := p.parseExpr(lab.expr)
 	p.popV()
@@ -18560,6 +19415,10 @@ func (p *parser) parseLabeledExpr(lab *labeledExpr) (interface{}, bool) {
 }
 
 func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseLitMatcher"))
+	}
+
 	start := p.pt
 	for _, want := range lit.val {
 		cur := p.pt.rn
@@ -18578,27 +19437,44 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 }
 
 func (p *parser) parseNotCodeExpr(not *notCodeExpr) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseNotCodeExpr"))
+	}
+
+	state := p.cloneState()
+
 	ok, err := not.run(p)
 	if err != nil {
 		p.addErr(err)
 	}
+	p.restoreState(state)
 
 	return nil, !ok
 }
 
 func (p *parser) parseNotExpr(not *notExpr) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseNotExpr"))
+	}
+
 	pt := p.pt
+	state := p.cloneState()
 	p.pushV()
 	p.maxFailInvertExpected = !p.maxFailInvertExpected
 	_, ok := p.parseExpr(not.expr)
 	p.maxFailInvertExpected = !p.maxFailInvertExpected
 	p.popV()
+	p.restoreState(state)
 	p.restore(pt)
 
 	return nil, !ok
 }
 
 func (p *parser) parseOneOrMoreExpr(expr *oneOrMoreExpr) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseOneOrMoreExpr"))
+	}
+
 	var vals []interface{}
 
 	for {
@@ -18617,6 +19493,9 @@ func (p *parser) parseOneOrMoreExpr(expr *oneOrMoreExpr) (interface{}, bool) {
 }
 
 func (p *parser) parseRecoveryExpr(recover *recoveryExpr) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseRecoveryExpr (" + strings.Join(recover.failureLabel, ",") + ")"))
+	}
 
 	p.pushRecovery(recover.failureLabel, recover.recoverExpr)
 	val, ok := p.parseExpr(recover.expr)
@@ -18626,6 +19505,10 @@ func (p *parser) parseRecoveryExpr(recover *recoveryExpr) (interface{}, bool) {
 }
 
 func (p *parser) parseRuleRefExpr(ref *ruleRefExpr) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseRuleRefExpr " + ref.name))
+	}
+
 	if ref.name == "" {
 		panic(fmt.Sprintf("%s: invalid rule: missing name", ref.pos))
 	}
@@ -18639,12 +19522,18 @@ func (p *parser) parseRuleRefExpr(ref *ruleRefExpr) (interface{}, bool) {
 }
 
 func (p *parser) parseSeqExpr(seq *seqExpr) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseSeqExpr"))
+	}
+
 	vals := make([]interface{}, 0, len(seq.exprs))
 
 	pt := p.pt
+	state := p.cloneState()
 	for _, expr := range seq.exprs {
 		val, ok := p.parseExpr(expr)
 		if !ok {
+			p.restoreState(state)
 			p.restore(pt)
 			return nil, false
 		}
@@ -18653,7 +19542,22 @@ func (p *parser) parseSeqExpr(seq *seqExpr) (interface{}, bool) {
 	return vals, true
 }
 
+func (p *parser) parseStateCodeExpr(state *stateCodeExpr) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseStateCodeExpr"))
+	}
+
+	err := state.run(p)
+	if err != nil {
+		p.addErr(err)
+	}
+	return nil, true
+}
+
 func (p *parser) parseThrowExpr(expr *throwExpr) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseThrowExpr"))
+	}
 
 	for i := len(p.recoveryStack) - 1; i >= 0; i-- {
 		if recoverExpr, ok := p.recoveryStack[i][expr.label]; ok {
@@ -18667,6 +19571,10 @@ func (p *parser) parseThrowExpr(expr *throwExpr) (interface{}, bool) {
 }
 
 func (p *parser) parseZeroOrMoreExpr(expr *zeroOrMoreExpr) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseZeroOrMoreExpr"))
+	}
+
 	var vals []interface{}
 
 	for {
@@ -18681,6 +19589,10 @@ func (p *parser) parseZeroOrMoreExpr(expr *zeroOrMoreExpr) (interface{}, bool) {
 }
 
 func (p *parser) parseZeroOrOneExpr(expr *zeroOrOneExpr) (interface{}, bool) {
+	if p.debug {
+		defer p.out(p.in("parseZeroOrOneExpr"))
+	}
+
 	p.pushV()
 	val, _ := p.parseExpr(expr.expr)
 	p.popV()

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -13,7 +13,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"sync"
 	"unicode"
 	"unicode/utf8"
 
@@ -18369,63 +18368,6 @@ func Entrypoint(ruleName string) Option {
 	}
 }
 
-// Statistics adds a user provided Stats struct to the parser to allow
-// the user to process the results after the parsing has finished.
-// Also the key for the "no match" counter is set.
-//
-// Example usage:
-//
-//     input := "input"
-//     stats := Stats{}
-//     _, err := Parse("input-file", []byte(input), Statistics(&stats, "no match"))
-//     if err != nil {
-//         log.Panicln(err)
-//     }
-//     b, err := json.MarshalIndent(stats.ChoiceAltCnt, "", "  ")
-//     if err != nil {
-//         log.Panicln(err)
-//     }
-//     fmt.Println(string(b))
-//
-func Statistics(stats *Stats, choiceNoMatch string) Option {
-	return func(p *parser) Option {
-		oldStats := p.Stats
-		p.Stats = stats
-		oldChoiceNoMatch := p.choiceNoMatch
-		p.choiceNoMatch = choiceNoMatch
-		if p.Stats.ChoiceAltCnt == nil {
-			p.Stats.ChoiceAltCnt = make(map[string]map[string]int)
-		}
-		return Statistics(oldStats, oldChoiceNoMatch)
-	}
-}
-
-// Debug creates an Option to set the debug flag to b. When set to true,
-// debugging information is printed to stdout while parsing.
-//
-// The default is false.
-func Debug(b bool) Option {
-	return func(p *parser) Option {
-		old := p.debug
-		p.debug = b
-		return Debug(old)
-	}
-}
-
-// Memoize creates an Option to set the memoize flag to b. When set to true,
-// the parser will cache all results so each expression is evaluated only
-// once. This guarantees linear parsing time even for pathological cases,
-// at the expense of more memory and slower times for typical cases.
-//
-// The default is false.
-func Memoize(b bool) Option {
-	return func(p *parser) Option {
-		old := p.memoize
-		p.memoize = b
-		return Memoize(old)
-	}
-}
-
 // AllowInvalidUTF8 creates an Option to allow invalid UTF-8 bytes.
 // Every invalid UTF-8 byte is treated as a utf8.RuneError (U+FFFD)
 // by character class matchers and is matched by the any matcher.
@@ -18461,16 +18403,6 @@ func GlobalStore(key string, value interface{}) Option {
 		old := p.cur.globalStore[key]
 		p.cur.globalStore[key] = value
 		return GlobalStore(key, old)
-	}
-}
-
-// InitState creates an Option to set a key to a certain value in
-// the global "state" store.
-func InitState(key string, value interface{}) Option {
-	return func(p *parser) Option {
-		old := p.cur.state[key]
-		p.cur.state[key] = value
-		return InitState(key, old)
 	}
 }
 
@@ -18525,11 +18457,6 @@ type savepoint struct {
 type current struct {
 	pos  position // start position of the match
 	text []byte   // raw text of the match
-
-	// state is a store for arbitrary key,value pairs that the user wants to be
-	// tied to the backtracking of the parser.
-	// This is always rolled back if a parsing rule fails.
-	state storeDict
 
 	// globalStore is a general store for the user to store arbitrary key-value
 	// pairs that they need to manage and that they do not want tied to the
@@ -18603,11 +18530,6 @@ type oneOrMoreExpr expr
 type ruleRefExpr struct {
 	pos  position
 	name string
-}
-
-type stateCodeExpr struct {
-	pos position
-	run func(*parser) error
 }
 
 type andCodeExpr struct {
@@ -18713,7 +18635,6 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		pt:       savepoint{position: position{line: 1}},
 		recover:  true,
 		cur: current{
-			state:       make(storeDict),
 			globalStore: make(storeDict),
 		},
 		maxFailPos:      position{col: 1, line: 1},
@@ -18778,12 +18699,6 @@ type parser struct {
 
 	depth   int
 	recover bool
-	debug   bool
-
-	memoize bool
-	// memoization table for the packrat algorithm:
-	// map[offset in source] map[expression or rule] {value, match}
-	memo map[int]map[interface{}]resultTuple
 
 	// rules table, maps the rule identifier to the rule node
 	rules map[string]*rule
@@ -18868,26 +18783,6 @@ func (p *parser) popRecovery() {
 	p.recoveryStack = p.recoveryStack[:len(p.recoveryStack)-1]
 }
 
-func (p *parser) print(prefix, s string) string {
-	if !p.debug {
-		return s
-	}
-
-	fmt.Printf("%s %d:%d:%d: %s [%#U]\n",
-		prefix, p.pt.line, p.pt.col, p.pt.offset, s, p.pt.rn)
-	return s
-}
-
-func (p *parser) in(s string) string {
-	p.depth++
-	return p.print(strings.Repeat(" ", p.depth)+">", s)
-}
-
-func (p *parser) out(s string) string {
-	p.depth--
-	return p.print(strings.Repeat(" ", p.depth)+"<", s)
-}
-
 func (p *parser) addErr(err error) {
 	p.addErrAt(err, p.pt.position, []string{})
 }
@@ -18956,91 +18851,15 @@ func (p *parser) read() {
 
 // restore parser position to the savepoint pt.
 func (p *parser) restore(pt savepoint) {
-	if p.debug {
-		defer p.out(p.in("restore"))
-	}
 	if pt.offset == p.pt.offset {
 		return
 	}
 	p.pt = pt
 }
 
-// Cloner is implemented by any value that has a Clone method, which returns a
-// copy of the value. This is mainly used for types which are not passed by
-// value (e.g map, slice, chan) or structs that contain such types.
-//
-// This is used in conjunction with the global state feature to create proper
-// copies of the state to allow the parser to properly restore the state in
-// the case of backtracking.
-type Cloner interface {
-	Clone() interface{}
-}
-
-var statePool = &sync.Pool{
-	New: func() interface{} { return make(storeDict) },
-}
-
-func (sd storeDict) Discard() {
-	for k := range sd {
-		delete(sd, k)
-	}
-	statePool.Put(sd)
-}
-
-// clone and return parser current state.
-func (p *parser) cloneState() storeDict {
-	if p.debug {
-		defer p.out(p.in("cloneState"))
-	}
-
-	state := statePool.Get().(storeDict)
-	for k, v := range p.cur.state {
-		if c, ok := v.(Cloner); ok {
-			state[k] = c.Clone()
-		} else {
-			state[k] = v
-		}
-	}
-	return state
-}
-
-// restore parser current state to the state storeDict.
-// every restoreState should applied only one time for every cloned state
-func (p *parser) restoreState(state storeDict) {
-	if p.debug {
-		defer p.out(p.in("restoreState"))
-	}
-	p.cur.state.Discard()
-	p.cur.state = state
-}
-
 // get the slice of bytes from the savepoint start to the current position.
 func (p *parser) sliceFrom(start savepoint) []byte {
 	return p.data[start.position.offset:p.pt.position.offset]
-}
-
-func (p *parser) getMemoized(node interface{}) (resultTuple, bool) {
-	if len(p.memo) == 0 {
-		return resultTuple{}, false
-	}
-	m := p.memo[p.pt.offset]
-	if len(m) == 0 {
-		return resultTuple{}, false
-	}
-	res, ok := m[node]
-	return res, ok
-}
-
-func (p *parser) setMemoized(pt savepoint, node interface{}, tuple resultTuple) {
-	if p.memo == nil {
-		p.memo = make(map[int]map[interface{}]resultTuple)
-	}
-	m := p.memo[pt.offset]
-	if m == nil {
-		m = make(map[interface{}]resultTuple)
-		p.memo[pt.offset] = m
-	}
-	m[node] = tuple
 }
 
 func (p *parser) buildRulesTable(g *grammar) {
@@ -19064,9 +18883,6 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 		// and return the panic as an error.
 		defer func() {
 			if e := recover(); e != nil {
-				if p.debug {
-					defer p.out(p.in("panic handler"))
-				}
 				val = nil
 				switch e := e.(type) {
 				case error:
@@ -19128,45 +18944,15 @@ func listJoin(list []string, sep string, lastSep string) string {
 }
 
 func (p *parser) parseRule(rule *rule) (interface{}, bool) {
-	if p.debug {
-		defer p.out(p.in("parseRule " + rule.name))
-	}
-
-	if p.memoize {
-		res, ok := p.getMemoized(rule)
-		if ok {
-			p.restore(res.end)
-			return res.v, res.b
-		}
-	}
-
-	start := p.pt
 	p.rstack = append(p.rstack, rule)
 	p.pushV()
 	val, ok := p.parseExpr(rule.expr)
 	p.popV()
 	p.rstack = p.rstack[:len(p.rstack)-1]
-	if ok && p.debug {
-		p.print(strings.Repeat(" ", p.depth)+"MATCH", string(p.sliceFrom(start)))
-	}
-
-	if p.memoize {
-		p.setMemoized(start, rule, resultTuple{val, ok, p.pt})
-	}
 	return val, ok
 }
 
 func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
-	var pt savepoint
-
-	if p.memoize {
-		res, ok := p.getMemoized(expr)
-		if ok {
-			p.restore(res.end)
-			return res.v, res.b
-		}
-		pt = p.pt
-	}
 
 	p.ExprCnt++
 	if p.ExprCnt > p.maxExprCnt {
@@ -19204,8 +18990,6 @@ func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
 		val, ok = p.parseRuleRefExpr(expr)
 	case *seqExpr:
 		val, ok = p.parseSeqExpr(expr)
-	case *stateCodeExpr:
-		val, ok = p.parseStateCodeExpr(expr)
 	case *throwExpr:
 		val, ok = p.parseThrowExpr(expr)
 	case *zeroOrMoreExpr:
@@ -19215,74 +18999,46 @@ func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
 	default:
 		panic(fmt.Sprintf("unknown expression type %T", expr))
 	}
-	if p.memoize {
-		p.setMemoized(pt, expr, resultTuple{val, ok, p.pt})
-	}
 	return val, ok
 }
 
 func (p *parser) parseActionExpr(act *actionExpr) (interface{}, bool) {
-	if p.debug {
-		defer p.out(p.in("parseActionExpr"))
-	}
-
 	start := p.pt
 	val, ok := p.parseExpr(act.expr)
 	if ok {
 		p.cur.pos = start.position
 		p.cur.text = p.sliceFrom(start)
-		state := p.cloneState()
 		actVal, err := act.run(p)
 		if err != nil {
 			p.addErrAt(err, start.position, []string{})
 		}
-		p.restoreState(state)
 
 		val = actVal
-	}
-	if ok && p.debug {
-		p.print(strings.Repeat(" ", p.depth)+"MATCH", string(p.sliceFrom(start)))
 	}
 	return val, ok
 }
 
 func (p *parser) parseAndCodeExpr(and *andCodeExpr) (interface{}, bool) {
-	if p.debug {
-		defer p.out(p.in("parseAndCodeExpr"))
-	}
-
-	state := p.cloneState()
 
 	ok, err := and.run(p)
 	if err != nil {
 		p.addErr(err)
 	}
-	p.restoreState(state)
 
 	return nil, ok
 }
 
 func (p *parser) parseAndExpr(and *andExpr) (interface{}, bool) {
-	if p.debug {
-		defer p.out(p.in("parseAndExpr"))
-	}
-
 	pt := p.pt
-	state := p.cloneState()
 	p.pushV()
 	_, ok := p.parseExpr(and.expr)
 	p.popV()
-	p.restoreState(state)
 	p.restore(pt)
 
 	return nil, ok
 }
 
 func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
-	if p.debug {
-		defer p.out(p.in("parseAnyMatcher"))
-	}
-
 	if p.pt.rn == utf8.RuneError && p.pt.w == 0 {
 		// EOF - see utf8.DecodeRune
 		p.failAt(false, p.pt.position, ".")
@@ -19295,10 +19051,6 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 }
 
 func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {
-	if p.debug {
-		defer p.out(p.in("parseCharClassMatcher"))
-	}
-
 	cur := p.pt.rn
 	start := p.pt
 
@@ -19360,50 +19112,22 @@ func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool
 	return nil, false
 }
 
-func (p *parser) incChoiceAltCnt(ch *choiceExpr, altI int) {
-	choiceIdent := fmt.Sprintf("%s %d:%d", p.rstack[len(p.rstack)-1].name, ch.pos.line, ch.pos.col)
-	m := p.ChoiceAltCnt[choiceIdent]
-	if m == nil {
-		m = make(map[string]int)
-		p.ChoiceAltCnt[choiceIdent] = m
-	}
-	// We increment altI by 1, so the keys do not start at 0
-	alt := strconv.Itoa(altI + 1)
-	if altI == choiceNoMatch {
-		alt = p.choiceNoMatch
-	}
-	m[alt]++
-}
-
 func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
-	if p.debug {
-		defer p.out(p.in("parseChoiceExpr"))
-	}
-
 	for altI, alt := range ch.alternatives {
 		// dummy assignment to prevent compile error if optimized
 		_ = altI
-
-		state := p.cloneState()
 
 		p.pushV()
 		val, ok := p.parseExpr(alt)
 		p.popV()
 		if ok {
-			p.incChoiceAltCnt(ch, altI)
 			return val, ok
 		}
-		p.restoreState(state)
 	}
-	p.incChoiceAltCnt(ch, choiceNoMatch)
 	return nil, false
 }
 
 func (p *parser) parseLabeledExpr(lab *labeledExpr) (interface{}, bool) {
-	if p.debug {
-		defer p.out(p.in("parseLabeledExpr"))
-	}
-
 	p.pushV()
 	val, ok := p.parseExpr(lab.expr)
 	p.popV()
@@ -19415,10 +19139,6 @@ func (p *parser) parseLabeledExpr(lab *labeledExpr) (interface{}, bool) {
 }
 
 func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
-	if p.debug {
-		defer p.out(p.in("parseLitMatcher"))
-	}
-
 	start := p.pt
 	for _, want := range lit.val {
 		cur := p.pt.rn
@@ -19437,44 +19157,27 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 }
 
 func (p *parser) parseNotCodeExpr(not *notCodeExpr) (interface{}, bool) {
-	if p.debug {
-		defer p.out(p.in("parseNotCodeExpr"))
-	}
-
-	state := p.cloneState()
-
 	ok, err := not.run(p)
 	if err != nil {
 		p.addErr(err)
 	}
-	p.restoreState(state)
 
 	return nil, !ok
 }
 
 func (p *parser) parseNotExpr(not *notExpr) (interface{}, bool) {
-	if p.debug {
-		defer p.out(p.in("parseNotExpr"))
-	}
-
 	pt := p.pt
-	state := p.cloneState()
 	p.pushV()
 	p.maxFailInvertExpected = !p.maxFailInvertExpected
 	_, ok := p.parseExpr(not.expr)
 	p.maxFailInvertExpected = !p.maxFailInvertExpected
 	p.popV()
-	p.restoreState(state)
 	p.restore(pt)
 
 	return nil, !ok
 }
 
 func (p *parser) parseOneOrMoreExpr(expr *oneOrMoreExpr) (interface{}, bool) {
-	if p.debug {
-		defer p.out(p.in("parseOneOrMoreExpr"))
-	}
-
 	var vals []interface{}
 
 	for {
@@ -19493,9 +19196,6 @@ func (p *parser) parseOneOrMoreExpr(expr *oneOrMoreExpr) (interface{}, bool) {
 }
 
 func (p *parser) parseRecoveryExpr(recover *recoveryExpr) (interface{}, bool) {
-	if p.debug {
-		defer p.out(p.in("parseRecoveryExpr (" + strings.Join(recover.failureLabel, ",") + ")"))
-	}
 
 	p.pushRecovery(recover.failureLabel, recover.recoverExpr)
 	val, ok := p.parseExpr(recover.expr)
@@ -19505,10 +19205,6 @@ func (p *parser) parseRecoveryExpr(recover *recoveryExpr) (interface{}, bool) {
 }
 
 func (p *parser) parseRuleRefExpr(ref *ruleRefExpr) (interface{}, bool) {
-	if p.debug {
-		defer p.out(p.in("parseRuleRefExpr " + ref.name))
-	}
-
 	if ref.name == "" {
 		panic(fmt.Sprintf("%s: invalid rule: missing name", ref.pos))
 	}
@@ -19522,18 +19218,12 @@ func (p *parser) parseRuleRefExpr(ref *ruleRefExpr) (interface{}, bool) {
 }
 
 func (p *parser) parseSeqExpr(seq *seqExpr) (interface{}, bool) {
-	if p.debug {
-		defer p.out(p.in("parseSeqExpr"))
-	}
-
 	vals := make([]interface{}, 0, len(seq.exprs))
 
 	pt := p.pt
-	state := p.cloneState()
 	for _, expr := range seq.exprs {
 		val, ok := p.parseExpr(expr)
 		if !ok {
-			p.restoreState(state)
 			p.restore(pt)
 			return nil, false
 		}
@@ -19542,22 +19232,7 @@ func (p *parser) parseSeqExpr(seq *seqExpr) (interface{}, bool) {
 	return vals, true
 }
 
-func (p *parser) parseStateCodeExpr(state *stateCodeExpr) (interface{}, bool) {
-	if p.debug {
-		defer p.out(p.in("parseStateCodeExpr"))
-	}
-
-	err := state.run(p)
-	if err != nil {
-		p.addErr(err)
-	}
-	return nil, true
-}
-
 func (p *parser) parseThrowExpr(expr *throwExpr) (interface{}, bool) {
-	if p.debug {
-		defer p.out(p.in("parseThrowExpr"))
-	}
 
 	for i := len(p.recoveryStack) - 1; i >= 0; i-- {
 		if recoverExpr, ok := p.recoveryStack[i][expr.label]; ok {
@@ -19571,10 +19246,6 @@ func (p *parser) parseThrowExpr(expr *throwExpr) (interface{}, bool) {
 }
 
 func (p *parser) parseZeroOrMoreExpr(expr *zeroOrMoreExpr) (interface{}, bool) {
-	if p.debug {
-		defer p.out(p.in("parseZeroOrMoreExpr"))
-	}
-
 	var vals []interface{}
 
 	for {
@@ -19589,10 +19260,6 @@ func (p *parser) parseZeroOrMoreExpr(expr *zeroOrMoreExpr) (interface{}, bool) {
 }
 
 func (p *parser) parseZeroOrOneExpr(expr *zeroOrOneExpr) (interface{}, bool) {
-	if p.debug {
-		defer p.out(p.in("parseZeroOrOneExpr"))
-	}
-
 	p.pushV()
 	val, _ := p.parseExpr(expr.expr)
 	p.popV()

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -2707,53 +2707,45 @@ var g = &grammar{
 		{
 			name: "QuotedString",
 			pos:  position{line: 370, col: 1, offset: 12551},
-			expr: &actionExpr{
+			expr: &choiceExpr{
 				pos: position{line: 370, col: 17, offset: 12567},
-				run: (*parser).callonQuotedString1,
-				expr: &labeledExpr{
-					pos:   position{line: 370, col: 17, offset: 12567},
-					label: "qs",
-					expr: &choiceExpr{
-						pos: position{line: 370, col: 21, offset: 12571},
-						alternatives: []interface{}{
-							&ruleRefExpr{
-								pos:  position{line: 370, col: 21, offset: 12571},
-								name: "SingleQuotedString",
-							},
-							&ruleRefExpr{
-								pos:  position{line: 370, col: 42, offset: 12592},
-								name: "DoubleQuotedString",
-							},
-						},
+				alternatives: []interface{}{
+					&ruleRefExpr{
+						pos:  position{line: 370, col: 17, offset: 12567},
+						name: "SingleQuotedString",
+					},
+					&ruleRefExpr{
+						pos:  position{line: 370, col: 38, offset: 12588},
+						name: "DoubleQuotedString",
 					},
 				},
 			},
 		},
 		{
 			name: "SingleQuotedString",
-			pos:  position{line: 374, col: 1, offset: 12640},
+			pos:  position{line: 372, col: 1, offset: 12610},
 			expr: &actionExpr{
-				pos: position{line: 374, col: 23, offset: 12662},
+				pos: position{line: 372, col: 23, offset: 12632},
 				run: (*parser).callonSingleQuotedString1,
 				expr: &seqExpr{
-					pos: position{line: 374, col: 23, offset: 12662},
+					pos: position{line: 372, col: 23, offset: 12632},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 374, col: 23, offset: 12662},
+							pos:        position{line: 372, col: 23, offset: 12632},
 							val:        "'`",
 							ignoreCase: false,
 							want:       "\"'`\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 374, col: 28, offset: 12667},
+							pos:   position{line: 372, col: 28, offset: 12637},
 							label: "elements",
 							expr: &ruleRefExpr{
-								pos:  position{line: 374, col: 37, offset: 12676},
+								pos:  position{line: 372, col: 37, offset: 12646},
 								name: "SingleQuotedStringElements",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 374, col: 64, offset: 12703},
+							pos:        position{line: 372, col: 64, offset: 12673},
 							val:        "`'",
 							ignoreCase: false,
 							want:       "\"`'\"",
@@ -2764,17 +2756,17 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedStringElements",
-			pos:  position{line: 378, col: 1, offset: 12814},
+			pos:  position{line: 376, col: 1, offset: 12765},
 			expr: &actionExpr{
-				pos: position{line: 378, col: 31, offset: 12844},
+				pos: position{line: 376, col: 31, offset: 12795},
 				run: (*parser).callonSingleQuotedStringElements1,
 				expr: &labeledExpr{
-					pos:   position{line: 378, col: 31, offset: 12844},
+					pos:   position{line: 376, col: 31, offset: 12795},
 					label: "elements",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 378, col: 41, offset: 12854},
+						pos: position{line: 376, col: 41, offset: 12805},
 						expr: &ruleRefExpr{
-							pos:  position{line: 378, col: 41, offset: 12854},
+							pos:  position{line: 376, col: 41, offset: 12805},
 							name: "SingleQuotedStringElement",
 						},
 					},
@@ -2783,95 +2775,95 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedStringElement",
-			pos:  position{line: 383, col: 1, offset: 13019},
+			pos:  position{line: 381, col: 1, offset: 12970},
 			expr: &actionExpr{
-				pos: position{line: 383, col: 30, offset: 13048},
+				pos: position{line: 381, col: 30, offset: 12999},
 				run: (*parser).callonSingleQuotedStringElement1,
 				expr: &labeledExpr{
-					pos:   position{line: 383, col: 30, offset: 13048},
+					pos:   position{line: 381, col: 30, offset: 12999},
 					label: "element",
 					expr: &choiceExpr{
-						pos: position{line: 384, col: 9, offset: 13067},
+						pos: position{line: 382, col: 9, offset: 13018},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 384, col: 9, offset: 13067},
+								pos:  position{line: 382, col: 9, offset: 13018},
 								name: "LineBreak",
 							},
 							&oneOrMoreExpr{
-								pos: position{line: 385, col: 11, offset: 13113},
+								pos: position{line: 383, col: 11, offset: 13064},
 								expr: &ruleRefExpr{
-									pos:  position{line: 385, col: 11, offset: 13113},
+									pos:  position{line: 383, col: 11, offset: 13064},
 									name: "Space",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 386, col: 11, offset: 13131},
+								pos:  position{line: 384, col: 11, offset: 13082},
 								name: "InlineIcon",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 387, col: 11, offset: 13153},
+								pos:  position{line: 385, col: 11, offset: 13104},
 								name: "InlineImage",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 388, col: 11, offset: 13176},
+								pos:  position{line: 386, col: 11, offset: 13127},
 								name: "InlineFootnote",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 389, col: 11, offset: 13202},
+								pos:  position{line: 387, col: 11, offset: 13153},
 								name: "InlinePassthrough",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 390, col: 11, offset: 13231},
+								pos:  position{line: 388, col: 11, offset: 13182},
 								name: "Link",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 391, col: 11, offset: 13247},
+								pos:  position{line: 389, col: 11, offset: 13198},
 								name: "AttributeSubstitution",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 392, col: 11, offset: 13280},
+								pos:  position{line: 390, col: 11, offset: 13231},
 								name: "BoldText",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 393, col: 11, offset: 13300},
+								pos:  position{line: 391, col: 11, offset: 13251},
 								name: "ItalicText",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 394, col: 11, offset: 13322},
+								pos:  position{line: 392, col: 11, offset: 13273},
 								name: "MarkedText",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 395, col: 11, offset: 13344},
+								pos:  position{line: 393, col: 11, offset: 13295},
 								name: "SubscriptText",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 396, col: 11, offset: 13369},
+								pos:  position{line: 394, col: 11, offset: 13320},
 								name: "SuperscriptText",
 							},
 							&seqExpr{
-								pos: position{line: 397, col: 11, offset: 13396},
+								pos: position{line: 395, col: 11, offset: 13347},
 								exprs: []interface{}{
 									&notExpr{
-										pos: position{line: 397, col: 11, offset: 13396},
+										pos: position{line: 395, col: 11, offset: 13347},
 										expr: &litMatcher{
-											pos:        position{line: 397, col: 12, offset: 13397},
+											pos:        position{line: 395, col: 12, offset: 13348},
 											val:        "`'",
 											ignoreCase: false,
 											want:       "\"`'\"",
 										},
 									},
 									&ruleRefExpr{
-										pos:  position{line: 397, col: 17, offset: 13402},
+										pos:  position{line: 395, col: 17, offset: 13353},
 										name: "MonospaceText",
 									},
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 398, col: 11, offset: 13427},
+								pos:  position{line: 396, col: 11, offset: 13378},
 								name: "DoubleQuotedString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 399, col: 11, offset: 13457},
+								pos:  position{line: 397, col: 11, offset: 13408},
 								name: "SingleQuotedStringFallbackCharacter",
 							},
 						},
@@ -2881,33 +2873,33 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedStringFallbackCharacter",
-			pos:  position{line: 403, col: 1, offset: 13527},
+			pos:  position{line: 401, col: 1, offset: 13478},
 			expr: &choiceExpr{
-				pos: position{line: 403, col: 41, offset: 13567},
+				pos: position{line: 401, col: 41, offset: 13518},
 				alternatives: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 403, col: 41, offset: 13567},
+						pos:        position{line: 401, col: 41, offset: 13518},
 						val:        "[^\\r\\n`]",
 						chars:      []rune{'\r', '\n', '`'},
 						ignoreCase: false,
 						inverted:   true,
 					},
 					&actionExpr{
-						pos: position{line: 403, col: 52, offset: 13578},
+						pos: position{line: 401, col: 52, offset: 13529},
 						run: (*parser).callonSingleQuotedStringFallbackCharacter3,
 						expr: &seqExpr{
-							pos: position{line: 403, col: 52, offset: 13578},
+							pos: position{line: 401, col: 52, offset: 13529},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 403, col: 52, offset: 13578},
+									pos:        position{line: 401, col: 52, offset: 13529},
 									val:        "`",
 									ignoreCase: false,
 									want:       "\"`\"",
 								},
 								&notExpr{
-									pos: position{line: 403, col: 56, offset: 13582},
+									pos: position{line: 401, col: 56, offset: 13533},
 									expr: &litMatcher{
-										pos:        position{line: 403, col: 57, offset: 13583},
+										pos:        position{line: 401, col: 57, offset: 13534},
 										val:        "'",
 										ignoreCase: false,
 										want:       "\"'\"",
@@ -2921,29 +2913,29 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedString",
-			pos:  position{line: 407, col: 1, offset: 13646},
+			pos:  position{line: 405, col: 1, offset: 13597},
 			expr: &actionExpr{
-				pos: position{line: 407, col: 23, offset: 13668},
+				pos: position{line: 405, col: 23, offset: 13619},
 				run: (*parser).callonDoubleQuotedString1,
 				expr: &seqExpr{
-					pos: position{line: 407, col: 23, offset: 13668},
+					pos: position{line: 405, col: 23, offset: 13619},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 407, col: 23, offset: 13668},
+							pos:        position{line: 405, col: 23, offset: 13619},
 							val:        "\"`",
 							ignoreCase: false,
 							want:       "\"\\\"`\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 407, col: 29, offset: 13674},
+							pos:   position{line: 405, col: 29, offset: 13625},
 							label: "elements",
 							expr: &ruleRefExpr{
-								pos:  position{line: 407, col: 38, offset: 13683},
+								pos:  position{line: 405, col: 38, offset: 13634},
 								name: "DoubleQuotedStringElements",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 407, col: 65, offset: 13710},
+							pos:        position{line: 405, col: 65, offset: 13661},
 							val:        "`\"",
 							ignoreCase: false,
 							want:       "\"`\\\"\"",
@@ -2954,17 +2946,17 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedStringElements",
-			pos:  position{line: 412, col: 1, offset: 13824},
+			pos:  position{line: 409, col: 1, offset: 13754},
 			expr: &actionExpr{
-				pos: position{line: 412, col: 31, offset: 13854},
+				pos: position{line: 409, col: 31, offset: 13784},
 				run: (*parser).callonDoubleQuotedStringElements1,
 				expr: &labeledExpr{
-					pos:   position{line: 412, col: 31, offset: 13854},
+					pos:   position{line: 409, col: 31, offset: 13784},
 					label: "elements",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 412, col: 41, offset: 13864},
+						pos: position{line: 409, col: 41, offset: 13794},
 						expr: &ruleRefExpr{
-							pos:  position{line: 412, col: 41, offset: 13864},
+							pos:  position{line: 409, col: 41, offset: 13794},
 							name: "DoubleQuotedStringElement",
 						},
 					},
@@ -2973,88 +2965,88 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedStringElement",
-			pos:  position{line: 417, col: 1, offset: 14029},
+			pos:  position{line: 414, col: 1, offset: 13959},
 			expr: &actionExpr{
-				pos: position{line: 417, col: 30, offset: 14058},
+				pos: position{line: 414, col: 30, offset: 13988},
 				run: (*parser).callonDoubleQuotedStringElement1,
 				expr: &labeledExpr{
-					pos:   position{line: 417, col: 30, offset: 14058},
+					pos:   position{line: 414, col: 30, offset: 13988},
 					label: "element",
 					expr: &choiceExpr{
-						pos: position{line: 418, col: 9, offset: 14077},
+						pos: position{line: 415, col: 9, offset: 14007},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 418, col: 9, offset: 14077},
+								pos:  position{line: 415, col: 9, offset: 14007},
 								name: "LineBreak",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 420, col: 11, offset: 14142},
+								pos:  position{line: 417, col: 11, offset: 14072},
 								name: "InlineIcon",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 421, col: 11, offset: 14164},
+								pos:  position{line: 418, col: 11, offset: 14094},
 								name: "InlineImage",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 422, col: 11, offset: 14187},
+								pos:  position{line: 419, col: 11, offset: 14117},
 								name: "InlineFootnote",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 423, col: 11, offset: 14213},
+								pos:  position{line: 420, col: 11, offset: 14143},
 								name: "InlinePassthrough",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 424, col: 11, offset: 14242},
+								pos:  position{line: 421, col: 11, offset: 14172},
 								name: "Link",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 425, col: 11, offset: 14258},
+								pos:  position{line: 422, col: 11, offset: 14188},
 								name: "AttributeSubstitution",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 426, col: 11, offset: 14291},
+								pos:  position{line: 423, col: 11, offset: 14221},
 								name: "BoldText",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 427, col: 11, offset: 14311},
+								pos:  position{line: 424, col: 11, offset: 14241},
 								name: "ItalicText",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 428, col: 11, offset: 14333},
+								pos:  position{line: 425, col: 11, offset: 14263},
 								name: "MarkedText",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 429, col: 11, offset: 14355},
+								pos:  position{line: 426, col: 11, offset: 14285},
 								name: "SubscriptText",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 430, col: 11, offset: 14380},
+								pos:  position{line: 427, col: 11, offset: 14310},
 								name: "SuperscriptText",
 							},
 							&seqExpr{
-								pos: position{line: 431, col: 11, offset: 14407},
+								pos: position{line: 428, col: 11, offset: 14337},
 								exprs: []interface{}{
 									&notExpr{
-										pos: position{line: 431, col: 11, offset: 14407},
+										pos: position{line: 428, col: 11, offset: 14337},
 										expr: &litMatcher{
-											pos:        position{line: 431, col: 12, offset: 14408},
+											pos:        position{line: 428, col: 12, offset: 14338},
 											val:        "`\"",
 											ignoreCase: false,
 											want:       "\"`\\\"\"",
 										},
 									},
 									&ruleRefExpr{
-										pos:  position{line: 431, col: 18, offset: 14414},
+										pos:  position{line: 428, col: 18, offset: 14344},
 										name: "MonospaceText",
 									},
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 432, col: 11, offset: 14439},
+								pos:  position{line: 429, col: 11, offset: 14369},
 								name: "SingleQuotedString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 433, col: 11, offset: 14469},
+								pos:  position{line: 430, col: 11, offset: 14399},
 								name: "DoubleQuotedStringFallbackCharacter",
 							},
 						},
@@ -3064,33 +3056,33 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedStringFallbackCharacter",
-			pos:  position{line: 437, col: 1, offset: 14547},
+			pos:  position{line: 434, col: 1, offset: 14477},
 			expr: &actionExpr{
-				pos: position{line: 437, col: 41, offset: 14587},
+				pos: position{line: 434, col: 41, offset: 14517},
 				run: (*parser).callonDoubleQuotedStringFallbackCharacter1,
 				expr: &choiceExpr{
-					pos: position{line: 437, col: 42, offset: 14588},
+					pos: position{line: 434, col: 42, offset: 14518},
 					alternatives: []interface{}{
 						&charClassMatcher{
-							pos:        position{line: 437, col: 42, offset: 14588},
+							pos:        position{line: 434, col: 42, offset: 14518},
 							val:        "[^\\r\\n`]",
 							chars:      []rune{'\r', '\n', '`'},
 							ignoreCase: false,
 							inverted:   true,
 						},
 						&seqExpr{
-							pos: position{line: 437, col: 53, offset: 14599},
+							pos: position{line: 434, col: 53, offset: 14529},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 437, col: 53, offset: 14599},
+									pos:        position{line: 434, col: 53, offset: 14529},
 									val:        "`",
 									ignoreCase: false,
 									want:       "\"`\"",
 								},
 								&notExpr{
-									pos: position{line: 437, col: 57, offset: 14603},
+									pos: position{line: 434, col: 57, offset: 14533},
 									expr: &litMatcher{
-										pos:        position{line: 437, col: 58, offset: 14604},
+										pos:        position{line: 434, col: 58, offset: 14534},
 										val:        "\"",
 										ignoreCase: false,
 										want:       "\"\\\"\"",
@@ -3104,34 +3096,34 @@ var g = &grammar{
 		},
 		{
 			name: "Section",
-			pos:  position{line: 444, col: 1, offset: 14776},
+			pos:  position{line: 441, col: 1, offset: 14706},
 			expr: &actionExpr{
-				pos: position{line: 444, col: 12, offset: 14787},
+				pos: position{line: 441, col: 12, offset: 14717},
 				run: (*parser).callonSection1,
 				expr: &seqExpr{
-					pos: position{line: 444, col: 12, offset: 14787},
+					pos: position{line: 441, col: 12, offset: 14717},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 444, col: 12, offset: 14787},
+							pos:   position{line: 441, col: 12, offset: 14717},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 444, col: 23, offset: 14798},
+								pos: position{line: 441, col: 23, offset: 14728},
 								expr: &ruleRefExpr{
-									pos:  position{line: 444, col: 24, offset: 14799},
+									pos:  position{line: 441, col: 24, offset: 14729},
 									name: "Attributes",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 445, col: 5, offset: 14817},
+							pos:   position{line: 442, col: 5, offset: 14747},
 							label: "level",
 							expr: &actionExpr{
-								pos: position{line: 445, col: 12, offset: 14824},
+								pos: position{line: 442, col: 12, offset: 14754},
 								run: (*parser).callonSection7,
 								expr: &oneOrMoreExpr{
-									pos: position{line: 445, col: 12, offset: 14824},
+									pos: position{line: 442, col: 12, offset: 14754},
 									expr: &litMatcher{
-										pos:        position{line: 445, col: 13, offset: 14825},
+										pos:        position{line: 442, col: 13, offset: 14755},
 										val:        "=",
 										ignoreCase: false,
 										want:       "\"=\"",
@@ -3140,37 +3132,37 @@ var g = &grammar{
 							},
 						},
 						&andCodeExpr{
-							pos: position{line: 449, col: 5, offset: 14920},
+							pos: position{line: 446, col: 5, offset: 14850},
 							run: (*parser).callonSection10,
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 453, col: 5, offset: 15076},
+							pos: position{line: 450, col: 5, offset: 15006},
 							expr: &ruleRefExpr{
-								pos:  position{line: 453, col: 5, offset: 15076},
+								pos:  position{line: 450, col: 5, offset: 15006},
 								name: "Space",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 453, col: 12, offset: 15083},
+							pos:   position{line: 450, col: 12, offset: 15013},
 							label: "title",
 							expr: &ruleRefExpr{
-								pos:  position{line: 453, col: 19, offset: 15090},
+								pos:  position{line: 450, col: 19, offset: 15020},
 								name: "TitleElements",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 453, col: 34, offset: 15105},
+							pos:   position{line: 450, col: 34, offset: 15035},
 							label: "id",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 453, col: 38, offset: 15109},
+								pos: position{line: 450, col: 38, offset: 15039},
 								expr: &ruleRefExpr{
-									pos:  position{line: 453, col: 38, offset: 15109},
+									pos:  position{line: 450, col: 38, offset: 15039},
 									name: "InlineElementID",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 453, col: 56, offset: 15127},
+							pos:  position{line: 450, col: 56, offset: 15057},
 							name: "EOL",
 						},
 					},
@@ -3179,34 +3171,34 @@ var g = &grammar{
 		},
 		{
 			name: "TitleElements",
-			pos:  position{line: 457, col: 1, offset: 15237},
+			pos:  position{line: 454, col: 1, offset: 15167},
 			expr: &actionExpr{
-				pos: position{line: 457, col: 18, offset: 15254},
+				pos: position{line: 454, col: 18, offset: 15184},
 				run: (*parser).callonTitleElements1,
 				expr: &labeledExpr{
-					pos:   position{line: 457, col: 18, offset: 15254},
+					pos:   position{line: 454, col: 18, offset: 15184},
 					label: "elements",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 457, col: 27, offset: 15263},
+						pos: position{line: 454, col: 27, offset: 15193},
 						expr: &seqExpr{
-							pos: position{line: 457, col: 28, offset: 15264},
+							pos: position{line: 454, col: 28, offset: 15194},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 457, col: 28, offset: 15264},
+									pos: position{line: 454, col: 28, offset: 15194},
 									expr: &ruleRefExpr{
-										pos:  position{line: 457, col: 29, offset: 15265},
+										pos:  position{line: 454, col: 29, offset: 15195},
 										name: "Newline",
 									},
 								},
 								&notExpr{
-									pos: position{line: 457, col: 37, offset: 15273},
+									pos: position{line: 454, col: 37, offset: 15203},
 									expr: &ruleRefExpr{
-										pos:  position{line: 457, col: 38, offset: 15274},
+										pos:  position{line: 454, col: 38, offset: 15204},
 										name: "InlineElementID",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 457, col: 54, offset: 15290},
+									pos:  position{line: 454, col: 54, offset: 15220},
 									name: "TitleElement",
 								},
 							},
@@ -3217,69 +3209,69 @@ var g = &grammar{
 		},
 		{
 			name: "TitleElement",
-			pos:  position{line: 461, col: 1, offset: 15415},
+			pos:  position{line: 458, col: 1, offset: 15345},
 			expr: &actionExpr{
-				pos: position{line: 461, col: 17, offset: 15431},
+				pos: position{line: 458, col: 17, offset: 15361},
 				run: (*parser).callonTitleElement1,
 				expr: &labeledExpr{
-					pos:   position{line: 461, col: 17, offset: 15431},
+					pos:   position{line: 458, col: 17, offset: 15361},
 					label: "element",
 					expr: &choiceExpr{
-						pos: position{line: 461, col: 26, offset: 15440},
+						pos: position{line: 458, col: 26, offset: 15370},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 461, col: 26, offset: 15440},
+								pos:  position{line: 458, col: 26, offset: 15370},
 								name: "Word",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 462, col: 11, offset: 15456},
+								pos:  position{line: 459, col: 11, offset: 15386},
 								name: "LineBreak",
 							},
 							&oneOrMoreExpr{
-								pos: position{line: 463, col: 11, offset: 15502},
+								pos: position{line: 460, col: 11, offset: 15432},
 								expr: &ruleRefExpr{
-									pos:  position{line: 463, col: 11, offset: 15502},
+									pos:  position{line: 460, col: 11, offset: 15432},
 									name: "Space",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 464, col: 11, offset: 15521},
+								pos:  position{line: 461, col: 11, offset: 15451},
 								name: "CrossReference",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 465, col: 11, offset: 15547},
+								pos:  position{line: 462, col: 11, offset: 15477},
 								name: "InlinePassthrough",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 466, col: 11, offset: 15576},
+								pos:  position{line: 463, col: 11, offset: 15506},
 								name: "InlineIcon",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 467, col: 11, offset: 15598},
+								pos:  position{line: 464, col: 11, offset: 15528},
 								name: "InlineImage",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 468, col: 11, offset: 15621},
+								pos:  position{line: 465, col: 11, offset: 15551},
 								name: "Link",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 469, col: 11, offset: 15637},
+								pos:  position{line: 466, col: 11, offset: 15567},
 								name: "InlineFootnote",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 470, col: 11, offset: 15663},
+								pos:  position{line: 467, col: 11, offset: 15593},
 								name: "QuotedString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 471, col: 11, offset: 15687},
+								pos:  position{line: 468, col: 11, offset: 15617},
 								name: "QuotedText",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 472, col: 11, offset: 15709},
+								pos:  position{line: 469, col: 11, offset: 15639},
 								name: "AttributeSubstitution",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 473, col: 11, offset: 15742},
+								pos:  position{line: 470, col: 11, offset: 15672},
 								name: "AnyChar",
 							},
 						},
@@ -3289,18 +3281,18 @@ var g = &grammar{
 		},
 		{
 			name: "TableOfContentsPlaceHolder",
-			pos:  position{line: 480, col: 1, offset: 15900},
+			pos:  position{line: 477, col: 1, offset: 15830},
 			expr: &seqExpr{
-				pos: position{line: 480, col: 31, offset: 15930},
+				pos: position{line: 477, col: 31, offset: 15860},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 480, col: 31, offset: 15930},
+						pos:        position{line: 477, col: 31, offset: 15860},
 						val:        "toc::[]",
 						ignoreCase: false,
 						want:       "\"toc::[]\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 480, col: 41, offset: 15940},
+						pos:  position{line: 477, col: 41, offset: 15870},
 						name: "EOL",
 					},
 				},
@@ -3308,40 +3300,40 @@ var g = &grammar{
 		},
 		{
 			name: "UserMacroBlock",
-			pos:  position{line: 485, col: 1, offset: 16056},
+			pos:  position{line: 482, col: 1, offset: 15986},
 			expr: &actionExpr{
-				pos: position{line: 485, col: 19, offset: 16074},
+				pos: position{line: 482, col: 19, offset: 16004},
 				run: (*parser).callonUserMacroBlock1,
 				expr: &seqExpr{
-					pos: position{line: 485, col: 19, offset: 16074},
+					pos: position{line: 482, col: 19, offset: 16004},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 485, col: 19, offset: 16074},
+							pos:   position{line: 482, col: 19, offset: 16004},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 485, col: 25, offset: 16080},
+								pos:  position{line: 482, col: 25, offset: 16010},
 								name: "UserMacroName",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 485, col: 40, offset: 16095},
+							pos:        position{line: 482, col: 40, offset: 16025},
 							val:        "::",
 							ignoreCase: false,
 							want:       "\"::\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 485, col: 45, offset: 16100},
+							pos:   position{line: 482, col: 45, offset: 16030},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 485, col: 52, offset: 16107},
+								pos:  position{line: 482, col: 52, offset: 16037},
 								name: "UserMacroValue",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 485, col: 68, offset: 16123},
+							pos:   position{line: 482, col: 68, offset: 16053},
 							label: "attrs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 485, col: 75, offset: 16130},
+								pos:  position{line: 482, col: 75, offset: 16060},
 								name: "UserMacroAttributes",
 							},
 						},
@@ -3351,40 +3343,40 @@ var g = &grammar{
 		},
 		{
 			name: "InlineUserMacro",
-			pos:  position{line: 489, col: 1, offset: 16249},
+			pos:  position{line: 486, col: 1, offset: 16179},
 			expr: &actionExpr{
-				pos: position{line: 489, col: 20, offset: 16268},
+				pos: position{line: 486, col: 20, offset: 16198},
 				run: (*parser).callonInlineUserMacro1,
 				expr: &seqExpr{
-					pos: position{line: 489, col: 20, offset: 16268},
+					pos: position{line: 486, col: 20, offset: 16198},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 489, col: 20, offset: 16268},
+							pos:   position{line: 486, col: 20, offset: 16198},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 489, col: 26, offset: 16274},
+								pos:  position{line: 486, col: 26, offset: 16204},
 								name: "UserMacroName",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 489, col: 41, offset: 16289},
+							pos:        position{line: 486, col: 41, offset: 16219},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 489, col: 45, offset: 16293},
+							pos:   position{line: 486, col: 45, offset: 16223},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 489, col: 52, offset: 16300},
+								pos:  position{line: 486, col: 52, offset: 16230},
 								name: "UserMacroValue",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 489, col: 68, offset: 16316},
+							pos:   position{line: 486, col: 68, offset: 16246},
 							label: "attrs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 489, col: 75, offset: 16323},
+								pos:  position{line: 486, col: 75, offset: 16253},
 								name: "UserMacroAttributes",
 							},
 						},
@@ -3394,14 +3386,14 @@ var g = &grammar{
 		},
 		{
 			name: "UserMacroName",
-			pos:  position{line: 493, col: 1, offset: 16443},
+			pos:  position{line: 490, col: 1, offset: 16373},
 			expr: &actionExpr{
-				pos: position{line: 493, col: 18, offset: 16460},
+				pos: position{line: 490, col: 18, offset: 16390},
 				run: (*parser).callonUserMacroName1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 493, col: 19, offset: 16461},
+					pos: position{line: 490, col: 19, offset: 16391},
 					expr: &charClassMatcher{
-						pos:        position{line: 493, col: 19, offset: 16461},
+						pos:        position{line: 490, col: 19, offset: 16391},
 						val:        "[\\pL0-9_-]",
 						chars:      []rune{'_', '-'},
 						ranges:     []rune{'0', '9'},
@@ -3414,14 +3406,14 @@ var g = &grammar{
 		},
 		{
 			name: "UserMacroValue",
-			pos:  position{line: 497, col: 1, offset: 16514},
+			pos:  position{line: 494, col: 1, offset: 16444},
 			expr: &actionExpr{
-				pos: position{line: 497, col: 19, offset: 16532},
+				pos: position{line: 494, col: 19, offset: 16462},
 				run: (*parser).callonUserMacroValue1,
 				expr: &zeroOrMoreExpr{
-					pos: position{line: 497, col: 19, offset: 16532},
+					pos: position{line: 494, col: 19, offset: 16462},
 					expr: &charClassMatcher{
-						pos:        position{line: 497, col: 19, offset: 16532},
+						pos:        position{line: 494, col: 19, offset: 16462},
 						val:        "[^:[ \\r\\n]",
 						chars:      []rune{':', '[', ' ', '\r', '\n'},
 						ignoreCase: false,
@@ -3432,32 +3424,32 @@ var g = &grammar{
 		},
 		{
 			name: "UserMacroAttributes",
-			pos:  position{line: 501, col: 1, offset: 16584},
+			pos:  position{line: 498, col: 1, offset: 16514},
 			expr: &actionExpr{
-				pos: position{line: 501, col: 24, offset: 16607},
+				pos: position{line: 498, col: 24, offset: 16537},
 				run: (*parser).callonUserMacroAttributes1,
 				expr: &seqExpr{
-					pos: position{line: 501, col: 24, offset: 16607},
+					pos: position{line: 498, col: 24, offset: 16537},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 501, col: 24, offset: 16607},
+							pos:        position{line: 498, col: 24, offset: 16537},
 							val:        "[",
 							ignoreCase: false,
 							want:       "\"[\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 501, col: 28, offset: 16611},
+							pos:   position{line: 498, col: 28, offset: 16541},
 							label: "attrs",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 501, col: 34, offset: 16617},
+								pos: position{line: 498, col: 34, offset: 16547},
 								expr: &ruleRefExpr{
-									pos:  position{line: 501, col: 35, offset: 16618},
+									pos:  position{line: 498, col: 35, offset: 16548},
 									name: "GenericAttribute",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 501, col: 54, offset: 16637},
+							pos:        position{line: 498, col: 54, offset: 16567},
 							val:        "]",
 							ignoreCase: false,
 							want:       "\"]\"",
@@ -3468,41 +3460,41 @@ var g = &grammar{
 		},
 		{
 			name: "FileInclusion",
-			pos:  position{line: 508, col: 1, offset: 16826},
+			pos:  position{line: 505, col: 1, offset: 16756},
 			expr: &actionExpr{
-				pos: position{line: 508, col: 18, offset: 16843},
+				pos: position{line: 505, col: 18, offset: 16773},
 				run: (*parser).callonFileInclusion1,
 				expr: &seqExpr{
-					pos: position{line: 508, col: 18, offset: 16843},
+					pos: position{line: 505, col: 18, offset: 16773},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 508, col: 18, offset: 16843},
+							pos:   position{line: 505, col: 18, offset: 16773},
 							label: "incl",
 							expr: &actionExpr{
-								pos: position{line: 508, col: 24, offset: 16849},
+								pos: position{line: 505, col: 24, offset: 16779},
 								run: (*parser).callonFileInclusion4,
 								expr: &seqExpr{
-									pos: position{line: 508, col: 24, offset: 16849},
+									pos: position{line: 505, col: 24, offset: 16779},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 508, col: 24, offset: 16849},
+											pos:        position{line: 505, col: 24, offset: 16779},
 											val:        "include::",
 											ignoreCase: false,
 											want:       "\"include::\"",
 										},
 										&labeledExpr{
-											pos:   position{line: 508, col: 36, offset: 16861},
+											pos:   position{line: 505, col: 36, offset: 16791},
 											label: "path",
 											expr: &ruleRefExpr{
-												pos:  position{line: 508, col: 42, offset: 16867},
+												pos:  position{line: 505, col: 42, offset: 16797},
 												name: "FileLocation",
 											},
 										},
 										&labeledExpr{
-											pos:   position{line: 508, col: 56, offset: 16881},
+											pos:   position{line: 505, col: 56, offset: 16811},
 											label: "inlineAttributes",
 											expr: &ruleRefExpr{
-												pos:  position{line: 508, col: 74, offset: 16899},
+												pos:  position{line: 505, col: 74, offset: 16829},
 												name: "FileIncludeAttributes",
 											},
 										},
@@ -3511,14 +3503,14 @@ var g = &grammar{
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 510, col: 8, offset: 17048},
+							pos: position{line: 507, col: 8, offset: 16978},
 							expr: &ruleRefExpr{
-								pos:  position{line: 510, col: 8, offset: 17048},
+								pos:  position{line: 507, col: 8, offset: 16978},
 								name: "Space",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 510, col: 15, offset: 17055},
+							pos:  position{line: 507, col: 15, offset: 16985},
 							name: "EOL",
 						},
 					},
@@ -3527,37 +3519,37 @@ var g = &grammar{
 		},
 		{
 			name: "FileIncludeAttributes",
-			pos:  position{line: 514, col: 1, offset: 17111},
+			pos:  position{line: 511, col: 1, offset: 17041},
 			expr: &actionExpr{
-				pos: position{line: 514, col: 26, offset: 17136},
+				pos: position{line: 511, col: 26, offset: 17066},
 				run: (*parser).callonFileIncludeAttributes1,
 				expr: &seqExpr{
-					pos: position{line: 514, col: 26, offset: 17136},
+					pos: position{line: 511, col: 26, offset: 17066},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 514, col: 26, offset: 17136},
+							pos:        position{line: 511, col: 26, offset: 17066},
 							val:        "[",
 							ignoreCase: false,
 							want:       "\"[\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 514, col: 30, offset: 17140},
+							pos:   position{line: 511, col: 30, offset: 17070},
 							label: "attrs",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 514, col: 36, offset: 17146},
+								pos: position{line: 511, col: 36, offset: 17076},
 								expr: &choiceExpr{
-									pos: position{line: 514, col: 37, offset: 17147},
+									pos: position{line: 511, col: 37, offset: 17077},
 									alternatives: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 514, col: 37, offset: 17147},
+											pos:  position{line: 511, col: 37, offset: 17077},
 											name: "LineRangesAttribute",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 514, col: 59, offset: 17169},
+											pos:  position{line: 511, col: 59, offset: 17099},
 											name: "TagRangesAttribute",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 514, col: 80, offset: 17190},
+											pos:  position{line: 511, col: 80, offset: 17120},
 											name: "GenericAttribute",
 										},
 									},
@@ -3565,7 +3557,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 514, col: 99, offset: 17209},
+							pos:        position{line: 511, col: 99, offset: 17139},
 							val:        "]",
 							ignoreCase: false,
 							want:       "\"]\"",
@@ -3576,31 +3568,31 @@ var g = &grammar{
 		},
 		{
 			name: "LineRangesAttribute",
-			pos:  position{line: 518, col: 1, offset: 17285},
+			pos:  position{line: 515, col: 1, offset: 17215},
 			expr: &actionExpr{
-				pos: position{line: 518, col: 24, offset: 17308},
+				pos: position{line: 515, col: 24, offset: 17238},
 				run: (*parser).callonLineRangesAttribute1,
 				expr: &seqExpr{
-					pos: position{line: 518, col: 24, offset: 17308},
+					pos: position{line: 515, col: 24, offset: 17238},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 518, col: 24, offset: 17308},
+							pos:        position{line: 515, col: 24, offset: 17238},
 							val:        "lines=",
 							ignoreCase: false,
 							want:       "\"lines=\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 518, col: 33, offset: 17317},
+							pos:   position{line: 515, col: 33, offset: 17247},
 							label: "lines",
 							expr: &ruleRefExpr{
-								pos:  position{line: 518, col: 40, offset: 17324},
+								pos:  position{line: 515, col: 40, offset: 17254},
 								name: "LineRangesAttributeValue",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 518, col: 66, offset: 17350},
+							pos: position{line: 515, col: 66, offset: 17280},
 							expr: &litMatcher{
-								pos:        position{line: 518, col: 66, offset: 17350},
+								pos:        position{line: 515, col: 66, offset: 17280},
 								val:        ",",
 								ignoreCase: false,
 								want:       "\",\"",
@@ -3612,73 +3604,73 @@ var g = &grammar{
 		},
 		{
 			name: "LineRangesAttributeValue",
-			pos:  position{line: 522, col: 1, offset: 17413},
+			pos:  position{line: 519, col: 1, offset: 17343},
 			expr: &actionExpr{
-				pos: position{line: 522, col: 29, offset: 17441},
+				pos: position{line: 519, col: 29, offset: 17371},
 				run: (*parser).callonLineRangesAttributeValue1,
 				expr: &seqExpr{
-					pos: position{line: 522, col: 29, offset: 17441},
+					pos: position{line: 519, col: 29, offset: 17371},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 522, col: 29, offset: 17441},
+							pos:   position{line: 519, col: 29, offset: 17371},
 							label: "value",
 							expr: &choiceExpr{
-								pos: position{line: 522, col: 36, offset: 17448},
+								pos: position{line: 519, col: 36, offset: 17378},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 522, col: 36, offset: 17448},
+										pos:  position{line: 519, col: 36, offset: 17378},
 										name: "MultipleLineRanges",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 523, col: 11, offset: 17566},
+										pos:  position{line: 520, col: 11, offset: 17496},
 										name: "MultipleQuotedLineRanges",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 524, col: 11, offset: 17603},
+										pos:  position{line: 521, col: 11, offset: 17533},
 										name: "MultiLineRange",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 525, col: 11, offset: 17630},
+										pos:  position{line: 522, col: 11, offset: 17560},
 										name: "MultiLineQuotedRange",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 526, col: 11, offset: 17663},
+										pos:  position{line: 523, col: 11, offset: 17593},
 										name: "SingleLineQuotedRange",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 527, col: 11, offset: 17696},
+										pos:  position{line: 524, col: 11, offset: 17626},
 										name: "SingleLineRange",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 528, col: 11, offset: 17724},
+										pos:  position{line: 525, col: 11, offset: 17654},
 										name: "UndefinedLineRange",
 									},
 								},
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 528, col: 31, offset: 17744},
+							pos: position{line: 525, col: 31, offset: 17674},
 							expr: &ruleRefExpr{
-								pos:  position{line: 528, col: 31, offset: 17744},
+								pos:  position{line: 525, col: 31, offset: 17674},
 								name: "Space",
 							},
 						},
 						&choiceExpr{
-							pos: position{line: 528, col: 39, offset: 17752},
+							pos: position{line: 525, col: 39, offset: 17682},
 							alternatives: []interface{}{
 								&andExpr{
-									pos: position{line: 528, col: 39, offset: 17752},
+									pos: position{line: 525, col: 39, offset: 17682},
 									expr: &litMatcher{
-										pos:        position{line: 528, col: 40, offset: 17753},
+										pos:        position{line: 525, col: 40, offset: 17683},
 										val:        ",",
 										ignoreCase: false,
 										want:       "\",\"",
 									},
 								},
 								&andExpr{
-									pos: position{line: 528, col: 46, offset: 17759},
+									pos: position{line: 525, col: 46, offset: 17689},
 									expr: &litMatcher{
-										pos:        position{line: 528, col: 47, offset: 17760},
+										pos:        position{line: 525, col: 47, offset: 17690},
 										val:        "]",
 										ignoreCase: false,
 										want:       "\"]\"",
@@ -3692,59 +3684,59 @@ var g = &grammar{
 		},
 		{
 			name: "MultipleLineRanges",
-			pos:  position{line: 532, col: 1, offset: 17796},
+			pos:  position{line: 529, col: 1, offset: 17726},
 			expr: &actionExpr{
-				pos: position{line: 532, col: 23, offset: 17818},
+				pos: position{line: 529, col: 23, offset: 17748},
 				run: (*parser).callonMultipleLineRanges1,
 				expr: &seqExpr{
-					pos: position{line: 532, col: 23, offset: 17818},
+					pos: position{line: 529, col: 23, offset: 17748},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 532, col: 23, offset: 17818},
+							pos:   position{line: 529, col: 23, offset: 17748},
 							label: "first",
 							expr: &choiceExpr{
-								pos: position{line: 532, col: 30, offset: 17825},
+								pos: position{line: 529, col: 30, offset: 17755},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 532, col: 30, offset: 17825},
+										pos:  position{line: 529, col: 30, offset: 17755},
 										name: "MultiLineRange",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 532, col: 47, offset: 17842},
+										pos:  position{line: 529, col: 47, offset: 17772},
 										name: "SingleLineRange",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 533, col: 5, offset: 17865},
+							pos:   position{line: 530, col: 5, offset: 17795},
 							label: "others",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 533, col: 12, offset: 17872},
+								pos: position{line: 530, col: 12, offset: 17802},
 								expr: &actionExpr{
-									pos: position{line: 533, col: 13, offset: 17873},
+									pos: position{line: 530, col: 13, offset: 17803},
 									run: (*parser).callonMultipleLineRanges9,
 									expr: &seqExpr{
-										pos: position{line: 533, col: 13, offset: 17873},
+										pos: position{line: 530, col: 13, offset: 17803},
 										exprs: []interface{}{
 											&litMatcher{
-												pos:        position{line: 533, col: 13, offset: 17873},
+												pos:        position{line: 530, col: 13, offset: 17803},
 												val:        ";",
 												ignoreCase: false,
 												want:       "\";\"",
 											},
 											&labeledExpr{
-												pos:   position{line: 533, col: 17, offset: 17877},
+												pos:   position{line: 530, col: 17, offset: 17807},
 												label: "other",
 												expr: &choiceExpr{
-													pos: position{line: 533, col: 24, offset: 17884},
+													pos: position{line: 530, col: 24, offset: 17814},
 													alternatives: []interface{}{
 														&ruleRefExpr{
-															pos:  position{line: 533, col: 24, offset: 17884},
+															pos:  position{line: 530, col: 24, offset: 17814},
 															name: "MultiLineRange",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 533, col: 41, offset: 17901},
+															pos:  position{line: 530, col: 41, offset: 17831},
 															name: "SingleLineRange",
 														},
 													},
@@ -3761,65 +3753,65 @@ var g = &grammar{
 		},
 		{
 			name: "MultipleQuotedLineRanges",
-			pos:  position{line: 539, col: 1, offset: 18045},
+			pos:  position{line: 536, col: 1, offset: 17975},
 			expr: &actionExpr{
-				pos: position{line: 539, col: 29, offset: 18073},
+				pos: position{line: 536, col: 29, offset: 18003},
 				run: (*parser).callonMultipleQuotedLineRanges1,
 				expr: &seqExpr{
-					pos: position{line: 539, col: 29, offset: 18073},
+					pos: position{line: 536, col: 29, offset: 18003},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 539, col: 29, offset: 18073},
+							pos:        position{line: 536, col: 29, offset: 18003},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 539, col: 34, offset: 18078},
+							pos:   position{line: 536, col: 34, offset: 18008},
 							label: "first",
 							expr: &choiceExpr{
-								pos: position{line: 539, col: 41, offset: 18085},
+								pos: position{line: 536, col: 41, offset: 18015},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 539, col: 41, offset: 18085},
+										pos:  position{line: 536, col: 41, offset: 18015},
 										name: "MultiLineRange",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 539, col: 58, offset: 18102},
+										pos:  position{line: 536, col: 58, offset: 18032},
 										name: "SingleLineRange",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 540, col: 5, offset: 18125},
+							pos:   position{line: 537, col: 5, offset: 18055},
 							label: "others",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 540, col: 12, offset: 18132},
+								pos: position{line: 537, col: 12, offset: 18062},
 								expr: &actionExpr{
-									pos: position{line: 540, col: 13, offset: 18133},
+									pos: position{line: 537, col: 13, offset: 18063},
 									run: (*parser).callonMultipleQuotedLineRanges10,
 									expr: &seqExpr{
-										pos: position{line: 540, col: 13, offset: 18133},
+										pos: position{line: 537, col: 13, offset: 18063},
 										exprs: []interface{}{
 											&litMatcher{
-												pos:        position{line: 540, col: 13, offset: 18133},
+												pos:        position{line: 537, col: 13, offset: 18063},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&labeledExpr{
-												pos:   position{line: 540, col: 17, offset: 18137},
+												pos:   position{line: 537, col: 17, offset: 18067},
 												label: "other",
 												expr: &choiceExpr{
-													pos: position{line: 540, col: 24, offset: 18144},
+													pos: position{line: 537, col: 24, offset: 18074},
 													alternatives: []interface{}{
 														&ruleRefExpr{
-															pos:  position{line: 540, col: 24, offset: 18144},
+															pos:  position{line: 537, col: 24, offset: 18074},
 															name: "MultiLineRange",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 540, col: 41, offset: 18161},
+															pos:  position{line: 537, col: 41, offset: 18091},
 															name: "SingleLineRange",
 														},
 													},
@@ -3831,7 +3823,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 542, col: 9, offset: 18216},
+							pos:        position{line: 539, col: 9, offset: 18146},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -3842,32 +3834,32 @@ var g = &grammar{
 		},
 		{
 			name: "MultiLineRange",
-			pos:  position{line: 546, col: 1, offset: 18310},
+			pos:  position{line: 543, col: 1, offset: 18240},
 			expr: &actionExpr{
-				pos: position{line: 546, col: 19, offset: 18328},
+				pos: position{line: 543, col: 19, offset: 18258},
 				run: (*parser).callonMultiLineRange1,
 				expr: &seqExpr{
-					pos: position{line: 546, col: 19, offset: 18328},
+					pos: position{line: 543, col: 19, offset: 18258},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 546, col: 19, offset: 18328},
+							pos:   position{line: 543, col: 19, offset: 18258},
 							label: "start",
 							expr: &ruleRefExpr{
-								pos:  position{line: 546, col: 26, offset: 18335},
+								pos:  position{line: 543, col: 26, offset: 18265},
 								name: "NUMBER",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 546, col: 34, offset: 18343},
+							pos:        position{line: 543, col: 34, offset: 18273},
 							val:        "..",
 							ignoreCase: false,
 							want:       "\"..\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 546, col: 39, offset: 18348},
+							pos:   position{line: 543, col: 39, offset: 18278},
 							label: "end",
 							expr: &ruleRefExpr{
-								pos:  position{line: 546, col: 44, offset: 18353},
+								pos:  position{line: 543, col: 44, offset: 18283},
 								name: "NUMBER",
 							},
 						},
@@ -3877,43 +3869,43 @@ var g = &grammar{
 		},
 		{
 			name: "MultiLineQuotedRange",
-			pos:  position{line: 550, col: 1, offset: 18445},
+			pos:  position{line: 547, col: 1, offset: 18375},
 			expr: &actionExpr{
-				pos: position{line: 550, col: 25, offset: 18469},
+				pos: position{line: 547, col: 25, offset: 18399},
 				run: (*parser).callonMultiLineQuotedRange1,
 				expr: &seqExpr{
-					pos: position{line: 550, col: 25, offset: 18469},
+					pos: position{line: 547, col: 25, offset: 18399},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 550, col: 25, offset: 18469},
+							pos:        position{line: 547, col: 25, offset: 18399},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 550, col: 30, offset: 18474},
+							pos:   position{line: 547, col: 30, offset: 18404},
 							label: "start",
 							expr: &ruleRefExpr{
-								pos:  position{line: 550, col: 37, offset: 18481},
+								pos:  position{line: 547, col: 37, offset: 18411},
 								name: "NUMBER",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 550, col: 45, offset: 18489},
+							pos:        position{line: 547, col: 45, offset: 18419},
 							val:        "..",
 							ignoreCase: false,
 							want:       "\"..\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 550, col: 50, offset: 18494},
+							pos:   position{line: 547, col: 50, offset: 18424},
 							label: "end",
 							expr: &ruleRefExpr{
-								pos:  position{line: 550, col: 55, offset: 18499},
+								pos:  position{line: 547, col: 55, offset: 18429},
 								name: "NUMBER",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 550, col: 63, offset: 18507},
+							pos:        position{line: 547, col: 63, offset: 18437},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -3924,15 +3916,15 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineRange",
-			pos:  position{line: 554, col: 1, offset: 18596},
+			pos:  position{line: 551, col: 1, offset: 18526},
 			expr: &actionExpr{
-				pos: position{line: 554, col: 20, offset: 18615},
+				pos: position{line: 551, col: 20, offset: 18545},
 				run: (*parser).callonSingleLineRange1,
 				expr: &labeledExpr{
-					pos:   position{line: 554, col: 20, offset: 18615},
+					pos:   position{line: 551, col: 20, offset: 18545},
 					label: "singleline",
 					expr: &ruleRefExpr{
-						pos:  position{line: 554, col: 32, offset: 18627},
+						pos:  position{line: 551, col: 32, offset: 18557},
 						name: "NUMBER",
 					},
 				},
@@ -3940,29 +3932,29 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineQuotedRange",
-			pos:  position{line: 558, col: 1, offset: 18726},
+			pos:  position{line: 555, col: 1, offset: 18656},
 			expr: &actionExpr{
-				pos: position{line: 558, col: 26, offset: 18751},
+				pos: position{line: 555, col: 26, offset: 18681},
 				run: (*parser).callonSingleLineQuotedRange1,
 				expr: &seqExpr{
-					pos: position{line: 558, col: 26, offset: 18751},
+					pos: position{line: 555, col: 26, offset: 18681},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 558, col: 26, offset: 18751},
+							pos:        position{line: 555, col: 26, offset: 18681},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 558, col: 31, offset: 18756},
+							pos:   position{line: 555, col: 31, offset: 18686},
 							label: "singleline",
 							expr: &ruleRefExpr{
-								pos:  position{line: 558, col: 43, offset: 18768},
+								pos:  position{line: 555, col: 43, offset: 18698},
 								name: "NUMBER",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 558, col: 51, offset: 18776},
+							pos:        position{line: 555, col: 51, offset: 18706},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -3973,14 +3965,14 @@ var g = &grammar{
 		},
 		{
 			name: "UndefinedLineRange",
-			pos:  position{line: 562, col: 1, offset: 18872},
+			pos:  position{line: 559, col: 1, offset: 18802},
 			expr: &actionExpr{
-				pos: position{line: 562, col: 23, offset: 18894},
+				pos: position{line: 559, col: 23, offset: 18824},
 				run: (*parser).callonUndefinedLineRange1,
 				expr: &zeroOrMoreExpr{
-					pos: position{line: 562, col: 23, offset: 18894},
+					pos: position{line: 559, col: 23, offset: 18824},
 					expr: &charClassMatcher{
-						pos:        position{line: 562, col: 23, offset: 18894},
+						pos:        position{line: 559, col: 23, offset: 18824},
 						val:        "[^\\], ]",
 						chars:      []rune{']', ',', ' '},
 						ignoreCase: false,
@@ -3991,24 +3983,24 @@ var g = &grammar{
 		},
 		{
 			name: "TagRangesAttribute",
-			pos:  position{line: 566, col: 1, offset: 18943},
+			pos:  position{line: 563, col: 1, offset: 18873},
 			expr: &actionExpr{
-				pos: position{line: 566, col: 23, offset: 18965},
+				pos: position{line: 563, col: 23, offset: 18895},
 				run: (*parser).callonTagRangesAttribute1,
 				expr: &seqExpr{
-					pos: position{line: 566, col: 23, offset: 18965},
+					pos: position{line: 563, col: 23, offset: 18895},
 					exprs: []interface{}{
 						&choiceExpr{
-							pos: position{line: 566, col: 24, offset: 18966},
+							pos: position{line: 563, col: 24, offset: 18896},
 							alternatives: []interface{}{
 								&litMatcher{
-									pos:        position{line: 566, col: 24, offset: 18966},
+									pos:        position{line: 563, col: 24, offset: 18896},
 									val:        "tags=",
 									ignoreCase: false,
 									want:       "\"tags=\"",
 								},
 								&litMatcher{
-									pos:        position{line: 566, col: 34, offset: 18976},
+									pos:        position{line: 563, col: 34, offset: 18906},
 									val:        "tag=",
 									ignoreCase: false,
 									want:       "\"tag=\"",
@@ -4016,17 +4008,17 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 566, col: 42, offset: 18984},
+							pos:   position{line: 563, col: 42, offset: 18914},
 							label: "tags",
 							expr: &ruleRefExpr{
-								pos:  position{line: 566, col: 48, offset: 18990},
+								pos:  position{line: 563, col: 48, offset: 18920},
 								name: "TagRangesAttributeValue",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 566, col: 73, offset: 19015},
+							pos: position{line: 563, col: 73, offset: 18945},
 							expr: &litMatcher{
-								pos:        position{line: 566, col: 73, offset: 19015},
+								pos:        position{line: 563, col: 73, offset: 18945},
 								val:        ",",
 								ignoreCase: false,
 								want:       "\",\"",
@@ -4038,44 +4030,44 @@ var g = &grammar{
 		},
 		{
 			name: "TagRangesAttributeValue",
-			pos:  position{line: 570, col: 1, offset: 19168},
+			pos:  position{line: 567, col: 1, offset: 19098},
 			expr: &actionExpr{
-				pos: position{line: 570, col: 28, offset: 19195},
+				pos: position{line: 567, col: 28, offset: 19125},
 				run: (*parser).callonTagRangesAttributeValue1,
 				expr: &seqExpr{
-					pos: position{line: 570, col: 28, offset: 19195},
+					pos: position{line: 567, col: 28, offset: 19125},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 570, col: 28, offset: 19195},
+							pos:   position{line: 567, col: 28, offset: 19125},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 570, col: 35, offset: 19202},
+								pos:  position{line: 567, col: 35, offset: 19132},
 								name: "MultipleTagRanges",
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 570, col: 54, offset: 19221},
+							pos: position{line: 567, col: 54, offset: 19151},
 							expr: &ruleRefExpr{
-								pos:  position{line: 570, col: 54, offset: 19221},
+								pos:  position{line: 567, col: 54, offset: 19151},
 								name: "Space",
 							},
 						},
 						&choiceExpr{
-							pos: position{line: 570, col: 62, offset: 19229},
+							pos: position{line: 567, col: 62, offset: 19159},
 							alternatives: []interface{}{
 								&andExpr{
-									pos: position{line: 570, col: 62, offset: 19229},
+									pos: position{line: 567, col: 62, offset: 19159},
 									expr: &litMatcher{
-										pos:        position{line: 570, col: 63, offset: 19230},
+										pos:        position{line: 567, col: 63, offset: 19160},
 										val:        ",",
 										ignoreCase: false,
 										want:       "\",\"",
 									},
 								},
 								&andExpr{
-									pos: position{line: 570, col: 69, offset: 19236},
+									pos: position{line: 567, col: 69, offset: 19166},
 									expr: &litMatcher{
-										pos:        position{line: 570, col: 70, offset: 19237},
+										pos:        position{line: 567, col: 70, offset: 19167},
 										val:        "]",
 										ignoreCase: false,
 										want:       "\"]\"",
@@ -4089,43 +4081,43 @@ var g = &grammar{
 		},
 		{
 			name: "MultipleTagRanges",
-			pos:  position{line: 574, col: 1, offset: 19273},
+			pos:  position{line: 571, col: 1, offset: 19203},
 			expr: &actionExpr{
-				pos: position{line: 574, col: 22, offset: 19294},
+				pos: position{line: 571, col: 22, offset: 19224},
 				run: (*parser).callonMultipleTagRanges1,
 				expr: &seqExpr{
-					pos: position{line: 574, col: 22, offset: 19294},
+					pos: position{line: 571, col: 22, offset: 19224},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 574, col: 22, offset: 19294},
+							pos:   position{line: 571, col: 22, offset: 19224},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 574, col: 29, offset: 19301},
+								pos:  position{line: 571, col: 29, offset: 19231},
 								name: "TagRange",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 575, col: 5, offset: 19316},
+							pos:   position{line: 572, col: 5, offset: 19246},
 							label: "others",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 575, col: 12, offset: 19323},
+								pos: position{line: 572, col: 12, offset: 19253},
 								expr: &actionExpr{
-									pos: position{line: 575, col: 13, offset: 19324},
+									pos: position{line: 572, col: 13, offset: 19254},
 									run: (*parser).callonMultipleTagRanges7,
 									expr: &seqExpr{
-										pos: position{line: 575, col: 13, offset: 19324},
+										pos: position{line: 572, col: 13, offset: 19254},
 										exprs: []interface{}{
 											&litMatcher{
-												pos:        position{line: 575, col: 13, offset: 19324},
+												pos:        position{line: 572, col: 13, offset: 19254},
 												val:        ";",
 												ignoreCase: false,
 												want:       "\";\"",
 											},
 											&labeledExpr{
-												pos:   position{line: 575, col: 17, offset: 19328},
+												pos:   position{line: 572, col: 17, offset: 19258},
 												label: "other",
 												expr: &ruleRefExpr{
-													pos:  position{line: 575, col: 24, offset: 19335},
+													pos:  position{line: 572, col: 24, offset: 19265},
 													name: "TagRange",
 												},
 											},
@@ -4140,25 +4132,25 @@ var g = &grammar{
 		},
 		{
 			name: "TagRange",
-			pos:  position{line: 581, col: 1, offset: 19472},
+			pos:  position{line: 578, col: 1, offset: 19402},
 			expr: &choiceExpr{
-				pos: position{line: 581, col: 13, offset: 19484},
+				pos: position{line: 578, col: 13, offset: 19414},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 581, col: 13, offset: 19484},
+						pos: position{line: 578, col: 13, offset: 19414},
 						run: (*parser).callonTagRange2,
 						expr: &labeledExpr{
-							pos:   position{line: 581, col: 13, offset: 19484},
+							pos:   position{line: 578, col: 13, offset: 19414},
 							label: "tag",
 							expr: &choiceExpr{
-								pos: position{line: 581, col: 18, offset: 19489},
+								pos: position{line: 578, col: 18, offset: 19419},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 581, col: 18, offset: 19489},
+										pos:  position{line: 578, col: 18, offset: 19419},
 										name: "Alphanums",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 581, col: 30, offset: 19501},
+										pos:  position{line: 578, col: 30, offset: 19431},
 										name: "TagWildcard",
 									},
 								},
@@ -4166,29 +4158,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 583, col: 5, offset: 19571},
+						pos: position{line: 580, col: 5, offset: 19501},
 						run: (*parser).callonTagRange7,
 						expr: &seqExpr{
-							pos: position{line: 583, col: 5, offset: 19571},
+							pos: position{line: 580, col: 5, offset: 19501},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 583, col: 5, offset: 19571},
+									pos:        position{line: 580, col: 5, offset: 19501},
 									val:        "!",
 									ignoreCase: false,
 									want:       "\"!\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 583, col: 9, offset: 19575},
+									pos:   position{line: 580, col: 9, offset: 19505},
 									label: "tag",
 									expr: &choiceExpr{
-										pos: position{line: 583, col: 14, offset: 19580},
+										pos: position{line: 580, col: 14, offset: 19510},
 										alternatives: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 583, col: 14, offset: 19580},
+												pos:  position{line: 580, col: 14, offset: 19510},
 												name: "Alphanums",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 583, col: 26, offset: 19592},
+												pos:  position{line: 580, col: 26, offset: 19522},
 												name: "TagWildcard",
 											},
 										},
@@ -4202,23 +4194,23 @@ var g = &grammar{
 		},
 		{
 			name: "TagWildcard",
-			pos:  position{line: 587, col: 1, offset: 19664},
+			pos:  position{line: 584, col: 1, offset: 19594},
 			expr: &actionExpr{
-				pos: position{line: 587, col: 16, offset: 19679},
+				pos: position{line: 584, col: 16, offset: 19609},
 				run: (*parser).callonTagWildcard1,
 				expr: &seqExpr{
-					pos: position{line: 587, col: 16, offset: 19679},
+					pos: position{line: 584, col: 16, offset: 19609},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 587, col: 16, offset: 19679},
+							pos:   position{line: 584, col: 16, offset: 19609},
 							label: "stars",
 							expr: &actionExpr{
-								pos: position{line: 587, col: 23, offset: 19686},
+								pos: position{line: 584, col: 23, offset: 19616},
 								run: (*parser).callonTagWildcard4,
 								expr: &oneOrMoreExpr{
-									pos: position{line: 587, col: 23, offset: 19686},
+									pos: position{line: 584, col: 23, offset: 19616},
 									expr: &litMatcher{
-										pos:        position{line: 587, col: 24, offset: 19687},
+										pos:        position{line: 584, col: 24, offset: 19617},
 										val:        "*",
 										ignoreCase: false,
 										want:       "\"*\"",
@@ -4227,7 +4219,7 @@ var g = &grammar{
 							},
 						},
 						&andCodeExpr{
-							pos: position{line: 590, col: 5, offset: 19744},
+							pos: position{line: 587, col: 5, offset: 19674},
 							run: (*parser).callonTagWildcard7,
 						},
 					},
@@ -4236,18 +4228,18 @@ var g = &grammar{
 		},
 		{
 			name: "VerbatimFileContent",
-			pos:  position{line: 598, col: 1, offset: 19994},
+			pos:  position{line: 595, col: 1, offset: 19924},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 598, col: 24, offset: 20017},
+				pos: position{line: 595, col: 24, offset: 19947},
 				expr: &choiceExpr{
-					pos: position{line: 598, col: 25, offset: 20018},
+					pos: position{line: 595, col: 25, offset: 19948},
 					alternatives: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 598, col: 25, offset: 20018},
+							pos:  position{line: 595, col: 25, offset: 19948},
 							name: "FileInclusion",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 598, col: 41, offset: 20034},
+							pos:  position{line: 595, col: 41, offset: 19964},
 							name: "VerbatimFileLine",
 						},
 					},
@@ -4256,30 +4248,30 @@ var g = &grammar{
 		},
 		{
 			name: "VerbatimFileLine",
-			pos:  position{line: 600, col: 1, offset: 20056},
+			pos:  position{line: 597, col: 1, offset: 19986},
 			expr: &actionExpr{
-				pos: position{line: 600, col: 21, offset: 20076},
+				pos: position{line: 597, col: 21, offset: 20006},
 				run: (*parser).callonVerbatimFileLine1,
 				expr: &seqExpr{
-					pos: position{line: 600, col: 21, offset: 20076},
+					pos: position{line: 597, col: 21, offset: 20006},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 600, col: 21, offset: 20076},
+							pos: position{line: 597, col: 21, offset: 20006},
 							expr: &ruleRefExpr{
-								pos:  position{line: 600, col: 22, offset: 20077},
+								pos:  position{line: 597, col: 22, offset: 20007},
 								name: "EOF",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 600, col: 26, offset: 20081},
+							pos:   position{line: 597, col: 26, offset: 20011},
 							label: "content",
 							expr: &actionExpr{
-								pos: position{line: 600, col: 35, offset: 20090},
+								pos: position{line: 597, col: 35, offset: 20020},
 								run: (*parser).callonVerbatimFileLine6,
 								expr: &zeroOrMoreExpr{
-									pos: position{line: 600, col: 35, offset: 20090},
+									pos: position{line: 597, col: 35, offset: 20020},
 									expr: &charClassMatcher{
-										pos:        position{line: 600, col: 35, offset: 20090},
+										pos:        position{line: 597, col: 35, offset: 20020},
 										val:        "[^\\r\\n]",
 										chars:      []rune{'\r', '\n'},
 										ignoreCase: false,
@@ -4289,7 +4281,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 602, col: 12, offset: 20154},
+							pos:  position{line: 599, col: 12, offset: 20084},
 							name: "EOL",
 						},
 					},
@@ -4298,34 +4290,34 @@ var g = &grammar{
 		},
 		{
 			name: "IncludedFileLine",
-			pos:  position{line: 609, col: 1, offset: 20360},
+			pos:  position{line: 606, col: 1, offset: 20290},
 			expr: &actionExpr{
-				pos: position{line: 609, col: 21, offset: 20380},
+				pos: position{line: 606, col: 21, offset: 20310},
 				run: (*parser).callonIncludedFileLine1,
 				expr: &seqExpr{
-					pos: position{line: 609, col: 21, offset: 20380},
+					pos: position{line: 606, col: 21, offset: 20310},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 609, col: 21, offset: 20380},
+							pos:   position{line: 606, col: 21, offset: 20310},
 							label: "content",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 609, col: 29, offset: 20388},
+								pos: position{line: 606, col: 29, offset: 20318},
 								expr: &choiceExpr{
-									pos: position{line: 609, col: 30, offset: 20389},
+									pos: position{line: 606, col: 30, offset: 20319},
 									alternatives: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 609, col: 30, offset: 20389},
+											pos:  position{line: 606, col: 30, offset: 20319},
 											name: "IncludedFileStartTag",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 609, col: 53, offset: 20412},
+											pos:  position{line: 606, col: 53, offset: 20342},
 											name: "IncludedFileEndTag",
 										},
 										&actionExpr{
-											pos: position{line: 609, col: 74, offset: 20433},
+											pos: position{line: 606, col: 74, offset: 20363},
 											run: (*parser).callonIncludedFileLine8,
 											expr: &anyMatcher{
-												line: 609, col: 74, offset: 20433,
+												line: 606, col: 74, offset: 20363,
 											},
 										},
 									},
@@ -4333,7 +4325,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 609, col: 107, offset: 20466},
+							pos:  position{line: 606, col: 107, offset: 20396},
 							name: "EOL",
 						},
 					},
@@ -4342,33 +4334,33 @@ var g = &grammar{
 		},
 		{
 			name: "IncludedFileStartTag",
-			pos:  position{line: 613, col: 1, offset: 20541},
+			pos:  position{line: 610, col: 1, offset: 20471},
 			expr: &actionExpr{
-				pos: position{line: 613, col: 25, offset: 20565},
+				pos: position{line: 610, col: 25, offset: 20495},
 				run: (*parser).callonIncludedFileStartTag1,
 				expr: &seqExpr{
-					pos: position{line: 613, col: 25, offset: 20565},
+					pos: position{line: 610, col: 25, offset: 20495},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 613, col: 25, offset: 20565},
+							pos:        position{line: 610, col: 25, offset: 20495},
 							val:        "tag::",
 							ignoreCase: false,
 							want:       "\"tag::\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 613, col: 33, offset: 20573},
+							pos:   position{line: 610, col: 33, offset: 20503},
 							label: "tag",
 							expr: &actionExpr{
-								pos: position{line: 613, col: 38, offset: 20578},
+								pos: position{line: 610, col: 38, offset: 20508},
 								run: (*parser).callonIncludedFileStartTag5,
 								expr: &ruleRefExpr{
-									pos:  position{line: 613, col: 38, offset: 20578},
+									pos:  position{line: 610, col: 38, offset: 20508},
 									name: "Alphanums",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 613, col: 78, offset: 20618},
+							pos:        position{line: 610, col: 78, offset: 20548},
 							val:        "[]",
 							ignoreCase: false,
 							want:       "\"[]\"",
@@ -4379,33 +4371,33 @@ var g = &grammar{
 		},
 		{
 			name: "IncludedFileEndTag",
-			pos:  position{line: 617, col: 1, offset: 20687},
+			pos:  position{line: 614, col: 1, offset: 20617},
 			expr: &actionExpr{
-				pos: position{line: 617, col: 23, offset: 20709},
+				pos: position{line: 614, col: 23, offset: 20639},
 				run: (*parser).callonIncludedFileEndTag1,
 				expr: &seqExpr{
-					pos: position{line: 617, col: 23, offset: 20709},
+					pos: position{line: 614, col: 23, offset: 20639},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 617, col: 23, offset: 20709},
+							pos:        position{line: 614, col: 23, offset: 20639},
 							val:        "end::",
 							ignoreCase: false,
 							want:       "\"end::\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 617, col: 31, offset: 20717},
+							pos:   position{line: 614, col: 31, offset: 20647},
 							label: "tag",
 							expr: &actionExpr{
-								pos: position{line: 617, col: 36, offset: 20722},
+								pos: position{line: 614, col: 36, offset: 20652},
 								run: (*parser).callonIncludedFileEndTag5,
 								expr: &ruleRefExpr{
-									pos:  position{line: 617, col: 36, offset: 20722},
+									pos:  position{line: 614, col: 36, offset: 20652},
 									name: "Alphanums",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 617, col: 76, offset: 20762},
+							pos:        position{line: 614, col: 76, offset: 20692},
 							val:        "[]",
 							ignoreCase: false,
 							want:       "\"[]\"",
@@ -4416,32 +4408,32 @@ var g = &grammar{
 		},
 		{
 			name: "ListParagraph",
-			pos:  position{line: 624, col: 1, offset: 20933},
+			pos:  position{line: 621, col: 1, offset: 20863},
 			expr: &choiceExpr{
-				pos: position{line: 624, col: 18, offset: 20950},
+				pos: position{line: 621, col: 18, offset: 20880},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 624, col: 18, offset: 20950},
+						pos: position{line: 621, col: 18, offset: 20880},
 						run: (*parser).callonListParagraph2,
 						expr: &labeledExpr{
-							pos:   position{line: 624, col: 18, offset: 20950},
+							pos:   position{line: 621, col: 18, offset: 20880},
 							label: "comment",
 							expr: &ruleRefExpr{
-								pos:  position{line: 624, col: 27, offset: 20959},
+								pos:  position{line: 621, col: 27, offset: 20889},
 								name: "SingleLineComment",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 626, col: 9, offset: 21018},
+						pos: position{line: 623, col: 9, offset: 20948},
 						run: (*parser).callonListParagraph5,
 						expr: &labeledExpr{
-							pos:   position{line: 626, col: 9, offset: 21018},
+							pos:   position{line: 623, col: 9, offset: 20948},
 							label: "lines",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 626, col: 15, offset: 21024},
+								pos: position{line: 623, col: 15, offset: 20954},
 								expr: &ruleRefExpr{
-									pos:  position{line: 626, col: 16, offset: 21025},
+									pos:  position{line: 623, col: 16, offset: 20955},
 									name: "ListParagraphLine",
 								},
 							},
@@ -4452,96 +4444,96 @@ var g = &grammar{
 		},
 		{
 			name: "ListParagraphLine",
-			pos:  position{line: 630, col: 1, offset: 21121},
+			pos:  position{line: 627, col: 1, offset: 21051},
 			expr: &actionExpr{
-				pos: position{line: 630, col: 22, offset: 21142},
+				pos: position{line: 627, col: 22, offset: 21072},
 				run: (*parser).callonListParagraphLine1,
 				expr: &seqExpr{
-					pos: position{line: 630, col: 22, offset: 21142},
+					pos: position{line: 627, col: 22, offset: 21072},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 630, col: 22, offset: 21142},
+							pos: position{line: 627, col: 22, offset: 21072},
 							expr: &ruleRefExpr{
-								pos:  position{line: 630, col: 23, offset: 21143},
+								pos:  position{line: 627, col: 23, offset: 21073},
 								name: "EOF",
 							},
 						},
 						&notExpr{
-							pos: position{line: 631, col: 5, offset: 21152},
+							pos: position{line: 628, col: 5, offset: 21082},
 							expr: &ruleRefExpr{
-								pos:  position{line: 631, col: 6, offset: 21153},
+								pos:  position{line: 628, col: 6, offset: 21083},
 								name: "BlankLine",
 							},
 						},
 						&notExpr{
-							pos: position{line: 632, col: 5, offset: 21169},
+							pos: position{line: 629, col: 5, offset: 21099},
 							expr: &ruleRefExpr{
-								pos:  position{line: 632, col: 6, offset: 21170},
+								pos:  position{line: 629, col: 6, offset: 21100},
 								name: "SingleLineComment",
 							},
 						},
 						&notExpr{
-							pos: position{line: 633, col: 5, offset: 21193},
+							pos: position{line: 630, col: 5, offset: 21123},
 							expr: &ruleRefExpr{
-								pos:  position{line: 633, col: 6, offset: 21194},
+								pos:  position{line: 630, col: 6, offset: 21124},
 								name: "OrderedListItemPrefix",
 							},
 						},
 						&notExpr{
-							pos: position{line: 634, col: 5, offset: 21221},
+							pos: position{line: 631, col: 5, offset: 21151},
 							expr: &ruleRefExpr{
-								pos:  position{line: 634, col: 6, offset: 21222},
+								pos:  position{line: 631, col: 6, offset: 21152},
 								name: "UnorderedListItemPrefix",
 							},
 						},
 						&notExpr{
-							pos: position{line: 635, col: 5, offset: 21251},
+							pos: position{line: 632, col: 5, offset: 21181},
 							expr: &ruleRefExpr{
-								pos:  position{line: 635, col: 6, offset: 21252},
+								pos:  position{line: 632, col: 6, offset: 21182},
 								name: "CalloutListItemPrefix",
 							},
 						},
 						&notExpr{
-							pos: position{line: 636, col: 5, offset: 21279},
+							pos: position{line: 633, col: 5, offset: 21209},
 							expr: &ruleRefExpr{
-								pos:  position{line: 636, col: 6, offset: 21280},
+								pos:  position{line: 633, col: 6, offset: 21210},
 								name: "ListItemContinuation",
 							},
 						},
 						&notExpr{
-							pos: position{line: 637, col: 5, offset: 21306},
+							pos: position{line: 634, col: 5, offset: 21236},
 							expr: &ruleRefExpr{
-								pos:  position{line: 637, col: 6, offset: 21307},
+								pos:  position{line: 634, col: 6, offset: 21237},
 								name: "ElementAttribute",
 							},
 						},
 						&notExpr{
-							pos: position{line: 638, col: 5, offset: 21329},
+							pos: position{line: 635, col: 5, offset: 21259},
 							expr: &ruleRefExpr{
-								pos:  position{line: 638, col: 6, offset: 21330},
+								pos:  position{line: 635, col: 6, offset: 21260},
 								name: "BlockDelimiter",
 							},
 						},
 						&notExpr{
-							pos: position{line: 639, col: 5, offset: 21350},
+							pos: position{line: 636, col: 5, offset: 21280},
 							expr: &ruleRefExpr{
-								pos:  position{line: 639, col: 6, offset: 21351},
+								pos:  position{line: 636, col: 6, offset: 21281},
 								name: "LabeledListItemPrefix",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 640, col: 5, offset: 21379},
+							pos:   position{line: 637, col: 5, offset: 21309},
 							label: "line",
 							expr: &actionExpr{
-								pos: position{line: 640, col: 11, offset: 21385},
+								pos: position{line: 637, col: 11, offset: 21315},
 								run: (*parser).callonListParagraphLine24,
 								expr: &labeledExpr{
-									pos:   position{line: 640, col: 11, offset: 21385},
+									pos:   position{line: 637, col: 11, offset: 21315},
 									label: "elements",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 640, col: 20, offset: 21394},
+										pos: position{line: 637, col: 20, offset: 21324},
 										expr: &ruleRefExpr{
-											pos:  position{line: 640, col: 21, offset: 21395},
+											pos:  position{line: 637, col: 21, offset: 21325},
 											name: "InlineElement",
 										},
 									},
@@ -4549,7 +4541,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 642, col: 12, offset: 21496},
+							pos:  position{line: 639, col: 12, offset: 21426},
 							name: "EOL",
 						},
 					},
@@ -4558,25 +4550,25 @@ var g = &grammar{
 		},
 		{
 			name: "ListItemContinuation",
-			pos:  position{line: 646, col: 1, offset: 21539},
+			pos:  position{line: 643, col: 1, offset: 21469},
 			expr: &seqExpr{
-				pos: position{line: 646, col: 25, offset: 21563},
+				pos: position{line: 643, col: 25, offset: 21493},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 646, col: 25, offset: 21563},
+						pos:        position{line: 643, col: 25, offset: 21493},
 						val:        "+",
 						ignoreCase: false,
 						want:       "\"+\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 646, col: 29, offset: 21567},
+						pos: position{line: 643, col: 29, offset: 21497},
 						expr: &ruleRefExpr{
-							pos:  position{line: 646, col: 29, offset: 21567},
+							pos:  position{line: 643, col: 29, offset: 21497},
 							name: "Space",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 646, col: 36, offset: 21574},
+						pos:  position{line: 643, col: 36, offset: 21504},
 						name: "Newline",
 					},
 				},
@@ -4584,22 +4576,22 @@ var g = &grammar{
 		},
 		{
 			name: "ContinuedListItemElement",
-			pos:  position{line: 648, col: 1, offset: 21648},
+			pos:  position{line: 645, col: 1, offset: 21578},
 			expr: &actionExpr{
-				pos: position{line: 648, col: 29, offset: 21676},
+				pos: position{line: 645, col: 29, offset: 21606},
 				run: (*parser).callonContinuedListItemElement1,
 				expr: &seqExpr{
-					pos: position{line: 648, col: 29, offset: 21676},
+					pos: position{line: 645, col: 29, offset: 21606},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 648, col: 29, offset: 21676},
+							pos:  position{line: 645, col: 29, offset: 21606},
 							name: "ListItemContinuation",
 						},
 						&labeledExpr{
-							pos:   position{line: 648, col: 50, offset: 21697},
+							pos:   position{line: 645, col: 50, offset: 21627},
 							label: "element",
 							expr: &ruleRefExpr{
-								pos:  position{line: 648, col: 58, offset: 21705},
+								pos:  position{line: 645, col: 58, offset: 21635},
 								name: "ContinuedListItemContent",
 							},
 						},
@@ -4609,80 +4601,80 @@ var g = &grammar{
 		},
 		{
 			name: "ContinuedListItemContent",
-			pos:  position{line: 652, col: 1, offset: 21815},
+			pos:  position{line: 649, col: 1, offset: 21745},
 			expr: &actionExpr{
-				pos: position{line: 652, col: 29, offset: 21843},
+				pos: position{line: 649, col: 29, offset: 21773},
 				run: (*parser).callonContinuedListItemContent1,
 				expr: &seqExpr{
-					pos: position{line: 652, col: 29, offset: 21843},
+					pos: position{line: 649, col: 29, offset: 21773},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 652, col: 29, offset: 21843},
+							pos: position{line: 649, col: 29, offset: 21773},
 							expr: &ruleRefExpr{
-								pos:  position{line: 652, col: 30, offset: 21844},
+								pos:  position{line: 649, col: 30, offset: 21774},
 								name: "EOF",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 653, col: 5, offset: 21854},
+							pos:   position{line: 650, col: 5, offset: 21784},
 							label: "content",
 							expr: &choiceExpr{
-								pos: position{line: 653, col: 14, offset: 21863},
+								pos: position{line: 650, col: 14, offset: 21793},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 653, col: 14, offset: 21863},
+										pos:  position{line: 650, col: 14, offset: 21793},
 										name: "DelimitedBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 654, col: 11, offset: 21889},
+										pos:  position{line: 651, col: 11, offset: 21819},
 										name: "FileInclusion",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 655, col: 11, offset: 21914},
+										pos:  position{line: 652, col: 11, offset: 21844},
 										name: "VerseParagraph",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 656, col: 11, offset: 21969},
+										pos:  position{line: 653, col: 11, offset: 21899},
 										name: "ImageBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 657, col: 11, offset: 21992},
+										pos:  position{line: 654, col: 11, offset: 21922},
 										name: "OrderedListItem",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 658, col: 11, offset: 22020},
+										pos:  position{line: 655, col: 11, offset: 21950},
 										name: "UnorderedListItem",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 659, col: 11, offset: 22050},
+										pos:  position{line: 656, col: 11, offset: 21980},
 										name: "LabeledListItem",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 661, col: 11, offset: 22117},
+										pos:  position{line: 658, col: 11, offset: 22047},
 										name: "BlankLine",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 662, col: 11, offset: 22169},
+										pos:  position{line: 659, col: 11, offset: 22099},
 										name: "LiteralBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 663, col: 11, offset: 22194},
+										pos:  position{line: 660, col: 11, offset: 22124},
 										name: "AttributeDeclaration",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 664, col: 11, offset: 22227},
+										pos:  position{line: 661, col: 11, offset: 22157},
 										name: "AttributeReset",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 665, col: 11, offset: 22254},
+										pos:  position{line: 662, col: 11, offset: 22184},
 										name: "TableOfContentsPlaceHolder",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 666, col: 11, offset: 22292},
+										pos:  position{line: 663, col: 11, offset: 22222},
 										name: "UserMacroBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 667, col: 11, offset: 22318},
+										pos:  position{line: 664, col: 11, offset: 22248},
 										name: "ContinuedParagraph",
 									},
 								},
@@ -4694,37 +4686,37 @@ var g = &grammar{
 		},
 		{
 			name: "OrderedListItem",
-			pos:  position{line: 674, col: 1, offset: 22488},
+			pos:  position{line: 671, col: 1, offset: 22418},
 			expr: &actionExpr{
-				pos: position{line: 674, col: 20, offset: 22507},
+				pos: position{line: 671, col: 20, offset: 22437},
 				run: (*parser).callonOrderedListItem1,
 				expr: &seqExpr{
-					pos: position{line: 674, col: 20, offset: 22507},
+					pos: position{line: 671, col: 20, offset: 22437},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 674, col: 20, offset: 22507},
+							pos:   position{line: 671, col: 20, offset: 22437},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 674, col: 31, offset: 22518},
+								pos: position{line: 671, col: 31, offset: 22448},
 								expr: &ruleRefExpr{
-									pos:  position{line: 674, col: 32, offset: 22519},
+									pos:  position{line: 671, col: 32, offset: 22449},
 									name: "Attributes",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 674, col: 45, offset: 22532},
+							pos:   position{line: 671, col: 45, offset: 22462},
 							label: "prefix",
 							expr: &ruleRefExpr{
-								pos:  position{line: 674, col: 53, offset: 22540},
+								pos:  position{line: 671, col: 53, offset: 22470},
 								name: "OrderedListItemPrefix",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 674, col: 76, offset: 22563},
+							pos:   position{line: 671, col: 76, offset: 22493},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 674, col: 85, offset: 22572},
+								pos:  position{line: 671, col: 85, offset: 22502},
 								name: "OrderedListItemContent",
 							},
 						},
@@ -4734,42 +4726,42 @@ var g = &grammar{
 		},
 		{
 			name: "OrderedListItemPrefix",
-			pos:  position{line: 678, col: 1, offset: 22716},
+			pos:  position{line: 675, col: 1, offset: 22646},
 			expr: &actionExpr{
-				pos: position{line: 679, col: 5, offset: 22747},
+				pos: position{line: 676, col: 5, offset: 22677},
 				run: (*parser).callonOrderedListItemPrefix1,
 				expr: &seqExpr{
-					pos: position{line: 679, col: 5, offset: 22747},
+					pos: position{line: 676, col: 5, offset: 22677},
 					exprs: []interface{}{
 						&zeroOrMoreExpr{
-							pos: position{line: 679, col: 5, offset: 22747},
+							pos: position{line: 676, col: 5, offset: 22677},
 							expr: &ruleRefExpr{
-								pos:  position{line: 679, col: 5, offset: 22747},
+								pos:  position{line: 676, col: 5, offset: 22677},
 								name: "Space",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 679, col: 12, offset: 22754},
+							pos:   position{line: 676, col: 12, offset: 22684},
 							label: "prefix",
 							expr: &choiceExpr{
-								pos: position{line: 681, col: 9, offset: 22819},
+								pos: position{line: 678, col: 9, offset: 22749},
 								alternatives: []interface{}{
 									&actionExpr{
-										pos: position{line: 681, col: 9, offset: 22819},
+										pos: position{line: 678, col: 9, offset: 22749},
 										run: (*parser).callonOrderedListItemPrefix7,
 										expr: &seqExpr{
-											pos: position{line: 681, col: 9, offset: 22819},
+											pos: position{line: 678, col: 9, offset: 22749},
 											exprs: []interface{}{
 												&labeledExpr{
-													pos:   position{line: 681, col: 9, offset: 22819},
+													pos:   position{line: 678, col: 9, offset: 22749},
 													label: "depth",
 													expr: &actionExpr{
-														pos: position{line: 681, col: 16, offset: 22826},
+														pos: position{line: 678, col: 16, offset: 22756},
 														run: (*parser).callonOrderedListItemPrefix10,
 														expr: &oneOrMoreExpr{
-															pos: position{line: 681, col: 16, offset: 22826},
+															pos: position{line: 678, col: 16, offset: 22756},
 															expr: &litMatcher{
-																pos:        position{line: 681, col: 17, offset: 22827},
+																pos:        position{line: 678, col: 17, offset: 22757},
 																val:        ".",
 																ignoreCase: false,
 																want:       "\".\"",
@@ -4778,22 +4770,22 @@ var g = &grammar{
 													},
 												},
 												&andCodeExpr{
-													pos: position{line: 685, col: 9, offset: 22931},
+													pos: position{line: 682, col: 9, offset: 22861},
 													run: (*parser).callonOrderedListItemPrefix13,
 												},
 											},
 										},
 									},
 									&actionExpr{
-										pos: position{line: 704, col: 11, offset: 23667},
+										pos: position{line: 701, col: 11, offset: 23597},
 										run: (*parser).callonOrderedListItemPrefix14,
 										expr: &seqExpr{
-											pos: position{line: 704, col: 11, offset: 23667},
+											pos: position{line: 701, col: 11, offset: 23597},
 											exprs: []interface{}{
 												&oneOrMoreExpr{
-													pos: position{line: 704, col: 11, offset: 23667},
+													pos: position{line: 701, col: 11, offset: 23597},
 													expr: &charClassMatcher{
-														pos:        position{line: 704, col: 12, offset: 23668},
+														pos:        position{line: 701, col: 12, offset: 23598},
 														val:        "[0-9]",
 														ranges:     []rune{'0', '9'},
 														ignoreCase: false,
@@ -4801,7 +4793,7 @@ var g = &grammar{
 													},
 												},
 												&litMatcher{
-													pos:        position{line: 704, col: 20, offset: 23676},
+													pos:        position{line: 701, col: 20, offset: 23606},
 													val:        ".",
 													ignoreCase: false,
 													want:       "\".\"",
@@ -4810,20 +4802,20 @@ var g = &grammar{
 										},
 									},
 									&actionExpr{
-										pos: position{line: 706, col: 13, offset: 23789},
+										pos: position{line: 703, col: 13, offset: 23719},
 										run: (*parser).callonOrderedListItemPrefix19,
 										expr: &seqExpr{
-											pos: position{line: 706, col: 13, offset: 23789},
+											pos: position{line: 703, col: 13, offset: 23719},
 											exprs: []interface{}{
 												&charClassMatcher{
-													pos:        position{line: 706, col: 14, offset: 23790},
+													pos:        position{line: 703, col: 14, offset: 23720},
 													val:        "[a-z]",
 													ranges:     []rune{'a', 'z'},
 													ignoreCase: false,
 													inverted:   false,
 												},
 												&litMatcher{
-													pos:        position{line: 706, col: 21, offset: 23797},
+													pos:        position{line: 703, col: 21, offset: 23727},
 													val:        ".",
 													ignoreCase: false,
 													want:       "\".\"",
@@ -4832,20 +4824,20 @@ var g = &grammar{
 										},
 									},
 									&actionExpr{
-										pos: position{line: 708, col: 13, offset: 23913},
+										pos: position{line: 705, col: 13, offset: 23843},
 										run: (*parser).callonOrderedListItemPrefix23,
 										expr: &seqExpr{
-											pos: position{line: 708, col: 13, offset: 23913},
+											pos: position{line: 705, col: 13, offset: 23843},
 											exprs: []interface{}{
 												&charClassMatcher{
-													pos:        position{line: 708, col: 14, offset: 23914},
+													pos:        position{line: 705, col: 14, offset: 23844},
 													val:        "[A-Z]",
 													ranges:     []rune{'A', 'Z'},
 													ignoreCase: false,
 													inverted:   false,
 												},
 												&litMatcher{
-													pos:        position{line: 708, col: 21, offset: 23921},
+													pos:        position{line: 705, col: 21, offset: 23851},
 													val:        ".",
 													ignoreCase: false,
 													want:       "\".\"",
@@ -4854,15 +4846,15 @@ var g = &grammar{
 										},
 									},
 									&actionExpr{
-										pos: position{line: 710, col: 13, offset: 24037},
+										pos: position{line: 707, col: 13, offset: 23967},
 										run: (*parser).callonOrderedListItemPrefix27,
 										expr: &seqExpr{
-											pos: position{line: 710, col: 13, offset: 24037},
+											pos: position{line: 707, col: 13, offset: 23967},
 											exprs: []interface{}{
 												&oneOrMoreExpr{
-													pos: position{line: 710, col: 13, offset: 24037},
+													pos: position{line: 707, col: 13, offset: 23967},
 													expr: &charClassMatcher{
-														pos:        position{line: 710, col: 14, offset: 24038},
+														pos:        position{line: 707, col: 14, offset: 23968},
 														val:        "[a-z]",
 														ranges:     []rune{'a', 'z'},
 														ignoreCase: false,
@@ -4870,7 +4862,7 @@ var g = &grammar{
 													},
 												},
 												&litMatcher{
-													pos:        position{line: 710, col: 22, offset: 24046},
+													pos:        position{line: 707, col: 22, offset: 23976},
 													val:        ")",
 													ignoreCase: false,
 													want:       "\")\"",
@@ -4879,15 +4871,15 @@ var g = &grammar{
 										},
 									},
 									&actionExpr{
-										pos: position{line: 712, col: 13, offset: 24162},
+										pos: position{line: 709, col: 13, offset: 24092},
 										run: (*parser).callonOrderedListItemPrefix32,
 										expr: &seqExpr{
-											pos: position{line: 712, col: 13, offset: 24162},
+											pos: position{line: 709, col: 13, offset: 24092},
 											exprs: []interface{}{
 												&oneOrMoreExpr{
-													pos: position{line: 712, col: 13, offset: 24162},
+													pos: position{line: 709, col: 13, offset: 24092},
 													expr: &charClassMatcher{
-														pos:        position{line: 712, col: 14, offset: 24163},
+														pos:        position{line: 709, col: 14, offset: 24093},
 														val:        "[A-Z]",
 														ranges:     []rune{'A', 'Z'},
 														ignoreCase: false,
@@ -4895,7 +4887,7 @@ var g = &grammar{
 													},
 												},
 												&litMatcher{
-													pos:        position{line: 712, col: 22, offset: 24171},
+													pos:        position{line: 709, col: 22, offset: 24101},
 													val:        ")",
 													ignoreCase: false,
 													want:       "\")\"",
@@ -4907,9 +4899,9 @@ var g = &grammar{
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 714, col: 12, offset: 24286},
+							pos: position{line: 711, col: 12, offset: 24216},
 							expr: &ruleRefExpr{
-								pos:  position{line: 714, col: 12, offset: 24286},
+								pos:  position{line: 711, col: 12, offset: 24216},
 								name: "Space",
 							},
 						},
@@ -4919,17 +4911,17 @@ var g = &grammar{
 		},
 		{
 			name: "OrderedListItemContent",
-			pos:  position{line: 718, col: 1, offset: 24325},
+			pos:  position{line: 715, col: 1, offset: 24255},
 			expr: &actionExpr{
-				pos: position{line: 718, col: 27, offset: 24351},
+				pos: position{line: 715, col: 27, offset: 24281},
 				run: (*parser).callonOrderedListItemContent1,
 				expr: &labeledExpr{
-					pos:   position{line: 718, col: 27, offset: 24351},
+					pos:   position{line: 715, col: 27, offset: 24281},
 					label: "elements",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 718, col: 37, offset: 24361},
+						pos: position{line: 715, col: 37, offset: 24291},
 						expr: &ruleRefExpr{
-							pos:  position{line: 718, col: 37, offset: 24361},
+							pos:  position{line: 715, col: 37, offset: 24291},
 							name: "ListParagraph",
 						},
 					},
@@ -4938,48 +4930,48 @@ var g = &grammar{
 		},
 		{
 			name: "UnorderedListItem",
-			pos:  position{line: 725, col: 1, offset: 24568},
+			pos:  position{line: 722, col: 1, offset: 24498},
 			expr: &actionExpr{
-				pos: position{line: 725, col: 22, offset: 24589},
+				pos: position{line: 722, col: 22, offset: 24519},
 				run: (*parser).callonUnorderedListItem1,
 				expr: &seqExpr{
-					pos: position{line: 725, col: 22, offset: 24589},
+					pos: position{line: 722, col: 22, offset: 24519},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 725, col: 22, offset: 24589},
+							pos:   position{line: 722, col: 22, offset: 24519},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 725, col: 33, offset: 24600},
+								pos: position{line: 722, col: 33, offset: 24530},
 								expr: &ruleRefExpr{
-									pos:  position{line: 725, col: 34, offset: 24601},
+									pos:  position{line: 722, col: 34, offset: 24531},
 									name: "Attributes",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 725, col: 47, offset: 24614},
+							pos:   position{line: 722, col: 47, offset: 24544},
 							label: "prefix",
 							expr: &ruleRefExpr{
-								pos:  position{line: 725, col: 55, offset: 24622},
+								pos:  position{line: 722, col: 55, offset: 24552},
 								name: "UnorderedListItemPrefix",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 725, col: 80, offset: 24647},
+							pos:   position{line: 722, col: 80, offset: 24577},
 							label: "checkstyle",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 725, col: 91, offset: 24658},
+								pos: position{line: 722, col: 91, offset: 24588},
 								expr: &ruleRefExpr{
-									pos:  position{line: 725, col: 92, offset: 24659},
+									pos:  position{line: 722, col: 92, offset: 24589},
 									name: "UnorderedListItemCheckStyle",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 725, col: 122, offset: 24689},
+							pos:   position{line: 722, col: 122, offset: 24619},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 725, col: 131, offset: 24698},
+								pos:  position{line: 722, col: 131, offset: 24628},
 								name: "UnorderedListItemContent",
 							},
 						},
@@ -4989,42 +4981,42 @@ var g = &grammar{
 		},
 		{
 			name: "UnorderedListItemPrefix",
-			pos:  position{line: 729, col: 1, offset: 24860},
+			pos:  position{line: 726, col: 1, offset: 24790},
 			expr: &actionExpr{
-				pos: position{line: 730, col: 5, offset: 24893},
+				pos: position{line: 727, col: 5, offset: 24823},
 				run: (*parser).callonUnorderedListItemPrefix1,
 				expr: &seqExpr{
-					pos: position{line: 730, col: 5, offset: 24893},
+					pos: position{line: 727, col: 5, offset: 24823},
 					exprs: []interface{}{
 						&zeroOrMoreExpr{
-							pos: position{line: 730, col: 5, offset: 24893},
+							pos: position{line: 727, col: 5, offset: 24823},
 							expr: &ruleRefExpr{
-								pos:  position{line: 730, col: 5, offset: 24893},
+								pos:  position{line: 727, col: 5, offset: 24823},
 								name: "Space",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 730, col: 12, offset: 24900},
+							pos:   position{line: 727, col: 12, offset: 24830},
 							label: "prefix",
 							expr: &choiceExpr{
-								pos: position{line: 730, col: 20, offset: 24908},
+								pos: position{line: 727, col: 20, offset: 24838},
 								alternatives: []interface{}{
 									&actionExpr{
-										pos: position{line: 732, col: 9, offset: 24967},
+										pos: position{line: 729, col: 9, offset: 24897},
 										run: (*parser).callonUnorderedListItemPrefix7,
 										expr: &seqExpr{
-											pos: position{line: 732, col: 9, offset: 24967},
+											pos: position{line: 729, col: 9, offset: 24897},
 											exprs: []interface{}{
 												&labeledExpr{
-													pos:   position{line: 732, col: 9, offset: 24967},
+													pos:   position{line: 729, col: 9, offset: 24897},
 													label: "depth",
 													expr: &actionExpr{
-														pos: position{line: 732, col: 16, offset: 24974},
+														pos: position{line: 729, col: 16, offset: 24904},
 														run: (*parser).callonUnorderedListItemPrefix10,
 														expr: &oneOrMoreExpr{
-															pos: position{line: 732, col: 16, offset: 24974},
+															pos: position{line: 729, col: 16, offset: 24904},
 															expr: &litMatcher{
-																pos:        position{line: 732, col: 17, offset: 24975},
+																pos:        position{line: 729, col: 17, offset: 24905},
 																val:        "*",
 																ignoreCase: false,
 																want:       "\"*\"",
@@ -5033,20 +5025,20 @@ var g = &grammar{
 													},
 												},
 												&andCodeExpr{
-													pos: position{line: 736, col: 9, offset: 25079},
+													pos: position{line: 733, col: 9, offset: 25009},
 													run: (*parser).callonUnorderedListItemPrefix13,
 												},
 											},
 										},
 									},
 									&labeledExpr{
-										pos:   position{line: 753, col: 14, offset: 25803},
+										pos:   position{line: 750, col: 14, offset: 25733},
 										label: "depth",
 										expr: &actionExpr{
-											pos: position{line: 753, col: 21, offset: 25810},
+											pos: position{line: 750, col: 21, offset: 25740},
 											run: (*parser).callonUnorderedListItemPrefix15,
 											expr: &litMatcher{
-												pos:        position{line: 753, col: 22, offset: 25811},
+												pos:        position{line: 750, col: 22, offset: 25741},
 												val:        "-",
 												ignoreCase: false,
 												want:       "\"-\"",
@@ -5057,9 +5049,9 @@ var g = &grammar{
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 755, col: 13, offset: 25899},
+							pos: position{line: 752, col: 13, offset: 25829},
 							expr: &ruleRefExpr{
-								pos:  position{line: 755, col: 13, offset: 25899},
+								pos:  position{line: 752, col: 13, offset: 25829},
 								name: "Space",
 							},
 						},
@@ -5069,53 +5061,53 @@ var g = &grammar{
 		},
 		{
 			name: "UnorderedListItemCheckStyle",
-			pos:  position{line: 759, col: 1, offset: 25939},
+			pos:  position{line: 756, col: 1, offset: 25869},
 			expr: &actionExpr{
-				pos: position{line: 759, col: 32, offset: 25970},
+				pos: position{line: 756, col: 32, offset: 25900},
 				run: (*parser).callonUnorderedListItemCheckStyle1,
 				expr: &seqExpr{
-					pos: position{line: 759, col: 32, offset: 25970},
+					pos: position{line: 756, col: 32, offset: 25900},
 					exprs: []interface{}{
 						&andExpr{
-							pos: position{line: 759, col: 32, offset: 25970},
+							pos: position{line: 756, col: 32, offset: 25900},
 							expr: &litMatcher{
-								pos:        position{line: 759, col: 33, offset: 25971},
+								pos:        position{line: 756, col: 33, offset: 25901},
 								val:        "[",
 								ignoreCase: false,
 								want:       "\"[\"",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 759, col: 37, offset: 25975},
+							pos:   position{line: 756, col: 37, offset: 25905},
 							label: "style",
 							expr: &choiceExpr{
-								pos: position{line: 760, col: 7, offset: 25990},
+								pos: position{line: 757, col: 7, offset: 25920},
 								alternatives: []interface{}{
 									&actionExpr{
-										pos: position{line: 760, col: 7, offset: 25990},
+										pos: position{line: 757, col: 7, offset: 25920},
 										run: (*parser).callonUnorderedListItemCheckStyle7,
 										expr: &litMatcher{
-											pos:        position{line: 760, col: 7, offset: 25990},
+											pos:        position{line: 757, col: 7, offset: 25920},
 											val:        "[ ]",
 											ignoreCase: false,
 											want:       "\"[ ]\"",
 										},
 									},
 									&actionExpr{
-										pos: position{line: 761, col: 7, offset: 26036},
+										pos: position{line: 758, col: 7, offset: 25966},
 										run: (*parser).callonUnorderedListItemCheckStyle9,
 										expr: &litMatcher{
-											pos:        position{line: 761, col: 7, offset: 26036},
+											pos:        position{line: 758, col: 7, offset: 25966},
 											val:        "[*]",
 											ignoreCase: false,
 											want:       "\"[*]\"",
 										},
 									},
 									&actionExpr{
-										pos: position{line: 762, col: 7, offset: 26080},
+										pos: position{line: 759, col: 7, offset: 26010},
 										run: (*parser).callonUnorderedListItemCheckStyle11,
 										expr: &litMatcher{
-											pos:        position{line: 762, col: 7, offset: 26080},
+											pos:        position{line: 759, col: 7, offset: 26010},
 											val:        "[x]",
 											ignoreCase: false,
 											want:       "\"[x]\"",
@@ -5125,9 +5117,9 @@ var g = &grammar{
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 763, col: 7, offset: 26123},
+							pos: position{line: 760, col: 7, offset: 26053},
 							expr: &ruleRefExpr{
-								pos:  position{line: 763, col: 7, offset: 26123},
+								pos:  position{line: 760, col: 7, offset: 26053},
 								name: "Space",
 							},
 						},
@@ -5137,17 +5129,17 @@ var g = &grammar{
 		},
 		{
 			name: "UnorderedListItemContent",
-			pos:  position{line: 767, col: 1, offset: 26169},
+			pos:  position{line: 764, col: 1, offset: 26099},
 			expr: &actionExpr{
-				pos: position{line: 767, col: 29, offset: 26197},
+				pos: position{line: 764, col: 29, offset: 26127},
 				run: (*parser).callonUnorderedListItemContent1,
 				expr: &labeledExpr{
-					pos:   position{line: 767, col: 29, offset: 26197},
+					pos:   position{line: 764, col: 29, offset: 26127},
 					label: "elements",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 767, col: 39, offset: 26207},
+						pos: position{line: 764, col: 39, offset: 26137},
 						expr: &ruleRefExpr{
-							pos:  position{line: 767, col: 39, offset: 26207},
+							pos:  position{line: 764, col: 39, offset: 26137},
 							name: "ListParagraph",
 						},
 					},
@@ -5156,47 +5148,47 @@ var g = &grammar{
 		},
 		{
 			name: "LabeledListItem",
-			pos:  position{line: 774, col: 1, offset: 26530},
+			pos:  position{line: 771, col: 1, offset: 26460},
 			expr: &actionExpr{
-				pos: position{line: 774, col: 20, offset: 26549},
+				pos: position{line: 771, col: 20, offset: 26479},
 				run: (*parser).callonLabeledListItem1,
 				expr: &seqExpr{
-					pos: position{line: 774, col: 20, offset: 26549},
+					pos: position{line: 771, col: 20, offset: 26479},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 774, col: 20, offset: 26549},
+							pos:   position{line: 771, col: 20, offset: 26479},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 774, col: 31, offset: 26560},
+								pos: position{line: 771, col: 31, offset: 26490},
 								expr: &ruleRefExpr{
-									pos:  position{line: 774, col: 32, offset: 26561},
+									pos:  position{line: 771, col: 32, offset: 26491},
 									name: "Attributes",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 774, col: 45, offset: 26574},
+							pos:   position{line: 771, col: 45, offset: 26504},
 							label: "term",
 							expr: &ruleRefExpr{
-								pos:  position{line: 774, col: 51, offset: 26580},
+								pos:  position{line: 771, col: 51, offset: 26510},
 								name: "VerbatimLabeledListItemTerm",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 774, col: 80, offset: 26609},
+							pos:   position{line: 771, col: 80, offset: 26539},
 							label: "separator",
 							expr: &ruleRefExpr{
-								pos:  position{line: 774, col: 91, offset: 26620},
+								pos:  position{line: 771, col: 91, offset: 26550},
 								name: "LabeledListItemSeparator",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 774, col: 117, offset: 26646},
+							pos:   position{line: 771, col: 117, offset: 26576},
 							label: "description",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 774, col: 129, offset: 26658},
+								pos: position{line: 771, col: 129, offset: 26588},
 								expr: &ruleRefExpr{
-									pos:  position{line: 774, col: 130, offset: 26659},
+									pos:  position{line: 771, col: 130, offset: 26589},
 									name: "LabeledListItemDescription",
 								},
 							},
@@ -5207,16 +5199,16 @@ var g = &grammar{
 		},
 		{
 			name: "LabeledListItemPrefix",
-			pos:  position{line: 778, col: 1, offset: 26809},
+			pos:  position{line: 775, col: 1, offset: 26739},
 			expr: &seqExpr{
-				pos: position{line: 778, col: 26, offset: 26834},
+				pos: position{line: 775, col: 26, offset: 26764},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 778, col: 26, offset: 26834},
+						pos:  position{line: 775, col: 26, offset: 26764},
 						name: "VerbatimLabeledListItemTerm",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 778, col: 54, offset: 26862},
+						pos:  position{line: 775, col: 54, offset: 26792},
 						name: "LabeledListItemSeparator",
 					},
 				},
@@ -5224,14 +5216,14 @@ var g = &grammar{
 		},
 		{
 			name: "VerbatimLabeledListItemChars",
-			pos:  position{line: 780, col: 1, offset: 26890},
+			pos:  position{line: 777, col: 1, offset: 26820},
 			expr: &choiceExpr{
-				pos: position{line: 780, col: 33, offset: 26922},
+				pos: position{line: 777, col: 33, offset: 26852},
 				alternatives: []interface{}{
 					&oneOrMoreExpr{
-						pos: position{line: 780, col: 33, offset: 26922},
+						pos: position{line: 777, col: 33, offset: 26852},
 						expr: &charClassMatcher{
-							pos:        position{line: 780, col: 33, offset: 26922},
+							pos:        position{line: 777, col: 33, offset: 26852},
 							val:        "[^:\\r\\n]",
 							chars:      []rune{':', '\r', '\n'},
 							ignoreCase: false,
@@ -5239,18 +5231,18 @@ var g = &grammar{
 						},
 					},
 					&seqExpr{
-						pos: position{line: 780, col: 45, offset: 26934},
+						pos: position{line: 777, col: 45, offset: 26864},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 780, col: 45, offset: 26934},
+								pos:        position{line: 777, col: 45, offset: 26864},
 								val:        ":",
 								ignoreCase: false,
 								want:       "\":\"",
 							},
 							&notExpr{
-								pos: position{line: 780, col: 49, offset: 26938},
+								pos: position{line: 777, col: 49, offset: 26868},
 								expr: &litMatcher{
-									pos:        position{line: 780, col: 50, offset: 26939},
+									pos:        position{line: 777, col: 50, offset: 26869},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
@@ -5263,20 +5255,20 @@ var g = &grammar{
 		},
 		{
 			name: "VerbatimLabeledListItemTerm",
-			pos:  position{line: 781, col: 1, offset: 26944},
+			pos:  position{line: 778, col: 1, offset: 26874},
 			expr: &actionExpr{
-				pos: position{line: 781, col: 32, offset: 26975},
+				pos: position{line: 778, col: 32, offset: 26905},
 				run: (*parser).callonVerbatimLabeledListItemTerm1,
 				expr: &labeledExpr{
-					pos:   position{line: 781, col: 32, offset: 26975},
+					pos:   position{line: 778, col: 32, offset: 26905},
 					label: "content",
 					expr: &actionExpr{
-						pos: position{line: 781, col: 42, offset: 26985},
+						pos: position{line: 778, col: 42, offset: 26915},
 						run: (*parser).callonVerbatimLabeledListItemTerm3,
 						expr: &oneOrMoreExpr{
-							pos: position{line: 781, col: 42, offset: 26985},
+							pos: position{line: 778, col: 42, offset: 26915},
 							expr: &ruleRefExpr{
-								pos:  position{line: 781, col: 42, offset: 26985},
+								pos:  position{line: 778, col: 42, offset: 26915},
 								name: "VerbatimLabeledListItemChars",
 							},
 						},
@@ -5286,36 +5278,36 @@ var g = &grammar{
 		},
 		{
 			name: "LabeledListItemTerm",
-			pos:  position{line: 787, col: 1, offset: 27146},
+			pos:  position{line: 784, col: 1, offset: 27076},
 			expr: &actionExpr{
-				pos: position{line: 787, col: 24, offset: 27169},
+				pos: position{line: 784, col: 24, offset: 27099},
 				run: (*parser).callonLabeledListItemTerm1,
 				expr: &labeledExpr{
-					pos:   position{line: 787, col: 24, offset: 27169},
+					pos:   position{line: 784, col: 24, offset: 27099},
 					label: "elements",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 787, col: 33, offset: 27178},
+						pos: position{line: 784, col: 33, offset: 27108},
 						expr: &seqExpr{
-							pos: position{line: 787, col: 34, offset: 27179},
+							pos: position{line: 784, col: 34, offset: 27109},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 787, col: 34, offset: 27179},
+									pos: position{line: 784, col: 34, offset: 27109},
 									expr: &ruleRefExpr{
-										pos:  position{line: 787, col: 35, offset: 27180},
+										pos:  position{line: 784, col: 35, offset: 27110},
 										name: "Newline",
 									},
 								},
 								&notExpr{
-									pos: position{line: 787, col: 43, offset: 27188},
+									pos: position{line: 784, col: 43, offset: 27118},
 									expr: &litMatcher{
-										pos:        position{line: 787, col: 44, offset: 27189},
+										pos:        position{line: 784, col: 44, offset: 27119},
 										val:        "::",
 										ignoreCase: false,
 										want:       "\"::\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 787, col: 49, offset: 27194},
+									pos:  position{line: 784, col: 49, offset: 27124},
 									name: "LabeledListItemTermElement",
 								},
 							},
@@ -5326,77 +5318,77 @@ var g = &grammar{
 		},
 		{
 			name: "LabeledListItemTermElement",
-			pos:  position{line: 791, col: 1, offset: 27325},
+			pos:  position{line: 788, col: 1, offset: 27255},
 			expr: &actionExpr{
-				pos: position{line: 791, col: 31, offset: 27355},
+				pos: position{line: 788, col: 31, offset: 27285},
 				run: (*parser).callonLabeledListItemTermElement1,
 				expr: &labeledExpr{
-					pos:   position{line: 791, col: 31, offset: 27355},
+					pos:   position{line: 788, col: 31, offset: 27285},
 					label: "element",
 					expr: &choiceExpr{
-						pos: position{line: 791, col: 40, offset: 27364},
+						pos: position{line: 788, col: 40, offset: 27294},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 791, col: 40, offset: 27364},
+								pos:  position{line: 788, col: 40, offset: 27294},
 								name: "Word",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 792, col: 11, offset: 27380},
+								pos:  position{line: 789, col: 11, offset: 27310},
 								name: "LineBreak",
 							},
 							&oneOrMoreExpr{
-								pos: position{line: 793, col: 11, offset: 27430},
+								pos: position{line: 790, col: 11, offset: 27360},
 								expr: &ruleRefExpr{
-									pos:  position{line: 793, col: 11, offset: 27430},
+									pos:  position{line: 790, col: 11, offset: 27360},
 									name: "Space",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 794, col: 11, offset: 27449},
+								pos:  position{line: 791, col: 11, offset: 27379},
 								name: "CrossReference",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 795, col: 11, offset: 27475},
+								pos:  position{line: 792, col: 11, offset: 27405},
 								name: "ConcealedIndexTerm",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 796, col: 11, offset: 27505},
+								pos:  position{line: 793, col: 11, offset: 27435},
 								name: "IndexTerm",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 797, col: 11, offset: 27526},
+								pos:  position{line: 794, col: 11, offset: 27456},
 								name: "InlinePassthrough",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 798, col: 11, offset: 27555},
+								pos:  position{line: 795, col: 11, offset: 27485},
 								name: "InlineIcon",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 799, col: 11, offset: 27577},
+								pos:  position{line: 796, col: 11, offset: 27507},
 								name: "InlineImage",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 800, col: 11, offset: 27601},
+								pos:  position{line: 797, col: 11, offset: 27531},
 								name: "Link",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 801, col: 11, offset: 27617},
+								pos:  position{line: 798, col: 11, offset: 27547},
 								name: "InlineFootnote",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 802, col: 11, offset: 27643},
+								pos:  position{line: 799, col: 11, offset: 27573},
 								name: "QuotedString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 803, col: 11, offset: 27667},
+								pos:  position{line: 800, col: 11, offset: 27597},
 								name: "QuotedText",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 804, col: 11, offset: 27689},
+								pos:  position{line: 801, col: 11, offset: 27619},
 								name: "AttributeSubstitution",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 805, col: 11, offset: 27722},
+								pos:  position{line: 802, col: 11, offset: 27652},
 								name: "AnyChar",
 							},
 						},
@@ -5406,23 +5398,23 @@ var g = &grammar{
 		},
 		{
 			name: "LabeledListItemSeparator",
-			pos:  position{line: 809, col: 1, offset: 27765},
+			pos:  position{line: 806, col: 1, offset: 27695},
 			expr: &actionExpr{
-				pos: position{line: 810, col: 5, offset: 27799},
+				pos: position{line: 807, col: 5, offset: 27729},
 				run: (*parser).callonLabeledListItemSeparator1,
 				expr: &seqExpr{
-					pos: position{line: 810, col: 5, offset: 27799},
+					pos: position{line: 807, col: 5, offset: 27729},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 810, col: 5, offset: 27799},
+							pos:   position{line: 807, col: 5, offset: 27729},
 							label: "separator",
 							expr: &actionExpr{
-								pos: position{line: 810, col: 16, offset: 27810},
+								pos: position{line: 807, col: 16, offset: 27740},
 								run: (*parser).callonLabeledListItemSeparator4,
 								expr: &oneOrMoreExpr{
-									pos: position{line: 810, col: 16, offset: 27810},
+									pos: position{line: 807, col: 16, offset: 27740},
 									expr: &litMatcher{
-										pos:        position{line: 810, col: 17, offset: 27811},
+										pos:        position{line: 807, col: 17, offset: 27741},
 										val:        ":",
 										ignoreCase: false,
 										want:       "\":\"",
@@ -5431,30 +5423,30 @@ var g = &grammar{
 							},
 						},
 						&andCodeExpr{
-							pos: position{line: 813, col: 5, offset: 27872},
+							pos: position{line: 810, col: 5, offset: 27802},
 							run: (*parser).callonLabeledListItemSeparator7,
 						},
 						&choiceExpr{
-							pos: position{line: 817, col: 6, offset: 28052},
+							pos: position{line: 814, col: 6, offset: 27982},
 							alternatives: []interface{}{
 								&oneOrMoreExpr{
-									pos: position{line: 817, col: 6, offset: 28052},
+									pos: position{line: 814, col: 6, offset: 27982},
 									expr: &choiceExpr{
-										pos: position{line: 817, col: 7, offset: 28053},
+										pos: position{line: 814, col: 7, offset: 27983},
 										alternatives: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 817, col: 7, offset: 28053},
+												pos:  position{line: 814, col: 7, offset: 27983},
 												name: "Space",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 817, col: 15, offset: 28061},
+												pos:  position{line: 814, col: 15, offset: 27991},
 												name: "Newline",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 817, col: 27, offset: 28073},
+									pos:  position{line: 814, col: 27, offset: 28003},
 									name: "EOL",
 								},
 							},
@@ -5465,17 +5457,17 @@ var g = &grammar{
 		},
 		{
 			name: "LabeledListItemDescription",
-			pos:  position{line: 821, col: 1, offset: 28117},
+			pos:  position{line: 818, col: 1, offset: 28047},
 			expr: &actionExpr{
-				pos: position{line: 821, col: 31, offset: 28147},
+				pos: position{line: 818, col: 31, offset: 28077},
 				run: (*parser).callonLabeledListItemDescription1,
 				expr: &labeledExpr{
-					pos:   position{line: 821, col: 31, offset: 28147},
+					pos:   position{line: 818, col: 31, offset: 28077},
 					label: "elements",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 821, col: 40, offset: 28156},
+						pos: position{line: 818, col: 40, offset: 28086},
 						expr: &ruleRefExpr{
-							pos:  position{line: 821, col: 41, offset: 28157},
+							pos:  position{line: 818, col: 41, offset: 28087},
 							name: "ListParagraph",
 						},
 					},
@@ -5484,55 +5476,55 @@ var g = &grammar{
 		},
 		{
 			name: "AdmonitionKind",
-			pos:  position{line: 828, col: 1, offset: 28355},
+			pos:  position{line: 825, col: 1, offset: 28285},
 			expr: &choiceExpr{
-				pos: position{line: 828, col: 19, offset: 28373},
+				pos: position{line: 825, col: 19, offset: 28303},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 828, col: 19, offset: 28373},
+						pos: position{line: 825, col: 19, offset: 28303},
 						run: (*parser).callonAdmonitionKind2,
 						expr: &litMatcher{
-							pos:        position{line: 828, col: 19, offset: 28373},
+							pos:        position{line: 825, col: 19, offset: 28303},
 							val:        "TIP",
 							ignoreCase: false,
 							want:       "\"TIP\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 830, col: 9, offset: 28421},
+						pos: position{line: 827, col: 9, offset: 28351},
 						run: (*parser).callonAdmonitionKind4,
 						expr: &litMatcher{
-							pos:        position{line: 830, col: 9, offset: 28421},
+							pos:        position{line: 827, col: 9, offset: 28351},
 							val:        "NOTE",
 							ignoreCase: false,
 							want:       "\"NOTE\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 832, col: 9, offset: 28471},
+						pos: position{line: 829, col: 9, offset: 28401},
 						run: (*parser).callonAdmonitionKind6,
 						expr: &litMatcher{
-							pos:        position{line: 832, col: 9, offset: 28471},
+							pos:        position{line: 829, col: 9, offset: 28401},
 							val:        "IMPORTANT",
 							ignoreCase: false,
 							want:       "\"IMPORTANT\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 834, col: 9, offset: 28531},
+						pos: position{line: 831, col: 9, offset: 28461},
 						run: (*parser).callonAdmonitionKind8,
 						expr: &litMatcher{
-							pos:        position{line: 834, col: 9, offset: 28531},
+							pos:        position{line: 831, col: 9, offset: 28461},
 							val:        "WARNING",
 							ignoreCase: false,
 							want:       "\"WARNING\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 836, col: 9, offset: 28587},
+						pos: position{line: 833, col: 9, offset: 28517},
 						run: (*parser).callonAdmonitionKind10,
 						expr: &litMatcher{
-							pos:        position{line: 836, col: 9, offset: 28587},
+							pos:        position{line: 833, col: 9, offset: 28517},
 							val:        "CAUTION",
 							ignoreCase: false,
 							want:       "\"CAUTION\"",
@@ -5543,48 +5535,48 @@ var g = &grammar{
 		},
 		{
 			name: "Paragraph",
-			pos:  position{line: 845, col: 1, offset: 28903},
+			pos:  position{line: 842, col: 1, offset: 28833},
 			expr: &choiceExpr{
-				pos: position{line: 847, col: 5, offset: 28952},
+				pos: position{line: 844, col: 5, offset: 28882},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 847, col: 5, offset: 28952},
+						pos: position{line: 844, col: 5, offset: 28882},
 						run: (*parser).callonParagraph2,
 						expr: &seqExpr{
-							pos: position{line: 847, col: 5, offset: 28952},
+							pos: position{line: 844, col: 5, offset: 28882},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 847, col: 5, offset: 28952},
+									pos:   position{line: 844, col: 5, offset: 28882},
 									label: "attributes",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 847, col: 16, offset: 28963},
+										pos: position{line: 844, col: 16, offset: 28893},
 										expr: &ruleRefExpr{
-											pos:  position{line: 847, col: 17, offset: 28964},
+											pos:  position{line: 844, col: 17, offset: 28894},
 											name: "Attributes",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 847, col: 30, offset: 28977},
+									pos:   position{line: 844, col: 30, offset: 28907},
 									label: "t",
 									expr: &ruleRefExpr{
-										pos:  position{line: 847, col: 33, offset: 28980},
+										pos:  position{line: 844, col: 33, offset: 28910},
 										name: "AdmonitionKind",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 847, col: 49, offset: 28996},
+									pos:        position{line: 844, col: 49, offset: 28926},
 									val:        ": ",
 									ignoreCase: false,
 									want:       "\": \"",
 								},
 								&labeledExpr{
-									pos:   position{line: 847, col: 54, offset: 29001},
+									pos:   position{line: 844, col: 54, offset: 28931},
 									label: "lines",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 847, col: 60, offset: 29007},
+										pos: position{line: 844, col: 60, offset: 28937},
 										expr: &ruleRefExpr{
-											pos:  position{line: 847, col: 61, offset: 29008},
+											pos:  position{line: 844, col: 61, offset: 28938},
 											name: "InlineElements",
 										},
 									},
@@ -5593,33 +5585,33 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 851, col: 5, offset: 29193},
+						pos: position{line: 848, col: 5, offset: 29123},
 						run: (*parser).callonParagraph13,
 						expr: &seqExpr{
-							pos: position{line: 851, col: 5, offset: 29193},
+							pos: position{line: 848, col: 5, offset: 29123},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 851, col: 5, offset: 29193},
+									pos:   position{line: 848, col: 5, offset: 29123},
 									label: "attributes",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 851, col: 16, offset: 29204},
+										pos: position{line: 848, col: 16, offset: 29134},
 										expr: &ruleRefExpr{
-											pos:  position{line: 851, col: 17, offset: 29205},
+											pos:  position{line: 848, col: 17, offset: 29135},
 											name: "Attributes",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 851, col: 30, offset: 29218},
+									pos:        position{line: 848, col: 30, offset: 29148},
 									val:        "> ",
 									ignoreCase: false,
 									want:       "\"> \"",
 								},
 								&labeledExpr{
-									pos:   position{line: 851, col: 35, offset: 29223},
+									pos:   position{line: 848, col: 35, offset: 29153},
 									label: "content",
 									expr: &ruleRefExpr{
-										pos:  position{line: 851, col: 44, offset: 29232},
+										pos:  position{line: 848, col: 44, offset: 29162},
 										name: "MarkdownQuoteBlockVerbatimContent",
 									},
 								},
@@ -5627,38 +5619,38 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 855, col: 5, offset: 29431},
+						pos: position{line: 852, col: 5, offset: 29361},
 						run: (*parser).callonParagraph21,
 						expr: &seqExpr{
-							pos: position{line: 855, col: 5, offset: 29431},
+							pos: position{line: 852, col: 5, offset: 29361},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 855, col: 5, offset: 29431},
+									pos:   position{line: 852, col: 5, offset: 29361},
 									label: "attributes",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 855, col: 16, offset: 29442},
+										pos: position{line: 852, col: 16, offset: 29372},
 										expr: &ruleRefExpr{
-											pos:  position{line: 855, col: 17, offset: 29443},
+											pos:  position{line: 852, col: 17, offset: 29373},
 											name: "Attributes",
 										},
 									},
 								},
 								&andCodeExpr{
-									pos: position{line: 855, col: 30, offset: 29456},
+									pos: position{line: 852, col: 30, offset: 29386},
 									run: (*parser).callonParagraph26,
 								},
 								&notExpr{
-									pos: position{line: 862, col: 7, offset: 29742},
+									pos: position{line: 859, col: 7, offset: 29672},
 									expr: &ruleRefExpr{
-										pos:  position{line: 862, col: 8, offset: 29743},
+										pos:  position{line: 859, col: 8, offset: 29673},
 										name: "BlockDelimiter",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 862, col: 23, offset: 29758},
+									pos:   position{line: 859, col: 23, offset: 29688},
 									label: "content",
 									expr: &ruleRefExpr{
-										pos:  position{line: 862, col: 32, offset: 29767},
+										pos:  position{line: 859, col: 32, offset: 29697},
 										name: "OpenPassthroughParagraphContent",
 									},
 								},
@@ -5666,36 +5658,36 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 866, col: 5, offset: 29968},
+						pos: position{line: 863, col: 5, offset: 29898},
 						run: (*parser).callonParagraph31,
 						expr: &seqExpr{
-							pos: position{line: 866, col: 5, offset: 29968},
+							pos: position{line: 863, col: 5, offset: 29898},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 866, col: 5, offset: 29968},
+									pos:   position{line: 863, col: 5, offset: 29898},
 									label: "attributes",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 866, col: 16, offset: 29979},
+										pos: position{line: 863, col: 16, offset: 29909},
 										expr: &ruleRefExpr{
-											pos:  position{line: 866, col: 17, offset: 29980},
+											pos:  position{line: 863, col: 17, offset: 29910},
 											name: "Attributes",
 										},
 									},
 								},
 								&notExpr{
-									pos: position{line: 866, col: 30, offset: 29993},
+									pos: position{line: 863, col: 30, offset: 29923},
 									expr: &ruleRefExpr{
-										pos:  position{line: 866, col: 31, offset: 29994},
+										pos:  position{line: 863, col: 31, offset: 29924},
 										name: "BlockDelimiter",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 866, col: 46, offset: 30009},
+									pos:   position{line: 863, col: 46, offset: 29939},
 									label: "lines",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 866, col: 52, offset: 30015},
+										pos: position{line: 863, col: 52, offset: 29945},
 										expr: &ruleRefExpr{
-											pos:  position{line: 866, col: 53, offset: 30016},
+											pos:  position{line: 863, col: 53, offset: 29946},
 											name: "InlineElements",
 										},
 									},
@@ -5708,36 +5700,36 @@ var g = &grammar{
 		},
 		{
 			name: "MarkdownQuoteBlockVerbatimContent",
-			pos:  position{line: 870, col: 1, offset: 30116},
+			pos:  position{line: 867, col: 1, offset: 30046},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 870, col: 38, offset: 30153},
+				pos: position{line: 867, col: 38, offset: 30083},
 				expr: &actionExpr{
-					pos: position{line: 870, col: 39, offset: 30154},
+					pos: position{line: 867, col: 39, offset: 30084},
 					run: (*parser).callonMarkdownQuoteBlockVerbatimContent2,
 					expr: &seqExpr{
-						pos: position{line: 870, col: 39, offset: 30154},
+						pos: position{line: 867, col: 39, offset: 30084},
 						exprs: []interface{}{
 							&notExpr{
-								pos: position{line: 870, col: 39, offset: 30154},
+								pos: position{line: 867, col: 39, offset: 30084},
 								expr: &ruleRefExpr{
-									pos:  position{line: 870, col: 40, offset: 30155},
+									pos:  position{line: 867, col: 40, offset: 30085},
 									name: "BlankLine",
 								},
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 870, col: 50, offset: 30165},
+								pos: position{line: 867, col: 50, offset: 30095},
 								expr: &litMatcher{
-									pos:        position{line: 870, col: 50, offset: 30165},
+									pos:        position{line: 867, col: 50, offset: 30095},
 									val:        "> ",
 									ignoreCase: false,
 									want:       "\"> \"",
 								},
 							},
 							&labeledExpr{
-								pos:   position{line: 870, col: 56, offset: 30171},
+								pos:   position{line: 867, col: 56, offset: 30101},
 								label: "content",
 								expr: &ruleRefExpr{
-									pos:  position{line: 870, col: 65, offset: 30180},
+									pos:  position{line: 867, col: 65, offset: 30110},
 									name: "VerbatimContent",
 								},
 							},
@@ -5748,29 +5740,29 @@ var g = &grammar{
 		},
 		{
 			name: "MarkdownQuoteBlockAttribution",
-			pos:  position{line: 874, col: 1, offset: 30325},
+			pos:  position{line: 871, col: 1, offset: 30255},
 			expr: &actionExpr{
-				pos: position{line: 874, col: 34, offset: 30358},
+				pos: position{line: 871, col: 34, offset: 30288},
 				run: (*parser).callonMarkdownQuoteBlockAttribution1,
 				expr: &seqExpr{
-					pos: position{line: 874, col: 34, offset: 30358},
+					pos: position{line: 871, col: 34, offset: 30288},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 874, col: 34, offset: 30358},
+							pos:        position{line: 871, col: 34, offset: 30288},
 							val:        "-- ",
 							ignoreCase: false,
 							want:       "\"-- \"",
 						},
 						&labeledExpr{
-							pos:   position{line: 874, col: 40, offset: 30364},
+							pos:   position{line: 871, col: 40, offset: 30294},
 							label: "author",
 							expr: &actionExpr{
-								pos: position{line: 874, col: 48, offset: 30372},
+								pos: position{line: 871, col: 48, offset: 30302},
 								run: (*parser).callonMarkdownQuoteBlockAttribution5,
 								expr: &oneOrMoreExpr{
-									pos: position{line: 874, col: 49, offset: 30373},
+									pos: position{line: 871, col: 49, offset: 30303},
 									expr: &charClassMatcher{
-										pos:        position{line: 874, col: 49, offset: 30373},
+										pos:        position{line: 871, col: 49, offset: 30303},
 										val:        "[^\\r\\n]",
 										chars:      []rune{'\r', '\n'},
 										ignoreCase: false,
@@ -5780,7 +5772,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 876, col: 8, offset: 30425},
+							pos:  position{line: 873, col: 8, offset: 30355},
 							name: "EOL",
 						},
 					},
@@ -5789,27 +5781,27 @@ var g = &grammar{
 		},
 		{
 			name: "OpenPassthroughParagraphContent",
-			pos:  position{line: 880, col: 1, offset: 30461},
+			pos:  position{line: 877, col: 1, offset: 30391},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 880, col: 36, offset: 30496},
+				pos: position{line: 877, col: 36, offset: 30426},
 				expr: &actionExpr{
-					pos: position{line: 880, col: 37, offset: 30497},
+					pos: position{line: 877, col: 37, offset: 30427},
 					run: (*parser).callonOpenPassthroughParagraphContent2,
 					expr: &seqExpr{
-						pos: position{line: 880, col: 37, offset: 30497},
+						pos: position{line: 877, col: 37, offset: 30427},
 						exprs: []interface{}{
 							&notExpr{
-								pos: position{line: 880, col: 37, offset: 30497},
+								pos: position{line: 877, col: 37, offset: 30427},
 								expr: &ruleRefExpr{
-									pos:  position{line: 880, col: 38, offset: 30498},
+									pos:  position{line: 877, col: 38, offset: 30428},
 									name: "BlankLine",
 								},
 							},
 							&labeledExpr{
-								pos:   position{line: 880, col: 48, offset: 30508},
+								pos:   position{line: 877, col: 48, offset: 30438},
 								label: "content",
 								expr: &ruleRefExpr{
-									pos:  position{line: 880, col: 57, offset: 30517},
+									pos:  position{line: 877, col: 57, offset: 30447},
 									name: "VerbatimContent",
 								},
 							},
@@ -5820,43 +5812,43 @@ var g = &grammar{
 		},
 		{
 			name: "SimpleParagraph",
-			pos:  position{line: 885, col: 1, offset: 30735},
+			pos:  position{line: 882, col: 1, offset: 30665},
 			expr: &actionExpr{
-				pos: position{line: 885, col: 20, offset: 30754},
+				pos: position{line: 882, col: 20, offset: 30684},
 				run: (*parser).callonSimpleParagraph1,
 				expr: &seqExpr{
-					pos: position{line: 885, col: 20, offset: 30754},
+					pos: position{line: 882, col: 20, offset: 30684},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 885, col: 20, offset: 30754},
+							pos:   position{line: 882, col: 20, offset: 30684},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 885, col: 31, offset: 30765},
+								pos: position{line: 882, col: 31, offset: 30695},
 								expr: &ruleRefExpr{
-									pos:  position{line: 885, col: 32, offset: 30766},
+									pos:  position{line: 882, col: 32, offset: 30696},
 									name: "Attributes",
 								},
 							},
 						},
 						&andCodeExpr{
-							pos: position{line: 886, col: 5, offset: 30785},
+							pos: position{line: 883, col: 5, offset: 30715},
 							run: (*parser).callonSimpleParagraph6,
 						},
 						&labeledExpr{
-							pos:   position{line: 894, col: 5, offset: 31079},
+							pos:   position{line: 891, col: 5, offset: 31009},
 							label: "firstLine",
 							expr: &ruleRefExpr{
-								pos:  position{line: 894, col: 16, offset: 31090},
+								pos:  position{line: 891, col: 16, offset: 31020},
 								name: "FirstParagraphLine",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 895, col: 5, offset: 31114},
+							pos:   position{line: 892, col: 5, offset: 31044},
 							label: "otherLines",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 895, col: 16, offset: 31125},
+								pos: position{line: 892, col: 16, offset: 31055},
 								expr: &ruleRefExpr{
-									pos:  position{line: 895, col: 17, offset: 31126},
+									pos:  position{line: 892, col: 17, offset: 31056},
 									name: "OtherParagraphLine",
 								},
 							},
@@ -5867,27 +5859,27 @@ var g = &grammar{
 		},
 		{
 			name: "FirstParagraphLine",
-			pos:  position{line: 899, col: 1, offset: 31264},
+			pos:  position{line: 896, col: 1, offset: 31194},
 			expr: &actionExpr{
-				pos: position{line: 900, col: 5, offset: 31292},
+				pos: position{line: 897, col: 5, offset: 31222},
 				run: (*parser).callonFirstParagraphLine1,
 				expr: &seqExpr{
-					pos: position{line: 900, col: 5, offset: 31292},
+					pos: position{line: 897, col: 5, offset: 31222},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 900, col: 5, offset: 31292},
+							pos:   position{line: 897, col: 5, offset: 31222},
 							label: "elements",
 							expr: &seqExpr{
-								pos: position{line: 900, col: 15, offset: 31302},
+								pos: position{line: 897, col: 15, offset: 31232},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 900, col: 15, offset: 31302},
+										pos:  position{line: 897, col: 15, offset: 31232},
 										name: "Word",
 									},
 									&zeroOrMoreExpr{
-										pos: position{line: 900, col: 20, offset: 31307},
+										pos: position{line: 897, col: 20, offset: 31237},
 										expr: &ruleRefExpr{
-											pos:  position{line: 900, col: 20, offset: 31307},
+											pos:  position{line: 897, col: 20, offset: 31237},
 											name: "InlineElement",
 										},
 									},
@@ -5895,7 +5887,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 900, col: 36, offset: 31323},
+							pos:  position{line: 897, col: 36, offset: 31253},
 							name: "EOL",
 						},
 					},
@@ -5904,15 +5896,15 @@ var g = &grammar{
 		},
 		{
 			name: "OtherParagraphLine",
-			pos:  position{line: 904, col: 1, offset: 31398},
+			pos:  position{line: 901, col: 1, offset: 31328},
 			expr: &actionExpr{
-				pos: position{line: 904, col: 23, offset: 31420},
+				pos: position{line: 901, col: 23, offset: 31350},
 				run: (*parser).callonOtherParagraphLine1,
 				expr: &labeledExpr{
-					pos:   position{line: 904, col: 23, offset: 31420},
+					pos:   position{line: 901, col: 23, offset: 31350},
 					label: "elements",
 					expr: &ruleRefExpr{
-						pos:  position{line: 904, col: 33, offset: 31430},
+						pos:  position{line: 901, col: 33, offset: 31360},
 						name: "InlineElements",
 					},
 				},
@@ -5920,46 +5912,46 @@ var g = &grammar{
 		},
 		{
 			name: "ContinuedParagraph",
-			pos:  position{line: 909, col: 1, offset: 31555},
+			pos:  position{line: 906, col: 1, offset: 31485},
 			expr: &choiceExpr{
-				pos: position{line: 911, col: 5, offset: 31613},
+				pos: position{line: 908, col: 5, offset: 31543},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 911, col: 5, offset: 31613},
+						pos: position{line: 908, col: 5, offset: 31543},
 						run: (*parser).callonContinuedParagraph2,
 						expr: &seqExpr{
-							pos: position{line: 911, col: 5, offset: 31613},
+							pos: position{line: 908, col: 5, offset: 31543},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 911, col: 5, offset: 31613},
+									pos:   position{line: 908, col: 5, offset: 31543},
 									label: "attributes",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 911, col: 16, offset: 31624},
+										pos: position{line: 908, col: 16, offset: 31554},
 										expr: &ruleRefExpr{
-											pos:  position{line: 911, col: 17, offset: 31625},
+											pos:  position{line: 908, col: 17, offset: 31555},
 											name: "Attributes",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 911, col: 30, offset: 31638},
+									pos:   position{line: 908, col: 30, offset: 31568},
 									label: "t",
 									expr: &ruleRefExpr{
-										pos:  position{line: 911, col: 33, offset: 31641},
+										pos:  position{line: 908, col: 33, offset: 31571},
 										name: "AdmonitionKind",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 911, col: 49, offset: 31657},
+									pos:        position{line: 908, col: 49, offset: 31587},
 									val:        ": ",
 									ignoreCase: false,
 									want:       "\": \"",
 								},
 								&labeledExpr{
-									pos:   position{line: 911, col: 54, offset: 31662},
+									pos:   position{line: 908, col: 54, offset: 31592},
 									label: "lines",
 									expr: &ruleRefExpr{
-										pos:  position{line: 911, col: 61, offset: 31669},
+										pos:  position{line: 908, col: 61, offset: 31599},
 										name: "ContinuedParagraphLines",
 									},
 								},
@@ -5967,27 +5959,27 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 915, col: 5, offset: 31873},
+						pos: position{line: 912, col: 5, offset: 31803},
 						run: (*parser).callonContinuedParagraph12,
 						expr: &seqExpr{
-							pos: position{line: 915, col: 5, offset: 31873},
+							pos: position{line: 912, col: 5, offset: 31803},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 915, col: 5, offset: 31873},
+									pos:   position{line: 912, col: 5, offset: 31803},
 									label: "attributes",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 915, col: 16, offset: 31884},
+										pos: position{line: 912, col: 16, offset: 31814},
 										expr: &ruleRefExpr{
-											pos:  position{line: 915, col: 17, offset: 31885},
+											pos:  position{line: 912, col: 17, offset: 31815},
 											name: "Attributes",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 915, col: 30, offset: 31898},
+									pos:   position{line: 912, col: 30, offset: 31828},
 									label: "lines",
 									expr: &ruleRefExpr{
-										pos:  position{line: 915, col: 37, offset: 31905},
+										pos:  position{line: 912, col: 37, offset: 31835},
 										name: "ContinuedParagraphLines",
 									},
 								},
@@ -5999,38 +5991,38 @@ var g = &grammar{
 		},
 		{
 			name: "ContinuedParagraphLines",
-			pos:  position{line: 919, col: 1, offset: 32010},
+			pos:  position{line: 916, col: 1, offset: 31940},
 			expr: &actionExpr{
-				pos: position{line: 919, col: 28, offset: 32037},
+				pos: position{line: 916, col: 28, offset: 31967},
 				run: (*parser).callonContinuedParagraphLines1,
 				expr: &seqExpr{
-					pos: position{line: 919, col: 28, offset: 32037},
+					pos: position{line: 916, col: 28, offset: 31967},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 919, col: 28, offset: 32037},
+							pos:   position{line: 916, col: 28, offset: 31967},
 							label: "firstLine",
 							expr: &ruleRefExpr{
-								pos:  position{line: 919, col: 39, offset: 32048},
+								pos:  position{line: 916, col: 39, offset: 31978},
 								name: "FirstParagraphLine",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 919, col: 59, offset: 32068},
+							pos:   position{line: 916, col: 59, offset: 31998},
 							label: "otherLines",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 919, col: 70, offset: 32079},
+								pos: position{line: 916, col: 70, offset: 32009},
 								expr: &seqExpr{
-									pos: position{line: 919, col: 71, offset: 32080},
+									pos: position{line: 916, col: 71, offset: 32010},
 									exprs: []interface{}{
 										&notExpr{
-											pos: position{line: 919, col: 71, offset: 32080},
+											pos: position{line: 916, col: 71, offset: 32010},
 											expr: &ruleRefExpr{
-												pos:  position{line: 919, col: 72, offset: 32081},
+												pos:  position{line: 916, col: 72, offset: 32011},
 												name: "ListItemContinuation",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 919, col: 93, offset: 32102},
+											pos:  position{line: 916, col: 93, offset: 32032},
 											name: "OtherParagraphLine",
 										},
 									},
@@ -6043,52 +6035,52 @@ var g = &grammar{
 		},
 		{
 			name: "VerseParagraph",
-			pos:  position{line: 923, col: 1, offset: 32212},
+			pos:  position{line: 920, col: 1, offset: 32142},
 			expr: &choiceExpr{
-				pos: position{line: 925, col: 5, offset: 32266},
+				pos: position{line: 922, col: 5, offset: 32196},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 925, col: 5, offset: 32266},
+						pos: position{line: 922, col: 5, offset: 32196},
 						run: (*parser).callonVerseParagraph2,
 						expr: &seqExpr{
-							pos: position{line: 925, col: 5, offset: 32266},
+							pos: position{line: 922, col: 5, offset: 32196},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 925, col: 5, offset: 32266},
+									pos:   position{line: 922, col: 5, offset: 32196},
 									label: "attributes",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 925, col: 16, offset: 32277},
+										pos: position{line: 922, col: 16, offset: 32207},
 										expr: &ruleRefExpr{
-											pos:  position{line: 925, col: 17, offset: 32278},
+											pos:  position{line: 922, col: 17, offset: 32208},
 											name: "Attributes",
 										},
 									},
 								},
 								&andCodeExpr{
-									pos: position{line: 926, col: 5, offset: 32296},
+									pos: position{line: 923, col: 5, offset: 32226},
 									run: (*parser).callonVerseParagraph7,
 								},
 								&labeledExpr{
-									pos:   position{line: 933, col: 5, offset: 32508},
+									pos:   position{line: 930, col: 5, offset: 32438},
 									label: "t",
 									expr: &ruleRefExpr{
-										pos:  position{line: 933, col: 8, offset: 32511},
+										pos:  position{line: 930, col: 8, offset: 32441},
 										name: "AdmonitionKind",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 933, col: 24, offset: 32527},
+									pos:        position{line: 930, col: 24, offset: 32457},
 									val:        ": ",
 									ignoreCase: false,
 									want:       "\": \"",
 								},
 								&labeledExpr{
-									pos:   position{line: 933, col: 29, offset: 32532},
+									pos:   position{line: 930, col: 29, offset: 32462},
 									label: "lines",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 933, col: 35, offset: 32538},
+										pos: position{line: 930, col: 35, offset: 32468},
 										expr: &ruleRefExpr{
-											pos:  position{line: 933, col: 36, offset: 32539},
+											pos:  position{line: 930, col: 36, offset: 32469},
 											name: "InlineElements",
 										},
 									},
@@ -6097,33 +6089,33 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 937, col: 5, offset: 32735},
+						pos: position{line: 934, col: 5, offset: 32665},
 						run: (*parser).callonVerseParagraph14,
 						expr: &seqExpr{
-							pos: position{line: 937, col: 5, offset: 32735},
+							pos: position{line: 934, col: 5, offset: 32665},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 937, col: 5, offset: 32735},
+									pos:   position{line: 934, col: 5, offset: 32665},
 									label: "attributes",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 937, col: 16, offset: 32746},
+										pos: position{line: 934, col: 16, offset: 32676},
 										expr: &ruleRefExpr{
-											pos:  position{line: 937, col: 17, offset: 32747},
+											pos:  position{line: 934, col: 17, offset: 32677},
 											name: "Attributes",
 										},
 									},
 								},
 								&andCodeExpr{
-									pos: position{line: 938, col: 5, offset: 32765},
+									pos: position{line: 935, col: 5, offset: 32695},
 									run: (*parser).callonVerseParagraph19,
 								},
 								&labeledExpr{
-									pos:   position{line: 945, col: 5, offset: 32977},
+									pos:   position{line: 942, col: 5, offset: 32907},
 									label: "lines",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 945, col: 11, offset: 32983},
+										pos: position{line: 942, col: 11, offset: 32913},
 										expr: &ruleRefExpr{
-											pos:  position{line: 945, col: 12, offset: 32984},
+											pos:  position{line: 942, col: 12, offset: 32914},
 											name: "InlineElements",
 										},
 									},
@@ -6136,57 +6128,57 @@ var g = &grammar{
 		},
 		{
 			name: "InlineElements",
-			pos:  position{line: 949, col: 1, offset: 33089},
+			pos:  position{line: 946, col: 1, offset: 33019},
 			expr: &actionExpr{
-				pos: position{line: 949, col: 19, offset: 33107},
+				pos: position{line: 946, col: 19, offset: 33037},
 				run: (*parser).callonInlineElements1,
 				expr: &seqExpr{
-					pos: position{line: 949, col: 19, offset: 33107},
+					pos: position{line: 946, col: 19, offset: 33037},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 949, col: 19, offset: 33107},
+							pos: position{line: 946, col: 19, offset: 33037},
 							expr: &ruleRefExpr{
-								pos:  position{line: 949, col: 20, offset: 33108},
+								pos:  position{line: 946, col: 20, offset: 33038},
 								name: "BlankLine",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 950, col: 5, offset: 33123},
+							pos:   position{line: 947, col: 5, offset: 33053},
 							label: "elements",
 							expr: &choiceExpr{
-								pos: position{line: 950, col: 15, offset: 33133},
+								pos: position{line: 947, col: 15, offset: 33063},
 								alternatives: []interface{}{
 									&actionExpr{
-										pos: position{line: 950, col: 15, offset: 33133},
+										pos: position{line: 947, col: 15, offset: 33063},
 										run: (*parser).callonInlineElements7,
 										expr: &labeledExpr{
-											pos:   position{line: 950, col: 15, offset: 33133},
+											pos:   position{line: 947, col: 15, offset: 33063},
 											label: "comment",
 											expr: &ruleRefExpr{
-												pos:  position{line: 950, col: 24, offset: 33142},
+												pos:  position{line: 947, col: 24, offset: 33072},
 												name: "SingleLineComment",
 											},
 										},
 									},
 									&actionExpr{
-										pos: position{line: 952, col: 9, offset: 33236},
+										pos: position{line: 949, col: 9, offset: 33166},
 										run: (*parser).callonInlineElements10,
 										expr: &seqExpr{
-											pos: position{line: 952, col: 9, offset: 33236},
+											pos: position{line: 949, col: 9, offset: 33166},
 											exprs: []interface{}{
 												&labeledExpr{
-													pos:   position{line: 952, col: 9, offset: 33236},
+													pos:   position{line: 949, col: 9, offset: 33166},
 													label: "elements",
 													expr: &oneOrMoreExpr{
-														pos: position{line: 952, col: 18, offset: 33245},
+														pos: position{line: 949, col: 18, offset: 33175},
 														expr: &ruleRefExpr{
-															pos:  position{line: 952, col: 19, offset: 33246},
+															pos:  position{line: 949, col: 19, offset: 33176},
 															name: "InlineElement",
 														},
 													},
 												},
 												&ruleRefExpr{
-													pos:  position{line: 952, col: 35, offset: 33262},
+													pos:  position{line: 949, col: 35, offset: 33192},
 													name: "EOL",
 												},
 											},
@@ -6201,98 +6193,98 @@ var g = &grammar{
 		},
 		{
 			name: "InlineElement",
-			pos:  position{line: 958, col: 1, offset: 33385},
+			pos:  position{line: 955, col: 1, offset: 33315},
 			expr: &actionExpr{
-				pos: position{line: 959, col: 5, offset: 33409},
+				pos: position{line: 956, col: 5, offset: 33339},
 				run: (*parser).callonInlineElement1,
 				expr: &labeledExpr{
-					pos:   position{line: 959, col: 5, offset: 33409},
+					pos:   position{line: 956, col: 5, offset: 33339},
 					label: "element",
 					expr: &choiceExpr{
-						pos: position{line: 959, col: 14, offset: 33418},
+						pos: position{line: 956, col: 14, offset: 33348},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 959, col: 14, offset: 33418},
+								pos:  position{line: 956, col: 14, offset: 33348},
 								name: "InlineWord",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 960, col: 11, offset: 33470},
+								pos:  position{line: 957, col: 11, offset: 33400},
 								name: "LineBreak",
 							},
 							&oneOrMoreExpr{
-								pos: position{line: 961, col: 11, offset: 33516},
+								pos: position{line: 958, col: 11, offset: 33446},
 								expr: &ruleRefExpr{
-									pos:  position{line: 961, col: 11, offset: 33516},
+									pos:  position{line: 958, col: 11, offset: 33446},
 									name: "Space",
 								},
 							},
 							&seqExpr{
-								pos: position{line: 962, col: 11, offset: 33535},
+								pos: position{line: 959, col: 11, offset: 33465},
 								exprs: []interface{}{
 									&notExpr{
-										pos: position{line: 962, col: 11, offset: 33535},
+										pos: position{line: 959, col: 11, offset: 33465},
 										expr: &ruleRefExpr{
-											pos:  position{line: 962, col: 12, offset: 33536},
+											pos:  position{line: 959, col: 12, offset: 33466},
 											name: "EOL",
 										},
 									},
 									&choiceExpr{
-										pos: position{line: 963, col: 13, offset: 33555},
+										pos: position{line: 960, col: 13, offset: 33485},
 										alternatives: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 963, col: 13, offset: 33555},
+												pos:  position{line: 960, col: 13, offset: 33485},
 												name: "QuotedString",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 964, col: 15, offset: 33583},
+												pos:  position{line: 961, col: 15, offset: 33513},
 												name: "QuotedText",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 965, col: 15, offset: 33609},
+												pos:  position{line: 962, col: 15, offset: 33539},
 												name: "InlineIcon",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 966, col: 15, offset: 33635},
+												pos:  position{line: 963, col: 15, offset: 33565},
 												name: "InlineImage",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 967, col: 15, offset: 33663},
+												pos:  position{line: 964, col: 15, offset: 33593},
 												name: "Link",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 968, col: 15, offset: 33684},
+												pos:  position{line: 965, col: 15, offset: 33614},
 												name: "InlinePassthrough",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 969, col: 15, offset: 33718},
+												pos:  position{line: 966, col: 15, offset: 33648},
 												name: "InlineFootnote",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 970, col: 15, offset: 33749},
+												pos:  position{line: 967, col: 15, offset: 33679},
 												name: "CrossReference",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 971, col: 15, offset: 33780},
+												pos:  position{line: 968, col: 15, offset: 33710},
 												name: "InlineUserMacro",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 972, col: 15, offset: 33812},
+												pos:  position{line: 969, col: 15, offset: 33742},
 												name: "AttributeSubstitution",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 973, col: 15, offset: 33850},
+												pos:  position{line: 970, col: 15, offset: 33780},
 												name: "InlineElementID",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 974, col: 15, offset: 33881},
+												pos:  position{line: 971, col: 15, offset: 33811},
 												name: "ConcealedIndexTerm",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 975, col: 15, offset: 33915},
+												pos:  position{line: 972, col: 15, offset: 33845},
 												name: "IndexTerm",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 976, col: 15, offset: 33940},
+												pos:  position{line: 973, col: 15, offset: 33870},
 												name: "AnyChar",
 											},
 										},
@@ -6306,34 +6298,34 @@ var g = &grammar{
 		},
 		{
 			name: "LineBreak",
-			pos:  position{line: 983, col: 1, offset: 34170},
+			pos:  position{line: 980, col: 1, offset: 34100},
 			expr: &actionExpr{
-				pos: position{line: 983, col: 14, offset: 34183},
+				pos: position{line: 980, col: 14, offset: 34113},
 				run: (*parser).callonLineBreak1,
 				expr: &seqExpr{
-					pos: position{line: 983, col: 14, offset: 34183},
+					pos: position{line: 980, col: 14, offset: 34113},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 983, col: 14, offset: 34183},
+							pos:  position{line: 980, col: 14, offset: 34113},
 							name: "Space",
 						},
 						&litMatcher{
-							pos:        position{line: 983, col: 20, offset: 34189},
+							pos:        position{line: 980, col: 20, offset: 34119},
 							val:        "+",
 							ignoreCase: false,
 							want:       "\"+\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 983, col: 24, offset: 34193},
+							pos: position{line: 980, col: 24, offset: 34123},
 							expr: &ruleRefExpr{
-								pos:  position{line: 983, col: 24, offset: 34193},
+								pos:  position{line: 980, col: 24, offset: 34123},
 								name: "Space",
 							},
 						},
 						&andExpr{
-							pos: position{line: 983, col: 31, offset: 34200},
+							pos: position{line: 980, col: 31, offset: 34130},
 							expr: &ruleRefExpr{
-								pos:  position{line: 983, col: 32, offset: 34201},
+								pos:  position{line: 980, col: 32, offset: 34131},
 								name: "EOL",
 							},
 						},
@@ -6343,20 +6335,20 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedText",
-			pos:  position{line: 990, col: 1, offset: 34492},
+			pos:  position{line: 987, col: 1, offset: 34422},
 			expr: &choiceExpr{
-				pos: position{line: 990, col: 15, offset: 34506},
+				pos: position{line: 987, col: 15, offset: 34436},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 990, col: 15, offset: 34506},
+						pos:  position{line: 987, col: 15, offset: 34436},
 						name: "UnconstrainedQuotedText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 990, col: 41, offset: 34532},
+						pos:  position{line: 987, col: 41, offset: 34462},
 						name: "ConstrainedQuotedText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 990, col: 65, offset: 34556},
+						pos:  position{line: 987, col: 65, offset: 34486},
 						name: "EscapedQuotedText",
 					},
 				},
@@ -6364,23 +6356,23 @@ var g = &grammar{
 		},
 		{
 			name: "ConstrainedQuotedTextMarker",
-			pos:  position{line: 992, col: 1, offset: 34577},
+			pos:  position{line: 989, col: 1, offset: 34507},
 			expr: &choiceExpr{
-				pos: position{line: 992, col: 32, offset: 34608},
+				pos: position{line: 989, col: 32, offset: 34538},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 992, col: 32, offset: 34608},
+						pos: position{line: 989, col: 32, offset: 34538},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 992, col: 32, offset: 34608},
+								pos:        position{line: 989, col: 32, offset: 34538},
 								val:        "*",
 								ignoreCase: false,
 								want:       "\"*\"",
 							},
 							&notExpr{
-								pos: position{line: 992, col: 36, offset: 34612},
+								pos: position{line: 989, col: 36, offset: 34542},
 								expr: &litMatcher{
-									pos:        position{line: 992, col: 37, offset: 34613},
+									pos:        position{line: 989, col: 37, offset: 34543},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
@@ -6389,18 +6381,18 @@ var g = &grammar{
 						},
 					},
 					&seqExpr{
-						pos: position{line: 992, col: 43, offset: 34619},
+						pos: position{line: 989, col: 43, offset: 34549},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 992, col: 43, offset: 34619},
+								pos:        position{line: 989, col: 43, offset: 34549},
 								val:        "_",
 								ignoreCase: false,
 								want:       "\"_\"",
 							},
 							&notExpr{
-								pos: position{line: 992, col: 47, offset: 34623},
+								pos: position{line: 989, col: 47, offset: 34553},
 								expr: &litMatcher{
-									pos:        position{line: 992, col: 48, offset: 34624},
+									pos:        position{line: 989, col: 48, offset: 34554},
 									val:        "_",
 									ignoreCase: false,
 									want:       "\"_\"",
@@ -6409,18 +6401,18 @@ var g = &grammar{
 						},
 					},
 					&seqExpr{
-						pos: position{line: 992, col: 54, offset: 34630},
+						pos: position{line: 989, col: 54, offset: 34560},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 992, col: 54, offset: 34630},
+								pos:        position{line: 989, col: 54, offset: 34560},
 								val:        "#",
 								ignoreCase: false,
 								want:       "\"#\"",
 							},
 							&notExpr{
-								pos: position{line: 992, col: 58, offset: 34634},
+								pos: position{line: 989, col: 58, offset: 34564},
 								expr: &litMatcher{
-									pos:        position{line: 992, col: 59, offset: 34635},
+									pos:        position{line: 989, col: 59, offset: 34565},
 									val:        "#",
 									ignoreCase: false,
 									want:       "\"#\"",
@@ -6429,18 +6421,18 @@ var g = &grammar{
 						},
 					},
 					&seqExpr{
-						pos: position{line: 992, col: 65, offset: 34641},
+						pos: position{line: 989, col: 65, offset: 34571},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 992, col: 65, offset: 34641},
+								pos:        position{line: 989, col: 65, offset: 34571},
 								val:        "`",
 								ignoreCase: false,
 								want:       "\"`\"",
 							},
 							&notExpr{
-								pos: position{line: 992, col: 69, offset: 34645},
+								pos: position{line: 989, col: 69, offset: 34575},
 								expr: &litMatcher{
-									pos:        position{line: 992, col: 70, offset: 34646},
+									pos:        position{line: 989, col: 70, offset: 34576},
 									val:        "`",
 									ignoreCase: false,
 									want:       "\"`\"",
@@ -6453,42 +6445,42 @@ var g = &grammar{
 		},
 		{
 			name: "UnconstrainedQuotedTextPrefix",
-			pos:  position{line: 994, col: 1, offset: 34653},
+			pos:  position{line: 991, col: 1, offset: 34583},
 			expr: &choiceExpr{
-				pos: position{line: 994, col: 34, offset: 34686},
+				pos: position{line: 991, col: 34, offset: 34616},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 994, col: 34, offset: 34686},
+						pos:        position{line: 991, col: 34, offset: 34616},
 						val:        "**",
 						ignoreCase: false,
 						want:       "\"**\"",
 					},
 					&litMatcher{
-						pos:        position{line: 994, col: 41, offset: 34693},
+						pos:        position{line: 991, col: 41, offset: 34623},
 						val:        "__",
 						ignoreCase: false,
 						want:       "\"__\"",
 					},
 					&litMatcher{
-						pos:        position{line: 994, col: 48, offset: 34700},
+						pos:        position{line: 991, col: 48, offset: 34630},
 						val:        "``",
 						ignoreCase: false,
 						want:       "\"``\"",
 					},
 					&litMatcher{
-						pos:        position{line: 994, col: 55, offset: 34707},
+						pos:        position{line: 991, col: 55, offset: 34637},
 						val:        "##",
 						ignoreCase: false,
 						want:       "\"##\"",
 					},
 					&litMatcher{
-						pos:        position{line: 994, col: 62, offset: 34714},
+						pos:        position{line: 991, col: 62, offset: 34644},
 						val:        "^",
 						ignoreCase: false,
 						want:       "\"^\"",
 					},
 					&litMatcher{
-						pos:        position{line: 994, col: 68, offset: 34720},
+						pos:        position{line: 991, col: 68, offset: 34650},
 						val:        "~",
 						ignoreCase: false,
 						want:       "\"~\"",
@@ -6498,42 +6490,42 @@ var g = &grammar{
 		},
 		{
 			name: "ConstrainedQuotedText",
-			pos:  position{line: 996, col: 1, offset: 34727},
+			pos:  position{line: 993, col: 1, offset: 34657},
 			expr: &actionExpr{
-				pos: position{line: 996, col: 26, offset: 34752},
+				pos: position{line: 993, col: 26, offset: 34682},
 				run: (*parser).callonConstrainedQuotedText1,
 				expr: &labeledExpr{
-					pos:   position{line: 996, col: 26, offset: 34752},
+					pos:   position{line: 993, col: 26, offset: 34682},
 					label: "text",
 					expr: &choiceExpr{
-						pos: position{line: 996, col: 32, offset: 34758},
+						pos: position{line: 993, col: 32, offset: 34688},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 996, col: 32, offset: 34758},
+								pos:  position{line: 993, col: 32, offset: 34688},
 								name: "SingleQuoteBoldText",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 997, col: 15, offset: 34794},
+								pos:  position{line: 994, col: 15, offset: 34724},
 								name: "SingleQuoteItalicText",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 998, col: 15, offset: 34831},
+								pos:  position{line: 995, col: 15, offset: 34761},
 								name: "SingleQuoteMarkedText",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 999, col: 15, offset: 34868},
+								pos:  position{line: 996, col: 15, offset: 34798},
 								name: "SingleQuoteMonospaceText",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1000, col: 15, offset: 34909},
+								pos:  position{line: 997, col: 15, offset: 34839},
 								name: "SubscriptText",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1001, col: 15, offset: 34939},
+								pos:  position{line: 998, col: 15, offset: 34869},
 								name: "SuperscriptText",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1002, col: 15, offset: 34971},
+								pos:  position{line: 999, col: 15, offset: 34901},
 								name: "SubscriptOrSuperscriptPrefix",
 							},
 						},
@@ -6543,24 +6535,24 @@ var g = &grammar{
 		},
 		{
 			name: "UnconstrainedQuotedText",
-			pos:  position{line: 1006, col: 1, offset: 35129},
+			pos:  position{line: 1003, col: 1, offset: 35059},
 			expr: &choiceExpr{
-				pos: position{line: 1006, col: 28, offset: 35156},
+				pos: position{line: 1003, col: 28, offset: 35086},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1006, col: 28, offset: 35156},
+						pos:  position{line: 1003, col: 28, offset: 35086},
 						name: "DoubleQuoteBoldText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1007, col: 15, offset: 35191},
+						pos:  position{line: 1004, col: 15, offset: 35121},
 						name: "DoubleQuoteItalicText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1008, col: 15, offset: 35228},
+						pos:  position{line: 1005, col: 15, offset: 35158},
 						name: "DoubleQuoteMarkedText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1009, col: 15, offset: 35265},
+						pos:  position{line: 1006, col: 15, offset: 35195},
 						name: "DoubleQuoteMonospaceText",
 					},
 				},
@@ -6568,32 +6560,32 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedQuotedText",
-			pos:  position{line: 1011, col: 1, offset: 35293},
+			pos:  position{line: 1008, col: 1, offset: 35223},
 			expr: &choiceExpr{
-				pos: position{line: 1011, col: 22, offset: 35314},
+				pos: position{line: 1008, col: 22, offset: 35244},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1011, col: 22, offset: 35314},
+						pos:  position{line: 1008, col: 22, offset: 35244},
 						name: "EscapedBoldText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1012, col: 15, offset: 35346},
+						pos:  position{line: 1009, col: 15, offset: 35276},
 						name: "EscapedItalicText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1013, col: 15, offset: 35379},
+						pos:  position{line: 1010, col: 15, offset: 35309},
 						name: "EscapedMarkedText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1014, col: 15, offset: 35412},
+						pos:  position{line: 1011, col: 15, offset: 35342},
 						name: "EscapedMonospaceText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1015, col: 15, offset: 35449},
+						pos:  position{line: 1012, col: 15, offset: 35379},
 						name: "EscapedSubscriptText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1016, col: 15, offset: 35486},
+						pos:  position{line: 1013, col: 15, offset: 35416},
 						name: "EscapedSuperscriptText",
 					},
 				},
@@ -6601,21 +6593,21 @@ var g = &grammar{
 		},
 		{
 			name: "SubscriptOrSuperscriptPrefix",
-			pos:  position{line: 1018, col: 1, offset: 35512},
+			pos:  position{line: 1015, col: 1, offset: 35442},
 			expr: &choiceExpr{
-				pos: position{line: 1018, col: 33, offset: 35544},
+				pos: position{line: 1015, col: 33, offset: 35474},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1018, col: 33, offset: 35544},
+						pos:        position{line: 1015, col: 33, offset: 35474},
 						val:        "^",
 						ignoreCase: false,
 						want:       "\"^\"",
 					},
 					&actionExpr{
-						pos: position{line: 1018, col: 39, offset: 35550},
+						pos: position{line: 1015, col: 39, offset: 35480},
 						run: (*parser).callonSubscriptOrSuperscriptPrefix3,
 						expr: &litMatcher{
-							pos:        position{line: 1018, col: 39, offset: 35550},
+							pos:        position{line: 1015, col: 39, offset: 35480},
 							val:        "~",
 							ignoreCase: false,
 							want:       "\"~\"",
@@ -6626,14 +6618,14 @@ var g = &grammar{
 		},
 		{
 			name: "OneOrMoreBackslashes",
-			pos:  position{line: 1022, col: 1, offset: 35687},
+			pos:  position{line: 1019, col: 1, offset: 35617},
 			expr: &actionExpr{
-				pos: position{line: 1022, col: 25, offset: 35711},
+				pos: position{line: 1019, col: 25, offset: 35641},
 				run: (*parser).callonOneOrMoreBackslashes1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1022, col: 25, offset: 35711},
+					pos: position{line: 1019, col: 25, offset: 35641},
 					expr: &litMatcher{
-						pos:        position{line: 1022, col: 25, offset: 35711},
+						pos:        position{line: 1019, col: 25, offset: 35641},
 						val:        "\\",
 						ignoreCase: false,
 						want:       "\"\\\\\"",
@@ -6643,23 +6635,23 @@ var g = &grammar{
 		},
 		{
 			name: "TwoOrMoreBackslashes",
-			pos:  position{line: 1026, col: 1, offset: 35756},
+			pos:  position{line: 1023, col: 1, offset: 35686},
 			expr: &actionExpr{
-				pos: position{line: 1026, col: 25, offset: 35780},
+				pos: position{line: 1023, col: 25, offset: 35710},
 				run: (*parser).callonTwoOrMoreBackslashes1,
 				expr: &seqExpr{
-					pos: position{line: 1026, col: 25, offset: 35780},
+					pos: position{line: 1023, col: 25, offset: 35710},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1026, col: 25, offset: 35780},
+							pos:        position{line: 1023, col: 25, offset: 35710},
 							val:        "\\\\",
 							ignoreCase: false,
 							want:       "\"\\\\\\\\\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1026, col: 30, offset: 35785},
+							pos: position{line: 1023, col: 30, offset: 35715},
 							expr: &litMatcher{
-								pos:        position{line: 1026, col: 30, offset: 35785},
+								pos:        position{line: 1023, col: 30, offset: 35715},
 								val:        "\\",
 								ignoreCase: false,
 								want:       "\"\\\\\"",
@@ -6671,16 +6663,16 @@ var g = &grammar{
 		},
 		{
 			name: "BoldText",
-			pos:  position{line: 1034, col: 1, offset: 35890},
+			pos:  position{line: 1031, col: 1, offset: 35820},
 			expr: &choiceExpr{
-				pos: position{line: 1034, col: 13, offset: 35902},
+				pos: position{line: 1031, col: 13, offset: 35832},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1034, col: 13, offset: 35902},
+						pos:  position{line: 1031, col: 13, offset: 35832},
 						name: "DoubleQuoteBoldText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1034, col: 35, offset: 35924},
+						pos:  position{line: 1031, col: 35, offset: 35854},
 						name: "SingleQuoteBoldText",
 					},
 				},
@@ -6688,49 +6680,49 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteBoldText",
-			pos:  position{line: 1036, col: 1, offset: 35993},
+			pos:  position{line: 1033, col: 1, offset: 35923},
 			expr: &actionExpr{
-				pos: position{line: 1036, col: 24, offset: 36016},
+				pos: position{line: 1033, col: 24, offset: 35946},
 				run: (*parser).callonDoubleQuoteBoldText1,
 				expr: &seqExpr{
-					pos: position{line: 1036, col: 24, offset: 36016},
+					pos: position{line: 1033, col: 24, offset: 35946},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1036, col: 24, offset: 36016},
+							pos:   position{line: 1033, col: 24, offset: 35946},
 							label: "attrs",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1036, col: 30, offset: 36022},
+								pos: position{line: 1033, col: 30, offset: 35952},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1036, col: 31, offset: 36023},
+									pos:  position{line: 1033, col: 31, offset: 35953},
 									name: "QuotedTextAttrs",
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 1036, col: 49, offset: 36041},
+							pos: position{line: 1033, col: 49, offset: 35971},
 							expr: &litMatcher{
-								pos:        position{line: 1036, col: 50, offset: 36042},
+								pos:        position{line: 1033, col: 50, offset: 35972},
 								val:        "\\\\",
 								ignoreCase: false,
 								want:       "\"\\\\\\\\\"",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1036, col: 55, offset: 36047},
+							pos:        position{line: 1033, col: 55, offset: 35977},
 							val:        "**",
 							ignoreCase: false,
 							want:       "\"**\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1036, col: 60, offset: 36052},
+							pos:   position{line: 1033, col: 60, offset: 35982},
 							label: "elements",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1036, col: 70, offset: 36062},
+								pos:  position{line: 1033, col: 70, offset: 35992},
 								name: "DoubleQuoteBoldTextElements",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1036, col: 99, offset: 36091},
+							pos:        position{line: 1033, col: 99, offset: 36021},
 							val:        "**",
 							ignoreCase: false,
 							want:       "\"**\"",
@@ -6741,37 +6733,37 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteBoldTextElements",
-			pos:  position{line: 1040, col: 1, offset: 36182},
+			pos:  position{line: 1037, col: 1, offset: 36112},
 			expr: &seqExpr{
-				pos: position{line: 1040, col: 32, offset: 36213},
+				pos: position{line: 1037, col: 32, offset: 36143},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1040, col: 32, offset: 36213},
+						pos:  position{line: 1037, col: 32, offset: 36143},
 						name: "DoubleQuoteBoldTextElement",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1040, col: 59, offset: 36240},
+						pos: position{line: 1037, col: 59, offset: 36170},
 						expr: &seqExpr{
-							pos: position{line: 1040, col: 60, offset: 36241},
+							pos: position{line: 1037, col: 60, offset: 36171},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1040, col: 60, offset: 36241},
+									pos: position{line: 1037, col: 60, offset: 36171},
 									expr: &litMatcher{
-										pos:        position{line: 1040, col: 62, offset: 36243},
+										pos:        position{line: 1037, col: 62, offset: 36173},
 										val:        "**",
 										ignoreCase: false,
 										want:       "\"**\"",
 									},
 								},
 								&choiceExpr{
-									pos: position{line: 1040, col: 69, offset: 36250},
+									pos: position{line: 1037, col: 69, offset: 36180},
 									alternatives: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 1040, col: 69, offset: 36250},
+											pos:  position{line: 1037, col: 69, offset: 36180},
 											name: "Space",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1040, col: 77, offset: 36258},
+											pos:  position{line: 1037, col: 77, offset: 36188},
 											name: "DoubleQuoteBoldTextElement",
 										},
 									},
@@ -6784,68 +6776,68 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteBoldTextElement",
-			pos:  position{line: 1042, col: 1, offset: 36325},
+			pos:  position{line: 1039, col: 1, offset: 36255},
 			expr: &choiceExpr{
-				pos: position{line: 1042, col: 31, offset: 36355},
+				pos: position{line: 1039, col: 31, offset: 36285},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1042, col: 31, offset: 36355},
+						pos:  position{line: 1039, col: 31, offset: 36285},
 						name: "Word",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1043, col: 11, offset: 36372},
+						pos:  position{line: 1040, col: 11, offset: 36302},
 						name: "SingleQuoteBoldText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1044, col: 11, offset: 36404},
+						pos:  position{line: 1041, col: 11, offset: 36334},
 						name: "ItalicText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1045, col: 11, offset: 36426},
+						pos:  position{line: 1042, col: 11, offset: 36356},
 						name: "MarkedText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1046, col: 11, offset: 36448},
+						pos:  position{line: 1043, col: 11, offset: 36378},
 						name: "MonospaceText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1047, col: 11, offset: 36473},
+						pos:  position{line: 1044, col: 11, offset: 36403},
 						name: "SubscriptText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1048, col: 11, offset: 36498},
+						pos:  position{line: 1045, col: 11, offset: 36428},
 						name: "SuperscriptText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1049, col: 11, offset: 36525},
+						pos:  position{line: 1046, col: 11, offset: 36455},
 						name: "InlineIcon",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1050, col: 11, offset: 36547},
+						pos:  position{line: 1047, col: 11, offset: 36477},
 						name: "InlineImage",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1051, col: 11, offset: 36570},
+						pos:  position{line: 1048, col: 11, offset: 36500},
 						name: "Link",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1052, col: 11, offset: 36586},
+						pos:  position{line: 1049, col: 11, offset: 36516},
 						name: "InlinePassthrough",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1053, col: 11, offset: 36615},
+						pos:  position{line: 1050, col: 11, offset: 36545},
 						name: "QuotedString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1054, col: 11, offset: 36639},
+						pos:  position{line: 1051, col: 11, offset: 36569},
 						name: "AttributeSubstitution",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1055, col: 11, offset: 36672},
+						pos:  position{line: 1052, col: 11, offset: 36602},
 						name: "DoubleQuoteBoldTextStringElement",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1056, col: 11, offset: 36716},
+						pos:  position{line: 1053, col: 11, offset: 36646},
 						name: "DoubleQuoteBoldTextFallbackCharacter",
 					},
 				},
@@ -6853,26 +6845,26 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteBoldTextStringElement",
-			pos:  position{line: 1059, col: 1, offset: 36758},
+			pos:  position{line: 1056, col: 1, offset: 36688},
 			expr: &actionExpr{
-				pos: position{line: 1059, col: 37, offset: 36794},
+				pos: position{line: 1056, col: 37, offset: 36724},
 				run: (*parser).callonDoubleQuoteBoldTextStringElement1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1059, col: 37, offset: 36794},
+					pos: position{line: 1056, col: 37, offset: 36724},
 					expr: &seqExpr{
-						pos: position{line: 1059, col: 38, offset: 36795},
+						pos: position{line: 1056, col: 38, offset: 36725},
 						exprs: []interface{}{
 							&notExpr{
-								pos: position{line: 1059, col: 38, offset: 36795},
+								pos: position{line: 1056, col: 38, offset: 36725},
 								expr: &litMatcher{
-									pos:        position{line: 1059, col: 39, offset: 36796},
+									pos:        position{line: 1056, col: 39, offset: 36726},
 									val:        "**",
 									ignoreCase: false,
 									want:       "\"**\"",
 								},
 							},
 							&charClassMatcher{
-								pos:        position{line: 1059, col: 44, offset: 36801},
+								pos:        position{line: 1056, col: 44, offset: 36731},
 								val:        "[^\\r\\n ^~{}]",
 								chars:      []rune{'\r', '\n', ' ', '^', '~', '{', '}'},
 								ignoreCase: false,
@@ -6885,31 +6877,31 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteBoldTextFallbackCharacter",
-			pos:  position{line: 1063, col: 1, offset: 36876},
+			pos:  position{line: 1060, col: 1, offset: 36806},
 			expr: &choiceExpr{
-				pos: position{line: 1064, col: 5, offset: 36922},
+				pos: position{line: 1061, col: 5, offset: 36852},
 				alternatives: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 1064, col: 5, offset: 36922},
+						pos:        position{line: 1061, col: 5, offset: 36852},
 						val:        "[^\\r\\n*]",
 						chars:      []rune{'\r', '\n', '*'},
 						ignoreCase: false,
 						inverted:   true,
 					},
 					&actionExpr{
-						pos: position{line: 1065, col: 7, offset: 37020},
+						pos: position{line: 1062, col: 7, offset: 36950},
 						run: (*parser).callonDoubleQuoteBoldTextFallbackCharacter3,
 						expr: &seqExpr{
-							pos: position{line: 1065, col: 7, offset: 37020},
+							pos: position{line: 1062, col: 7, offset: 36950},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1065, col: 7, offset: 37020},
+									pos:        position{line: 1062, col: 7, offset: 36950},
 									val:        "**",
 									ignoreCase: false,
 									want:       "\"**\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1065, col: 12, offset: 37025},
+									pos:  position{line: 1062, col: 12, offset: 36955},
 									name: "Alphanums",
 								},
 							},
@@ -6920,49 +6912,49 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteBoldText",
-			pos:  position{line: 1069, col: 1, offset: 37192},
+			pos:  position{line: 1066, col: 1, offset: 37122},
 			expr: &choiceExpr{
-				pos: position{line: 1069, col: 24, offset: 37215},
+				pos: position{line: 1066, col: 24, offset: 37145},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1069, col: 24, offset: 37215},
+						pos: position{line: 1066, col: 24, offset: 37145},
 						run: (*parser).callonSingleQuoteBoldText2,
 						expr: &seqExpr{
-							pos: position{line: 1069, col: 24, offset: 37215},
+							pos: position{line: 1066, col: 24, offset: 37145},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1069, col: 24, offset: 37215},
+									pos:   position{line: 1066, col: 24, offset: 37145},
 									label: "attrs",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1069, col: 30, offset: 37221},
+										pos: position{line: 1066, col: 30, offset: 37151},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1069, col: 31, offset: 37222},
+											pos:  position{line: 1066, col: 31, offset: 37152},
 											name: "QuotedTextAttrs",
 										},
 									},
 								},
 								&seqExpr{
-									pos: position{line: 1069, col: 50, offset: 37241},
+									pos: position{line: 1066, col: 50, offset: 37171},
 									exprs: []interface{}{
 										&notExpr{
-											pos: position{line: 1069, col: 50, offset: 37241},
+											pos: position{line: 1066, col: 50, offset: 37171},
 											expr: &litMatcher{
-												pos:        position{line: 1069, col: 51, offset: 37242},
+												pos:        position{line: 1066, col: 51, offset: 37172},
 												val:        "\\",
 												ignoreCase: false,
 												want:       "\"\\\\\"",
 											},
 										},
 										&litMatcher{
-											pos:        position{line: 1069, col: 55, offset: 37246},
+											pos:        position{line: 1066, col: 55, offset: 37176},
 											val:        "*",
 											ignoreCase: false,
 											want:       "\"*\"",
 										},
 										&notExpr{
-											pos: position{line: 1069, col: 59, offset: 37250},
+											pos: position{line: 1066, col: 59, offset: 37180},
 											expr: &litMatcher{
-												pos:        position{line: 1069, col: 60, offset: 37251},
+												pos:        position{line: 1066, col: 60, offset: 37181},
 												val:        "*",
 												ignoreCase: false,
 												want:       "\"*\"",
@@ -6971,25 +6963,25 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1069, col: 65, offset: 37256},
+									pos:   position{line: 1066, col: 65, offset: 37186},
 									label: "elements",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1069, col: 75, offset: 37266},
+										pos:  position{line: 1066, col: 75, offset: 37196},
 										name: "SingleQuoteBoldTextElements",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1069, col: 104, offset: 37295},
+									pos:        position{line: 1066, col: 104, offset: 37225},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
 								},
 								&andExpr{
-									pos: position{line: 1069, col: 108, offset: 37299},
+									pos: position{line: 1066, col: 108, offset: 37229},
 									expr: &notExpr{
-										pos: position{line: 1069, col: 110, offset: 37301},
+										pos: position{line: 1066, col: 110, offset: 37231},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1069, col: 111, offset: 37302},
+											pos:  position{line: 1066, col: 111, offset: 37232},
 											name: "Alphanum",
 										},
 									},
@@ -6998,58 +6990,58 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1071, col: 5, offset: 37498},
+						pos: position{line: 1068, col: 5, offset: 37428},
 						run: (*parser).callonSingleQuoteBoldText19,
 						expr: &seqExpr{
-							pos: position{line: 1071, col: 5, offset: 37498},
+							pos: position{line: 1068, col: 5, offset: 37428},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1071, col: 5, offset: 37498},
+									pos:   position{line: 1068, col: 5, offset: 37428},
 									label: "attrs",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1071, col: 11, offset: 37504},
+										pos: position{line: 1068, col: 11, offset: 37434},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1071, col: 12, offset: 37505},
+											pos:  position{line: 1068, col: 12, offset: 37435},
 											name: "QuotedTextAttrs",
 										},
 									},
 								},
 								&notExpr{
-									pos: position{line: 1071, col: 30, offset: 37523},
+									pos: position{line: 1068, col: 30, offset: 37453},
 									expr: &litMatcher{
-										pos:        position{line: 1071, col: 31, offset: 37524},
+										pos:        position{line: 1068, col: 31, offset: 37454},
 										val:        "\\\\",
 										ignoreCase: false,
 										want:       "\"\\\\\\\\\"",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1071, col: 36, offset: 37529},
+									pos:        position{line: 1068, col: 36, offset: 37459},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1071, col: 40, offset: 37533},
+									pos:   position{line: 1068, col: 40, offset: 37463},
 									label: "elements",
 									expr: &seqExpr{
-										pos: position{line: 1071, col: 50, offset: 37543},
+										pos: position{line: 1068, col: 50, offset: 37473},
 										exprs: []interface{}{
 											&litMatcher{
-												pos:        position{line: 1071, col: 50, offset: 37543},
+												pos:        position{line: 1068, col: 50, offset: 37473},
 												val:        "*",
 												ignoreCase: false,
 												want:       "\"*\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1071, col: 54, offset: 37547},
+												pos:  position{line: 1068, col: 54, offset: 37477},
 												name: "SingleQuoteBoldTextElements",
 											},
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1071, col: 83, offset: 37576},
+									pos:        position{line: 1068, col: 83, offset: 37506},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
@@ -7062,21 +7054,21 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteBoldTextElements",
-			pos:  position{line: 1075, col: 1, offset: 37786},
+			pos:  position{line: 1072, col: 1, offset: 37716},
 			expr: &seqExpr{
-				pos: position{line: 1075, col: 32, offset: 37817},
+				pos: position{line: 1072, col: 32, offset: 37747},
 				exprs: []interface{}{
 					&notExpr{
-						pos: position{line: 1075, col: 32, offset: 37817},
+						pos: position{line: 1072, col: 32, offset: 37747},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1075, col: 33, offset: 37818},
+							pos:  position{line: 1072, col: 33, offset: 37748},
 							name: "Space",
 						},
 					},
 					&oneOrMoreExpr{
-						pos: position{line: 1075, col: 39, offset: 37824},
+						pos: position{line: 1072, col: 39, offset: 37754},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1075, col: 39, offset: 37824},
+							pos:  position{line: 1072, col: 39, offset: 37754},
 							name: "SingleQuoteBoldTextElement",
 						},
 					},
@@ -7085,43 +7077,43 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteBoldTextElement",
-			pos:  position{line: 1077, col: 1, offset: 37855},
+			pos:  position{line: 1074, col: 1, offset: 37785},
 			expr: &choiceExpr{
-				pos: position{line: 1077, col: 31, offset: 37885},
+				pos: position{line: 1074, col: 31, offset: 37815},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1077, col: 31, offset: 37885},
+						pos:  position{line: 1074, col: 31, offset: 37815},
 						name: "Word",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1078, col: 11, offset: 37902},
+						pos:  position{line: 1075, col: 11, offset: 37832},
 						name: "DoubleQuoteBoldText",
 					},
 					&seqExpr{
-						pos: position{line: 1079, col: 11, offset: 37933},
+						pos: position{line: 1076, col: 11, offset: 37863},
 						exprs: []interface{}{
 							&oneOrMoreExpr{
-								pos: position{line: 1079, col: 11, offset: 37933},
+								pos: position{line: 1076, col: 11, offset: 37863},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1079, col: 11, offset: 37933},
+									pos:  position{line: 1076, col: 11, offset: 37863},
 									name: "Space",
 								},
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 1079, col: 18, offset: 37940},
+								pos: position{line: 1076, col: 18, offset: 37870},
 								expr: &seqExpr{
-									pos: position{line: 1079, col: 19, offset: 37941},
+									pos: position{line: 1076, col: 19, offset: 37871},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 1079, col: 19, offset: 37941},
+											pos:        position{line: 1076, col: 19, offset: 37871},
 											val:        "*",
 											ignoreCase: false,
 											want:       "\"*\"",
 										},
 										&notExpr{
-											pos: position{line: 1079, col: 23, offset: 37945},
+											pos: position{line: 1076, col: 23, offset: 37875},
 											expr: &litMatcher{
-												pos:        position{line: 1079, col: 24, offset: 37946},
+												pos:        position{line: 1076, col: 24, offset: 37876},
 												val:        "*",
 												ignoreCase: false,
 												want:       "\"*\"",
@@ -7133,55 +7125,55 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1080, col: 11, offset: 37963},
+						pos:  position{line: 1077, col: 11, offset: 37893},
 						name: "ItalicText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1081, col: 11, offset: 37985},
+						pos:  position{line: 1078, col: 11, offset: 37915},
 						name: "MarkedText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1082, col: 11, offset: 38007},
+						pos:  position{line: 1079, col: 11, offset: 37937},
 						name: "MonospaceText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1083, col: 11, offset: 38032},
+						pos:  position{line: 1080, col: 11, offset: 37962},
 						name: "SubscriptText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1084, col: 11, offset: 38057},
+						pos:  position{line: 1081, col: 11, offset: 37987},
 						name: "SuperscriptText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1085, col: 11, offset: 38084},
+						pos:  position{line: 1082, col: 11, offset: 38014},
 						name: "InlineIcon",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1086, col: 11, offset: 38106},
+						pos:  position{line: 1083, col: 11, offset: 38036},
 						name: "InlineImage",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1087, col: 11, offset: 38130},
+						pos:  position{line: 1084, col: 11, offset: 38060},
 						name: "Link",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1088, col: 11, offset: 38148},
+						pos:  position{line: 1085, col: 11, offset: 38078},
 						name: "InlinePassthrough",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1089, col: 11, offset: 38177},
+						pos:  position{line: 1086, col: 11, offset: 38107},
 						name: "QuotedString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1090, col: 11, offset: 38201},
+						pos:  position{line: 1087, col: 11, offset: 38131},
 						name: "AttributeSubstitution",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1091, col: 11, offset: 38234},
+						pos:  position{line: 1088, col: 11, offset: 38164},
 						name: "SingleQuoteBoldTextStringElement",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1092, col: 11, offset: 38278},
+						pos:  position{line: 1089, col: 11, offset: 38208},
 						name: "SingleQuoteBoldTextFallbackCharacter",
 					},
 				},
@@ -7189,14 +7181,14 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteBoldTextStringElement",
-			pos:  position{line: 1094, col: 1, offset: 38318},
+			pos:  position{line: 1091, col: 1, offset: 38248},
 			expr: &actionExpr{
-				pos: position{line: 1094, col: 37, offset: 38354},
+				pos: position{line: 1091, col: 37, offset: 38284},
 				run: (*parser).callonSingleQuoteBoldTextStringElement1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1094, col: 37, offset: 38354},
+					pos: position{line: 1091, col: 37, offset: 38284},
 					expr: &charClassMatcher{
-						pos:        position{line: 1094, col: 37, offset: 38354},
+						pos:        position{line: 1091, col: 37, offset: 38284},
 						val:        "[^\\r\\n{} *^~]",
 						chars:      []rune{'\r', '\n', '{', '}', ' ', '*', '^', '~'},
 						ignoreCase: false,
@@ -7207,31 +7199,31 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteBoldTextFallbackCharacter",
-			pos:  position{line: 1098, col: 1, offset: 38584},
+			pos:  position{line: 1095, col: 1, offset: 38514},
 			expr: &choiceExpr{
-				pos: position{line: 1099, col: 5, offset: 38630},
+				pos: position{line: 1096, col: 5, offset: 38560},
 				alternatives: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 1099, col: 5, offset: 38630},
+						pos:        position{line: 1096, col: 5, offset: 38560},
 						val:        "[^\\r\\n*]",
 						chars:      []rune{'\r', '\n', '*'},
 						ignoreCase: false,
 						inverted:   true,
 					},
 					&actionExpr{
-						pos: position{line: 1100, col: 7, offset: 38728},
+						pos: position{line: 1097, col: 7, offset: 38658},
 						run: (*parser).callonSingleQuoteBoldTextFallbackCharacter3,
 						expr: &seqExpr{
-							pos: position{line: 1100, col: 7, offset: 38728},
+							pos: position{line: 1097, col: 7, offset: 38658},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1100, col: 7, offset: 38728},
+									pos:        position{line: 1097, col: 7, offset: 38658},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1100, col: 11, offset: 38732},
+									pos:  position{line: 1097, col: 11, offset: 38662},
 									name: "Alphanums",
 								},
 							},
@@ -7242,40 +7234,40 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedBoldText",
-			pos:  position{line: 1104, col: 1, offset: 38899},
+			pos:  position{line: 1101, col: 1, offset: 38829},
 			expr: &choiceExpr{
-				pos: position{line: 1105, col: 5, offset: 38924},
+				pos: position{line: 1102, col: 5, offset: 38854},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1105, col: 5, offset: 38924},
+						pos: position{line: 1102, col: 5, offset: 38854},
 						run: (*parser).callonEscapedBoldText2,
 						expr: &seqExpr{
-							pos: position{line: 1105, col: 5, offset: 38924},
+							pos: position{line: 1102, col: 5, offset: 38854},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1105, col: 5, offset: 38924},
+									pos:   position{line: 1102, col: 5, offset: 38854},
 									label: "backslashes",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1105, col: 18, offset: 38937},
+										pos:  position{line: 1102, col: 18, offset: 38867},
 										name: "TwoOrMoreBackslashes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1105, col: 40, offset: 38959},
+									pos:        position{line: 1102, col: 40, offset: 38889},
 									val:        "**",
 									ignoreCase: false,
 									want:       "\"**\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1105, col: 45, offset: 38964},
+									pos:   position{line: 1102, col: 45, offset: 38894},
 									label: "elements",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1105, col: 55, offset: 38974},
+										pos:  position{line: 1102, col: 55, offset: 38904},
 										name: "DoubleQuoteBoldTextElements",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1105, col: 84, offset: 39003},
+									pos:        position{line: 1102, col: 84, offset: 38933},
 									val:        "**",
 									ignoreCase: false,
 									want:       "\"**\"",
@@ -7284,35 +7276,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1107, col: 9, offset: 39162},
+						pos: position{line: 1104, col: 9, offset: 39092},
 						run: (*parser).callonEscapedBoldText10,
 						expr: &seqExpr{
-							pos: position{line: 1107, col: 9, offset: 39162},
+							pos: position{line: 1104, col: 9, offset: 39092},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1107, col: 9, offset: 39162},
+									pos:   position{line: 1104, col: 9, offset: 39092},
 									label: "backslashes",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1107, col: 22, offset: 39175},
+										pos:  position{line: 1104, col: 22, offset: 39105},
 										name: "OneOrMoreBackslashes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1107, col: 44, offset: 39197},
+									pos:        position{line: 1104, col: 44, offset: 39127},
 									val:        "**",
 									ignoreCase: false,
 									want:       "\"**\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1107, col: 49, offset: 39202},
+									pos:   position{line: 1104, col: 49, offset: 39132},
 									label: "elements",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1107, col: 59, offset: 39212},
+										pos:  position{line: 1104, col: 59, offset: 39142},
 										name: "SingleQuoteBoldTextElements",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1107, col: 88, offset: 39241},
+									pos:        position{line: 1104, col: 88, offset: 39171},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
@@ -7321,35 +7313,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1110, col: 9, offset: 39444},
+						pos: position{line: 1107, col: 9, offset: 39374},
 						run: (*parser).callonEscapedBoldText18,
 						expr: &seqExpr{
-							pos: position{line: 1110, col: 9, offset: 39444},
+							pos: position{line: 1107, col: 9, offset: 39374},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1110, col: 9, offset: 39444},
+									pos:   position{line: 1107, col: 9, offset: 39374},
 									label: "backslashes",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1110, col: 22, offset: 39457},
+										pos:  position{line: 1107, col: 22, offset: 39387},
 										name: "OneOrMoreBackslashes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1110, col: 44, offset: 39479},
+									pos:        position{line: 1107, col: 44, offset: 39409},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1110, col: 48, offset: 39483},
+									pos:   position{line: 1107, col: 48, offset: 39413},
 									label: "elements",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1110, col: 58, offset: 39493},
+										pos:  position{line: 1107, col: 58, offset: 39423},
 										name: "SingleQuoteBoldTextElements",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1110, col: 87, offset: 39522},
+									pos:        position{line: 1107, col: 87, offset: 39452},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
@@ -7362,16 +7354,16 @@ var g = &grammar{
 		},
 		{
 			name: "ItalicText",
-			pos:  position{line: 1118, col: 1, offset: 39738},
+			pos:  position{line: 1115, col: 1, offset: 39668},
 			expr: &choiceExpr{
-				pos: position{line: 1118, col: 15, offset: 39752},
+				pos: position{line: 1115, col: 15, offset: 39682},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1118, col: 15, offset: 39752},
+						pos:  position{line: 1115, col: 15, offset: 39682},
 						name: "DoubleQuoteItalicText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1118, col: 39, offset: 39776},
+						pos:  position{line: 1115, col: 39, offset: 39706},
 						name: "SingleQuoteItalicText",
 					},
 				},
@@ -7379,49 +7371,49 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteItalicText",
-			pos:  position{line: 1120, col: 1, offset: 39801},
+			pos:  position{line: 1117, col: 1, offset: 39731},
 			expr: &actionExpr{
-				pos: position{line: 1120, col: 26, offset: 39826},
+				pos: position{line: 1117, col: 26, offset: 39756},
 				run: (*parser).callonDoubleQuoteItalicText1,
 				expr: &seqExpr{
-					pos: position{line: 1120, col: 26, offset: 39826},
+					pos: position{line: 1117, col: 26, offset: 39756},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1120, col: 26, offset: 39826},
+							pos:   position{line: 1117, col: 26, offset: 39756},
 							label: "attrs",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1120, col: 32, offset: 39832},
+								pos: position{line: 1117, col: 32, offset: 39762},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1120, col: 33, offset: 39833},
+									pos:  position{line: 1117, col: 33, offset: 39763},
 									name: "QuotedTextAttrs",
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 1120, col: 51, offset: 39851},
+							pos: position{line: 1117, col: 51, offset: 39781},
 							expr: &litMatcher{
-								pos:        position{line: 1120, col: 52, offset: 39852},
+								pos:        position{line: 1117, col: 52, offset: 39782},
 								val:        "\\\\",
 								ignoreCase: false,
 								want:       "\"\\\\\\\\\"",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1120, col: 57, offset: 39857},
+							pos:        position{line: 1117, col: 57, offset: 39787},
 							val:        "__",
 							ignoreCase: false,
 							want:       "\"__\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1120, col: 62, offset: 39862},
+							pos:   position{line: 1117, col: 62, offset: 39792},
 							label: "elements",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1120, col: 72, offset: 39872},
+								pos:  position{line: 1117, col: 72, offset: 39802},
 								name: "DoubleQuoteItalicTextElements",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1120, col: 103, offset: 39903},
+							pos:        position{line: 1117, col: 103, offset: 39833},
 							val:        "__",
 							ignoreCase: false,
 							want:       "\"__\"",
@@ -7432,37 +7424,37 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteItalicTextElements",
-			pos:  position{line: 1124, col: 1, offset: 40041},
+			pos:  position{line: 1121, col: 1, offset: 39971},
 			expr: &seqExpr{
-				pos: position{line: 1124, col: 34, offset: 40074},
+				pos: position{line: 1121, col: 34, offset: 40004},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1124, col: 34, offset: 40074},
+						pos:  position{line: 1121, col: 34, offset: 40004},
 						name: "DoubleQuoteItalicTextElement",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1124, col: 63, offset: 40103},
+						pos: position{line: 1121, col: 63, offset: 40033},
 						expr: &seqExpr{
-							pos: position{line: 1124, col: 64, offset: 40104},
+							pos: position{line: 1121, col: 64, offset: 40034},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1124, col: 64, offset: 40104},
+									pos: position{line: 1121, col: 64, offset: 40034},
 									expr: &litMatcher{
-										pos:        position{line: 1124, col: 66, offset: 40106},
+										pos:        position{line: 1121, col: 66, offset: 40036},
 										val:        "__",
 										ignoreCase: false,
 										want:       "\"__\"",
 									},
 								},
 								&choiceExpr{
-									pos: position{line: 1124, col: 73, offset: 40113},
+									pos: position{line: 1121, col: 73, offset: 40043},
 									alternatives: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 1124, col: 73, offset: 40113},
+											pos:  position{line: 1121, col: 73, offset: 40043},
 											name: "Space",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1124, col: 81, offset: 40121},
+											pos:  position{line: 1121, col: 81, offset: 40051},
 											name: "DoubleQuoteItalicTextElement",
 										},
 									},
@@ -7475,64 +7467,64 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteItalicTextElement",
-			pos:  position{line: 1126, col: 1, offset: 40190},
+			pos:  position{line: 1123, col: 1, offset: 40120},
 			expr: &choiceExpr{
-				pos: position{line: 1126, col: 33, offset: 40222},
+				pos: position{line: 1123, col: 33, offset: 40152},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1126, col: 33, offset: 40222},
+						pos:  position{line: 1123, col: 33, offset: 40152},
 						name: "Word",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1127, col: 11, offset: 40239},
+						pos:  position{line: 1124, col: 11, offset: 40169},
 						name: "SingleQuoteItalicText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1128, col: 11, offset: 40273},
+						pos:  position{line: 1125, col: 11, offset: 40203},
 						name: "BoldText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1129, col: 11, offset: 40293},
+						pos:  position{line: 1126, col: 11, offset: 40223},
 						name: "MarkedText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1130, col: 11, offset: 40315},
+						pos:  position{line: 1127, col: 11, offset: 40245},
 						name: "MonospaceText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1131, col: 11, offset: 40340},
+						pos:  position{line: 1128, col: 11, offset: 40270},
 						name: "SubscriptText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1132, col: 11, offset: 40365},
+						pos:  position{line: 1129, col: 11, offset: 40295},
 						name: "SuperscriptText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1133, col: 11, offset: 40392},
+						pos:  position{line: 1130, col: 11, offset: 40322},
 						name: "InlineIcon",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1134, col: 11, offset: 40414},
+						pos:  position{line: 1131, col: 11, offset: 40344},
 						name: "InlineImage",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1135, col: 11, offset: 40438},
+						pos:  position{line: 1132, col: 11, offset: 40368},
 						name: "Link",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1136, col: 11, offset: 40455},
+						pos:  position{line: 1133, col: 11, offset: 40385},
 						name: "InlinePassthrough",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1137, col: 11, offset: 40484},
+						pos:  position{line: 1134, col: 11, offset: 40414},
 						name: "QuotedString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1138, col: 11, offset: 40508},
+						pos:  position{line: 1135, col: 11, offset: 40438},
 						name: "DoubleQuoteItalicTextStringElement",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1139, col: 11, offset: 40554},
+						pos:  position{line: 1136, col: 11, offset: 40484},
 						name: "DoubleQuoteItalicTextFallbackCharacter",
 					},
 				},
@@ -7540,26 +7532,26 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteItalicTextStringElement",
-			pos:  position{line: 1141, col: 1, offset: 40596},
+			pos:  position{line: 1138, col: 1, offset: 40526},
 			expr: &actionExpr{
-				pos: position{line: 1141, col: 39, offset: 40634},
+				pos: position{line: 1138, col: 39, offset: 40564},
 				run: (*parser).callonDoubleQuoteItalicTextStringElement1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1141, col: 39, offset: 40634},
+					pos: position{line: 1138, col: 39, offset: 40564},
 					expr: &seqExpr{
-						pos: position{line: 1141, col: 40, offset: 40635},
+						pos: position{line: 1138, col: 40, offset: 40565},
 						exprs: []interface{}{
 							&notExpr{
-								pos: position{line: 1141, col: 40, offset: 40635},
+								pos: position{line: 1138, col: 40, offset: 40565},
 								expr: &litMatcher{
-									pos:        position{line: 1141, col: 41, offset: 40636},
+									pos:        position{line: 1138, col: 41, offset: 40566},
 									val:        "__",
 									ignoreCase: false,
 									want:       "\"__\"",
 								},
 							},
 							&charClassMatcher{
-								pos:        position{line: 1141, col: 46, offset: 40641},
+								pos:        position{line: 1138, col: 46, offset: 40571},
 								val:        "[^\\r\\n ^~{}]",
 								chars:      []rune{'\r', '\n', ' ', '^', '~', '{', '}'},
 								ignoreCase: false,
@@ -7572,31 +7564,31 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteItalicTextFallbackCharacter",
-			pos:  position{line: 1145, col: 1, offset: 40716},
+			pos:  position{line: 1142, col: 1, offset: 40646},
 			expr: &choiceExpr{
-				pos: position{line: 1146, col: 5, offset: 40764},
+				pos: position{line: 1143, col: 5, offset: 40694},
 				alternatives: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 1146, col: 5, offset: 40764},
+						pos:        position{line: 1143, col: 5, offset: 40694},
 						val:        "[^\\r\\n_]",
 						chars:      []rune{'\r', '\n', '_'},
 						ignoreCase: false,
 						inverted:   true,
 					},
 					&actionExpr{
-						pos: position{line: 1147, col: 7, offset: 40864},
+						pos: position{line: 1144, col: 7, offset: 40794},
 						run: (*parser).callonDoubleQuoteItalicTextFallbackCharacter3,
 						expr: &seqExpr{
-							pos: position{line: 1147, col: 7, offset: 40864},
+							pos: position{line: 1144, col: 7, offset: 40794},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1147, col: 7, offset: 40864},
+									pos:        position{line: 1144, col: 7, offset: 40794},
 									val:        "__",
 									ignoreCase: false,
 									want:       "\"__\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1147, col: 12, offset: 40869},
+									pos:  position{line: 1144, col: 12, offset: 40799},
 									name: "Alphanums",
 								},
 							},
@@ -7607,49 +7599,49 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteItalicText",
-			pos:  position{line: 1151, col: 1, offset: 41038},
+			pos:  position{line: 1148, col: 1, offset: 40968},
 			expr: &choiceExpr{
-				pos: position{line: 1151, col: 26, offset: 41063},
+				pos: position{line: 1148, col: 26, offset: 40993},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1151, col: 26, offset: 41063},
+						pos: position{line: 1148, col: 26, offset: 40993},
 						run: (*parser).callonSingleQuoteItalicText2,
 						expr: &seqExpr{
-							pos: position{line: 1151, col: 26, offset: 41063},
+							pos: position{line: 1148, col: 26, offset: 40993},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1151, col: 26, offset: 41063},
+									pos:   position{line: 1148, col: 26, offset: 40993},
 									label: "attrs",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1151, col: 32, offset: 41069},
+										pos: position{line: 1148, col: 32, offset: 40999},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1151, col: 33, offset: 41070},
+											pos:  position{line: 1148, col: 33, offset: 41000},
 											name: "QuotedTextAttrs",
 										},
 									},
 								},
 								&seqExpr{
-									pos: position{line: 1151, col: 52, offset: 41089},
+									pos: position{line: 1148, col: 52, offset: 41019},
 									exprs: []interface{}{
 										&notExpr{
-											pos: position{line: 1151, col: 52, offset: 41089},
+											pos: position{line: 1148, col: 52, offset: 41019},
 											expr: &litMatcher{
-												pos:        position{line: 1151, col: 53, offset: 41090},
+												pos:        position{line: 1148, col: 53, offset: 41020},
 												val:        "\\",
 												ignoreCase: false,
 												want:       "\"\\\\\"",
 											},
 										},
 										&litMatcher{
-											pos:        position{line: 1151, col: 57, offset: 41094},
+											pos:        position{line: 1148, col: 57, offset: 41024},
 											val:        "_",
 											ignoreCase: false,
 											want:       "\"_\"",
 										},
 										&notExpr{
-											pos: position{line: 1151, col: 61, offset: 41098},
+											pos: position{line: 1148, col: 61, offset: 41028},
 											expr: &litMatcher{
-												pos:        position{line: 1151, col: 62, offset: 41099},
+												pos:        position{line: 1148, col: 62, offset: 41029},
 												val:        "_",
 												ignoreCase: false,
 												want:       "\"_\"",
@@ -7658,15 +7650,15 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1151, col: 67, offset: 41104},
+									pos:   position{line: 1148, col: 67, offset: 41034},
 									label: "elements",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1151, col: 77, offset: 41114},
+										pos:  position{line: 1148, col: 77, offset: 41044},
 										name: "SingleQuoteItalicTextElements",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1151, col: 108, offset: 41145},
+									pos:        position{line: 1148, col: 108, offset: 41075},
 									val:        "_",
 									ignoreCase: false,
 									want:       "\"_\"",
@@ -7675,58 +7667,58 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1153, col: 5, offset: 41337},
+						pos: position{line: 1150, col: 5, offset: 41267},
 						run: (*parser).callonSingleQuoteItalicText16,
 						expr: &seqExpr{
-							pos: position{line: 1153, col: 5, offset: 41337},
+							pos: position{line: 1150, col: 5, offset: 41267},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1153, col: 5, offset: 41337},
+									pos:   position{line: 1150, col: 5, offset: 41267},
 									label: "attrs",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1153, col: 11, offset: 41343},
+										pos: position{line: 1150, col: 11, offset: 41273},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1153, col: 12, offset: 41344},
+											pos:  position{line: 1150, col: 12, offset: 41274},
 											name: "QuotedTextAttrs",
 										},
 									},
 								},
 								&notExpr{
-									pos: position{line: 1153, col: 30, offset: 41362},
+									pos: position{line: 1150, col: 30, offset: 41292},
 									expr: &litMatcher{
-										pos:        position{line: 1153, col: 31, offset: 41363},
+										pos:        position{line: 1150, col: 31, offset: 41293},
 										val:        "\\\\",
 										ignoreCase: false,
 										want:       "\"\\\\\\\\\"",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1153, col: 36, offset: 41368},
+									pos:        position{line: 1150, col: 36, offset: 41298},
 									val:        "_",
 									ignoreCase: false,
 									want:       "\"_\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1153, col: 40, offset: 41372},
+									pos:   position{line: 1150, col: 40, offset: 41302},
 									label: "elements",
 									expr: &seqExpr{
-										pos: position{line: 1153, col: 50, offset: 41382},
+										pos: position{line: 1150, col: 50, offset: 41312},
 										exprs: []interface{}{
 											&litMatcher{
-												pos:        position{line: 1153, col: 50, offset: 41382},
+												pos:        position{line: 1150, col: 50, offset: 41312},
 												val:        "_",
 												ignoreCase: false,
 												want:       "\"_\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1153, col: 54, offset: 41386},
+												pos:  position{line: 1150, col: 54, offset: 41316},
 												name: "SingleQuoteItalicTextElements",
 											},
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1153, col: 85, offset: 41417},
+									pos:        position{line: 1150, col: 85, offset: 41347},
 									val:        "_",
 									ignoreCase: false,
 									want:       "\"_\"",
@@ -7739,21 +7731,21 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteItalicTextElements",
-			pos:  position{line: 1157, col: 1, offset: 41631},
+			pos:  position{line: 1154, col: 1, offset: 41561},
 			expr: &seqExpr{
-				pos: position{line: 1157, col: 34, offset: 41664},
+				pos: position{line: 1154, col: 34, offset: 41594},
 				exprs: []interface{}{
 					&notExpr{
-						pos: position{line: 1157, col: 34, offset: 41664},
+						pos: position{line: 1154, col: 34, offset: 41594},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1157, col: 35, offset: 41665},
+							pos:  position{line: 1154, col: 35, offset: 41595},
 							name: "Space",
 						},
 					},
 					&oneOrMoreExpr{
-						pos: position{line: 1157, col: 41, offset: 41671},
+						pos: position{line: 1154, col: 41, offset: 41601},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1157, col: 41, offset: 41671},
+							pos:  position{line: 1154, col: 41, offset: 41601},
 							name: "SingleQuoteItalicTextElement",
 						},
 					},
@@ -7762,43 +7754,43 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteItalicTextElement",
-			pos:  position{line: 1159, col: 1, offset: 41704},
+			pos:  position{line: 1156, col: 1, offset: 41634},
 			expr: &choiceExpr{
-				pos: position{line: 1159, col: 33, offset: 41736},
+				pos: position{line: 1156, col: 33, offset: 41666},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1159, col: 33, offset: 41736},
+						pos:  position{line: 1156, col: 33, offset: 41666},
 						name: "Word",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1160, col: 11, offset: 41753},
+						pos:  position{line: 1157, col: 11, offset: 41683},
 						name: "DoubleQuoteItalicText",
 					},
 					&seqExpr{
-						pos: position{line: 1161, col: 11, offset: 41786},
+						pos: position{line: 1158, col: 11, offset: 41716},
 						exprs: []interface{}{
 							&oneOrMoreExpr{
-								pos: position{line: 1161, col: 11, offset: 41786},
+								pos: position{line: 1158, col: 11, offset: 41716},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1161, col: 11, offset: 41786},
+									pos:  position{line: 1158, col: 11, offset: 41716},
 									name: "Space",
 								},
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 1161, col: 18, offset: 41793},
+								pos: position{line: 1158, col: 18, offset: 41723},
 								expr: &seqExpr{
-									pos: position{line: 1161, col: 19, offset: 41794},
+									pos: position{line: 1158, col: 19, offset: 41724},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 1161, col: 19, offset: 41794},
+											pos:        position{line: 1158, col: 19, offset: 41724},
 											val:        "_",
 											ignoreCase: false,
 											want:       "\"_\"",
 										},
 										&notExpr{
-											pos: position{line: 1161, col: 23, offset: 41798},
+											pos: position{line: 1158, col: 23, offset: 41728},
 											expr: &litMatcher{
-												pos:        position{line: 1161, col: 24, offset: 41799},
+												pos:        position{line: 1158, col: 24, offset: 41729},
 												val:        "_",
 												ignoreCase: false,
 												want:       "\"_\"",
@@ -7810,55 +7802,55 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1162, col: 11, offset: 41816},
+						pos:  position{line: 1159, col: 11, offset: 41746},
 						name: "BoldText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1163, col: 11, offset: 41836},
+						pos:  position{line: 1160, col: 11, offset: 41766},
 						name: "MarkedText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1164, col: 11, offset: 41858},
+						pos:  position{line: 1161, col: 11, offset: 41788},
 						name: "MonospaceText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1165, col: 11, offset: 41883},
+						pos:  position{line: 1162, col: 11, offset: 41813},
 						name: "SubscriptText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1166, col: 11, offset: 41908},
+						pos:  position{line: 1163, col: 11, offset: 41838},
 						name: "SuperscriptText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1167, col: 11, offset: 41935},
+						pos:  position{line: 1164, col: 11, offset: 41865},
 						name: "InlineIcon",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1168, col: 11, offset: 41957},
+						pos:  position{line: 1165, col: 11, offset: 41887},
 						name: "InlineImage",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1169, col: 11, offset: 41981},
+						pos:  position{line: 1166, col: 11, offset: 41911},
 						name: "Link",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1170, col: 11, offset: 41999},
+						pos:  position{line: 1167, col: 11, offset: 41929},
 						name: "InlinePassthrough",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1171, col: 11, offset: 42029},
+						pos:  position{line: 1168, col: 11, offset: 41959},
 						name: "QuotedString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1172, col: 11, offset: 42053},
+						pos:  position{line: 1169, col: 11, offset: 41983},
 						name: "AttributeSubstitution",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1173, col: 11, offset: 42086},
+						pos:  position{line: 1170, col: 11, offset: 42016},
 						name: "SingleQuoteItalicTextStringElement",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1174, col: 11, offset: 42132},
+						pos:  position{line: 1171, col: 11, offset: 42062},
 						name: "SingleQuoteItalicTextFallbackCharacter",
 					},
 				},
@@ -7866,14 +7858,14 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteItalicTextStringElement",
-			pos:  position{line: 1176, col: 1, offset: 42174},
+			pos:  position{line: 1173, col: 1, offset: 42104},
 			expr: &actionExpr{
-				pos: position{line: 1176, col: 39, offset: 42212},
+				pos: position{line: 1173, col: 39, offset: 42142},
 				run: (*parser).callonSingleQuoteItalicTextStringElement1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1176, col: 39, offset: 42212},
+					pos: position{line: 1173, col: 39, offset: 42142},
 					expr: &charClassMatcher{
-						pos:        position{line: 1176, col: 39, offset: 42212},
+						pos:        position{line: 1173, col: 39, offset: 42142},
 						val:        "[^\\r\\n{} _^~]",
 						chars:      []rune{'\r', '\n', '{', '}', ' ', '_', '^', '~'},
 						ignoreCase: false,
@@ -7884,31 +7876,31 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteItalicTextFallbackCharacter",
-			pos:  position{line: 1180, col: 1, offset: 42442},
+			pos:  position{line: 1177, col: 1, offset: 42372},
 			expr: &choiceExpr{
-				pos: position{line: 1181, col: 5, offset: 42490},
+				pos: position{line: 1178, col: 5, offset: 42420},
 				alternatives: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 1181, col: 5, offset: 42490},
+						pos:        position{line: 1178, col: 5, offset: 42420},
 						val:        "[^\\r\\n_]",
 						chars:      []rune{'\r', '\n', '_'},
 						ignoreCase: false,
 						inverted:   true,
 					},
 					&actionExpr{
-						pos: position{line: 1182, col: 7, offset: 42590},
+						pos: position{line: 1179, col: 7, offset: 42520},
 						run: (*parser).callonSingleQuoteItalicTextFallbackCharacter3,
 						expr: &seqExpr{
-							pos: position{line: 1182, col: 7, offset: 42590},
+							pos: position{line: 1179, col: 7, offset: 42520},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1182, col: 7, offset: 42590},
+									pos:        position{line: 1179, col: 7, offset: 42520},
 									val:        "_",
 									ignoreCase: false,
 									want:       "\"_\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1182, col: 11, offset: 42594},
+									pos:  position{line: 1179, col: 11, offset: 42524},
 									name: "Alphanums",
 								},
 							},
@@ -7919,40 +7911,40 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedItalicText",
-			pos:  position{line: 1186, col: 1, offset: 42764},
+			pos:  position{line: 1183, col: 1, offset: 42694},
 			expr: &choiceExpr{
-				pos: position{line: 1187, col: 5, offset: 42791},
+				pos: position{line: 1184, col: 5, offset: 42721},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1187, col: 5, offset: 42791},
+						pos: position{line: 1184, col: 5, offset: 42721},
 						run: (*parser).callonEscapedItalicText2,
 						expr: &seqExpr{
-							pos: position{line: 1187, col: 5, offset: 42791},
+							pos: position{line: 1184, col: 5, offset: 42721},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1187, col: 5, offset: 42791},
+									pos:   position{line: 1184, col: 5, offset: 42721},
 									label: "backslashes",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1187, col: 18, offset: 42804},
+										pos:  position{line: 1184, col: 18, offset: 42734},
 										name: "TwoOrMoreBackslashes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1187, col: 40, offset: 42826},
+									pos:        position{line: 1184, col: 40, offset: 42756},
 									val:        "__",
 									ignoreCase: false,
 									want:       "\"__\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1187, col: 45, offset: 42831},
+									pos:   position{line: 1184, col: 45, offset: 42761},
 									label: "elements",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1187, col: 55, offset: 42841},
+										pos:  position{line: 1184, col: 55, offset: 42771},
 										name: "DoubleQuoteItalicTextElements",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1187, col: 86, offset: 42872},
+									pos:        position{line: 1184, col: 86, offset: 42802},
 									val:        "__",
 									ignoreCase: false,
 									want:       "\"__\"",
@@ -7961,35 +7953,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1189, col: 9, offset: 43031},
+						pos: position{line: 1186, col: 9, offset: 42961},
 						run: (*parser).callonEscapedItalicText10,
 						expr: &seqExpr{
-							pos: position{line: 1189, col: 9, offset: 43031},
+							pos: position{line: 1186, col: 9, offset: 42961},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1189, col: 9, offset: 43031},
+									pos:   position{line: 1186, col: 9, offset: 42961},
 									label: "backslashes",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1189, col: 22, offset: 43044},
+										pos:  position{line: 1186, col: 22, offset: 42974},
 										name: "OneOrMoreBackslashes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1189, col: 44, offset: 43066},
+									pos:        position{line: 1186, col: 44, offset: 42996},
 									val:        "__",
 									ignoreCase: false,
 									want:       "\"__\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1189, col: 49, offset: 43071},
+									pos:   position{line: 1186, col: 49, offset: 43001},
 									label: "elements",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1189, col: 59, offset: 43081},
+										pos:  position{line: 1186, col: 59, offset: 43011},
 										name: "SingleQuoteItalicTextElements",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1189, col: 90, offset: 43112},
+									pos:        position{line: 1186, col: 90, offset: 43042},
 									val:        "_",
 									ignoreCase: false,
 									want:       "\"_\"",
@@ -7998,35 +7990,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1192, col: 9, offset: 43315},
+						pos: position{line: 1189, col: 9, offset: 43245},
 						run: (*parser).callonEscapedItalicText18,
 						expr: &seqExpr{
-							pos: position{line: 1192, col: 9, offset: 43315},
+							pos: position{line: 1189, col: 9, offset: 43245},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1192, col: 9, offset: 43315},
+									pos:   position{line: 1189, col: 9, offset: 43245},
 									label: "backslashes",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1192, col: 22, offset: 43328},
+										pos:  position{line: 1189, col: 22, offset: 43258},
 										name: "OneOrMoreBackslashes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1192, col: 44, offset: 43350},
+									pos:        position{line: 1189, col: 44, offset: 43280},
 									val:        "_",
 									ignoreCase: false,
 									want:       "\"_\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1192, col: 48, offset: 43354},
+									pos:   position{line: 1189, col: 48, offset: 43284},
 									label: "elements",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1192, col: 58, offset: 43364},
+										pos:  position{line: 1189, col: 58, offset: 43294},
 										name: "SingleQuoteItalicTextElements",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1192, col: 89, offset: 43395},
+									pos:        position{line: 1189, col: 89, offset: 43325},
 									val:        "_",
 									ignoreCase: false,
 									want:       "\"_\"",
@@ -8039,16 +8031,16 @@ var g = &grammar{
 		},
 		{
 			name: "MonospaceText",
-			pos:  position{line: 1199, col: 1, offset: 43612},
+			pos:  position{line: 1196, col: 1, offset: 43542},
 			expr: &choiceExpr{
-				pos: position{line: 1199, col: 18, offset: 43629},
+				pos: position{line: 1196, col: 18, offset: 43559},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1199, col: 18, offset: 43629},
+						pos:  position{line: 1196, col: 18, offset: 43559},
 						name: "DoubleQuoteMonospaceText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1199, col: 45, offset: 43656},
+						pos:  position{line: 1196, col: 45, offset: 43586},
 						name: "SingleQuoteMonospaceText",
 					},
 				},
@@ -8056,49 +8048,49 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteMonospaceText",
-			pos:  position{line: 1201, col: 1, offset: 43684},
+			pos:  position{line: 1198, col: 1, offset: 43614},
 			expr: &actionExpr{
-				pos: position{line: 1201, col: 29, offset: 43712},
+				pos: position{line: 1198, col: 29, offset: 43642},
 				run: (*parser).callonDoubleQuoteMonospaceText1,
 				expr: &seqExpr{
-					pos: position{line: 1201, col: 29, offset: 43712},
+					pos: position{line: 1198, col: 29, offset: 43642},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1201, col: 29, offset: 43712},
+							pos:   position{line: 1198, col: 29, offset: 43642},
 							label: "attrs",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1201, col: 35, offset: 43718},
+								pos: position{line: 1198, col: 35, offset: 43648},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1201, col: 36, offset: 43719},
+									pos:  position{line: 1198, col: 36, offset: 43649},
 									name: "QuotedTextAttrs",
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 1201, col: 54, offset: 43737},
+							pos: position{line: 1198, col: 54, offset: 43667},
 							expr: &litMatcher{
-								pos:        position{line: 1201, col: 55, offset: 43738},
+								pos:        position{line: 1198, col: 55, offset: 43668},
 								val:        "\\\\",
 								ignoreCase: false,
 								want:       "\"\\\\\\\\\"",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1201, col: 60, offset: 43743},
+							pos:        position{line: 1198, col: 60, offset: 43673},
 							val:        "``",
 							ignoreCase: false,
 							want:       "\"``\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1201, col: 65, offset: 43748},
+							pos:   position{line: 1198, col: 65, offset: 43678},
 							label: "elements",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1201, col: 75, offset: 43758},
+								pos:  position{line: 1198, col: 75, offset: 43688},
 								name: "DoubleQuoteMonospaceTextElements",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1201, col: 109, offset: 43792},
+							pos:        position{line: 1198, col: 109, offset: 43722},
 							val:        "``",
 							ignoreCase: false,
 							want:       "\"``\"",
@@ -8109,37 +8101,37 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteMonospaceTextElements",
-			pos:  position{line: 1205, col: 1, offset: 43933},
+			pos:  position{line: 1202, col: 1, offset: 43863},
 			expr: &seqExpr{
-				pos: position{line: 1205, col: 37, offset: 43969},
+				pos: position{line: 1202, col: 37, offset: 43899},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1205, col: 37, offset: 43969},
+						pos:  position{line: 1202, col: 37, offset: 43899},
 						name: "DoubleQuoteMonospaceTextElement",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1205, col: 69, offset: 44001},
+						pos: position{line: 1202, col: 69, offset: 43931},
 						expr: &seqExpr{
-							pos: position{line: 1205, col: 70, offset: 44002},
+							pos: position{line: 1202, col: 70, offset: 43932},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1205, col: 70, offset: 44002},
+									pos: position{line: 1202, col: 70, offset: 43932},
 									expr: &litMatcher{
-										pos:        position{line: 1205, col: 72, offset: 44004},
+										pos:        position{line: 1202, col: 72, offset: 43934},
 										val:        "``",
 										ignoreCase: false,
 										want:       "\"``\"",
 									},
 								},
 								&choiceExpr{
-									pos: position{line: 1205, col: 79, offset: 44011},
+									pos: position{line: 1202, col: 79, offset: 43941},
 									alternatives: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 1205, col: 79, offset: 44011},
+											pos:  position{line: 1202, col: 79, offset: 43941},
 											name: "Space",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1205, col: 87, offset: 44019},
+											pos:  position{line: 1202, col: 87, offset: 43949},
 											name: "DoubleQuoteMonospaceTextElement",
 										},
 									},
@@ -8152,64 +8144,64 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteMonospaceTextElement",
-			pos:  position{line: 1207, col: 1, offset: 44090},
+			pos:  position{line: 1204, col: 1, offset: 44020},
 			expr: &choiceExpr{
-				pos: position{line: 1207, col: 36, offset: 44125},
+				pos: position{line: 1204, col: 36, offset: 44055},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1207, col: 36, offset: 44125},
+						pos:  position{line: 1204, col: 36, offset: 44055},
 						name: "Word",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1208, col: 11, offset: 44142},
+						pos:  position{line: 1205, col: 11, offset: 44072},
 						name: "SingleQuoteMonospaceText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1209, col: 11, offset: 44179},
+						pos:  position{line: 1206, col: 11, offset: 44109},
 						name: "BoldText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1210, col: 11, offset: 44199},
+						pos:  position{line: 1207, col: 11, offset: 44129},
 						name: "ItalicText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1211, col: 11, offset: 44221},
+						pos:  position{line: 1208, col: 11, offset: 44151},
 						name: "MarkedText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1212, col: 11, offset: 44243},
+						pos:  position{line: 1209, col: 11, offset: 44173},
 						name: "SubscriptText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1213, col: 11, offset: 44268},
+						pos:  position{line: 1210, col: 11, offset: 44198},
 						name: "SuperscriptText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1214, col: 11, offset: 44295},
+						pos:  position{line: 1211, col: 11, offset: 44225},
 						name: "InlineIcon",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1215, col: 11, offset: 44317},
+						pos:  position{line: 1212, col: 11, offset: 44247},
 						name: "InlineImage",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1216, col: 11, offset: 44340},
+						pos:  position{line: 1213, col: 11, offset: 44270},
 						name: "Link",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1217, col: 11, offset: 44356},
+						pos:  position{line: 1214, col: 11, offset: 44286},
 						name: "InlinePassthrough",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1218, col: 11, offset: 44386},
+						pos:  position{line: 1215, col: 11, offset: 44316},
 						name: "QuotedString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1219, col: 11, offset: 44410},
+						pos:  position{line: 1216, col: 11, offset: 44340},
 						name: "DoubleQuoteMonospaceTextStringElement",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1220, col: 11, offset: 44459},
+						pos:  position{line: 1217, col: 11, offset: 44389},
 						name: "DoubleQuoteMonospaceTextFallbackCharacter",
 					},
 				},
@@ -8217,26 +8209,26 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteMonospaceTextStringElement",
-			pos:  position{line: 1222, col: 1, offset: 44504},
+			pos:  position{line: 1219, col: 1, offset: 44434},
 			expr: &actionExpr{
-				pos: position{line: 1222, col: 42, offset: 44545},
+				pos: position{line: 1219, col: 42, offset: 44475},
 				run: (*parser).callonDoubleQuoteMonospaceTextStringElement1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1222, col: 42, offset: 44545},
+					pos: position{line: 1219, col: 42, offset: 44475},
 					expr: &seqExpr{
-						pos: position{line: 1222, col: 43, offset: 44546},
+						pos: position{line: 1219, col: 43, offset: 44476},
 						exprs: []interface{}{
 							&notExpr{
-								pos: position{line: 1222, col: 43, offset: 44546},
+								pos: position{line: 1219, col: 43, offset: 44476},
 								expr: &litMatcher{
-									pos:        position{line: 1222, col: 44, offset: 44547},
+									pos:        position{line: 1219, col: 44, offset: 44477},
 									val:        "``",
 									ignoreCase: false,
 									want:       "\"``\"",
 								},
 							},
 							&charClassMatcher{
-								pos:        position{line: 1222, col: 49, offset: 44552},
+								pos:        position{line: 1219, col: 49, offset: 44482},
 								val:        "[^\\r\\n ^~{}]",
 								chars:      []rune{'\r', '\n', ' ', '^', '~', '{', '}'},
 								ignoreCase: false,
@@ -8249,31 +8241,31 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteMonospaceTextFallbackCharacter",
-			pos:  position{line: 1226, col: 1, offset: 44627},
+			pos:  position{line: 1223, col: 1, offset: 44557},
 			expr: &choiceExpr{
-				pos: position{line: 1227, col: 5, offset: 44678},
+				pos: position{line: 1224, col: 5, offset: 44608},
 				alternatives: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 1227, col: 5, offset: 44678},
+						pos:        position{line: 1224, col: 5, offset: 44608},
 						val:        "[^\\r\\n`]",
 						chars:      []rune{'\r', '\n', '`'},
 						ignoreCase: false,
 						inverted:   true,
 					},
 					&actionExpr{
-						pos: position{line: 1228, col: 7, offset: 44781},
+						pos: position{line: 1225, col: 7, offset: 44711},
 						run: (*parser).callonDoubleQuoteMonospaceTextFallbackCharacter3,
 						expr: &seqExpr{
-							pos: position{line: 1228, col: 7, offset: 44781},
+							pos: position{line: 1225, col: 7, offset: 44711},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1228, col: 7, offset: 44781},
+									pos:        position{line: 1225, col: 7, offset: 44711},
 									val:        "``",
 									ignoreCase: false,
 									want:       "\"``\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1228, col: 12, offset: 44786},
+									pos:  position{line: 1225, col: 12, offset: 44716},
 									name: "Alphanums",
 								},
 							},
@@ -8284,49 +8276,49 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteMonospaceText",
-			pos:  position{line: 1232, col: 1, offset: 44958},
+			pos:  position{line: 1229, col: 1, offset: 44888},
 			expr: &choiceExpr{
-				pos: position{line: 1232, col: 29, offset: 44986},
+				pos: position{line: 1229, col: 29, offset: 44916},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1232, col: 29, offset: 44986},
+						pos: position{line: 1229, col: 29, offset: 44916},
 						run: (*parser).callonSingleQuoteMonospaceText2,
 						expr: &seqExpr{
-							pos: position{line: 1232, col: 29, offset: 44986},
+							pos: position{line: 1229, col: 29, offset: 44916},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1232, col: 29, offset: 44986},
+									pos:   position{line: 1229, col: 29, offset: 44916},
 									label: "attrs",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1232, col: 35, offset: 44992},
+										pos: position{line: 1229, col: 35, offset: 44922},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1232, col: 36, offset: 44993},
+											pos:  position{line: 1229, col: 36, offset: 44923},
 											name: "QuotedTextAttrs",
 										},
 									},
 								},
 								&seqExpr{
-									pos: position{line: 1232, col: 55, offset: 45012},
+									pos: position{line: 1229, col: 55, offset: 44942},
 									exprs: []interface{}{
 										&notExpr{
-											pos: position{line: 1232, col: 55, offset: 45012},
+											pos: position{line: 1229, col: 55, offset: 44942},
 											expr: &litMatcher{
-												pos:        position{line: 1232, col: 56, offset: 45013},
+												pos:        position{line: 1229, col: 56, offset: 44943},
 												val:        "\\",
 												ignoreCase: false,
 												want:       "\"\\\\\"",
 											},
 										},
 										&litMatcher{
-											pos:        position{line: 1232, col: 60, offset: 45017},
+											pos:        position{line: 1229, col: 60, offset: 44947},
 											val:        "`",
 											ignoreCase: false,
 											want:       "\"`\"",
 										},
 										&notExpr{
-											pos: position{line: 1232, col: 64, offset: 45021},
+											pos: position{line: 1229, col: 64, offset: 44951},
 											expr: &litMatcher{
-												pos:        position{line: 1232, col: 65, offset: 45022},
+												pos:        position{line: 1229, col: 65, offset: 44952},
 												val:        "`",
 												ignoreCase: false,
 												want:       "\"`\"",
@@ -8335,15 +8327,15 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1232, col: 70, offset: 45027},
+									pos:   position{line: 1229, col: 70, offset: 44957},
 									label: "elements",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1232, col: 80, offset: 45037},
+										pos:  position{line: 1229, col: 80, offset: 44967},
 										name: "SingleQuoteMonospaceTextElements",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1232, col: 114, offset: 45071},
+									pos:        position{line: 1229, col: 114, offset: 45001},
 									val:        "`",
 									ignoreCase: false,
 									want:       "\"`\"",
@@ -8352,58 +8344,58 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1234, col: 5, offset: 45266},
+						pos: position{line: 1231, col: 5, offset: 45196},
 						run: (*parser).callonSingleQuoteMonospaceText16,
 						expr: &seqExpr{
-							pos: position{line: 1234, col: 5, offset: 45266},
+							pos: position{line: 1231, col: 5, offset: 45196},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1234, col: 5, offset: 45266},
+									pos:   position{line: 1231, col: 5, offset: 45196},
 									label: "attrs",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1234, col: 11, offset: 45272},
+										pos: position{line: 1231, col: 11, offset: 45202},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1234, col: 12, offset: 45273},
+											pos:  position{line: 1231, col: 12, offset: 45203},
 											name: "QuotedTextAttrs",
 										},
 									},
 								},
 								&notExpr{
-									pos: position{line: 1234, col: 30, offset: 45291},
+									pos: position{line: 1231, col: 30, offset: 45221},
 									expr: &litMatcher{
-										pos:        position{line: 1234, col: 31, offset: 45292},
+										pos:        position{line: 1231, col: 31, offset: 45222},
 										val:        "\\\\",
 										ignoreCase: false,
 										want:       "\"\\\\\\\\\"",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1234, col: 36, offset: 45297},
+									pos:        position{line: 1231, col: 36, offset: 45227},
 									val:        "`",
 									ignoreCase: false,
 									want:       "\"`\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1234, col: 40, offset: 45301},
+									pos:   position{line: 1231, col: 40, offset: 45231},
 									label: "elements",
 									expr: &seqExpr{
-										pos: position{line: 1234, col: 50, offset: 45311},
+										pos: position{line: 1231, col: 50, offset: 45241},
 										exprs: []interface{}{
 											&litMatcher{
-												pos:        position{line: 1234, col: 50, offset: 45311},
+												pos:        position{line: 1231, col: 50, offset: 45241},
 												val:        "`",
 												ignoreCase: false,
 												want:       "\"`\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1234, col: 54, offset: 45315},
+												pos:  position{line: 1231, col: 54, offset: 45245},
 												name: "SingleQuoteMonospaceTextElements",
 											},
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1234, col: 88, offset: 45349},
+									pos:        position{line: 1231, col: 88, offset: 45279},
 									val:        "`",
 									ignoreCase: false,
 									want:       "\"`\"",
@@ -8416,21 +8408,21 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteMonospaceTextElements",
-			pos:  position{line: 1238, col: 1, offset: 45569},
+			pos:  position{line: 1235, col: 1, offset: 45499},
 			expr: &seqExpr{
-				pos: position{line: 1238, col: 37, offset: 45605},
+				pos: position{line: 1235, col: 37, offset: 45535},
 				exprs: []interface{}{
 					&notExpr{
-						pos: position{line: 1238, col: 37, offset: 45605},
+						pos: position{line: 1235, col: 37, offset: 45535},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1238, col: 38, offset: 45606},
+							pos:  position{line: 1235, col: 38, offset: 45536},
 							name: "Space",
 						},
 					},
 					&oneOrMoreExpr{
-						pos: position{line: 1238, col: 44, offset: 45612},
+						pos: position{line: 1235, col: 44, offset: 45542},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1238, col: 44, offset: 45612},
+							pos:  position{line: 1235, col: 44, offset: 45542},
 							name: "SingleQuoteMonospaceTextElement",
 						},
 					},
@@ -8439,43 +8431,43 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteMonospaceTextElement",
-			pos:  position{line: 1240, col: 1, offset: 45648},
+			pos:  position{line: 1237, col: 1, offset: 45578},
 			expr: &choiceExpr{
-				pos: position{line: 1240, col: 37, offset: 45684},
+				pos: position{line: 1237, col: 37, offset: 45614},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1240, col: 37, offset: 45684},
+						pos:  position{line: 1237, col: 37, offset: 45614},
 						name: "Word",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1241, col: 11, offset: 45701},
+						pos:  position{line: 1238, col: 11, offset: 45631},
 						name: "DoubleQuoteMonospaceText",
 					},
 					&seqExpr{
-						pos: position{line: 1242, col: 11, offset: 45738},
+						pos: position{line: 1239, col: 11, offset: 45668},
 						exprs: []interface{}{
 							&oneOrMoreExpr{
-								pos: position{line: 1242, col: 11, offset: 45738},
+								pos: position{line: 1239, col: 11, offset: 45668},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1242, col: 11, offset: 45738},
+									pos:  position{line: 1239, col: 11, offset: 45668},
 									name: "Space",
 								},
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 1242, col: 18, offset: 45745},
+								pos: position{line: 1239, col: 18, offset: 45675},
 								expr: &seqExpr{
-									pos: position{line: 1242, col: 19, offset: 45746},
+									pos: position{line: 1239, col: 19, offset: 45676},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 1242, col: 19, offset: 45746},
+											pos:        position{line: 1239, col: 19, offset: 45676},
 											val:        "`",
 											ignoreCase: false,
 											want:       "\"`\"",
 										},
 										&notExpr{
-											pos: position{line: 1242, col: 23, offset: 45750},
+											pos: position{line: 1239, col: 23, offset: 45680},
 											expr: &litMatcher{
-												pos:        position{line: 1242, col: 24, offset: 45751},
+												pos:        position{line: 1239, col: 24, offset: 45681},
 												val:        "`",
 												ignoreCase: false,
 												want:       "\"`\"",
@@ -8487,59 +8479,59 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1243, col: 11, offset: 45880},
+						pos:  position{line: 1240, col: 11, offset: 45810},
 						name: "Newline",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1244, col: 11, offset: 45919},
+						pos:  position{line: 1241, col: 11, offset: 45849},
 						name: "BoldText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1245, col: 11, offset: 45939},
+						pos:  position{line: 1242, col: 11, offset: 45869},
 						name: "ItalicText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1246, col: 11, offset: 45961},
+						pos:  position{line: 1243, col: 11, offset: 45891},
 						name: "MarkedText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1247, col: 11, offset: 45983},
+						pos:  position{line: 1244, col: 11, offset: 45913},
 						name: "SubscriptText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1248, col: 11, offset: 46008},
+						pos:  position{line: 1245, col: 11, offset: 45938},
 						name: "SuperscriptText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1249, col: 11, offset: 46035},
+						pos:  position{line: 1246, col: 11, offset: 45965},
 						name: "InlineIcon",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1250, col: 11, offset: 46057},
+						pos:  position{line: 1247, col: 11, offset: 45987},
 						name: "InlineImage",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1251, col: 11, offset: 46081},
+						pos:  position{line: 1248, col: 11, offset: 46011},
 						name: "Link",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1252, col: 11, offset: 46098},
+						pos:  position{line: 1249, col: 11, offset: 46028},
 						name: "InlinePassthrough",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1253, col: 11, offset: 46128},
+						pos:  position{line: 1250, col: 11, offset: 46058},
 						name: "QuotedString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1254, col: 11, offset: 46152},
+						pos:  position{line: 1251, col: 11, offset: 46082},
 						name: "AttributeSubstitution",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1255, col: 11, offset: 46185},
+						pos:  position{line: 1252, col: 11, offset: 46115},
 						name: "SingleQuoteMonospaceTextStringElement",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1256, col: 11, offset: 46234},
+						pos:  position{line: 1253, col: 11, offset: 46164},
 						name: "SingleQuoteMonospaceTextFallbackCharacter",
 					},
 				},
@@ -8547,14 +8539,14 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteMonospaceTextStringElement",
-			pos:  position{line: 1258, col: 1, offset: 46279},
+			pos:  position{line: 1255, col: 1, offset: 46209},
 			expr: &actionExpr{
-				pos: position{line: 1258, col: 42, offset: 46320},
+				pos: position{line: 1255, col: 42, offset: 46250},
 				run: (*parser).callonSingleQuoteMonospaceTextStringElement1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1258, col: 42, offset: 46320},
+					pos: position{line: 1255, col: 42, offset: 46250},
 					expr: &charClassMatcher{
-						pos:        position{line: 1258, col: 42, offset: 46320},
+						pos:        position{line: 1255, col: 42, offset: 46250},
 						val:        "[^\\r\\n {}`^~]",
 						chars:      []rune{'\r', '\n', ' ', '{', '}', '`', '^', '~'},
 						ignoreCase: false,
@@ -8565,31 +8557,31 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteMonospaceTextFallbackCharacter",
-			pos:  position{line: 1262, col: 1, offset: 46542},
+			pos:  position{line: 1259, col: 1, offset: 46472},
 			expr: &choiceExpr{
-				pos: position{line: 1263, col: 5, offset: 46593},
+				pos: position{line: 1260, col: 5, offset: 46523},
 				alternatives: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 1263, col: 5, offset: 46593},
+						pos:        position{line: 1260, col: 5, offset: 46523},
 						val:        "[^\\r\\n`]",
 						chars:      []rune{'\r', '\n', '`'},
 						ignoreCase: false,
 						inverted:   true,
 					},
 					&actionExpr{
-						pos: position{line: 1264, col: 7, offset: 46696},
+						pos: position{line: 1261, col: 7, offset: 46626},
 						run: (*parser).callonSingleQuoteMonospaceTextFallbackCharacter3,
 						expr: &seqExpr{
-							pos: position{line: 1264, col: 7, offset: 46696},
+							pos: position{line: 1261, col: 7, offset: 46626},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1264, col: 7, offset: 46696},
+									pos:        position{line: 1261, col: 7, offset: 46626},
 									val:        "`",
 									ignoreCase: false,
 									want:       "\"`\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1264, col: 11, offset: 46700},
+									pos:  position{line: 1261, col: 11, offset: 46630},
 									name: "Alphanums",
 								},
 							},
@@ -8600,40 +8592,40 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedMonospaceText",
-			pos:  position{line: 1268, col: 1, offset: 46873},
+			pos:  position{line: 1265, col: 1, offset: 46803},
 			expr: &choiceExpr{
-				pos: position{line: 1269, col: 5, offset: 46903},
+				pos: position{line: 1266, col: 5, offset: 46833},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1269, col: 5, offset: 46903},
+						pos: position{line: 1266, col: 5, offset: 46833},
 						run: (*parser).callonEscapedMonospaceText2,
 						expr: &seqExpr{
-							pos: position{line: 1269, col: 5, offset: 46903},
+							pos: position{line: 1266, col: 5, offset: 46833},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1269, col: 5, offset: 46903},
+									pos:   position{line: 1266, col: 5, offset: 46833},
 									label: "backslashes",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1269, col: 18, offset: 46916},
+										pos:  position{line: 1266, col: 18, offset: 46846},
 										name: "TwoOrMoreBackslashes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1269, col: 40, offset: 46938},
+									pos:        position{line: 1266, col: 40, offset: 46868},
 									val:        "``",
 									ignoreCase: false,
 									want:       "\"``\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1269, col: 45, offset: 46943},
+									pos:   position{line: 1266, col: 45, offset: 46873},
 									label: "elements",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1269, col: 55, offset: 46953},
+										pos:  position{line: 1266, col: 55, offset: 46883},
 										name: "DoubleQuoteMonospaceTextElements",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1269, col: 89, offset: 46987},
+									pos:        position{line: 1266, col: 89, offset: 46917},
 									val:        "``",
 									ignoreCase: false,
 									want:       "\"``\"",
@@ -8642,35 +8634,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1271, col: 9, offset: 47146},
+						pos: position{line: 1268, col: 9, offset: 47076},
 						run: (*parser).callonEscapedMonospaceText10,
 						expr: &seqExpr{
-							pos: position{line: 1271, col: 9, offset: 47146},
+							pos: position{line: 1268, col: 9, offset: 47076},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1271, col: 9, offset: 47146},
+									pos:   position{line: 1268, col: 9, offset: 47076},
 									label: "backslashes",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1271, col: 22, offset: 47159},
+										pos:  position{line: 1268, col: 22, offset: 47089},
 										name: "OneOrMoreBackslashes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1271, col: 44, offset: 47181},
+									pos:        position{line: 1268, col: 44, offset: 47111},
 									val:        "``",
 									ignoreCase: false,
 									want:       "\"``\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1271, col: 49, offset: 47186},
+									pos:   position{line: 1268, col: 49, offset: 47116},
 									label: "elements",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1271, col: 59, offset: 47196},
+										pos:  position{line: 1268, col: 59, offset: 47126},
 										name: "SingleQuoteMonospaceTextElements",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1271, col: 93, offset: 47230},
+									pos:        position{line: 1268, col: 93, offset: 47160},
 									val:        "`",
 									ignoreCase: false,
 									want:       "\"`\"",
@@ -8679,35 +8671,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1274, col: 9, offset: 47433},
+						pos: position{line: 1271, col: 9, offset: 47363},
 						run: (*parser).callonEscapedMonospaceText18,
 						expr: &seqExpr{
-							pos: position{line: 1274, col: 9, offset: 47433},
+							pos: position{line: 1271, col: 9, offset: 47363},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1274, col: 9, offset: 47433},
+									pos:   position{line: 1271, col: 9, offset: 47363},
 									label: "backslashes",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1274, col: 22, offset: 47446},
+										pos:  position{line: 1271, col: 22, offset: 47376},
 										name: "OneOrMoreBackslashes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1274, col: 44, offset: 47468},
+									pos:        position{line: 1271, col: 44, offset: 47398},
 									val:        "`",
 									ignoreCase: false,
 									want:       "\"`\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1274, col: 48, offset: 47472},
+									pos:   position{line: 1271, col: 48, offset: 47402},
 									label: "elements",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1274, col: 58, offset: 47482},
+										pos:  position{line: 1271, col: 58, offset: 47412},
 										name: "SingleQuoteMonospaceTextElements",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1274, col: 92, offset: 47516},
+									pos:        position{line: 1271, col: 92, offset: 47446},
 									val:        "`",
 									ignoreCase: false,
 									want:       "\"`\"",
@@ -8720,16 +8712,16 @@ var g = &grammar{
 		},
 		{
 			name: "MarkedText",
-			pos:  position{line: 1282, col: 1, offset: 47732},
+			pos:  position{line: 1279, col: 1, offset: 47662},
 			expr: &choiceExpr{
-				pos: position{line: 1282, col: 15, offset: 47746},
+				pos: position{line: 1279, col: 15, offset: 47676},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1282, col: 15, offset: 47746},
+						pos:  position{line: 1279, col: 15, offset: 47676},
 						name: "DoubleQuoteMarkedText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1282, col: 39, offset: 47770},
+						pos:  position{line: 1279, col: 39, offset: 47700},
 						name: "SingleQuoteMarkedText",
 					},
 				},
@@ -8737,49 +8729,49 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteMarkedText",
-			pos:  position{line: 1284, col: 1, offset: 47795},
+			pos:  position{line: 1281, col: 1, offset: 47725},
 			expr: &actionExpr{
-				pos: position{line: 1284, col: 26, offset: 47820},
+				pos: position{line: 1281, col: 26, offset: 47750},
 				run: (*parser).callonDoubleQuoteMarkedText1,
 				expr: &seqExpr{
-					pos: position{line: 1284, col: 26, offset: 47820},
+					pos: position{line: 1281, col: 26, offset: 47750},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1284, col: 26, offset: 47820},
+							pos:   position{line: 1281, col: 26, offset: 47750},
 							label: "attrs",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1284, col: 32, offset: 47826},
+								pos: position{line: 1281, col: 32, offset: 47756},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1284, col: 33, offset: 47827},
+									pos:  position{line: 1281, col: 33, offset: 47757},
 									name: "QuotedTextAttrs",
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 1284, col: 51, offset: 47845},
+							pos: position{line: 1281, col: 51, offset: 47775},
 							expr: &litMatcher{
-								pos:        position{line: 1284, col: 52, offset: 47846},
+								pos:        position{line: 1281, col: 52, offset: 47776},
 								val:        "\\\\",
 								ignoreCase: false,
 								want:       "\"\\\\\\\\\"",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1284, col: 57, offset: 47851},
+							pos:        position{line: 1281, col: 57, offset: 47781},
 							val:        "##",
 							ignoreCase: false,
 							want:       "\"##\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1284, col: 62, offset: 47856},
+							pos:   position{line: 1281, col: 62, offset: 47786},
 							label: "elements",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1284, col: 72, offset: 47866},
+								pos:  position{line: 1281, col: 72, offset: 47796},
 								name: "DoubleQuoteMarkedTextElements",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1284, col: 103, offset: 47897},
+							pos:        position{line: 1281, col: 103, offset: 47827},
 							val:        "##",
 							ignoreCase: false,
 							want:       "\"##\"",
@@ -8790,37 +8782,37 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteMarkedTextElements",
-			pos:  position{line: 1288, col: 1, offset: 48035},
+			pos:  position{line: 1285, col: 1, offset: 47965},
 			expr: &seqExpr{
-				pos: position{line: 1288, col: 34, offset: 48068},
+				pos: position{line: 1285, col: 34, offset: 47998},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1288, col: 34, offset: 48068},
+						pos:  position{line: 1285, col: 34, offset: 47998},
 						name: "DoubleQuoteMarkedTextElement",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1288, col: 63, offset: 48097},
+						pos: position{line: 1285, col: 63, offset: 48027},
 						expr: &seqExpr{
-							pos: position{line: 1288, col: 64, offset: 48098},
+							pos: position{line: 1285, col: 64, offset: 48028},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1288, col: 64, offset: 48098},
+									pos: position{line: 1285, col: 64, offset: 48028},
 									expr: &litMatcher{
-										pos:        position{line: 1288, col: 66, offset: 48100},
+										pos:        position{line: 1285, col: 66, offset: 48030},
 										val:        "##",
 										ignoreCase: false,
 										want:       "\"##\"",
 									},
 								},
 								&choiceExpr{
-									pos: position{line: 1288, col: 73, offset: 48107},
+									pos: position{line: 1285, col: 73, offset: 48037},
 									alternatives: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 1288, col: 73, offset: 48107},
+											pos:  position{line: 1285, col: 73, offset: 48037},
 											name: "Space",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1288, col: 81, offset: 48115},
+											pos:  position{line: 1285, col: 81, offset: 48045},
 											name: "DoubleQuoteMarkedTextElement",
 										},
 									},
@@ -8833,64 +8825,64 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteMarkedTextElement",
-			pos:  position{line: 1290, col: 1, offset: 48184},
+			pos:  position{line: 1287, col: 1, offset: 48114},
 			expr: &choiceExpr{
-				pos: position{line: 1290, col: 33, offset: 48216},
+				pos: position{line: 1287, col: 33, offset: 48146},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1290, col: 33, offset: 48216},
+						pos:  position{line: 1287, col: 33, offset: 48146},
 						name: "Word",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1291, col: 11, offset: 48232},
+						pos:  position{line: 1288, col: 11, offset: 48162},
 						name: "SingleQuoteMarkedText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1292, col: 11, offset: 48265},
+						pos:  position{line: 1289, col: 11, offset: 48195},
 						name: "BoldText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1293, col: 11, offset: 48285},
+						pos:  position{line: 1290, col: 11, offset: 48215},
 						name: "ItalicText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1294, col: 11, offset: 48307},
+						pos:  position{line: 1291, col: 11, offset: 48237},
 						name: "MonospaceText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1295, col: 11, offset: 48332},
+						pos:  position{line: 1292, col: 11, offset: 48262},
 						name: "SubscriptText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1296, col: 11, offset: 48357},
+						pos:  position{line: 1293, col: 11, offset: 48287},
 						name: "SuperscriptText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1297, col: 11, offset: 48384},
+						pos:  position{line: 1294, col: 11, offset: 48314},
 						name: "InlineIcon",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1298, col: 11, offset: 48406},
+						pos:  position{line: 1295, col: 11, offset: 48336},
 						name: "InlineImage",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1299, col: 11, offset: 48429},
+						pos:  position{line: 1296, col: 11, offset: 48359},
 						name: "Link",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1300, col: 11, offset: 48445},
+						pos:  position{line: 1297, col: 11, offset: 48375},
 						name: "InlinePassthrough",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1301, col: 11, offset: 48474},
+						pos:  position{line: 1298, col: 11, offset: 48404},
 						name: "QuotedString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1302, col: 11, offset: 48498},
+						pos:  position{line: 1299, col: 11, offset: 48428},
 						name: "DoubleQuoteMarkedTextStringElement",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1303, col: 11, offset: 48544},
+						pos:  position{line: 1300, col: 11, offset: 48474},
 						name: "DoubleQuoteMarkedTextFallbackCharacter",
 					},
 				},
@@ -8898,26 +8890,26 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteMarkedTextStringElement",
-			pos:  position{line: 1305, col: 1, offset: 48586},
+			pos:  position{line: 1302, col: 1, offset: 48516},
 			expr: &actionExpr{
-				pos: position{line: 1305, col: 39, offset: 48624},
+				pos: position{line: 1302, col: 39, offset: 48554},
 				run: (*parser).callonDoubleQuoteMarkedTextStringElement1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1305, col: 39, offset: 48624},
+					pos: position{line: 1302, col: 39, offset: 48554},
 					expr: &seqExpr{
-						pos: position{line: 1305, col: 40, offset: 48625},
+						pos: position{line: 1302, col: 40, offset: 48555},
 						exprs: []interface{}{
 							&notExpr{
-								pos: position{line: 1305, col: 40, offset: 48625},
+								pos: position{line: 1302, col: 40, offset: 48555},
 								expr: &litMatcher{
-									pos:        position{line: 1305, col: 41, offset: 48626},
+									pos:        position{line: 1302, col: 41, offset: 48556},
 									val:        "##",
 									ignoreCase: false,
 									want:       "\"##\"",
 								},
 							},
 							&charClassMatcher{
-								pos:        position{line: 1305, col: 46, offset: 48631},
+								pos:        position{line: 1302, col: 46, offset: 48561},
 								val:        "[^\\r\\n ^~{}]",
 								chars:      []rune{'\r', '\n', ' ', '^', '~', '{', '}'},
 								ignoreCase: false,
@@ -8930,31 +8922,31 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteMarkedTextFallbackCharacter",
-			pos:  position{line: 1309, col: 1, offset: 48705},
+			pos:  position{line: 1306, col: 1, offset: 48635},
 			expr: &choiceExpr{
-				pos: position{line: 1310, col: 5, offset: 48752},
+				pos: position{line: 1307, col: 5, offset: 48682},
 				alternatives: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 1310, col: 5, offset: 48752},
+						pos:        position{line: 1307, col: 5, offset: 48682},
 						val:        "[^\\r\\n#]",
 						chars:      []rune{'\r', '\n', '#'},
 						ignoreCase: false,
 						inverted:   true,
 					},
 					&actionExpr{
-						pos: position{line: 1311, col: 7, offset: 48852},
+						pos: position{line: 1308, col: 7, offset: 48782},
 						run: (*parser).callonDoubleQuoteMarkedTextFallbackCharacter3,
 						expr: &seqExpr{
-							pos: position{line: 1311, col: 7, offset: 48852},
+							pos: position{line: 1308, col: 7, offset: 48782},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1311, col: 7, offset: 48852},
+									pos:        position{line: 1308, col: 7, offset: 48782},
 									val:        "##",
 									ignoreCase: false,
 									want:       "\"##\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1311, col: 12, offset: 48857},
+									pos:  position{line: 1308, col: 12, offset: 48787},
 									name: "Alphanums",
 								},
 							},
@@ -8965,49 +8957,49 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteMarkedText",
-			pos:  position{line: 1315, col: 1, offset: 49026},
+			pos:  position{line: 1312, col: 1, offset: 48956},
 			expr: &choiceExpr{
-				pos: position{line: 1315, col: 26, offset: 49051},
+				pos: position{line: 1312, col: 26, offset: 48981},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1315, col: 26, offset: 49051},
+						pos: position{line: 1312, col: 26, offset: 48981},
 						run: (*parser).callonSingleQuoteMarkedText2,
 						expr: &seqExpr{
-							pos: position{line: 1315, col: 26, offset: 49051},
+							pos: position{line: 1312, col: 26, offset: 48981},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1315, col: 26, offset: 49051},
+									pos:   position{line: 1312, col: 26, offset: 48981},
 									label: "attrs",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1315, col: 32, offset: 49057},
+										pos: position{line: 1312, col: 32, offset: 48987},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1315, col: 33, offset: 49058},
+											pos:  position{line: 1312, col: 33, offset: 48988},
 											name: "QuotedTextAttrs",
 										},
 									},
 								},
 								&seqExpr{
-									pos: position{line: 1315, col: 52, offset: 49077},
+									pos: position{line: 1312, col: 52, offset: 49007},
 									exprs: []interface{}{
 										&notExpr{
-											pos: position{line: 1315, col: 52, offset: 49077},
+											pos: position{line: 1312, col: 52, offset: 49007},
 											expr: &litMatcher{
-												pos:        position{line: 1315, col: 53, offset: 49078},
+												pos:        position{line: 1312, col: 53, offset: 49008},
 												val:        "\\",
 												ignoreCase: false,
 												want:       "\"\\\\\"",
 											},
 										},
 										&litMatcher{
-											pos:        position{line: 1315, col: 57, offset: 49082},
+											pos:        position{line: 1312, col: 57, offset: 49012},
 											val:        "#",
 											ignoreCase: false,
 											want:       "\"#\"",
 										},
 										&notExpr{
-											pos: position{line: 1315, col: 61, offset: 49086},
+											pos: position{line: 1312, col: 61, offset: 49016},
 											expr: &litMatcher{
-												pos:        position{line: 1315, col: 62, offset: 49087},
+												pos:        position{line: 1312, col: 62, offset: 49017},
 												val:        "#",
 												ignoreCase: false,
 												want:       "\"#\"",
@@ -9016,15 +9008,15 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1315, col: 67, offset: 49092},
+									pos:   position{line: 1312, col: 67, offset: 49022},
 									label: "elements",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1315, col: 77, offset: 49102},
+										pos:  position{line: 1312, col: 77, offset: 49032},
 										name: "SingleQuoteMarkedTextElements",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1315, col: 108, offset: 49133},
+									pos:        position{line: 1312, col: 108, offset: 49063},
 									val:        "#",
 									ignoreCase: false,
 									want:       "\"#\"",
@@ -9033,58 +9025,58 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1317, col: 5, offset: 49325},
+						pos: position{line: 1314, col: 5, offset: 49255},
 						run: (*parser).callonSingleQuoteMarkedText16,
 						expr: &seqExpr{
-							pos: position{line: 1317, col: 5, offset: 49325},
+							pos: position{line: 1314, col: 5, offset: 49255},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1317, col: 5, offset: 49325},
+									pos:   position{line: 1314, col: 5, offset: 49255},
 									label: "attrs",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1317, col: 11, offset: 49331},
+										pos: position{line: 1314, col: 11, offset: 49261},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1317, col: 12, offset: 49332},
+											pos:  position{line: 1314, col: 12, offset: 49262},
 											name: "QuotedTextAttrs",
 										},
 									},
 								},
 								&notExpr{
-									pos: position{line: 1317, col: 30, offset: 49350},
+									pos: position{line: 1314, col: 30, offset: 49280},
 									expr: &litMatcher{
-										pos:        position{line: 1317, col: 31, offset: 49351},
+										pos:        position{line: 1314, col: 31, offset: 49281},
 										val:        "\\\\",
 										ignoreCase: false,
 										want:       "\"\\\\\\\\\"",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1317, col: 36, offset: 49356},
+									pos:        position{line: 1314, col: 36, offset: 49286},
 									val:        "#",
 									ignoreCase: false,
 									want:       "\"#\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1317, col: 40, offset: 49360},
+									pos:   position{line: 1314, col: 40, offset: 49290},
 									label: "elements",
 									expr: &seqExpr{
-										pos: position{line: 1317, col: 50, offset: 49370},
+										pos: position{line: 1314, col: 50, offset: 49300},
 										exprs: []interface{}{
 											&litMatcher{
-												pos:        position{line: 1317, col: 50, offset: 49370},
+												pos:        position{line: 1314, col: 50, offset: 49300},
 												val:        "#",
 												ignoreCase: false,
 												want:       "\"#\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1317, col: 54, offset: 49374},
+												pos:  position{line: 1314, col: 54, offset: 49304},
 												name: "SingleQuoteMarkedTextElements",
 											},
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1317, col: 85, offset: 49405},
+									pos:        position{line: 1314, col: 85, offset: 49335},
 									val:        "#",
 									ignoreCase: false,
 									want:       "\"#\"",
@@ -9097,21 +9089,21 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteMarkedTextElements",
-			pos:  position{line: 1321, col: 1, offset: 49618},
+			pos:  position{line: 1318, col: 1, offset: 49548},
 			expr: &seqExpr{
-				pos: position{line: 1321, col: 34, offset: 49651},
+				pos: position{line: 1318, col: 34, offset: 49581},
 				exprs: []interface{}{
 					&notExpr{
-						pos: position{line: 1321, col: 34, offset: 49651},
+						pos: position{line: 1318, col: 34, offset: 49581},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1321, col: 35, offset: 49652},
+							pos:  position{line: 1318, col: 35, offset: 49582},
 							name: "Space",
 						},
 					},
 					&oneOrMoreExpr{
-						pos: position{line: 1321, col: 41, offset: 49658},
+						pos: position{line: 1318, col: 41, offset: 49588},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1321, col: 41, offset: 49658},
+							pos:  position{line: 1318, col: 41, offset: 49588},
 							name: "SingleQuoteMarkedTextElement",
 						},
 					},
@@ -9120,43 +9112,43 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteMarkedTextElement",
-			pos:  position{line: 1323, col: 1, offset: 49691},
+			pos:  position{line: 1320, col: 1, offset: 49621},
 			expr: &choiceExpr{
-				pos: position{line: 1323, col: 33, offset: 49723},
+				pos: position{line: 1320, col: 33, offset: 49653},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1323, col: 33, offset: 49723},
+						pos:  position{line: 1320, col: 33, offset: 49653},
 						name: "Word",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1324, col: 11, offset: 49739},
+						pos:  position{line: 1321, col: 11, offset: 49669},
 						name: "DoubleQuoteMarkedText",
 					},
 					&seqExpr{
-						pos: position{line: 1325, col: 11, offset: 49772},
+						pos: position{line: 1322, col: 11, offset: 49702},
 						exprs: []interface{}{
 							&oneOrMoreExpr{
-								pos: position{line: 1325, col: 11, offset: 49772},
+								pos: position{line: 1322, col: 11, offset: 49702},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1325, col: 11, offset: 49772},
+									pos:  position{line: 1322, col: 11, offset: 49702},
 									name: "Space",
 								},
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 1325, col: 18, offset: 49779},
+								pos: position{line: 1322, col: 18, offset: 49709},
 								expr: &seqExpr{
-									pos: position{line: 1325, col: 19, offset: 49780},
+									pos: position{line: 1322, col: 19, offset: 49710},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 1325, col: 19, offset: 49780},
+											pos:        position{line: 1322, col: 19, offset: 49710},
 											val:        "#",
 											ignoreCase: false,
 											want:       "\"#\"",
 										},
 										&notExpr{
-											pos: position{line: 1325, col: 23, offset: 49784},
+											pos: position{line: 1322, col: 23, offset: 49714},
 											expr: &litMatcher{
-												pos:        position{line: 1325, col: 24, offset: 49785},
+												pos:        position{line: 1322, col: 24, offset: 49715},
 												val:        "#",
 												ignoreCase: false,
 												want:       "\"#\"",
@@ -9168,55 +9160,55 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1326, col: 11, offset: 49802},
+						pos:  position{line: 1323, col: 11, offset: 49732},
 						name: "BoldText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1327, col: 11, offset: 49822},
+						pos:  position{line: 1324, col: 11, offset: 49752},
 						name: "ItalicText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1328, col: 11, offset: 49844},
+						pos:  position{line: 1325, col: 11, offset: 49774},
 						name: "MonospaceText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1329, col: 11, offset: 49869},
+						pos:  position{line: 1326, col: 11, offset: 49799},
 						name: "SubscriptText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1330, col: 11, offset: 49894},
+						pos:  position{line: 1327, col: 11, offset: 49824},
 						name: "SuperscriptText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1331, col: 11, offset: 49921},
+						pos:  position{line: 1328, col: 11, offset: 49851},
 						name: "InlineIcon",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1332, col: 11, offset: 49943},
+						pos:  position{line: 1329, col: 11, offset: 49873},
 						name: "InlineImage",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1333, col: 11, offset: 49966},
+						pos:  position{line: 1330, col: 11, offset: 49896},
 						name: "Link",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1334, col: 11, offset: 49982},
+						pos:  position{line: 1331, col: 11, offset: 49912},
 						name: "InlinePassthrough",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1335, col: 11, offset: 50011},
+						pos:  position{line: 1332, col: 11, offset: 49941},
 						name: "QuotedString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1336, col: 11, offset: 50035},
+						pos:  position{line: 1333, col: 11, offset: 49965},
 						name: "AttributeSubstitution",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1337, col: 11, offset: 50068},
+						pos:  position{line: 1334, col: 11, offset: 49998},
 						name: "SingleQuoteMarkedTextStringElement",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1338, col: 11, offset: 50114},
+						pos:  position{line: 1335, col: 11, offset: 50044},
 						name: "SingleQuoteMarkedTextFallbackCharacter",
 					},
 				},
@@ -9224,14 +9216,14 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteMarkedTextStringElement",
-			pos:  position{line: 1340, col: 1, offset: 50156},
+			pos:  position{line: 1337, col: 1, offset: 50086},
 			expr: &actionExpr{
-				pos: position{line: 1340, col: 39, offset: 50194},
+				pos: position{line: 1337, col: 39, offset: 50124},
 				run: (*parser).callonSingleQuoteMarkedTextStringElement1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1340, col: 39, offset: 50194},
+					pos: position{line: 1337, col: 39, offset: 50124},
 					expr: &charClassMatcher{
-						pos:        position{line: 1340, col: 39, offset: 50194},
+						pos:        position{line: 1337, col: 39, offset: 50124},
 						val:        "[^\\r\\n{} #^~]",
 						chars:      []rune{'\r', '\n', '{', '}', ' ', '#', '^', '~'},
 						ignoreCase: false,
@@ -9242,31 +9234,31 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteMarkedTextFallbackCharacter",
-			pos:  position{line: 1344, col: 1, offset: 50424},
+			pos:  position{line: 1341, col: 1, offset: 50354},
 			expr: &choiceExpr{
-				pos: position{line: 1345, col: 5, offset: 50471},
+				pos: position{line: 1342, col: 5, offset: 50401},
 				alternatives: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 1345, col: 5, offset: 50471},
+						pos:        position{line: 1342, col: 5, offset: 50401},
 						val:        "[^\\r\\n#]",
 						chars:      []rune{'\r', '\n', '#'},
 						ignoreCase: false,
 						inverted:   true,
 					},
 					&actionExpr{
-						pos: position{line: 1346, col: 7, offset: 50569},
+						pos: position{line: 1343, col: 7, offset: 50499},
 						run: (*parser).callonSingleQuoteMarkedTextFallbackCharacter3,
 						expr: &seqExpr{
-							pos: position{line: 1346, col: 7, offset: 50569},
+							pos: position{line: 1343, col: 7, offset: 50499},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1346, col: 7, offset: 50569},
+									pos:        position{line: 1343, col: 7, offset: 50499},
 									val:        "#",
 									ignoreCase: false,
 									want:       "\"#\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1346, col: 11, offset: 50573},
+									pos:  position{line: 1343, col: 11, offset: 50503},
 									name: "Alphanums",
 								},
 							},
@@ -9277,40 +9269,40 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedMarkedText",
-			pos:  position{line: 1350, col: 1, offset: 50740},
+			pos:  position{line: 1347, col: 1, offset: 50670},
 			expr: &choiceExpr{
-				pos: position{line: 1351, col: 5, offset: 50766},
+				pos: position{line: 1348, col: 5, offset: 50696},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1351, col: 5, offset: 50766},
+						pos: position{line: 1348, col: 5, offset: 50696},
 						run: (*parser).callonEscapedMarkedText2,
 						expr: &seqExpr{
-							pos: position{line: 1351, col: 5, offset: 50766},
+							pos: position{line: 1348, col: 5, offset: 50696},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1351, col: 5, offset: 50766},
+									pos:   position{line: 1348, col: 5, offset: 50696},
 									label: "backslashes",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1351, col: 18, offset: 50779},
+										pos:  position{line: 1348, col: 18, offset: 50709},
 										name: "TwoOrMoreBackslashes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1351, col: 40, offset: 50801},
+									pos:        position{line: 1348, col: 40, offset: 50731},
 									val:        "##",
 									ignoreCase: false,
 									want:       "\"##\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1351, col: 45, offset: 50806},
+									pos:   position{line: 1348, col: 45, offset: 50736},
 									label: "elements",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1351, col: 55, offset: 50816},
+										pos:  position{line: 1348, col: 55, offset: 50746},
 										name: "DoubleQuoteMarkedTextElements",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1351, col: 86, offset: 50847},
+									pos:        position{line: 1348, col: 86, offset: 50777},
 									val:        "##",
 									ignoreCase: false,
 									want:       "\"##\"",
@@ -9319,35 +9311,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1353, col: 9, offset: 51006},
+						pos: position{line: 1350, col: 9, offset: 50936},
 						run: (*parser).callonEscapedMarkedText10,
 						expr: &seqExpr{
-							pos: position{line: 1353, col: 9, offset: 51006},
+							pos: position{line: 1350, col: 9, offset: 50936},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1353, col: 9, offset: 51006},
+									pos:   position{line: 1350, col: 9, offset: 50936},
 									label: "backslashes",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1353, col: 22, offset: 51019},
+										pos:  position{line: 1350, col: 22, offset: 50949},
 										name: "OneOrMoreBackslashes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1353, col: 44, offset: 51041},
+									pos:        position{line: 1350, col: 44, offset: 50971},
 									val:        "##",
 									ignoreCase: false,
 									want:       "\"##\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1353, col: 49, offset: 51046},
+									pos:   position{line: 1350, col: 49, offset: 50976},
 									label: "elements",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1353, col: 59, offset: 51056},
+										pos:  position{line: 1350, col: 59, offset: 50986},
 										name: "SingleQuoteMarkedTextElements",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1353, col: 90, offset: 51087},
+									pos:        position{line: 1350, col: 90, offset: 51017},
 									val:        "#",
 									ignoreCase: false,
 									want:       "\"#\"",
@@ -9356,35 +9348,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1356, col: 9, offset: 51290},
+						pos: position{line: 1353, col: 9, offset: 51220},
 						run: (*parser).callonEscapedMarkedText18,
 						expr: &seqExpr{
-							pos: position{line: 1356, col: 9, offset: 51290},
+							pos: position{line: 1353, col: 9, offset: 51220},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1356, col: 9, offset: 51290},
+									pos:   position{line: 1353, col: 9, offset: 51220},
 									label: "backslashes",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1356, col: 22, offset: 51303},
+										pos:  position{line: 1353, col: 22, offset: 51233},
 										name: "OneOrMoreBackslashes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1356, col: 44, offset: 51325},
+									pos:        position{line: 1353, col: 44, offset: 51255},
 									val:        "#",
 									ignoreCase: false,
 									want:       "\"#\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1356, col: 48, offset: 51329},
+									pos:   position{line: 1353, col: 48, offset: 51259},
 									label: "elements",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1356, col: 58, offset: 51339},
+										pos:  position{line: 1353, col: 58, offset: 51269},
 										name: "SingleQuoteMarkedTextElements",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1356, col: 89, offset: 51370},
+									pos:        position{line: 1353, col: 89, offset: 51300},
 									val:        "#",
 									ignoreCase: false,
 									want:       "\"#\"",
@@ -9397,49 +9389,49 @@ var g = &grammar{
 		},
 		{
 			name: "SubscriptText",
-			pos:  position{line: 1361, col: 1, offset: 51525},
+			pos:  position{line: 1358, col: 1, offset: 51455},
 			expr: &actionExpr{
-				pos: position{line: 1361, col: 18, offset: 51542},
+				pos: position{line: 1358, col: 18, offset: 51472},
 				run: (*parser).callonSubscriptText1,
 				expr: &seqExpr{
-					pos: position{line: 1361, col: 18, offset: 51542},
+					pos: position{line: 1358, col: 18, offset: 51472},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1361, col: 18, offset: 51542},
+							pos:   position{line: 1358, col: 18, offset: 51472},
 							label: "attrs",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1361, col: 24, offset: 51548},
+								pos: position{line: 1358, col: 24, offset: 51478},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1361, col: 25, offset: 51549},
+									pos:  position{line: 1358, col: 25, offset: 51479},
 									name: "QuotedTextAttrs",
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 1361, col: 43, offset: 51567},
+							pos: position{line: 1358, col: 43, offset: 51497},
 							expr: &litMatcher{
-								pos:        position{line: 1361, col: 44, offset: 51568},
+								pos:        position{line: 1358, col: 44, offset: 51498},
 								val:        "\\",
 								ignoreCase: false,
 								want:       "\"\\\\\"",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1361, col: 48, offset: 51572},
+							pos:        position{line: 1358, col: 48, offset: 51502},
 							val:        "~",
 							ignoreCase: false,
 							want:       "\"~\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1361, col: 52, offset: 51576},
+							pos:   position{line: 1358, col: 52, offset: 51506},
 							label: "element",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1361, col: 61, offset: 51585},
+								pos:  position{line: 1358, col: 61, offset: 51515},
 								name: "SubscriptTextElement",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1361, col: 83, offset: 51607},
+							pos:        position{line: 1358, col: 83, offset: 51537},
 							val:        "~",
 							ignoreCase: false,
 							want:       "\"~\"",
@@ -9450,16 +9442,16 @@ var g = &grammar{
 		},
 		{
 			name: "SubscriptTextElement",
-			pos:  position{line: 1365, col: 1, offset: 51707},
+			pos:  position{line: 1362, col: 1, offset: 51637},
 			expr: &choiceExpr{
-				pos: position{line: 1365, col: 25, offset: 51731},
+				pos: position{line: 1362, col: 25, offset: 51661},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1365, col: 25, offset: 51731},
+						pos:  position{line: 1362, col: 25, offset: 51661},
 						name: "QuotedText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1365, col: 38, offset: 51744},
+						pos:  position{line: 1362, col: 38, offset: 51674},
 						name: "NonSubscriptText",
 					},
 				},
@@ -9467,14 +9459,14 @@ var g = &grammar{
 		},
 		{
 			name: "NonSubscriptText",
-			pos:  position{line: 1367, col: 1, offset: 51765},
+			pos:  position{line: 1364, col: 1, offset: 51695},
 			expr: &actionExpr{
-				pos: position{line: 1367, col: 21, offset: 51785},
+				pos: position{line: 1364, col: 21, offset: 51715},
 				run: (*parser).callonNonSubscriptText1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1367, col: 21, offset: 51785},
+					pos: position{line: 1364, col: 21, offset: 51715},
 					expr: &charClassMatcher{
-						pos:        position{line: 1367, col: 21, offset: 51785},
+						pos:        position{line: 1364, col: 21, offset: 51715},
 						val:        "[^\\r\\n ~]",
 						chars:      []rune{'\r', '\n', ' ', '~'},
 						ignoreCase: false,
@@ -9485,37 +9477,37 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedSubscriptText",
-			pos:  position{line: 1371, col: 1, offset: 51866},
+			pos:  position{line: 1368, col: 1, offset: 51796},
 			expr: &actionExpr{
-				pos: position{line: 1371, col: 25, offset: 51890},
+				pos: position{line: 1368, col: 25, offset: 51820},
 				run: (*parser).callonEscapedSubscriptText1,
 				expr: &seqExpr{
-					pos: position{line: 1371, col: 25, offset: 51890},
+					pos: position{line: 1368, col: 25, offset: 51820},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1371, col: 25, offset: 51890},
+							pos:   position{line: 1368, col: 25, offset: 51820},
 							label: "backslashes",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1371, col: 38, offset: 51903},
+								pos:  position{line: 1368, col: 38, offset: 51833},
 								name: "OneOrMoreBackslashes",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1371, col: 60, offset: 51925},
+							pos:        position{line: 1368, col: 60, offset: 51855},
 							val:        "~",
 							ignoreCase: false,
 							want:       "\"~\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1371, col: 64, offset: 51929},
+							pos:   position{line: 1368, col: 64, offset: 51859},
 							label: "element",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1371, col: 73, offset: 51938},
+								pos:  position{line: 1368, col: 73, offset: 51868},
 								name: "SubscriptTextElement",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1371, col: 95, offset: 51960},
+							pos:        position{line: 1368, col: 95, offset: 51890},
 							val:        "~",
 							ignoreCase: false,
 							want:       "\"~\"",
@@ -9526,49 +9518,49 @@ var g = &grammar{
 		},
 		{
 			name: "SuperscriptText",
-			pos:  position{line: 1375, col: 1, offset: 52093},
+			pos:  position{line: 1372, col: 1, offset: 52023},
 			expr: &actionExpr{
-				pos: position{line: 1375, col: 20, offset: 52112},
+				pos: position{line: 1372, col: 20, offset: 52042},
 				run: (*parser).callonSuperscriptText1,
 				expr: &seqExpr{
-					pos: position{line: 1375, col: 20, offset: 52112},
+					pos: position{line: 1372, col: 20, offset: 52042},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1375, col: 20, offset: 52112},
+							pos:   position{line: 1372, col: 20, offset: 52042},
 							label: "attrs",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1375, col: 26, offset: 52118},
+								pos: position{line: 1372, col: 26, offset: 52048},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1375, col: 27, offset: 52119},
+									pos:  position{line: 1372, col: 27, offset: 52049},
 									name: "QuotedTextAttrs",
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 1375, col: 45, offset: 52137},
+							pos: position{line: 1372, col: 45, offset: 52067},
 							expr: &litMatcher{
-								pos:        position{line: 1375, col: 46, offset: 52138},
+								pos:        position{line: 1372, col: 46, offset: 52068},
 								val:        "\\",
 								ignoreCase: false,
 								want:       "\"\\\\\"",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1375, col: 50, offset: 52142},
+							pos:        position{line: 1372, col: 50, offset: 52072},
 							val:        "^",
 							ignoreCase: false,
 							want:       "\"^\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1375, col: 54, offset: 52146},
+							pos:   position{line: 1372, col: 54, offset: 52076},
 							label: "element",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1375, col: 63, offset: 52155},
+								pos:  position{line: 1372, col: 63, offset: 52085},
 								name: "SuperscriptTextElement",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1375, col: 87, offset: 52179},
+							pos:        position{line: 1372, col: 87, offset: 52109},
 							val:        "^",
 							ignoreCase: false,
 							want:       "\"^\"",
@@ -9579,16 +9571,16 @@ var g = &grammar{
 		},
 		{
 			name: "SuperscriptTextElement",
-			pos:  position{line: 1379, col: 1, offset: 52281},
+			pos:  position{line: 1376, col: 1, offset: 52211},
 			expr: &choiceExpr{
-				pos: position{line: 1379, col: 27, offset: 52307},
+				pos: position{line: 1376, col: 27, offset: 52237},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1379, col: 27, offset: 52307},
+						pos:  position{line: 1376, col: 27, offset: 52237},
 						name: "QuotedText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1379, col: 40, offset: 52320},
+						pos:  position{line: 1376, col: 40, offset: 52250},
 						name: "NonSuperscriptText",
 					},
 				},
@@ -9596,14 +9588,14 @@ var g = &grammar{
 		},
 		{
 			name: "NonSuperscriptText",
-			pos:  position{line: 1381, col: 1, offset: 52343},
+			pos:  position{line: 1378, col: 1, offset: 52273},
 			expr: &actionExpr{
-				pos: position{line: 1381, col: 23, offset: 52365},
+				pos: position{line: 1378, col: 23, offset: 52295},
 				run: (*parser).callonNonSuperscriptText1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1381, col: 23, offset: 52365},
+					pos: position{line: 1378, col: 23, offset: 52295},
 					expr: &charClassMatcher{
-						pos:        position{line: 1381, col: 23, offset: 52365},
+						pos:        position{line: 1378, col: 23, offset: 52295},
 						val:        "[^\\r\\n ^]",
 						chars:      []rune{'\r', '\n', ' ', '^'},
 						ignoreCase: false,
@@ -9614,37 +9606,37 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedSuperscriptText",
-			pos:  position{line: 1385, col: 1, offset: 52446},
+			pos:  position{line: 1382, col: 1, offset: 52376},
 			expr: &actionExpr{
-				pos: position{line: 1385, col: 27, offset: 52472},
+				pos: position{line: 1382, col: 27, offset: 52402},
 				run: (*parser).callonEscapedSuperscriptText1,
 				expr: &seqExpr{
-					pos: position{line: 1385, col: 27, offset: 52472},
+					pos: position{line: 1382, col: 27, offset: 52402},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1385, col: 27, offset: 52472},
+							pos:   position{line: 1382, col: 27, offset: 52402},
 							label: "backslashes",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1385, col: 40, offset: 52485},
+								pos:  position{line: 1382, col: 40, offset: 52415},
 								name: "OneOrMoreBackslashes",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1385, col: 62, offset: 52507},
+							pos:        position{line: 1382, col: 62, offset: 52437},
 							val:        "^",
 							ignoreCase: false,
 							want:       "\"^\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1385, col: 66, offset: 52511},
+							pos:   position{line: 1382, col: 66, offset: 52441},
 							label: "element",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1385, col: 75, offset: 52520},
+								pos:  position{line: 1382, col: 75, offset: 52450},
 								name: "SuperscriptTextElement",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1385, col: 99, offset: 52544},
+							pos:        position{line: 1382, col: 99, offset: 52474},
 							val:        "^",
 							ignoreCase: false,
 							want:       "\"^\"",
@@ -9655,20 +9647,20 @@ var g = &grammar{
 		},
 		{
 			name: "InlinePassthrough",
-			pos:  position{line: 1392, col: 1, offset: 52793},
+			pos:  position{line: 1389, col: 1, offset: 52723},
 			expr: &choiceExpr{
-				pos: position{line: 1392, col: 22, offset: 52814},
+				pos: position{line: 1389, col: 22, offset: 52744},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1392, col: 22, offset: 52814},
+						pos:  position{line: 1389, col: 22, offset: 52744},
 						name: "TriplePlusPassthrough",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1392, col: 46, offset: 52838},
+						pos:  position{line: 1389, col: 46, offset: 52768},
 						name: "SinglePlusPassthrough",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1392, col: 70, offset: 52862},
+						pos:  position{line: 1389, col: 70, offset: 52792},
 						name: "PassthroughMacro",
 					},
 				},
@@ -9676,9 +9668,9 @@ var g = &grammar{
 		},
 		{
 			name: "SinglePlusPassthroughPrefix",
-			pos:  position{line: 1394, col: 1, offset: 52882},
+			pos:  position{line: 1391, col: 1, offset: 52812},
 			expr: &litMatcher{
-				pos:        position{line: 1394, col: 32, offset: 52913},
+				pos:        position{line: 1391, col: 32, offset: 52843},
 				val:        "+",
 				ignoreCase: false,
 				want:       "\"+\"",
@@ -9686,33 +9678,33 @@ var g = &grammar{
 		},
 		{
 			name: "SinglePlusPassthrough",
-			pos:  position{line: 1396, col: 1, offset: 52920},
+			pos:  position{line: 1393, col: 1, offset: 52850},
 			expr: &actionExpr{
-				pos: position{line: 1396, col: 26, offset: 52945},
+				pos: position{line: 1393, col: 26, offset: 52875},
 				run: (*parser).callonSinglePlusPassthrough1,
 				expr: &seqExpr{
-					pos: position{line: 1396, col: 26, offset: 52945},
+					pos: position{line: 1393, col: 26, offset: 52875},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1396, col: 26, offset: 52945},
+							pos:  position{line: 1393, col: 26, offset: 52875},
 							name: "SinglePlusPassthroughPrefix",
 						},
 						&labeledExpr{
-							pos:   position{line: 1396, col: 54, offset: 52973},
+							pos:   position{line: 1393, col: 54, offset: 52903},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1396, col: 63, offset: 52982},
+								pos:  position{line: 1393, col: 63, offset: 52912},
 								name: "SinglePlusPassthroughContent",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1396, col: 93, offset: 53012},
+							pos:  position{line: 1393, col: 93, offset: 52942},
 							name: "SinglePlusPassthroughPrefix",
 						},
 						&notExpr{
-							pos: position{line: 1396, col: 121, offset: 53040},
+							pos: position{line: 1393, col: 121, offset: 52970},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1396, col: 122, offset: 53041},
+								pos:  position{line: 1393, col: 122, offset: 52971},
 								name: "Alphanum",
 							},
 						},
@@ -9722,85 +9714,85 @@ var g = &grammar{
 		},
 		{
 			name: "SinglePlusPassthroughContent",
-			pos:  position{line: 1400, col: 1, offset: 53150},
+			pos:  position{line: 1397, col: 1, offset: 53080},
 			expr: &choiceExpr{
-				pos: position{line: 1400, col: 33, offset: 53182},
+				pos: position{line: 1397, col: 33, offset: 53112},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1400, col: 34, offset: 53183},
+						pos: position{line: 1397, col: 34, offset: 53113},
 						run: (*parser).callonSinglePlusPassthroughContent2,
 						expr: &seqExpr{
-							pos: position{line: 1400, col: 34, offset: 53183},
+							pos: position{line: 1397, col: 34, offset: 53113},
 							exprs: []interface{}{
 								&seqExpr{
-									pos: position{line: 1400, col: 35, offset: 53184},
+									pos: position{line: 1397, col: 35, offset: 53114},
 									exprs: []interface{}{
 										&notExpr{
-											pos: position{line: 1400, col: 35, offset: 53184},
+											pos: position{line: 1397, col: 35, offset: 53114},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1400, col: 36, offset: 53185},
+												pos:  position{line: 1397, col: 36, offset: 53115},
 												name: "SinglePlusPassthroughPrefix",
 											},
 										},
 										&notExpr{
-											pos: position{line: 1400, col: 64, offset: 53213},
+											pos: position{line: 1397, col: 64, offset: 53143},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1400, col: 65, offset: 53214},
+												pos:  position{line: 1397, col: 65, offset: 53144},
 												name: "Space",
 											},
 										},
 										&notExpr{
-											pos: position{line: 1400, col: 71, offset: 53220},
+											pos: position{line: 1397, col: 71, offset: 53150},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1400, col: 72, offset: 53221},
+												pos:  position{line: 1397, col: 72, offset: 53151},
 												name: "Newline",
 											},
 										},
 										&anyMatcher{
-											line: 1400, col: 80, offset: 53229,
+											line: 1397, col: 80, offset: 53159,
 										},
 									},
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1400, col: 83, offset: 53232},
+									pos: position{line: 1397, col: 83, offset: 53162},
 									expr: &seqExpr{
-										pos: position{line: 1400, col: 84, offset: 53233},
+										pos: position{line: 1397, col: 84, offset: 53163},
 										exprs: []interface{}{
 											&notExpr{
-												pos: position{line: 1400, col: 84, offset: 53233},
+												pos: position{line: 1397, col: 84, offset: 53163},
 												expr: &seqExpr{
-													pos: position{line: 1400, col: 86, offset: 53235},
+													pos: position{line: 1397, col: 86, offset: 53165},
 													exprs: []interface{}{
 														&oneOrMoreExpr{
-															pos: position{line: 1400, col: 86, offset: 53235},
+															pos: position{line: 1397, col: 86, offset: 53165},
 															expr: &ruleRefExpr{
-																pos:  position{line: 1400, col: 86, offset: 53235},
+																pos:  position{line: 1397, col: 86, offset: 53165},
 																name: "Space",
 															},
 														},
 														&ruleRefExpr{
-															pos:  position{line: 1400, col: 93, offset: 53242},
+															pos:  position{line: 1397, col: 93, offset: 53172},
 															name: "SinglePlusPassthroughPrefix",
 														},
 													},
 												},
 											},
 											&notExpr{
-												pos: position{line: 1400, col: 122, offset: 53271},
+												pos: position{line: 1397, col: 122, offset: 53201},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1400, col: 123, offset: 53272},
+													pos:  position{line: 1397, col: 123, offset: 53202},
 													name: "SinglePlusPassthroughPrefix",
 												},
 											},
 											&notExpr{
-												pos: position{line: 1400, col: 151, offset: 53300},
+												pos: position{line: 1397, col: 151, offset: 53230},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1400, col: 152, offset: 53301},
+													pos:  position{line: 1397, col: 152, offset: 53231},
 													name: "Newline",
 												},
 											},
 											&anyMatcher{
-												line: 1400, col: 160, offset: 53309,
+												line: 1397, col: 160, offset: 53239,
 											},
 										},
 									},
@@ -9809,34 +9801,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1402, col: 7, offset: 53453},
+						pos: position{line: 1399, col: 7, offset: 53383},
 						run: (*parser).callonSinglePlusPassthroughContent24,
 						expr: &seqExpr{
-							pos: position{line: 1402, col: 8, offset: 53454},
+							pos: position{line: 1399, col: 8, offset: 53384},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1402, col: 8, offset: 53454},
+									pos: position{line: 1399, col: 8, offset: 53384},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1402, col: 9, offset: 53455},
+										pos:  position{line: 1399, col: 9, offset: 53385},
 										name: "Space",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1402, col: 15, offset: 53461},
+									pos: position{line: 1399, col: 15, offset: 53391},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1402, col: 16, offset: 53462},
+										pos:  position{line: 1399, col: 16, offset: 53392},
 										name: "Newline",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1402, col: 24, offset: 53470},
+									pos: position{line: 1399, col: 24, offset: 53400},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1402, col: 25, offset: 53471},
+										pos:  position{line: 1399, col: 25, offset: 53401},
 										name: "SinglePlusPassthroughPrefix",
 									},
 								},
 								&anyMatcher{
-									line: 1402, col: 53, offset: 53499,
+									line: 1399, col: 53, offset: 53429,
 								},
 							},
 						},
@@ -9846,9 +9838,9 @@ var g = &grammar{
 		},
 		{
 			name: "TriplePlusPassthroughPrefix",
-			pos:  position{line: 1406, col: 1, offset: 53585},
+			pos:  position{line: 1403, col: 1, offset: 53515},
 			expr: &litMatcher{
-				pos:        position{line: 1406, col: 32, offset: 53616},
+				pos:        position{line: 1403, col: 32, offset: 53546},
 				val:        "+++",
 				ignoreCase: false,
 				want:       "\"+++\"",
@@ -9856,33 +9848,33 @@ var g = &grammar{
 		},
 		{
 			name: "TriplePlusPassthrough",
-			pos:  position{line: 1408, col: 1, offset: 53625},
+			pos:  position{line: 1405, col: 1, offset: 53555},
 			expr: &actionExpr{
-				pos: position{line: 1408, col: 26, offset: 53650},
+				pos: position{line: 1405, col: 26, offset: 53580},
 				run: (*parser).callonTriplePlusPassthrough1,
 				expr: &seqExpr{
-					pos: position{line: 1408, col: 26, offset: 53650},
+					pos: position{line: 1405, col: 26, offset: 53580},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1408, col: 26, offset: 53650},
+							pos:  position{line: 1405, col: 26, offset: 53580},
 							name: "TriplePlusPassthroughPrefix",
 						},
 						&labeledExpr{
-							pos:   position{line: 1408, col: 54, offset: 53678},
+							pos:   position{line: 1405, col: 54, offset: 53608},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1408, col: 63, offset: 53687},
+								pos:  position{line: 1405, col: 63, offset: 53617},
 								name: "TriplePlusPassthroughContent",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1408, col: 93, offset: 53717},
+							pos:  position{line: 1405, col: 93, offset: 53647},
 							name: "TriplePlusPassthroughPrefix",
 						},
 						&notExpr{
-							pos: position{line: 1408, col: 121, offset: 53745},
+							pos: position{line: 1405, col: 121, offset: 53675},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1408, col: 122, offset: 53746},
+								pos:  position{line: 1405, col: 122, offset: 53676},
 								name: "Alphanum",
 							},
 						},
@@ -9892,63 +9884,63 @@ var g = &grammar{
 		},
 		{
 			name: "TriplePlusPassthroughContent",
-			pos:  position{line: 1412, col: 1, offset: 53855},
+			pos:  position{line: 1409, col: 1, offset: 53785},
 			expr: &choiceExpr{
-				pos: position{line: 1412, col: 33, offset: 53887},
+				pos: position{line: 1409, col: 33, offset: 53817},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1412, col: 34, offset: 53888},
+						pos: position{line: 1409, col: 34, offset: 53818},
 						run: (*parser).callonTriplePlusPassthroughContent2,
 						expr: &zeroOrMoreExpr{
-							pos: position{line: 1412, col: 34, offset: 53888},
+							pos: position{line: 1409, col: 34, offset: 53818},
 							expr: &seqExpr{
-								pos: position{line: 1412, col: 35, offset: 53889},
+								pos: position{line: 1409, col: 35, offset: 53819},
 								exprs: []interface{}{
 									&notExpr{
-										pos: position{line: 1412, col: 35, offset: 53889},
+										pos: position{line: 1409, col: 35, offset: 53819},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1412, col: 36, offset: 53890},
+											pos:  position{line: 1409, col: 36, offset: 53820},
 											name: "TriplePlusPassthroughPrefix",
 										},
 									},
 									&anyMatcher{
-										line: 1412, col: 64, offset: 53918,
+										line: 1409, col: 64, offset: 53848,
 									},
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1414, col: 7, offset: 54085},
+						pos: position{line: 1411, col: 7, offset: 54015},
 						run: (*parser).callonTriplePlusPassthroughContent8,
 						expr: &zeroOrOneExpr{
-							pos: position{line: 1414, col: 7, offset: 54085},
+							pos: position{line: 1411, col: 7, offset: 54015},
 							expr: &seqExpr{
-								pos: position{line: 1414, col: 8, offset: 54086},
+								pos: position{line: 1411, col: 8, offset: 54016},
 								exprs: []interface{}{
 									&notExpr{
-										pos: position{line: 1414, col: 8, offset: 54086},
+										pos: position{line: 1411, col: 8, offset: 54016},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1414, col: 9, offset: 54087},
+											pos:  position{line: 1411, col: 9, offset: 54017},
 											name: "Space",
 										},
 									},
 									&notExpr{
-										pos: position{line: 1414, col: 15, offset: 54093},
+										pos: position{line: 1411, col: 15, offset: 54023},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1414, col: 16, offset: 54094},
+											pos:  position{line: 1411, col: 16, offset: 54024},
 											name: "Newline",
 										},
 									},
 									&notExpr{
-										pos: position{line: 1414, col: 24, offset: 54102},
+										pos: position{line: 1411, col: 24, offset: 54032},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1414, col: 25, offset: 54103},
+											pos:  position{line: 1411, col: 25, offset: 54033},
 											name: "TriplePlusPassthroughPrefix",
 										},
 									},
 									&anyMatcher{
-										line: 1414, col: 53, offset: 54131,
+										line: 1411, col: 53, offset: 54061,
 									},
 								},
 							},
@@ -9959,35 +9951,35 @@ var g = &grammar{
 		},
 		{
 			name: "PassthroughMacro",
-			pos:  position{line: 1418, col: 1, offset: 54218},
+			pos:  position{line: 1415, col: 1, offset: 54148},
 			expr: &choiceExpr{
-				pos: position{line: 1418, col: 21, offset: 54238},
+				pos: position{line: 1415, col: 21, offset: 54168},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1418, col: 21, offset: 54238},
+						pos: position{line: 1415, col: 21, offset: 54168},
 						run: (*parser).callonPassthroughMacro2,
 						expr: &seqExpr{
-							pos: position{line: 1418, col: 21, offset: 54238},
+							pos: position{line: 1415, col: 21, offset: 54168},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1418, col: 21, offset: 54238},
+									pos:        position{line: 1415, col: 21, offset: 54168},
 									val:        "pass:[",
 									ignoreCase: false,
 									want:       "\"pass:[\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1418, col: 30, offset: 54247},
+									pos:   position{line: 1415, col: 30, offset: 54177},
 									label: "content",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1418, col: 38, offset: 54255},
+										pos: position{line: 1415, col: 38, offset: 54185},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1418, col: 39, offset: 54256},
+											pos:  position{line: 1415, col: 39, offset: 54186},
 											name: "PassthroughMacroCharacter",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1418, col: 67, offset: 54284},
+									pos:        position{line: 1415, col: 67, offset: 54214},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -9996,31 +9988,31 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1420, col: 5, offset: 54382},
+						pos: position{line: 1417, col: 5, offset: 54312},
 						run: (*parser).callonPassthroughMacro9,
 						expr: &seqExpr{
-							pos: position{line: 1420, col: 5, offset: 54382},
+							pos: position{line: 1417, col: 5, offset: 54312},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1420, col: 5, offset: 54382},
+									pos:        position{line: 1417, col: 5, offset: 54312},
 									val:        "pass:q[",
 									ignoreCase: false,
 									want:       "\"pass:q[\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1420, col: 15, offset: 54392},
+									pos:   position{line: 1417, col: 15, offset: 54322},
 									label: "content",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1420, col: 23, offset: 54400},
+										pos: position{line: 1417, col: 23, offset: 54330},
 										expr: &choiceExpr{
-											pos: position{line: 1420, col: 24, offset: 54401},
+											pos: position{line: 1417, col: 24, offset: 54331},
 											alternatives: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 1420, col: 24, offset: 54401},
+													pos:  position{line: 1417, col: 24, offset: 54331},
 													name: "QuotedText",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1420, col: 37, offset: 54414},
+													pos:  position{line: 1417, col: 37, offset: 54344},
 													name: "PassthroughMacroCharacter",
 												},
 											},
@@ -10028,7 +10020,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1420, col: 65, offset: 54442},
+									pos:        position{line: 1417, col: 65, offset: 54372},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -10041,12 +10033,12 @@ var g = &grammar{
 		},
 		{
 			name: "PassthroughMacroCharacter",
-			pos:  position{line: 1424, col: 1, offset: 54542},
+			pos:  position{line: 1421, col: 1, offset: 54472},
 			expr: &actionExpr{
-				pos: position{line: 1424, col: 30, offset: 54571},
+				pos: position{line: 1421, col: 30, offset: 54501},
 				run: (*parser).callonPassthroughMacroCharacter1,
 				expr: &charClassMatcher{
-					pos:        position{line: 1424, col: 30, offset: 54571},
+					pos:        position{line: 1421, col: 30, offset: 54501},
 					val:        "[^\\]]",
 					chars:      []rune{']'},
 					ignoreCase: false,
@@ -10056,16 +10048,16 @@ var g = &grammar{
 		},
 		{
 			name: "CrossReference",
-			pos:  position{line: 1431, col: 1, offset: 54751},
+			pos:  position{line: 1428, col: 1, offset: 54681},
 			expr: &choiceExpr{
-				pos: position{line: 1431, col: 19, offset: 54769},
+				pos: position{line: 1428, col: 19, offset: 54699},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1431, col: 19, offset: 54769},
+						pos:  position{line: 1428, col: 19, offset: 54699},
 						name: "InternalCrossReference",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1431, col: 44, offset: 54794},
+						pos:  position{line: 1428, col: 44, offset: 54724},
 						name: "ExternalCrossReference",
 					},
 				},
@@ -10073,53 +10065,53 @@ var g = &grammar{
 		},
 		{
 			name: "InternalCrossReference",
-			pos:  position{line: 1433, col: 1, offset: 54821},
+			pos:  position{line: 1430, col: 1, offset: 54751},
 			expr: &choiceExpr{
-				pos: position{line: 1433, col: 27, offset: 54847},
+				pos: position{line: 1430, col: 27, offset: 54777},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1433, col: 27, offset: 54847},
+						pos: position{line: 1430, col: 27, offset: 54777},
 						run: (*parser).callonInternalCrossReference2,
 						expr: &seqExpr{
-							pos: position{line: 1433, col: 27, offset: 54847},
+							pos: position{line: 1430, col: 27, offset: 54777},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1433, col: 27, offset: 54847},
+									pos:        position{line: 1430, col: 27, offset: 54777},
 									val:        "<<",
 									ignoreCase: false,
 									want:       "\"<<\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1433, col: 32, offset: 54852},
+									pos:   position{line: 1430, col: 32, offset: 54782},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1433, col: 36, offset: 54856},
+										pos:  position{line: 1430, col: 36, offset: 54786},
 										name: "ID",
 									},
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1433, col: 40, offset: 54860},
+									pos: position{line: 1430, col: 40, offset: 54790},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1433, col: 40, offset: 54860},
+										pos:  position{line: 1430, col: 40, offset: 54790},
 										name: "Space",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1433, col: 47, offset: 54867},
+									pos:        position{line: 1430, col: 47, offset: 54797},
 									val:        ",",
 									ignoreCase: false,
 									want:       "\",\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1433, col: 51, offset: 54871},
+									pos:   position{line: 1430, col: 51, offset: 54801},
 									label: "label",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1433, col: 58, offset: 54878},
+										pos:  position{line: 1430, col: 58, offset: 54808},
 										name: "CrossReferenceLabel",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1433, col: 79, offset: 54899},
+									pos:        position{line: 1430, col: 79, offset: 54829},
 									val:        ">>",
 									ignoreCase: false,
 									want:       "\">>\"",
@@ -10128,27 +10120,27 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1435, col: 5, offset: 54984},
+						pos: position{line: 1432, col: 5, offset: 54914},
 						run: (*parser).callonInternalCrossReference13,
 						expr: &seqExpr{
-							pos: position{line: 1435, col: 5, offset: 54984},
+							pos: position{line: 1432, col: 5, offset: 54914},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1435, col: 5, offset: 54984},
+									pos:        position{line: 1432, col: 5, offset: 54914},
 									val:        "<<",
 									ignoreCase: false,
 									want:       "\"<<\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1435, col: 10, offset: 54989},
+									pos:   position{line: 1432, col: 10, offset: 54919},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1435, col: 14, offset: 54993},
+										pos:  position{line: 1432, col: 14, offset: 54923},
 										name: "ID",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1435, col: 18, offset: 54997},
+									pos:        position{line: 1432, col: 18, offset: 54927},
 									val:        ">>",
 									ignoreCase: false,
 									want:       "\">>\"",
@@ -10161,32 +10153,32 @@ var g = &grammar{
 		},
 		{
 			name: "ExternalCrossReference",
-			pos:  position{line: 1439, col: 1, offset: 55073},
+			pos:  position{line: 1436, col: 1, offset: 55003},
 			expr: &actionExpr{
-				pos: position{line: 1439, col: 27, offset: 55099},
+				pos: position{line: 1436, col: 27, offset: 55029},
 				run: (*parser).callonExternalCrossReference1,
 				expr: &seqExpr{
-					pos: position{line: 1439, col: 27, offset: 55099},
+					pos: position{line: 1436, col: 27, offset: 55029},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1439, col: 27, offset: 55099},
+							pos:        position{line: 1436, col: 27, offset: 55029},
 							val:        "xref:",
 							ignoreCase: false,
 							want:       "\"xref:\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1439, col: 35, offset: 55107},
+							pos:   position{line: 1436, col: 35, offset: 55037},
 							label: "url",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1439, col: 40, offset: 55112},
+								pos:  position{line: 1436, col: 40, offset: 55042},
 								name: "FileLocation",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1439, col: 54, offset: 55126},
+							pos:   position{line: 1436, col: 54, offset: 55056},
 							label: "inlineAttributes",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1439, col: 72, offset: 55144},
+								pos:  position{line: 1436, col: 72, offset: 55074},
 								name: "LinkAttributes",
 							},
 						},
@@ -10196,24 +10188,24 @@ var g = &grammar{
 		},
 		{
 			name: "CrossReferenceLabel",
-			pos:  position{line: 1443, col: 1, offset: 55271},
+			pos:  position{line: 1440, col: 1, offset: 55201},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1443, col: 24, offset: 55294},
+				pos:  position{line: 1440, col: 24, offset: 55224},
 				name: "ElementTitleContent",
 			},
 		},
 		{
 			name: "Link",
-			pos:  position{line: 1448, col: 1, offset: 55421},
+			pos:  position{line: 1445, col: 1, offset: 55351},
 			expr: &choiceExpr{
-				pos: position{line: 1448, col: 9, offset: 55429},
+				pos: position{line: 1445, col: 9, offset: 55359},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1448, col: 9, offset: 55429},
+						pos:  position{line: 1445, col: 9, offset: 55359},
 						name: "RelativeLink",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1448, col: 24, offset: 55444},
+						pos:  position{line: 1445, col: 24, offset: 55374},
 						name: "ExternalLink",
 					},
 				},
@@ -10221,32 +10213,32 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeLink",
-			pos:  position{line: 1451, col: 1, offset: 55528},
+			pos:  position{line: 1448, col: 1, offset: 55458},
 			expr: &actionExpr{
-				pos: position{line: 1451, col: 17, offset: 55544},
+				pos: position{line: 1448, col: 17, offset: 55474},
 				run: (*parser).callonRelativeLink1,
 				expr: &seqExpr{
-					pos: position{line: 1451, col: 17, offset: 55544},
+					pos: position{line: 1448, col: 17, offset: 55474},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1451, col: 17, offset: 55544},
+							pos:        position{line: 1448, col: 17, offset: 55474},
 							val:        "link:",
 							ignoreCase: false,
 							want:       "\"link:\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1451, col: 25, offset: 55552},
+							pos:   position{line: 1448, col: 25, offset: 55482},
 							label: "url",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1451, col: 30, offset: 55557},
+								pos:  position{line: 1448, col: 30, offset: 55487},
 								name: "Location",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1451, col: 40, offset: 55567},
+							pos:   position{line: 1448, col: 40, offset: 55497},
 							label: "inlineAttributes",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1451, col: 58, offset: 55585},
+								pos:  position{line: 1448, col: 58, offset: 55515},
 								name: "LinkAttributes",
 							},
 						},
@@ -10256,28 +10248,28 @@ var g = &grammar{
 		},
 		{
 			name: "ExternalLink",
-			pos:  position{line: 1455, col: 1, offset: 55700},
+			pos:  position{line: 1452, col: 1, offset: 55630},
 			expr: &actionExpr{
-				pos: position{line: 1455, col: 17, offset: 55716},
+				pos: position{line: 1452, col: 17, offset: 55646},
 				run: (*parser).callonExternalLink1,
 				expr: &seqExpr{
-					pos: position{line: 1455, col: 17, offset: 55716},
+					pos: position{line: 1452, col: 17, offset: 55646},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1455, col: 17, offset: 55716},
+							pos:   position{line: 1452, col: 17, offset: 55646},
 							label: "url",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1455, col: 22, offset: 55721},
+								pos:  position{line: 1452, col: 22, offset: 55651},
 								name: "LocationWithScheme",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1455, col: 42, offset: 55741},
+							pos:   position{line: 1452, col: 42, offset: 55671},
 							label: "inlineAttributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1455, col: 59, offset: 55758},
+								pos: position{line: 1452, col: 59, offset: 55688},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1455, col: 60, offset: 55759},
+									pos:  position{line: 1452, col: 60, offset: 55689},
 									name: "LinkAttributes",
 								},
 							},
@@ -10288,50 +10280,50 @@ var g = &grammar{
 		},
 		{
 			name: "LinkAttributes",
-			pos:  position{line: 1459, col: 1, offset: 55856},
+			pos:  position{line: 1456, col: 1, offset: 55786},
 			expr: &actionExpr{
-				pos: position{line: 1459, col: 19, offset: 55874},
+				pos: position{line: 1456, col: 19, offset: 55804},
 				run: (*parser).callonLinkAttributes1,
 				expr: &seqExpr{
-					pos: position{line: 1459, col: 19, offset: 55874},
+					pos: position{line: 1456, col: 19, offset: 55804},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1459, col: 19, offset: 55874},
+							pos:        position{line: 1456, col: 19, offset: 55804},
 							val:        "[",
 							ignoreCase: false,
 							want:       "\"[\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1459, col: 23, offset: 55878},
+							pos:   position{line: 1456, col: 23, offset: 55808},
 							label: "firstAttr",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1459, col: 33, offset: 55888},
+								pos: position{line: 1456, col: 33, offset: 55818},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1459, col: 34, offset: 55889},
+									pos:  position{line: 1456, col: 34, offset: 55819},
 									name: "FirstLinkAttributeElement",
 								},
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1460, col: 5, offset: 55922},
+							pos: position{line: 1457, col: 5, offset: 55852},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1460, col: 5, offset: 55922},
+								pos:  position{line: 1457, col: 5, offset: 55852},
 								name: "Space",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1460, col: 12, offset: 55929},
+							pos:   position{line: 1457, col: 12, offset: 55859},
 							label: "otherattrs",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1460, col: 23, offset: 55940},
+								pos: position{line: 1457, col: 23, offset: 55870},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1460, col: 24, offset: 55941},
+									pos:  position{line: 1457, col: 24, offset: 55871},
 									name: "GenericAttribute",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1460, col: 43, offset: 55960},
+							pos:        position{line: 1457, col: 43, offset: 55890},
 							val:        "]",
 							ignoreCase: false,
 							want:       "\"]\"",
@@ -10342,46 +10334,46 @@ var g = &grammar{
 		},
 		{
 			name: "FirstLinkAttributeElement",
-			pos:  position{line: 1464, col: 1, offset: 56081},
+			pos:  position{line: 1461, col: 1, offset: 56011},
 			expr: &actionExpr{
-				pos: position{line: 1464, col: 30, offset: 56110},
+				pos: position{line: 1461, col: 30, offset: 56040},
 				run: (*parser).callonFirstLinkAttributeElement1,
 				expr: &labeledExpr{
-					pos:   position{line: 1464, col: 30, offset: 56110},
+					pos:   position{line: 1461, col: 30, offset: 56040},
 					label: "element",
 					expr: &choiceExpr{
-						pos: position{line: 1466, col: 5, offset: 56163},
+						pos: position{line: 1463, col: 5, offset: 56093},
 						alternatives: []interface{}{
 							&actionExpr{
-								pos: position{line: 1466, col: 6, offset: 56164},
+								pos: position{line: 1463, col: 6, offset: 56094},
 								run: (*parser).callonFirstLinkAttributeElement4,
 								expr: &seqExpr{
-									pos: position{line: 1466, col: 6, offset: 56164},
+									pos: position{line: 1463, col: 6, offset: 56094},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 1466, col: 6, offset: 56164},
+											pos:        position{line: 1463, col: 6, offset: 56094},
 											val:        "\"",
 											ignoreCase: false,
 											want:       "\"\\\"\"",
 										},
 										&labeledExpr{
-											pos:   position{line: 1466, col: 11, offset: 56169},
+											pos:   position{line: 1463, col: 11, offset: 56099},
 											label: "elements",
 											expr: &oneOrMoreExpr{
-												pos: position{line: 1466, col: 20, offset: 56178},
+												pos: position{line: 1463, col: 20, offset: 56108},
 												expr: &choiceExpr{
-													pos: position{line: 1466, col: 21, offset: 56179},
+													pos: position{line: 1463, col: 21, offset: 56109},
 													alternatives: []interface{}{
 														&ruleRefExpr{
-															pos:  position{line: 1466, col: 21, offset: 56179},
+															pos:  position{line: 1463, col: 21, offset: 56109},
 															name: "QuotedString",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 1466, col: 36, offset: 56194},
+															pos:  position{line: 1463, col: 36, offset: 56124},
 															name: "QuotedText",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 1466, col: 49, offset: 56207},
+															pos:  position{line: 1463, col: 49, offset: 56137},
 															name: "QuotedAttributeChar",
 														},
 													},
@@ -10389,17 +10381,17 @@ var g = &grammar{
 											},
 										},
 										&litMatcher{
-											pos:        position{line: 1466, col: 71, offset: 56229},
+											pos:        position{line: 1463, col: 71, offset: 56159},
 											val:        "\"",
 											ignoreCase: false,
 											want:       "\"\\\"\"",
 										},
 										&andExpr{
-											pos: position{line: 1466, col: 76, offset: 56234},
+											pos: position{line: 1463, col: 76, offset: 56164},
 											expr: &notExpr{
-												pos: position{line: 1466, col: 78, offset: 56236},
+												pos: position{line: 1463, col: 78, offset: 56166},
 												expr: &litMatcher{
-													pos:        position{line: 1466, col: 79, offset: 56237},
+													pos:        position{line: 1463, col: 79, offset: 56167},
 													val:        "=",
 													ignoreCase: false,
 													want:       "\"=\"",
@@ -10407,9 +10399,9 @@ var g = &grammar{
 											},
 										},
 										&zeroOrOneExpr{
-											pos: position{line: 1466, col: 84, offset: 56242},
+											pos: position{line: 1463, col: 84, offset: 56172},
 											expr: &litMatcher{
-												pos:        position{line: 1466, col: 84, offset: 56242},
+												pos:        position{line: 1463, col: 84, offset: 56172},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
@@ -10419,29 +10411,29 @@ var g = &grammar{
 								},
 							},
 							&actionExpr{
-								pos: position{line: 1470, col: 6, offset: 56373},
+								pos: position{line: 1467, col: 6, offset: 56303},
 								run: (*parser).callonFirstLinkAttributeElement19,
 								expr: &seqExpr{
-									pos: position{line: 1470, col: 6, offset: 56373},
+									pos: position{line: 1467, col: 6, offset: 56303},
 									exprs: []interface{}{
 										&labeledExpr{
-											pos:   position{line: 1470, col: 6, offset: 56373},
+											pos:   position{line: 1467, col: 6, offset: 56303},
 											label: "elements",
 											expr: &oneOrMoreExpr{
-												pos: position{line: 1470, col: 15, offset: 56382},
+												pos: position{line: 1467, col: 15, offset: 56312},
 												expr: &choiceExpr{
-													pos: position{line: 1470, col: 16, offset: 56383},
+													pos: position{line: 1467, col: 16, offset: 56313},
 													alternatives: []interface{}{
 														&ruleRefExpr{
-															pos:  position{line: 1470, col: 16, offset: 56383},
+															pos:  position{line: 1467, col: 16, offset: 56313},
 															name: "QuotedString",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 1470, col: 31, offset: 56398},
+															pos:  position{line: 1467, col: 31, offset: 56328},
 															name: "QuotedText",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 1470, col: 44, offset: 56411},
+															pos:  position{line: 1467, col: 44, offset: 56341},
 															name: "UnquotedAttributeChar",
 														},
 													},
@@ -10449,11 +10441,11 @@ var g = &grammar{
 											},
 										},
 										&andExpr{
-											pos: position{line: 1470, col: 68, offset: 56435},
+											pos: position{line: 1467, col: 68, offset: 56365},
 											expr: &notExpr{
-												pos: position{line: 1470, col: 70, offset: 56437},
+												pos: position{line: 1467, col: 70, offset: 56367},
 												expr: &litMatcher{
-													pos:        position{line: 1470, col: 71, offset: 56438},
+													pos:        position{line: 1467, col: 71, offset: 56368},
 													val:        "=",
 													ignoreCase: false,
 													want:       "\"=\"",
@@ -10461,9 +10453,9 @@ var g = &grammar{
 											},
 										},
 										&zeroOrOneExpr{
-											pos: position{line: 1470, col: 76, offset: 56443},
+											pos: position{line: 1467, col: 76, offset: 56373},
 											expr: &litMatcher{
-												pos:        position{line: 1470, col: 76, offset: 56443},
+												pos:        position{line: 1467, col: 76, offset: 56373},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
@@ -10479,12 +10471,12 @@ var g = &grammar{
 		},
 		{
 			name: "AttributeChar",
-			pos:  position{line: 1476, col: 1, offset: 56563},
+			pos:  position{line: 1473, col: 1, offset: 56493},
 			expr: &actionExpr{
-				pos: position{line: 1476, col: 18, offset: 56580},
+				pos: position{line: 1473, col: 18, offset: 56510},
 				run: (*parser).callonAttributeChar1,
 				expr: &charClassMatcher{
-					pos:        position{line: 1476, col: 18, offset: 56580},
+					pos:        position{line: 1473, col: 18, offset: 56510},
 					val:        "[^\\r\\n\"=\\],]",
 					chars:      []rune{'\r', '\n', '"', '=', ']', ','},
 					ignoreCase: false,
@@ -10494,12 +10486,12 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedAttributeChar",
-			pos:  position{line: 1480, col: 1, offset: 56670},
+			pos:  position{line: 1477, col: 1, offset: 56600},
 			expr: &actionExpr{
-				pos: position{line: 1480, col: 24, offset: 56693},
+				pos: position{line: 1477, col: 24, offset: 56623},
 				run: (*parser).callonQuotedAttributeChar1,
 				expr: &charClassMatcher{
-					pos:        position{line: 1480, col: 24, offset: 56693},
+					pos:        position{line: 1477, col: 24, offset: 56623},
 					val:        "[^\\r\\n\"=\\]]",
 					chars:      []rune{'\r', '\n', '"', '=', ']'},
 					ignoreCase: false,
@@ -10509,12 +10501,12 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedAttributeChar",
-			pos:  position{line: 1484, col: 1, offset: 56790},
+			pos:  position{line: 1481, col: 1, offset: 56720},
 			expr: &actionExpr{
-				pos: position{line: 1484, col: 26, offset: 56815},
+				pos: position{line: 1481, col: 26, offset: 56745},
 				run: (*parser).callonUnquotedAttributeChar1,
 				expr: &charClassMatcher{
-					pos:        position{line: 1484, col: 26, offset: 56815},
+					pos:        position{line: 1481, col: 26, offset: 56745},
 					val:        "[^\\r\\n\"=\\],]",
 					chars:      []rune{'\r', '\n', '"', '=', ']', ','},
 					ignoreCase: false,
@@ -10524,46 +10516,46 @@ var g = &grammar{
 		},
 		{
 			name: "InlineLinks",
-			pos:  position{line: 1489, col: 1, offset: 56977},
+			pos:  position{line: 1486, col: 1, offset: 56907},
 			expr: &actionExpr{
-				pos: position{line: 1490, col: 5, offset: 56998},
+				pos: position{line: 1487, col: 5, offset: 56928},
 				run: (*parser).callonInlineLinks1,
 				expr: &seqExpr{
-					pos: position{line: 1490, col: 5, offset: 56998},
+					pos: position{line: 1487, col: 5, offset: 56928},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1490, col: 5, offset: 56998},
+							pos:   position{line: 1487, col: 5, offset: 56928},
 							label: "elements",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1490, col: 14, offset: 57007},
+								pos: position{line: 1487, col: 14, offset: 56937},
 								expr: &choiceExpr{
-									pos: position{line: 1490, col: 15, offset: 57008},
+									pos: position{line: 1487, col: 15, offset: 56938},
 									alternatives: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 1490, col: 15, offset: 57008},
+											pos:  position{line: 1487, col: 15, offset: 56938},
 											name: "Word",
 										},
 										&oneOrMoreExpr{
-											pos: position{line: 1491, col: 11, offset: 57024},
+											pos: position{line: 1488, col: 11, offset: 56954},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1491, col: 11, offset: 57024},
+												pos:  position{line: 1488, col: 11, offset: 56954},
 												name: "Space",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1492, col: 11, offset: 57043},
+											pos:  position{line: 1489, col: 11, offset: 56973},
 											name: "ResolvedLink",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1493, col: 11, offset: 57068},
+											pos:  position{line: 1490, col: 11, offset: 56998},
 											name: "Parenthesis",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1494, col: 11, offset: 57091},
+											pos:  position{line: 1491, col: 11, offset: 57021},
 											name: "AnyChar",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1495, col: 11, offset: 57110},
+											pos:  position{line: 1492, col: 11, offset: 57040},
 											name: "Newline",
 										},
 									},
@@ -10571,7 +10563,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1495, col: 21, offset: 57120},
+							pos:  position{line: 1492, col: 21, offset: 57050},
 							name: "EOF",
 						},
 					},
@@ -10580,16 +10572,16 @@ var g = &grammar{
 		},
 		{
 			name: "ResolvedLink",
-			pos:  position{line: 1499, col: 1, offset: 57194},
+			pos:  position{line: 1496, col: 1, offset: 57124},
 			expr: &choiceExpr{
-				pos: position{line: 1499, col: 17, offset: 57210},
+				pos: position{line: 1496, col: 17, offset: 57140},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1499, col: 17, offset: 57210},
+						pos:  position{line: 1496, col: 17, offset: 57140},
 						name: "ResolvedRelativeLink",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1499, col: 40, offset: 57233},
+						pos:  position{line: 1496, col: 40, offset: 57163},
 						name: "ResolvedExternalLink",
 					},
 				},
@@ -10597,41 +10589,41 @@ var g = &grammar{
 		},
 		{
 			name: "ResolvedRelativeLink",
-			pos:  position{line: 1502, col: 1, offset: 57364},
+			pos:  position{line: 1499, col: 1, offset: 57294},
 			expr: &actionExpr{
-				pos: position{line: 1502, col: 25, offset: 57388},
+				pos: position{line: 1499, col: 25, offset: 57318},
 				run: (*parser).callonResolvedRelativeLink1,
 				expr: &seqExpr{
-					pos: position{line: 1502, col: 25, offset: 57388},
+					pos: position{line: 1499, col: 25, offset: 57318},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1502, col: 25, offset: 57388},
+							pos:        position{line: 1499, col: 25, offset: 57318},
 							val:        "link:",
 							ignoreCase: false,
 							want:       "\"link:\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1502, col: 33, offset: 57396},
+							pos:   position{line: 1499, col: 33, offset: 57326},
 							label: "url",
 							expr: &choiceExpr{
-								pos: position{line: 1502, col: 38, offset: 57401},
+								pos: position{line: 1499, col: 38, offset: 57331},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1502, col: 38, offset: 57401},
+										pos:  position{line: 1499, col: 38, offset: 57331},
 										name: "ResolvedLocation",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1502, col: 57, offset: 57420},
+										pos:  position{line: 1499, col: 57, offset: 57350},
 										name: "ResolvedFileLocation",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1502, col: 79, offset: 57442},
+							pos:   position{line: 1499, col: 79, offset: 57372},
 							label: "inlineAttributes",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1502, col: 97, offset: 57460},
+								pos:  position{line: 1499, col: 97, offset: 57390},
 								name: "LinkAttributes",
 							},
 						},
@@ -10641,28 +10633,28 @@ var g = &grammar{
 		},
 		{
 			name: "ResolvedExternalLink",
-			pos:  position{line: 1506, col: 1, offset: 57575},
+			pos:  position{line: 1503, col: 1, offset: 57505},
 			expr: &actionExpr{
-				pos: position{line: 1506, col: 25, offset: 57599},
+				pos: position{line: 1503, col: 25, offset: 57529},
 				run: (*parser).callonResolvedExternalLink1,
 				expr: &seqExpr{
-					pos: position{line: 1506, col: 25, offset: 57599},
+					pos: position{line: 1503, col: 25, offset: 57529},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1506, col: 25, offset: 57599},
+							pos:   position{line: 1503, col: 25, offset: 57529},
 							label: "url",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1506, col: 30, offset: 57604},
+								pos:  position{line: 1503, col: 30, offset: 57534},
 								name: "ResolvedLocation",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1506, col: 48, offset: 57622},
+							pos:   position{line: 1503, col: 48, offset: 57552},
 							label: "inlineAttributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1506, col: 65, offset: 57639},
+								pos: position{line: 1503, col: 65, offset: 57569},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1506, col: 66, offset: 57640},
+									pos:  position{line: 1503, col: 66, offset: 57570},
 									name: "LinkAttributes",
 								},
 							},
@@ -10673,55 +10665,55 @@ var g = &grammar{
 		},
 		{
 			name: "ImageBlock",
-			pos:  position{line: 1513, col: 1, offset: 57842},
+			pos:  position{line: 1510, col: 1, offset: 57772},
 			expr: &actionExpr{
-				pos: position{line: 1513, col: 15, offset: 57856},
+				pos: position{line: 1510, col: 15, offset: 57786},
 				run: (*parser).callonImageBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1513, col: 15, offset: 57856},
+					pos: position{line: 1510, col: 15, offset: 57786},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1513, col: 15, offset: 57856},
+							pos:   position{line: 1510, col: 15, offset: 57786},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1513, col: 26, offset: 57867},
+								pos: position{line: 1510, col: 26, offset: 57797},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1513, col: 27, offset: 57868},
+									pos:  position{line: 1510, col: 27, offset: 57798},
 									name: "Attributes",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1513, col: 40, offset: 57881},
+							pos:        position{line: 1510, col: 40, offset: 57811},
 							val:        "image::",
 							ignoreCase: false,
 							want:       "\"image::\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1513, col: 50, offset: 57891},
+							pos:   position{line: 1510, col: 50, offset: 57821},
 							label: "path",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1513, col: 56, offset: 57897},
+								pos:  position{line: 1510, col: 56, offset: 57827},
 								name: "Location",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1513, col: 66, offset: 57907},
+							pos:   position{line: 1510, col: 66, offset: 57837},
 							label: "inlineAttributes",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1513, col: 84, offset: 57925},
+								pos:  position{line: 1510, col: 84, offset: 57855},
 								name: "ImageAttributes",
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1513, col: 101, offset: 57942},
+							pos: position{line: 1510, col: 101, offset: 57872},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1513, col: 101, offset: 57942},
+								pos:  position{line: 1510, col: 101, offset: 57872},
 								name: "Space",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1513, col: 108, offset: 57949},
+							pos:  position{line: 1510, col: 108, offset: 57879},
 							name: "EOL",
 						},
 					},
@@ -10730,41 +10722,41 @@ var g = &grammar{
 		},
 		{
 			name: "InlineImage",
-			pos:  position{line: 1517, col: 1, offset: 58065},
+			pos:  position{line: 1514, col: 1, offset: 57995},
 			expr: &actionExpr{
-				pos: position{line: 1517, col: 16, offset: 58080},
+				pos: position{line: 1514, col: 16, offset: 58010},
 				run: (*parser).callonInlineImage1,
 				expr: &seqExpr{
-					pos: position{line: 1517, col: 16, offset: 58080},
+					pos: position{line: 1514, col: 16, offset: 58010},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1517, col: 16, offset: 58080},
+							pos:        position{line: 1514, col: 16, offset: 58010},
 							val:        "image:",
 							ignoreCase: false,
 							want:       "\"image:\"",
 						},
 						&notExpr{
-							pos: position{line: 1517, col: 25, offset: 58089},
+							pos: position{line: 1514, col: 25, offset: 58019},
 							expr: &litMatcher{
-								pos:        position{line: 1517, col: 26, offset: 58090},
+								pos:        position{line: 1514, col: 26, offset: 58020},
 								val:        ":",
 								ignoreCase: false,
 								want:       "\":\"",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1517, col: 30, offset: 58094},
+							pos:   position{line: 1514, col: 30, offset: 58024},
 							label: "path",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1517, col: 36, offset: 58100},
+								pos:  position{line: 1514, col: 36, offset: 58030},
 								name: "Location",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1517, col: 46, offset: 58110},
+							pos:   position{line: 1514, col: 46, offset: 58040},
 							label: "inlineAttributes",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1517, col: 64, offset: 58128},
+								pos:  position{line: 1514, col: 64, offset: 58058},
 								name: "ImageAttributes",
 							},
 						},
@@ -10774,99 +10766,99 @@ var g = &grammar{
 		},
 		{
 			name: "ImageAttributes",
-			pos:  position{line: 1521, col: 1, offset: 58246},
+			pos:  position{line: 1518, col: 1, offset: 58176},
 			expr: &actionExpr{
-				pos: position{line: 1521, col: 20, offset: 58265},
+				pos: position{line: 1518, col: 20, offset: 58195},
 				run: (*parser).callonImageAttributes1,
 				expr: &seqExpr{
-					pos: position{line: 1521, col: 20, offset: 58265},
+					pos: position{line: 1518, col: 20, offset: 58195},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1521, col: 20, offset: 58265},
+							pos:        position{line: 1518, col: 20, offset: 58195},
 							val:        "[",
 							ignoreCase: false,
 							want:       "\"[\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1521, col: 24, offset: 58269},
+							pos:   position{line: 1518, col: 24, offset: 58199},
 							label: "alt",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1521, col: 28, offset: 58273},
+								pos: position{line: 1518, col: 28, offset: 58203},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1521, col: 29, offset: 58274},
+									pos:  position{line: 1518, col: 29, offset: 58204},
 									name: "StandaloneAttributeValue",
 								},
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 1521, col: 56, offset: 58301},
+							pos: position{line: 1518, col: 56, offset: 58231},
 							expr: &litMatcher{
-								pos:        position{line: 1521, col: 56, offset: 58301},
+								pos:        position{line: 1518, col: 56, offset: 58231},
 								val:        ",",
 								ignoreCase: false,
 								want:       "\",\"",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1521, col: 61, offset: 58306},
+							pos:   position{line: 1518, col: 61, offset: 58236},
 							label: "width",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1521, col: 67, offset: 58312},
+								pos: position{line: 1518, col: 67, offset: 58242},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1521, col: 68, offset: 58313},
+									pos:  position{line: 1518, col: 68, offset: 58243},
 									name: "StandaloneAttributeValue",
 								},
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 1521, col: 95, offset: 58340},
+							pos: position{line: 1518, col: 95, offset: 58270},
 							expr: &litMatcher{
-								pos:        position{line: 1521, col: 95, offset: 58340},
+								pos:        position{line: 1518, col: 95, offset: 58270},
 								val:        ",",
 								ignoreCase: false,
 								want:       "\",\"",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1521, col: 100, offset: 58345},
+							pos:   position{line: 1518, col: 100, offset: 58275},
 							label: "height",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1521, col: 107, offset: 58352},
+								pos: position{line: 1518, col: 107, offset: 58282},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1521, col: 108, offset: 58353},
+									pos:  position{line: 1518, col: 108, offset: 58283},
 									name: "StandaloneAttributeValue",
 								},
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 1521, col: 135, offset: 58380},
+							pos: position{line: 1518, col: 135, offset: 58310},
 							expr: &litMatcher{
-								pos:        position{line: 1521, col: 135, offset: 58380},
+								pos:        position{line: 1518, col: 135, offset: 58310},
 								val:        ",",
 								ignoreCase: false,
 								want:       "\",\"",
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1521, col: 140, offset: 58385},
+							pos: position{line: 1518, col: 140, offset: 58315},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1521, col: 140, offset: 58385},
+								pos:  position{line: 1518, col: 140, offset: 58315},
 								name: "Space",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1521, col: 147, offset: 58392},
+							pos:   position{line: 1518, col: 147, offset: 58322},
 							label: "otherattrs",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1521, col: 158, offset: 58403},
+								pos: position{line: 1518, col: 158, offset: 58333},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1521, col: 159, offset: 58404},
+									pos:  position{line: 1518, col: 159, offset: 58334},
 									name: "GenericAttribute",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1521, col: 178, offset: 58423},
+							pos:        position{line: 1518, col: 178, offset: 58353},
 							val:        "]",
 							ignoreCase: false,
 							want:       "\"]\"",
@@ -10877,29 +10869,29 @@ var g = &grammar{
 		},
 		{
 			name: "InlineIcon",
-			pos:  position{line: 1528, col: 1, offset: 58715},
+			pos:  position{line: 1525, col: 1, offset: 58645},
 			expr: &actionExpr{
-				pos: position{line: 1528, col: 15, offset: 58729},
+				pos: position{line: 1525, col: 15, offset: 58659},
 				run: (*parser).callonInlineIcon1,
 				expr: &seqExpr{
-					pos: position{line: 1528, col: 15, offset: 58729},
+					pos: position{line: 1525, col: 15, offset: 58659},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1528, col: 15, offset: 58729},
+							pos:        position{line: 1525, col: 15, offset: 58659},
 							val:        "icon:",
 							ignoreCase: false,
 							want:       "\"icon:\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1528, col: 23, offset: 58737},
+							pos:   position{line: 1525, col: 23, offset: 58667},
 							label: "iconClass",
 							expr: &actionExpr{
-								pos: position{line: 1528, col: 34, offset: 58748},
+								pos: position{line: 1525, col: 34, offset: 58678},
 								run: (*parser).callonInlineIcon5,
 								expr: &oneOrMoreExpr{
-									pos: position{line: 1528, col: 34, offset: 58748},
+									pos: position{line: 1525, col: 34, offset: 58678},
 									expr: &charClassMatcher{
-										pos:        position{line: 1528, col: 34, offset: 58748},
+										pos:        position{line: 1525, col: 34, offset: 58678},
 										val:        "[\\pL0-9_-]",
 										chars:      []rune{'_', '-'},
 										ranges:     []rune{'0', '9'},
@@ -10911,10 +10903,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1528, col: 78, offset: 58792},
+							pos:   position{line: 1525, col: 78, offset: 58722},
 							label: "inlineAttributes",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1528, col: 96, offset: 58810},
+								pos:  position{line: 1525, col: 96, offset: 58740},
 								name: "IconAttributes",
 							},
 						},
@@ -10924,59 +10916,59 @@ var g = &grammar{
 		},
 		{
 			name: "IconAttributes",
-			pos:  position{line: 1532, col: 1, offset: 58917},
+			pos:  position{line: 1529, col: 1, offset: 58847},
 			expr: &actionExpr{
-				pos: position{line: 1532, col: 19, offset: 58935},
+				pos: position{line: 1529, col: 19, offset: 58865},
 				run: (*parser).callonIconAttributes1,
 				expr: &seqExpr{
-					pos: position{line: 1532, col: 19, offset: 58935},
+					pos: position{line: 1529, col: 19, offset: 58865},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1532, col: 19, offset: 58935},
+							pos:        position{line: 1529, col: 19, offset: 58865},
 							val:        "[",
 							ignoreCase: false,
 							want:       "\"[\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1532, col: 23, offset: 58939},
+							pos:   position{line: 1529, col: 23, offset: 58869},
 							label: "size",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1532, col: 28, offset: 58944},
+								pos: position{line: 1529, col: 28, offset: 58874},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1532, col: 29, offset: 58945},
+									pos:  position{line: 1529, col: 29, offset: 58875},
 									name: "StandaloneAttributeValue",
 								},
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 1532, col: 56, offset: 58972},
+							pos: position{line: 1529, col: 56, offset: 58902},
 							expr: &litMatcher{
-								pos:        position{line: 1532, col: 56, offset: 58972},
+								pos:        position{line: 1529, col: 56, offset: 58902},
 								val:        ",",
 								ignoreCase: false,
 								want:       "\",\"",
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1532, col: 61, offset: 58977},
+							pos: position{line: 1529, col: 61, offset: 58907},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1532, col: 61, offset: 58977},
+								pos:  position{line: 1529, col: 61, offset: 58907},
 								name: "Space",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1532, col: 68, offset: 58984},
+							pos:   position{line: 1529, col: 68, offset: 58914},
 							label: "others",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1532, col: 75, offset: 58991},
+								pos: position{line: 1529, col: 75, offset: 58921},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1532, col: 76, offset: 58992},
+									pos:  position{line: 1529, col: 76, offset: 58922},
 									name: "GenericAttribute",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1532, col: 95, offset: 59011},
+							pos:        position{line: 1529, col: 95, offset: 58941},
 							val:        "]",
 							ignoreCase: false,
 							want:       "\"]\"",
@@ -10987,32 +10979,32 @@ var g = &grammar{
 		},
 		{
 			name: "InlineFootnote",
-			pos:  position{line: 1539, col: 1, offset: 59289},
+			pos:  position{line: 1536, col: 1, offset: 59219},
 			expr: &choiceExpr{
-				pos: position{line: 1539, col: 19, offset: 59307},
+				pos: position{line: 1536, col: 19, offset: 59237},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1539, col: 19, offset: 59307},
+						pos: position{line: 1536, col: 19, offset: 59237},
 						run: (*parser).callonInlineFootnote2,
 						expr: &seqExpr{
-							pos: position{line: 1539, col: 19, offset: 59307},
+							pos: position{line: 1536, col: 19, offset: 59237},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1539, col: 19, offset: 59307},
+									pos:        position{line: 1536, col: 19, offset: 59237},
 									val:        "footnote:[",
 									ignoreCase: false,
 									want:       "\"footnote:[\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1539, col: 32, offset: 59320},
+									pos:   position{line: 1536, col: 32, offset: 59250},
 									label: "content",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1539, col: 41, offset: 59329},
+										pos:  position{line: 1536, col: 41, offset: 59259},
 										name: "FootnoteContent",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1539, col: 58, offset: 59346},
+									pos:        position{line: 1536, col: 58, offset: 59276},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -11021,44 +11013,44 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1541, col: 5, offset: 59416},
+						pos: position{line: 1538, col: 5, offset: 59346},
 						run: (*parser).callonInlineFootnote8,
 						expr: &seqExpr{
-							pos: position{line: 1541, col: 5, offset: 59416},
+							pos: position{line: 1538, col: 5, offset: 59346},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1541, col: 5, offset: 59416},
+									pos:        position{line: 1538, col: 5, offset: 59346},
 									val:        "footnote:",
 									ignoreCase: false,
 									want:       "\"footnote:\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1541, col: 17, offset: 59428},
+									pos:   position{line: 1538, col: 17, offset: 59358},
 									label: "ref",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1541, col: 22, offset: 59433},
+										pos:  position{line: 1538, col: 22, offset: 59363},
 										name: "FootnoteRef",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1541, col: 35, offset: 59446},
+									pos:        position{line: 1538, col: 35, offset: 59376},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1541, col: 39, offset: 59450},
+									pos:   position{line: 1538, col: 39, offset: 59380},
 									label: "content",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1541, col: 47, offset: 59458},
+										pos: position{line: 1538, col: 47, offset: 59388},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1541, col: 48, offset: 59459},
+											pos:  position{line: 1538, col: 48, offset: 59389},
 											name: "FootnoteContent",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1541, col: 66, offset: 59477},
+									pos:        position{line: 1538, col: 66, offset: 59407},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -11071,37 +11063,37 @@ var g = &grammar{
 		},
 		{
 			name: "FootnoteRef",
-			pos:  position{line: 1545, col: 1, offset: 59542},
+			pos:  position{line: 1542, col: 1, offset: 59472},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1545, col: 16, offset: 59557},
+				pos:  position{line: 1542, col: 16, offset: 59487},
 				name: "Alphanums",
 			},
 		},
 		{
 			name: "FootnoteContent",
-			pos:  position{line: 1547, col: 1, offset: 59570},
+			pos:  position{line: 1544, col: 1, offset: 59500},
 			expr: &actionExpr{
-				pos: position{line: 1547, col: 20, offset: 59589},
+				pos: position{line: 1544, col: 20, offset: 59519},
 				run: (*parser).callonFootnoteContent1,
 				expr: &labeledExpr{
-					pos:   position{line: 1547, col: 20, offset: 59589},
+					pos:   position{line: 1544, col: 20, offset: 59519},
 					label: "elements",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 1547, col: 29, offset: 59598},
+						pos: position{line: 1544, col: 29, offset: 59528},
 						expr: &seqExpr{
-							pos: position{line: 1547, col: 30, offset: 59599},
+							pos: position{line: 1544, col: 30, offset: 59529},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1547, col: 30, offset: 59599},
+									pos: position{line: 1544, col: 30, offset: 59529},
 									expr: &litMatcher{
-										pos:        position{line: 1547, col: 31, offset: 59600},
+										pos:        position{line: 1544, col: 31, offset: 59530},
 										val:        "]",
 										ignoreCase: false,
 										want:       "\"]\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1547, col: 35, offset: 59604},
+									pos:  position{line: 1544, col: 35, offset: 59534},
 									name: "InlineElement",
 								},
 							},
@@ -11112,64 +11104,64 @@ var g = &grammar{
 		},
 		{
 			name: "DelimitedBlock",
-			pos:  position{line: 1554, col: 1, offset: 59935},
+			pos:  position{line: 1551, col: 1, offset: 59865},
 			expr: &actionExpr{
-				pos: position{line: 1554, col: 19, offset: 59953},
+				pos: position{line: 1551, col: 19, offset: 59883},
 				run: (*parser).callonDelimitedBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1554, col: 19, offset: 59953},
+					pos: position{line: 1551, col: 19, offset: 59883},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1554, col: 19, offset: 59953},
+							pos: position{line: 1551, col: 19, offset: 59883},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1554, col: 20, offset: 59954},
+								pos:  position{line: 1551, col: 20, offset: 59884},
 								name: "Alphanum",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1555, col: 5, offset: 60043},
+							pos:   position{line: 1552, col: 5, offset: 59973},
 							label: "block",
 							expr: &choiceExpr{
-								pos: position{line: 1555, col: 12, offset: 60050},
+								pos: position{line: 1552, col: 12, offset: 59980},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1555, col: 12, offset: 60050},
+										pos:  position{line: 1552, col: 12, offset: 59980},
 										name: "FencedBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1556, col: 11, offset: 60074},
+										pos:  position{line: 1553, col: 11, offset: 60004},
 										name: "ListingBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1557, col: 11, offset: 60099},
+										pos:  position{line: 1554, col: 11, offset: 60029},
 										name: "ExampleBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1558, col: 11, offset: 60124},
+										pos:  position{line: 1555, col: 11, offset: 60054},
 										name: "VerseBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1559, col: 11, offset: 60147},
+										pos:  position{line: 1556, col: 11, offset: 60077},
 										name: "QuoteBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1560, col: 11, offset: 60170},
+										pos:  position{line: 1557, col: 11, offset: 60100},
 										name: "SidebarBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1561, col: 11, offset: 60194},
+										pos:  position{line: 1558, col: 11, offset: 60124},
 										name: "SingleLineComment",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1562, col: 11, offset: 60223},
+										pos:  position{line: 1559, col: 11, offset: 60153},
 										name: "PassthroughBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1563, col: 11, offset: 60251},
+										pos:  position{line: 1560, col: 11, offset: 60181},
 										name: "Table",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1564, col: 11, offset: 60268},
+										pos:  position{line: 1561, col: 11, offset: 60198},
 										name: "CommentBlock",
 									},
 								},
@@ -11181,52 +11173,52 @@ var g = &grammar{
 		},
 		{
 			name: "BlockDelimiter",
-			pos:  position{line: 1568, col: 1, offset: 60313},
+			pos:  position{line: 1565, col: 1, offset: 60243},
 			expr: &choiceExpr{
-				pos: position{line: 1568, col: 19, offset: 60331},
+				pos: position{line: 1565, col: 19, offset: 60261},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 1568, col: 19, offset: 60331},
+						pos: position{line: 1565, col: 19, offset: 60261},
 						exprs: []interface{}{
 							&notExpr{
-								pos: position{line: 1568, col: 19, offset: 60331},
+								pos: position{line: 1565, col: 19, offset: 60261},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1568, col: 21, offset: 60333},
+									pos:  position{line: 1565, col: 21, offset: 60263},
 									name: "Alphanum",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1568, col: 31, offset: 60343},
+								pos:  position{line: 1565, col: 31, offset: 60273},
 								name: "LiteralBlockDelimiter",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1569, col: 19, offset: 60415},
+						pos:  position{line: 1566, col: 19, offset: 60345},
 						name: "FencedBlockDelimiter",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1570, col: 19, offset: 60456},
+						pos:  position{line: 1567, col: 19, offset: 60386},
 						name: "ListingBlockDelimiter",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1571, col: 19, offset: 60498},
+						pos:  position{line: 1568, col: 19, offset: 60428},
 						name: "ExampleBlockDelimiter",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1572, col: 19, offset: 60540},
+						pos:  position{line: 1569, col: 19, offset: 60470},
 						name: "CommentBlockDelimiter",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1573, col: 19, offset: 60582},
+						pos:  position{line: 1570, col: 19, offset: 60512},
 						name: "QuoteBlockDelimiter",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1574, col: 19, offset: 60621},
+						pos:  position{line: 1571, col: 19, offset: 60551},
 						name: "SidebarBlockDelimiter",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1575, col: 19, offset: 60662},
+						pos:  position{line: 1572, col: 19, offset: 60592},
 						name: "PassthroughBlockDelimiter",
 					},
 				},
@@ -11234,16 +11226,16 @@ var g = &grammar{
 		},
 		{
 			name: "VerbatimContent",
-			pos:  position{line: 1577, col: 1, offset: 60691},
+			pos:  position{line: 1574, col: 1, offset: 60621},
 			expr: &choiceExpr{
-				pos: position{line: 1577, col: 20, offset: 60710},
+				pos: position{line: 1574, col: 20, offset: 60640},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1577, col: 20, offset: 60710},
+						pos:  position{line: 1574, col: 20, offset: 60640},
 						name: "FileInclusion",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1577, col: 36, offset: 60726},
+						pos:  position{line: 1574, col: 36, offset: 60656},
 						name: "VerbatimLine",
 					},
 				},
@@ -11251,41 +11243,41 @@ var g = &grammar{
 		},
 		{
 			name: "VerbatimLine",
-			pos:  position{line: 1579, col: 1, offset: 60742},
+			pos:  position{line: 1576, col: 1, offset: 60672},
 			expr: &actionExpr{
-				pos: position{line: 1579, col: 17, offset: 60758},
+				pos: position{line: 1576, col: 17, offset: 60688},
 				run: (*parser).callonVerbatimLine1,
 				expr: &seqExpr{
-					pos: position{line: 1579, col: 17, offset: 60758},
+					pos: position{line: 1576, col: 17, offset: 60688},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1579, col: 17, offset: 60758},
+							pos: position{line: 1576, col: 17, offset: 60688},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1579, col: 18, offset: 60759},
+								pos:  position{line: 1576, col: 18, offset: 60689},
 								name: "EOF",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1579, col: 22, offset: 60763},
+							pos:   position{line: 1576, col: 22, offset: 60693},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1579, col: 31, offset: 60772},
+								pos:  position{line: 1576, col: 31, offset: 60702},
 								name: "VerbatimLineContent",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1579, col: 52, offset: 60793},
+							pos:   position{line: 1576, col: 52, offset: 60723},
 							label: "callouts",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1579, col: 61, offset: 60802},
+								pos: position{line: 1576, col: 61, offset: 60732},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1579, col: 62, offset: 60803},
+									pos:  position{line: 1576, col: 62, offset: 60733},
 									name: "Callouts",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1579, col: 73, offset: 60814},
+							pos:  position{line: 1576, col: 73, offset: 60744},
 							name: "EOL",
 						},
 					},
@@ -11294,36 +11286,36 @@ var g = &grammar{
 		},
 		{
 			name: "VerbatimLineContent",
-			pos:  position{line: 1583, col: 1, offset: 60888},
+			pos:  position{line: 1580, col: 1, offset: 60818},
 			expr: &actionExpr{
-				pos: position{line: 1583, col: 24, offset: 60911},
+				pos: position{line: 1580, col: 24, offset: 60841},
 				run: (*parser).callonVerbatimLineContent1,
 				expr: &zeroOrMoreExpr{
-					pos: position{line: 1583, col: 24, offset: 60911},
+					pos: position{line: 1580, col: 24, offset: 60841},
 					expr: &seqExpr{
-						pos: position{line: 1583, col: 25, offset: 60912},
+						pos: position{line: 1580, col: 25, offset: 60842},
 						exprs: []interface{}{
 							&notExpr{
-								pos: position{line: 1583, col: 25, offset: 60912},
+								pos: position{line: 1580, col: 25, offset: 60842},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1583, col: 26, offset: 60913},
+									pos:  position{line: 1580, col: 26, offset: 60843},
 									name: "Callouts",
 								},
 							},
 							&choiceExpr{
-								pos: position{line: 1583, col: 36, offset: 60923},
+								pos: position{line: 1580, col: 36, offset: 60853},
 								alternatives: []interface{}{
 									&oneOrMoreExpr{
-										pos: position{line: 1583, col: 36, offset: 60923},
+										pos: position{line: 1580, col: 36, offset: 60853},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1583, col: 36, offset: 60923},
+											pos:  position{line: 1580, col: 36, offset: 60853},
 											name: "Space",
 										},
 									},
 									&oneOrMoreExpr{
-										pos: position{line: 1583, col: 45, offset: 60932},
+										pos: position{line: 1580, col: 45, offset: 60862},
 										expr: &charClassMatcher{
-											pos:        position{line: 1583, col: 45, offset: 60932},
+											pos:        position{line: 1580, col: 45, offset: 60862},
 											val:        "[^ \\r\\n]",
 											chars:      []rune{' ', '\r', '\n'},
 											ignoreCase: false,
@@ -11339,40 +11331,40 @@ var g = &grammar{
 		},
 		{
 			name: "Callouts",
-			pos:  position{line: 1587, col: 1, offset: 60986},
+			pos:  position{line: 1584, col: 1, offset: 60916},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 1587, col: 13, offset: 60998},
+				pos: position{line: 1584, col: 13, offset: 60928},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1587, col: 13, offset: 60998},
+					pos:  position{line: 1584, col: 13, offset: 60928},
 					name: "Callout",
 				},
 			},
 		},
 		{
 			name: "Callout",
-			pos:  position{line: 1589, col: 1, offset: 61010},
+			pos:  position{line: 1586, col: 1, offset: 60940},
 			expr: &actionExpr{
-				pos: position{line: 1589, col: 12, offset: 61021},
+				pos: position{line: 1586, col: 12, offset: 60951},
 				run: (*parser).callonCallout1,
 				expr: &seqExpr{
-					pos: position{line: 1589, col: 12, offset: 61021},
+					pos: position{line: 1586, col: 12, offset: 60951},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1589, col: 12, offset: 61021},
+							pos:        position{line: 1586, col: 12, offset: 60951},
 							val:        "<",
 							ignoreCase: false,
 							want:       "\"<\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1589, col: 16, offset: 61025},
+							pos:   position{line: 1586, col: 16, offset: 60955},
 							label: "ref",
 							expr: &actionExpr{
-								pos: position{line: 1589, col: 21, offset: 61030},
+								pos: position{line: 1586, col: 21, offset: 60960},
 								run: (*parser).callonCallout5,
 								expr: &oneOrMoreExpr{
-									pos: position{line: 1589, col: 21, offset: 61030},
+									pos: position{line: 1586, col: 21, offset: 60960},
 									expr: &charClassMatcher{
-										pos:        position{line: 1589, col: 21, offset: 61030},
+										pos:        position{line: 1586, col: 21, offset: 60960},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -11382,29 +11374,29 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1589, col: 69, offset: 61078},
+							pos:        position{line: 1586, col: 69, offset: 61008},
 							val:        ">",
 							ignoreCase: false,
 							want:       "\">\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1589, col: 73, offset: 61082},
+							pos: position{line: 1586, col: 73, offset: 61012},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1589, col: 73, offset: 61082},
+								pos:  position{line: 1586, col: 73, offset: 61012},
 								name: "Space",
 							},
 						},
 						&andExpr{
-							pos: position{line: 1589, col: 80, offset: 61089},
+							pos: position{line: 1586, col: 80, offset: 61019},
 							expr: &choiceExpr{
-								pos: position{line: 1589, col: 82, offset: 61091},
+								pos: position{line: 1586, col: 82, offset: 61021},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1589, col: 82, offset: 61091},
+										pos:  position{line: 1586, col: 82, offset: 61021},
 										name: "EOL",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1589, col: 88, offset: 61097},
+										pos:  position{line: 1586, col: 88, offset: 61027},
 										name: "Callout",
 									},
 								},
@@ -11416,28 +11408,28 @@ var g = &grammar{
 		},
 		{
 			name: "CalloutListItem",
-			pos:  position{line: 1593, col: 1, offset: 61154},
+			pos:  position{line: 1590, col: 1, offset: 61084},
 			expr: &actionExpr{
-				pos: position{line: 1593, col: 20, offset: 61173},
+				pos: position{line: 1590, col: 20, offset: 61103},
 				run: (*parser).callonCalloutListItem1,
 				expr: &seqExpr{
-					pos: position{line: 1593, col: 20, offset: 61173},
+					pos: position{line: 1590, col: 20, offset: 61103},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1593, col: 20, offset: 61173},
+							pos:   position{line: 1590, col: 20, offset: 61103},
 							label: "ref",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1593, col: 25, offset: 61178},
+								pos:  position{line: 1590, col: 25, offset: 61108},
 								name: "CalloutListItemPrefix",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1593, col: 48, offset: 61201},
+							pos:   position{line: 1590, col: 48, offset: 61131},
 							label: "description",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1593, col: 61, offset: 61214},
+								pos: position{line: 1590, col: 61, offset: 61144},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1593, col: 61, offset: 61214},
+									pos:  position{line: 1590, col: 61, offset: 61144},
 									name: "ListParagraph",
 								},
 							},
@@ -11448,29 +11440,29 @@ var g = &grammar{
 		},
 		{
 			name: "CalloutListItemPrefix",
-			pos:  position{line: 1597, col: 1, offset: 61315},
+			pos:  position{line: 1594, col: 1, offset: 61245},
 			expr: &actionExpr{
-				pos: position{line: 1597, col: 26, offset: 61340},
+				pos: position{line: 1594, col: 26, offset: 61270},
 				run: (*parser).callonCalloutListItemPrefix1,
 				expr: &seqExpr{
-					pos: position{line: 1597, col: 26, offset: 61340},
+					pos: position{line: 1594, col: 26, offset: 61270},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1597, col: 26, offset: 61340},
+							pos:        position{line: 1594, col: 26, offset: 61270},
 							val:        "<",
 							ignoreCase: false,
 							want:       "\"<\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1597, col: 30, offset: 61344},
+							pos:   position{line: 1594, col: 30, offset: 61274},
 							label: "ref",
 							expr: &actionExpr{
-								pos: position{line: 1597, col: 35, offset: 61349},
+								pos: position{line: 1594, col: 35, offset: 61279},
 								run: (*parser).callonCalloutListItemPrefix5,
 								expr: &oneOrMoreExpr{
-									pos: position{line: 1597, col: 35, offset: 61349},
+									pos: position{line: 1594, col: 35, offset: 61279},
 									expr: &charClassMatcher{
-										pos:        position{line: 1597, col: 35, offset: 61349},
+										pos:        position{line: 1594, col: 35, offset: 61279},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -11480,15 +11472,15 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1597, col: 83, offset: 61397},
+							pos:        position{line: 1594, col: 83, offset: 61327},
 							val:        ">",
 							ignoreCase: false,
 							want:       "\">\"",
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 1597, col: 87, offset: 61401},
+							pos: position{line: 1594, col: 87, offset: 61331},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1597, col: 87, offset: 61401},
+								pos:  position{line: 1594, col: 87, offset: 61331},
 								name: "Space",
 							},
 						},
@@ -11498,25 +11490,25 @@ var g = &grammar{
 		},
 		{
 			name: "FencedBlockDelimiter",
-			pos:  position{line: 1604, col: 1, offset: 61635},
+			pos:  position{line: 1601, col: 1, offset: 61565},
 			expr: &seqExpr{
-				pos: position{line: 1604, col: 25, offset: 61659},
+				pos: position{line: 1601, col: 25, offset: 61589},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1604, col: 25, offset: 61659},
+						pos:        position{line: 1601, col: 25, offset: 61589},
 						val:        "```",
 						ignoreCase: false,
 						want:       "\"```\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1604, col: 31, offset: 61665},
+						pos: position{line: 1601, col: 31, offset: 61595},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1604, col: 31, offset: 61665},
+							pos:  position{line: 1601, col: 31, offset: 61595},
 							name: "Space",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1604, col: 38, offset: 61672},
+						pos:  position{line: 1601, col: 38, offset: 61602},
 						name: "EOL",
 					},
 				},
@@ -11524,25 +11516,25 @@ var g = &grammar{
 		},
 		{
 			name: "FencedBlockStartDelimiter",
-			pos:  position{line: 1606, col: 1, offset: 61734},
+			pos:  position{line: 1603, col: 1, offset: 61664},
 			expr: &seqExpr{
-				pos: position{line: 1606, col: 30, offset: 61763},
+				pos: position{line: 1603, col: 30, offset: 61693},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1606, col: 30, offset: 61763},
+						pos:        position{line: 1603, col: 30, offset: 61693},
 						val:        "```",
 						ignoreCase: false,
 						want:       "\"```\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1606, col: 36, offset: 61769},
+						pos: position{line: 1603, col: 36, offset: 61699},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1606, col: 36, offset: 61769},
+							pos:  position{line: 1603, col: 36, offset: 61699},
 							name: "Space",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1606, col: 43, offset: 61776},
+						pos:  position{line: 1603, col: 43, offset: 61706},
 						name: "EOL",
 					},
 				},
@@ -11550,34 +11542,34 @@ var g = &grammar{
 		},
 		{
 			name: "FencedBlockEndDelimiter",
-			pos:  position{line: 1608, col: 1, offset: 61783},
+			pos:  position{line: 1605, col: 1, offset: 61713},
 			expr: &choiceExpr{
-				pos: position{line: 1608, col: 28, offset: 61810},
+				pos: position{line: 1605, col: 28, offset: 61740},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 1608, col: 29, offset: 61811},
+						pos: position{line: 1605, col: 29, offset: 61741},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 1608, col: 29, offset: 61811},
+								pos:        position{line: 1605, col: 29, offset: 61741},
 								val:        "```",
 								ignoreCase: false,
 								want:       "\"```\"",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 1608, col: 35, offset: 61817},
+								pos: position{line: 1605, col: 35, offset: 61747},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1608, col: 35, offset: 61817},
+									pos:  position{line: 1605, col: 35, offset: 61747},
 									name: "Space",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1608, col: 42, offset: 61824},
+								pos:  position{line: 1605, col: 42, offset: 61754},
 								name: "EOL",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1608, col: 49, offset: 61831},
+						pos:  position{line: 1605, col: 49, offset: 61761},
 						name: "EOF",
 					},
 				},
@@ -11585,38 +11577,38 @@ var g = &grammar{
 		},
 		{
 			name: "FencedBlock",
-			pos:  position{line: 1610, col: 1, offset: 61838},
+			pos:  position{line: 1607, col: 1, offset: 61768},
 			expr: &actionExpr{
-				pos: position{line: 1610, col: 16, offset: 61853},
+				pos: position{line: 1607, col: 16, offset: 61783},
 				run: (*parser).callonFencedBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1610, col: 16, offset: 61853},
+					pos: position{line: 1607, col: 16, offset: 61783},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1610, col: 16, offset: 61853},
+							pos:   position{line: 1607, col: 16, offset: 61783},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1610, col: 27, offset: 61864},
+								pos: position{line: 1607, col: 27, offset: 61794},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1610, col: 28, offset: 61865},
+									pos:  position{line: 1607, col: 28, offset: 61795},
 									name: "Attributes",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1610, col: 41, offset: 61878},
+							pos:  position{line: 1607, col: 41, offset: 61808},
 							name: "FencedBlockStartDelimiter",
 						},
 						&labeledExpr{
-							pos:   position{line: 1610, col: 67, offset: 61904},
+							pos:   position{line: 1607, col: 67, offset: 61834},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1610, col: 76, offset: 61913},
+								pos:  position{line: 1607, col: 76, offset: 61843},
 								name: "FencedBlockVerbatimContent",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1610, col: 104, offset: 61941},
+							pos:  position{line: 1607, col: 104, offset: 61871},
 							name: "FencedBlockEndDelimiter",
 						},
 					},
@@ -11625,27 +11617,27 @@ var g = &grammar{
 		},
 		{
 			name: "FencedBlockVerbatimContent",
-			pos:  position{line: 1614, col: 1, offset: 62060},
+			pos:  position{line: 1611, col: 1, offset: 61990},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1614, col: 31, offset: 62090},
+				pos: position{line: 1611, col: 31, offset: 62020},
 				expr: &actionExpr{
-					pos: position{line: 1614, col: 32, offset: 62091},
+					pos: position{line: 1611, col: 32, offset: 62021},
 					run: (*parser).callonFencedBlockVerbatimContent2,
 					expr: &seqExpr{
-						pos: position{line: 1614, col: 32, offset: 62091},
+						pos: position{line: 1611, col: 32, offset: 62021},
 						exprs: []interface{}{
 							&notExpr{
-								pos: position{line: 1614, col: 32, offset: 62091},
+								pos: position{line: 1611, col: 32, offset: 62021},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1614, col: 33, offset: 62092},
+									pos:  position{line: 1611, col: 33, offset: 62022},
 									name: "FencedBlockEndDelimiter",
 								},
 							},
 							&labeledExpr{
-								pos:   position{line: 1614, col: 57, offset: 62116},
+								pos:   position{line: 1611, col: 57, offset: 62046},
 								label: "content",
 								expr: &ruleRefExpr{
-									pos:  position{line: 1614, col: 66, offset: 62125},
+									pos:  position{line: 1611, col: 66, offset: 62055},
 									name: "VerbatimContent",
 								},
 							},
@@ -11656,25 +11648,25 @@ var g = &grammar{
 		},
 		{
 			name: "ListingBlockDelimiter",
-			pos:  position{line: 1621, col: 1, offset: 62469},
+			pos:  position{line: 1618, col: 1, offset: 62399},
 			expr: &seqExpr{
-				pos: position{line: 1621, col: 26, offset: 62494},
+				pos: position{line: 1618, col: 26, offset: 62424},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1621, col: 26, offset: 62494},
+						pos:        position{line: 1618, col: 26, offset: 62424},
 						val:        "----",
 						ignoreCase: false,
 						want:       "\"----\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1621, col: 33, offset: 62501},
+						pos: position{line: 1618, col: 33, offset: 62431},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1621, col: 33, offset: 62501},
+							pos:  position{line: 1618, col: 33, offset: 62431},
 							name: "Space",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1621, col: 40, offset: 62508},
+						pos:  position{line: 1618, col: 40, offset: 62438},
 						name: "EOL",
 					},
 				},
@@ -11682,25 +11674,25 @@ var g = &grammar{
 		},
 		{
 			name: "ListingBlockStartDelimiter",
-			pos:  position{line: 1623, col: 1, offset: 62515},
+			pos:  position{line: 1620, col: 1, offset: 62445},
 			expr: &seqExpr{
-				pos: position{line: 1623, col: 31, offset: 62545},
+				pos: position{line: 1620, col: 31, offset: 62475},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1623, col: 31, offset: 62545},
+						pos:        position{line: 1620, col: 31, offset: 62475},
 						val:        "----",
 						ignoreCase: false,
 						want:       "\"----\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1623, col: 38, offset: 62552},
+						pos: position{line: 1620, col: 38, offset: 62482},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1623, col: 38, offset: 62552},
+							pos:  position{line: 1620, col: 38, offset: 62482},
 							name: "Space",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1623, col: 45, offset: 62559},
+						pos:  position{line: 1620, col: 45, offset: 62489},
 						name: "EOL",
 					},
 				},
@@ -11708,34 +11700,34 @@ var g = &grammar{
 		},
 		{
 			name: "ListingBlockEndDelimiter",
-			pos:  position{line: 1625, col: 1, offset: 62566},
+			pos:  position{line: 1622, col: 1, offset: 62496},
 			expr: &choiceExpr{
-				pos: position{line: 1625, col: 29, offset: 62594},
+				pos: position{line: 1622, col: 29, offset: 62524},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 1625, col: 30, offset: 62595},
+						pos: position{line: 1622, col: 30, offset: 62525},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 1625, col: 30, offset: 62595},
+								pos:        position{line: 1622, col: 30, offset: 62525},
 								val:        "----",
 								ignoreCase: false,
 								want:       "\"----\"",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 1625, col: 37, offset: 62602},
+								pos: position{line: 1622, col: 37, offset: 62532},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1625, col: 37, offset: 62602},
+									pos:  position{line: 1622, col: 37, offset: 62532},
 									name: "Space",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1625, col: 44, offset: 62609},
+								pos:  position{line: 1622, col: 44, offset: 62539},
 								name: "EOL",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1625, col: 51, offset: 62616},
+						pos:  position{line: 1622, col: 51, offset: 62546},
 						name: "EOF",
 					},
 				},
@@ -11743,38 +11735,38 @@ var g = &grammar{
 		},
 		{
 			name: "ListingBlock",
-			pos:  position{line: 1627, col: 1, offset: 62623},
+			pos:  position{line: 1624, col: 1, offset: 62553},
 			expr: &actionExpr{
-				pos: position{line: 1627, col: 17, offset: 62639},
+				pos: position{line: 1624, col: 17, offset: 62569},
 				run: (*parser).callonListingBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1627, col: 17, offset: 62639},
+					pos: position{line: 1624, col: 17, offset: 62569},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1627, col: 17, offset: 62639},
+							pos:   position{line: 1624, col: 17, offset: 62569},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1627, col: 28, offset: 62650},
+								pos: position{line: 1624, col: 28, offset: 62580},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1627, col: 29, offset: 62651},
+									pos:  position{line: 1624, col: 29, offset: 62581},
 									name: "Attributes",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1627, col: 42, offset: 62664},
+							pos:  position{line: 1624, col: 42, offset: 62594},
 							name: "ListingBlockStartDelimiter",
 						},
 						&labeledExpr{
-							pos:   position{line: 1627, col: 69, offset: 62691},
+							pos:   position{line: 1624, col: 69, offset: 62621},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1627, col: 78, offset: 62700},
+								pos:  position{line: 1624, col: 78, offset: 62630},
 								name: "ListingBlockVerbatimContent",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1627, col: 107, offset: 62729},
+							pos:  position{line: 1624, col: 107, offset: 62659},
 							name: "ListingBlockEndDelimiter",
 						},
 					},
@@ -11783,27 +11775,27 @@ var g = &grammar{
 		},
 		{
 			name: "ListingBlockVerbatimContent",
-			pos:  position{line: 1631, col: 1, offset: 62850},
+			pos:  position{line: 1628, col: 1, offset: 62780},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1631, col: 32, offset: 62881},
+				pos: position{line: 1628, col: 32, offset: 62811},
 				expr: &actionExpr{
-					pos: position{line: 1631, col: 33, offset: 62882},
+					pos: position{line: 1628, col: 33, offset: 62812},
 					run: (*parser).callonListingBlockVerbatimContent2,
 					expr: &seqExpr{
-						pos: position{line: 1631, col: 33, offset: 62882},
+						pos: position{line: 1628, col: 33, offset: 62812},
 						exprs: []interface{}{
 							&notExpr{
-								pos: position{line: 1631, col: 33, offset: 62882},
+								pos: position{line: 1628, col: 33, offset: 62812},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1631, col: 34, offset: 62883},
+									pos:  position{line: 1628, col: 34, offset: 62813},
 									name: "ListingBlockEndDelimiter",
 								},
 							},
 							&labeledExpr{
-								pos:   position{line: 1631, col: 59, offset: 62908},
+								pos:   position{line: 1628, col: 59, offset: 62838},
 								label: "content",
 								expr: &ruleRefExpr{
-									pos:  position{line: 1631, col: 68, offset: 62917},
+									pos:  position{line: 1628, col: 68, offset: 62847},
 									name: "VerbatimContent",
 								},
 							},
@@ -11814,25 +11806,25 @@ var g = &grammar{
 		},
 		{
 			name: "ExampleBlockDelimiter",
-			pos:  position{line: 1638, col: 1, offset: 63261},
+			pos:  position{line: 1635, col: 1, offset: 63191},
 			expr: &seqExpr{
-				pos: position{line: 1638, col: 26, offset: 63286},
+				pos: position{line: 1635, col: 26, offset: 63216},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1638, col: 26, offset: 63286},
+						pos:        position{line: 1635, col: 26, offset: 63216},
 						val:        "====",
 						ignoreCase: false,
 						want:       "\"====\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1638, col: 33, offset: 63293},
+						pos: position{line: 1635, col: 33, offset: 63223},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1638, col: 33, offset: 63293},
+							pos:  position{line: 1635, col: 33, offset: 63223},
 							name: "Space",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1638, col: 40, offset: 63300},
+						pos:  position{line: 1635, col: 40, offset: 63230},
 						name: "EOL",
 					},
 				},
@@ -11840,25 +11832,25 @@ var g = &grammar{
 		},
 		{
 			name: "ExampleBlockStartDelimiter",
-			pos:  position{line: 1640, col: 1, offset: 63307},
+			pos:  position{line: 1637, col: 1, offset: 63237},
 			expr: &seqExpr{
-				pos: position{line: 1640, col: 31, offset: 63337},
+				pos: position{line: 1637, col: 31, offset: 63267},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1640, col: 31, offset: 63337},
+						pos:        position{line: 1637, col: 31, offset: 63267},
 						val:        "====",
 						ignoreCase: false,
 						want:       "\"====\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1640, col: 38, offset: 63344},
+						pos: position{line: 1637, col: 38, offset: 63274},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1640, col: 38, offset: 63344},
+							pos:  position{line: 1637, col: 38, offset: 63274},
 							name: "Space",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1640, col: 45, offset: 63351},
+						pos:  position{line: 1637, col: 45, offset: 63281},
 						name: "EOL",
 					},
 				},
@@ -11866,34 +11858,34 @@ var g = &grammar{
 		},
 		{
 			name: "ExampleBlockEndDelimiter",
-			pos:  position{line: 1642, col: 1, offset: 63358},
+			pos:  position{line: 1639, col: 1, offset: 63288},
 			expr: &choiceExpr{
-				pos: position{line: 1642, col: 29, offset: 63386},
+				pos: position{line: 1639, col: 29, offset: 63316},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 1642, col: 30, offset: 63387},
+						pos: position{line: 1639, col: 30, offset: 63317},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 1642, col: 30, offset: 63387},
+								pos:        position{line: 1639, col: 30, offset: 63317},
 								val:        "====",
 								ignoreCase: false,
 								want:       "\"====\"",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 1642, col: 37, offset: 63394},
+								pos: position{line: 1639, col: 37, offset: 63324},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1642, col: 37, offset: 63394},
+									pos:  position{line: 1639, col: 37, offset: 63324},
 									name: "Space",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1642, col: 44, offset: 63401},
+								pos:  position{line: 1639, col: 44, offset: 63331},
 								name: "EOL",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1642, col: 51, offset: 63408},
+						pos:  position{line: 1639, col: 51, offset: 63338},
 						name: "EOF",
 					},
 				},
@@ -11901,38 +11893,38 @@ var g = &grammar{
 		},
 		{
 			name: "ExampleBlock",
-			pos:  position{line: 1644, col: 1, offset: 63415},
+			pos:  position{line: 1641, col: 1, offset: 63345},
 			expr: &actionExpr{
-				pos: position{line: 1644, col: 17, offset: 63431},
+				pos: position{line: 1641, col: 17, offset: 63361},
 				run: (*parser).callonExampleBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1644, col: 17, offset: 63431},
+					pos: position{line: 1641, col: 17, offset: 63361},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1644, col: 17, offset: 63431},
+							pos:   position{line: 1641, col: 17, offset: 63361},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1644, col: 28, offset: 63442},
+								pos: position{line: 1641, col: 28, offset: 63372},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1644, col: 29, offset: 63443},
+									pos:  position{line: 1641, col: 29, offset: 63373},
 									name: "Attributes",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1644, col: 42, offset: 63456},
+							pos:  position{line: 1641, col: 42, offset: 63386},
 							name: "ExampleBlockStartDelimiter",
 						},
 						&labeledExpr{
-							pos:   position{line: 1644, col: 69, offset: 63483},
+							pos:   position{line: 1641, col: 69, offset: 63413},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1644, col: 78, offset: 63492},
+								pos:  position{line: 1641, col: 78, offset: 63422},
 								name: "ExampleBlockVerbatimContent",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1644, col: 107, offset: 63521},
+							pos:  position{line: 1641, col: 107, offset: 63451},
 							name: "ExampleBlockEndDelimiter",
 						},
 					},
@@ -11941,27 +11933,27 @@ var g = &grammar{
 		},
 		{
 			name: "ExampleBlockVerbatimContent",
-			pos:  position{line: 1648, col: 1, offset: 63642},
+			pos:  position{line: 1645, col: 1, offset: 63572},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1648, col: 32, offset: 63673},
+				pos: position{line: 1645, col: 32, offset: 63603},
 				expr: &actionExpr{
-					pos: position{line: 1648, col: 33, offset: 63674},
+					pos: position{line: 1645, col: 33, offset: 63604},
 					run: (*parser).callonExampleBlockVerbatimContent2,
 					expr: &seqExpr{
-						pos: position{line: 1648, col: 33, offset: 63674},
+						pos: position{line: 1645, col: 33, offset: 63604},
 						exprs: []interface{}{
 							&notExpr{
-								pos: position{line: 1648, col: 33, offset: 63674},
+								pos: position{line: 1645, col: 33, offset: 63604},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1648, col: 34, offset: 63675},
+									pos:  position{line: 1645, col: 34, offset: 63605},
 									name: "ExampleBlockEndDelimiter",
 								},
 							},
 							&labeledExpr{
-								pos:   position{line: 1648, col: 59, offset: 63700},
+								pos:   position{line: 1645, col: 59, offset: 63630},
 								label: "content",
 								expr: &ruleRefExpr{
-									pos:  position{line: 1648, col: 68, offset: 63709},
+									pos:  position{line: 1645, col: 68, offset: 63639},
 									name: "VerbatimContent",
 								},
 							},
@@ -11972,25 +11964,25 @@ var g = &grammar{
 		},
 		{
 			name: "QuoteBlockDelimiter",
-			pos:  position{line: 1655, col: 1, offset: 64051},
+			pos:  position{line: 1652, col: 1, offset: 63981},
 			expr: &seqExpr{
-				pos: position{line: 1655, col: 24, offset: 64074},
+				pos: position{line: 1652, col: 24, offset: 64004},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1655, col: 24, offset: 64074},
+						pos:        position{line: 1652, col: 24, offset: 64004},
 						val:        "____",
 						ignoreCase: false,
 						want:       "\"____\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1655, col: 31, offset: 64081},
+						pos: position{line: 1652, col: 31, offset: 64011},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1655, col: 31, offset: 64081},
+							pos:  position{line: 1652, col: 31, offset: 64011},
 							name: "Space",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1655, col: 38, offset: 64088},
+						pos:  position{line: 1652, col: 38, offset: 64018},
 						name: "EOL",
 					},
 				},
@@ -11998,25 +11990,25 @@ var g = &grammar{
 		},
 		{
 			name: "QuoteBlockStartDelimiter",
-			pos:  position{line: 1657, col: 1, offset: 64120},
+			pos:  position{line: 1654, col: 1, offset: 64050},
 			expr: &seqExpr{
-				pos: position{line: 1657, col: 29, offset: 64148},
+				pos: position{line: 1654, col: 29, offset: 64078},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1657, col: 29, offset: 64148},
+						pos:        position{line: 1654, col: 29, offset: 64078},
 						val:        "____",
 						ignoreCase: false,
 						want:       "\"____\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1657, col: 36, offset: 64155},
+						pos: position{line: 1654, col: 36, offset: 64085},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1657, col: 36, offset: 64155},
+							pos:  position{line: 1654, col: 36, offset: 64085},
 							name: "Space",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1657, col: 43, offset: 64162},
+						pos:  position{line: 1654, col: 43, offset: 64092},
 						name: "EOL",
 					},
 				},
@@ -12024,34 +12016,34 @@ var g = &grammar{
 		},
 		{
 			name: "QuoteBlockEndDelimiter",
-			pos:  position{line: 1659, col: 1, offset: 64194},
+			pos:  position{line: 1656, col: 1, offset: 64124},
 			expr: &choiceExpr{
-				pos: position{line: 1659, col: 27, offset: 64220},
+				pos: position{line: 1656, col: 27, offset: 64150},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 1659, col: 28, offset: 64221},
+						pos: position{line: 1656, col: 28, offset: 64151},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 1659, col: 28, offset: 64221},
+								pos:        position{line: 1656, col: 28, offset: 64151},
 								val:        "____",
 								ignoreCase: false,
 								want:       "\"____\"",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 1659, col: 35, offset: 64228},
+								pos: position{line: 1656, col: 35, offset: 64158},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1659, col: 35, offset: 64228},
+									pos:  position{line: 1656, col: 35, offset: 64158},
 									name: "Space",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1659, col: 42, offset: 64235},
+								pos:  position{line: 1656, col: 42, offset: 64165},
 								name: "EOL",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1659, col: 49, offset: 64242},
+						pos:  position{line: 1656, col: 49, offset: 64172},
 						name: "EOF",
 					},
 				},
@@ -12059,38 +12051,38 @@ var g = &grammar{
 		},
 		{
 			name: "QuoteBlock",
-			pos:  position{line: 1661, col: 1, offset: 64274},
+			pos:  position{line: 1658, col: 1, offset: 64204},
 			expr: &actionExpr{
-				pos: position{line: 1661, col: 15, offset: 64288},
+				pos: position{line: 1658, col: 15, offset: 64218},
 				run: (*parser).callonQuoteBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1661, col: 15, offset: 64288},
+					pos: position{line: 1658, col: 15, offset: 64218},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1661, col: 15, offset: 64288},
+							pos:   position{line: 1658, col: 15, offset: 64218},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1661, col: 26, offset: 64299},
+								pos: position{line: 1658, col: 26, offset: 64229},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1661, col: 27, offset: 64300},
+									pos:  position{line: 1658, col: 27, offset: 64230},
 									name: "Attributes",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1661, col: 40, offset: 64313},
+							pos:  position{line: 1658, col: 40, offset: 64243},
 							name: "QuoteBlockStartDelimiter",
 						},
 						&labeledExpr{
-							pos:   position{line: 1661, col: 65, offset: 64338},
+							pos:   position{line: 1658, col: 65, offset: 64268},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1661, col: 74, offset: 64347},
+								pos:  position{line: 1658, col: 74, offset: 64277},
 								name: "QuoteBlockVerbatimElement",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1661, col: 101, offset: 64374},
+							pos:  position{line: 1658, col: 101, offset: 64304},
 							name: "QuoteBlockEndDelimiter",
 						},
 					},
@@ -12099,27 +12091,27 @@ var g = &grammar{
 		},
 		{
 			name: "QuoteBlockVerbatimElement",
-			pos:  position{line: 1665, col: 1, offset: 64491},
+			pos:  position{line: 1662, col: 1, offset: 64421},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1665, col: 30, offset: 64520},
+				pos: position{line: 1662, col: 30, offset: 64450},
 				expr: &actionExpr{
-					pos: position{line: 1665, col: 31, offset: 64521},
+					pos: position{line: 1662, col: 31, offset: 64451},
 					run: (*parser).callonQuoteBlockVerbatimElement2,
 					expr: &seqExpr{
-						pos: position{line: 1665, col: 31, offset: 64521},
+						pos: position{line: 1662, col: 31, offset: 64451},
 						exprs: []interface{}{
 							&notExpr{
-								pos: position{line: 1665, col: 31, offset: 64521},
+								pos: position{line: 1662, col: 31, offset: 64451},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1665, col: 32, offset: 64522},
+									pos:  position{line: 1662, col: 32, offset: 64452},
 									name: "QuoteBlockEndDelimiter",
 								},
 							},
 							&labeledExpr{
-								pos:   position{line: 1665, col: 55, offset: 64545},
+								pos:   position{line: 1662, col: 55, offset: 64475},
 								label: "content",
 								expr: &ruleRefExpr{
-									pos:  position{line: 1665, col: 64, offset: 64554},
+									pos:  position{line: 1662, col: 64, offset: 64484},
 									name: "VerbatimContent",
 								},
 							},
@@ -12130,39 +12122,39 @@ var g = &grammar{
 		},
 		{
 			name: "VerseBlock",
-			pos:  position{line: 1674, col: 1, offset: 64947},
+			pos:  position{line: 1671, col: 1, offset: 64877},
 			expr: &actionExpr{
-				pos: position{line: 1674, col: 15, offset: 64961},
+				pos: position{line: 1671, col: 15, offset: 64891},
 				run: (*parser).callonVerseBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1674, col: 15, offset: 64961},
+					pos: position{line: 1671, col: 15, offset: 64891},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1674, col: 15, offset: 64961},
+							pos:   position{line: 1671, col: 15, offset: 64891},
 							label: "attributes",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1674, col: 27, offset: 64973},
+								pos:  position{line: 1671, col: 27, offset: 64903},
 								name: "Attributes",
 							},
 						},
 						&andCodeExpr{
-							pos: position{line: 1675, col: 5, offset: 64991},
+							pos: position{line: 1672, col: 5, offset: 64921},
 							run: (*parser).callonVerseBlock5,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1679, col: 5, offset: 65190},
+							pos:  position{line: 1676, col: 5, offset: 65120},
 							name: "QuoteBlockStartDelimiter",
 						},
 						&labeledExpr{
-							pos:   position{line: 1679, col: 30, offset: 65215},
+							pos:   position{line: 1676, col: 30, offset: 65145},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1679, col: 39, offset: 65224},
+								pos:  position{line: 1676, col: 39, offset: 65154},
 								name: "VerseBlockVerbatimContent",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1679, col: 66, offset: 65251},
+							pos:  position{line: 1676, col: 66, offset: 65181},
 							name: "QuoteBlockEndDelimiter",
 						},
 					},
@@ -12171,27 +12163,27 @@ var g = &grammar{
 		},
 		{
 			name: "VerseBlockVerbatimContent",
-			pos:  position{line: 1683, col: 1, offset: 65376},
+			pos:  position{line: 1680, col: 1, offset: 65306},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1683, col: 30, offset: 65405},
+				pos: position{line: 1680, col: 30, offset: 65335},
 				expr: &actionExpr{
-					pos: position{line: 1683, col: 31, offset: 65406},
+					pos: position{line: 1680, col: 31, offset: 65336},
 					run: (*parser).callonVerseBlockVerbatimContent2,
 					expr: &seqExpr{
-						pos: position{line: 1683, col: 31, offset: 65406},
+						pos: position{line: 1680, col: 31, offset: 65336},
 						exprs: []interface{}{
 							&notExpr{
-								pos: position{line: 1683, col: 31, offset: 65406},
+								pos: position{line: 1680, col: 31, offset: 65336},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1683, col: 32, offset: 65407},
+									pos:  position{line: 1680, col: 32, offset: 65337},
 									name: "QuoteBlockEndDelimiter",
 								},
 							},
 							&labeledExpr{
-								pos:   position{line: 1683, col: 55, offset: 65430},
+								pos:   position{line: 1680, col: 55, offset: 65360},
 								label: "content",
 								expr: &ruleRefExpr{
-									pos:  position{line: 1683, col: 64, offset: 65439},
+									pos:  position{line: 1680, col: 64, offset: 65369},
 									name: "VerbatimContent",
 								},
 							},
@@ -12202,25 +12194,25 @@ var g = &grammar{
 		},
 		{
 			name: "SidebarBlockDelimiter",
-			pos:  position{line: 1690, col: 1, offset: 65783},
+			pos:  position{line: 1687, col: 1, offset: 65713},
 			expr: &seqExpr{
-				pos: position{line: 1690, col: 26, offset: 65808},
+				pos: position{line: 1687, col: 26, offset: 65738},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1690, col: 26, offset: 65808},
+						pos:        position{line: 1687, col: 26, offset: 65738},
 						val:        "****",
 						ignoreCase: false,
 						want:       "\"****\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1690, col: 33, offset: 65815},
+						pos: position{line: 1687, col: 33, offset: 65745},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1690, col: 33, offset: 65815},
+							pos:  position{line: 1687, col: 33, offset: 65745},
 							name: "Space",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1690, col: 40, offset: 65822},
+						pos:  position{line: 1687, col: 40, offset: 65752},
 						name: "EOL",
 					},
 				},
@@ -12228,25 +12220,25 @@ var g = &grammar{
 		},
 		{
 			name: "SidebarBlockStartDelimiter",
-			pos:  position{line: 1692, col: 1, offset: 65829},
+			pos:  position{line: 1689, col: 1, offset: 65759},
 			expr: &seqExpr{
-				pos: position{line: 1692, col: 31, offset: 65859},
+				pos: position{line: 1689, col: 31, offset: 65789},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1692, col: 31, offset: 65859},
+						pos:        position{line: 1689, col: 31, offset: 65789},
 						val:        "****",
 						ignoreCase: false,
 						want:       "\"****\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1692, col: 38, offset: 65866},
+						pos: position{line: 1689, col: 38, offset: 65796},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1692, col: 38, offset: 65866},
+							pos:  position{line: 1689, col: 38, offset: 65796},
 							name: "Space",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1692, col: 45, offset: 65873},
+						pos:  position{line: 1689, col: 45, offset: 65803},
 						name: "EOL",
 					},
 				},
@@ -12254,34 +12246,34 @@ var g = &grammar{
 		},
 		{
 			name: "SidebarBlockEndDelimiter",
-			pos:  position{line: 1694, col: 1, offset: 65880},
+			pos:  position{line: 1691, col: 1, offset: 65810},
 			expr: &choiceExpr{
-				pos: position{line: 1694, col: 29, offset: 65908},
+				pos: position{line: 1691, col: 29, offset: 65838},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 1694, col: 30, offset: 65909},
+						pos: position{line: 1691, col: 30, offset: 65839},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 1694, col: 30, offset: 65909},
+								pos:        position{line: 1691, col: 30, offset: 65839},
 								val:        "****",
 								ignoreCase: false,
 								want:       "\"****\"",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 1694, col: 37, offset: 65916},
+								pos: position{line: 1691, col: 37, offset: 65846},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1694, col: 37, offset: 65916},
+									pos:  position{line: 1691, col: 37, offset: 65846},
 									name: "Space",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1694, col: 44, offset: 65923},
+								pos:  position{line: 1691, col: 44, offset: 65853},
 								name: "EOL",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1694, col: 51, offset: 65930},
+						pos:  position{line: 1691, col: 51, offset: 65860},
 						name: "EOF",
 					},
 				},
@@ -12289,38 +12281,38 @@ var g = &grammar{
 		},
 		{
 			name: "SidebarBlock",
-			pos:  position{line: 1696, col: 1, offset: 65937},
+			pos:  position{line: 1693, col: 1, offset: 65867},
 			expr: &actionExpr{
-				pos: position{line: 1696, col: 17, offset: 65953},
+				pos: position{line: 1693, col: 17, offset: 65883},
 				run: (*parser).callonSidebarBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1696, col: 17, offset: 65953},
+					pos: position{line: 1693, col: 17, offset: 65883},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1696, col: 17, offset: 65953},
+							pos:   position{line: 1693, col: 17, offset: 65883},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1696, col: 28, offset: 65964},
+								pos: position{line: 1693, col: 28, offset: 65894},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1696, col: 29, offset: 65965},
+									pos:  position{line: 1693, col: 29, offset: 65895},
 									name: "Attributes",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1696, col: 42, offset: 65978},
+							pos:  position{line: 1693, col: 42, offset: 65908},
 							name: "SidebarBlockStartDelimiter",
 						},
 						&labeledExpr{
-							pos:   position{line: 1696, col: 69, offset: 66005},
+							pos:   position{line: 1693, col: 69, offset: 65935},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1696, col: 78, offset: 66014},
+								pos:  position{line: 1693, col: 78, offset: 65944},
 								name: "SidebarBlockVerbatimContent",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1696, col: 107, offset: 66043},
+							pos:  position{line: 1693, col: 107, offset: 65973},
 							name: "SidebarBlockEndDelimiter",
 						},
 					},
@@ -12329,27 +12321,27 @@ var g = &grammar{
 		},
 		{
 			name: "SidebarBlockVerbatimContent",
-			pos:  position{line: 1700, col: 1, offset: 66164},
+			pos:  position{line: 1697, col: 1, offset: 66094},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1700, col: 32, offset: 66195},
+				pos: position{line: 1697, col: 32, offset: 66125},
 				expr: &actionExpr{
-					pos: position{line: 1700, col: 33, offset: 66196},
+					pos: position{line: 1697, col: 33, offset: 66126},
 					run: (*parser).callonSidebarBlockVerbatimContent2,
 					expr: &seqExpr{
-						pos: position{line: 1700, col: 33, offset: 66196},
+						pos: position{line: 1697, col: 33, offset: 66126},
 						exprs: []interface{}{
 							&notExpr{
-								pos: position{line: 1700, col: 33, offset: 66196},
+								pos: position{line: 1697, col: 33, offset: 66126},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1700, col: 34, offset: 66197},
+									pos:  position{line: 1697, col: 34, offset: 66127},
 									name: "SidebarBlockEndDelimiter",
 								},
 							},
 							&labeledExpr{
-								pos:   position{line: 1700, col: 59, offset: 66222},
+								pos:   position{line: 1697, col: 59, offset: 66152},
 								label: "content",
 								expr: &ruleRefExpr{
-									pos:  position{line: 1700, col: 68, offset: 66231},
+									pos:  position{line: 1697, col: 68, offset: 66161},
 									name: "VerbatimContent",
 								},
 							},
@@ -12360,25 +12352,25 @@ var g = &grammar{
 		},
 		{
 			name: "PassthroughBlockDelimiter",
-			pos:  position{line: 1707, col: 1, offset: 66579},
+			pos:  position{line: 1704, col: 1, offset: 66509},
 			expr: &seqExpr{
-				pos: position{line: 1707, col: 30, offset: 66608},
+				pos: position{line: 1704, col: 30, offset: 66538},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1707, col: 30, offset: 66608},
+						pos:        position{line: 1704, col: 30, offset: 66538},
 						val:        "++++",
 						ignoreCase: false,
 						want:       "\"++++\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1707, col: 37, offset: 66615},
+						pos: position{line: 1704, col: 37, offset: 66545},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1707, col: 37, offset: 66615},
+							pos:  position{line: 1704, col: 37, offset: 66545},
 							name: "Space",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1707, col: 44, offset: 66622},
+						pos:  position{line: 1704, col: 44, offset: 66552},
 						name: "EOL",
 					},
 				},
@@ -12386,25 +12378,25 @@ var g = &grammar{
 		},
 		{
 			name: "PassthroughBlockStartDelimiter",
-			pos:  position{line: 1709, col: 1, offset: 66629},
+			pos:  position{line: 1706, col: 1, offset: 66559},
 			expr: &seqExpr{
-				pos: position{line: 1709, col: 35, offset: 66663},
+				pos: position{line: 1706, col: 35, offset: 66593},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1709, col: 35, offset: 66663},
+						pos:        position{line: 1706, col: 35, offset: 66593},
 						val:        "++++",
 						ignoreCase: false,
 						want:       "\"++++\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1709, col: 42, offset: 66670},
+						pos: position{line: 1706, col: 42, offset: 66600},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1709, col: 42, offset: 66670},
+							pos:  position{line: 1706, col: 42, offset: 66600},
 							name: "Space",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1709, col: 49, offset: 66677},
+						pos:  position{line: 1706, col: 49, offset: 66607},
 						name: "EOL",
 					},
 				},
@@ -12412,34 +12404,34 @@ var g = &grammar{
 		},
 		{
 			name: "PassthroughBlockEndDelimiter",
-			pos:  position{line: 1711, col: 1, offset: 66684},
+			pos:  position{line: 1708, col: 1, offset: 66614},
 			expr: &choiceExpr{
-				pos: position{line: 1711, col: 33, offset: 66716},
+				pos: position{line: 1708, col: 33, offset: 66646},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 1711, col: 34, offset: 66717},
+						pos: position{line: 1708, col: 34, offset: 66647},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 1711, col: 34, offset: 66717},
+								pos:        position{line: 1708, col: 34, offset: 66647},
 								val:        "++++",
 								ignoreCase: false,
 								want:       "\"++++\"",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 1711, col: 41, offset: 66724},
+								pos: position{line: 1708, col: 41, offset: 66654},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1711, col: 41, offset: 66724},
+									pos:  position{line: 1708, col: 41, offset: 66654},
 									name: "Space",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1711, col: 48, offset: 66731},
+								pos:  position{line: 1708, col: 48, offset: 66661},
 								name: "EOL",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1711, col: 55, offset: 66738},
+						pos:  position{line: 1708, col: 55, offset: 66668},
 						name: "EOF",
 					},
 				},
@@ -12447,38 +12439,38 @@ var g = &grammar{
 		},
 		{
 			name: "PassthroughBlock",
-			pos:  position{line: 1713, col: 1, offset: 66745},
+			pos:  position{line: 1710, col: 1, offset: 66675},
 			expr: &actionExpr{
-				pos: position{line: 1713, col: 21, offset: 66765},
+				pos: position{line: 1710, col: 21, offset: 66695},
 				run: (*parser).callonPassthroughBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1713, col: 21, offset: 66765},
+					pos: position{line: 1710, col: 21, offset: 66695},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1713, col: 21, offset: 66765},
+							pos:   position{line: 1710, col: 21, offset: 66695},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1713, col: 32, offset: 66776},
+								pos: position{line: 1710, col: 32, offset: 66706},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1713, col: 33, offset: 66777},
+									pos:  position{line: 1710, col: 33, offset: 66707},
 									name: "Attributes",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1713, col: 46, offset: 66790},
+							pos:  position{line: 1710, col: 46, offset: 66720},
 							name: "PassthroughBlockStartDelimiter",
 						},
 						&labeledExpr{
-							pos:   position{line: 1713, col: 77, offset: 66821},
+							pos:   position{line: 1710, col: 77, offset: 66751},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1713, col: 86, offset: 66830},
+								pos:  position{line: 1710, col: 86, offset: 66760},
 								name: "PassthroughBlockVerbatimContent",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1713, col: 119, offset: 66863},
+							pos:  position{line: 1710, col: 119, offset: 66793},
 							name: "PassthroughBlockEndDelimiter",
 						},
 					},
@@ -12487,27 +12479,27 @@ var g = &grammar{
 		},
 		{
 			name: "PassthroughBlockVerbatimContent",
-			pos:  position{line: 1717, col: 1, offset: 66992},
+			pos:  position{line: 1714, col: 1, offset: 66922},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1717, col: 36, offset: 67027},
+				pos: position{line: 1714, col: 36, offset: 66957},
 				expr: &actionExpr{
-					pos: position{line: 1717, col: 37, offset: 67028},
+					pos: position{line: 1714, col: 37, offset: 66958},
 					run: (*parser).callonPassthroughBlockVerbatimContent2,
 					expr: &seqExpr{
-						pos: position{line: 1717, col: 37, offset: 67028},
+						pos: position{line: 1714, col: 37, offset: 66958},
 						exprs: []interface{}{
 							&notExpr{
-								pos: position{line: 1717, col: 37, offset: 67028},
+								pos: position{line: 1714, col: 37, offset: 66958},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1717, col: 38, offset: 67029},
+									pos:  position{line: 1714, col: 38, offset: 66959},
 									name: "PassthroughBlockEndDelimiter",
 								},
 							},
 							&labeledExpr{
-								pos:   position{line: 1717, col: 67, offset: 67058},
+								pos:   position{line: 1714, col: 67, offset: 66988},
 								label: "content",
 								expr: &ruleRefExpr{
-									pos:  position{line: 1717, col: 76, offset: 67067},
+									pos:  position{line: 1714, col: 76, offset: 66997},
 									name: "VerbatimContent",
 								},
 							},
@@ -12518,87 +12510,87 @@ var g = &grammar{
 		},
 		{
 			name: "NormalBlockContent",
-			pos:  position{line: 1725, col: 1, offset: 67421},
+			pos:  position{line: 1722, col: 1, offset: 67351},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1725, col: 23, offset: 67443},
+				pos: position{line: 1722, col: 23, offset: 67373},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1725, col: 23, offset: 67443},
+					pos:  position{line: 1722, col: 23, offset: 67373},
 					name: "NormalBlockElement",
 				},
 			},
 		},
 		{
 			name: "NormalBlockElement",
-			pos:  position{line: 1727, col: 1, offset: 67466},
+			pos:  position{line: 1724, col: 1, offset: 67396},
 			expr: &actionExpr{
-				pos: position{line: 1728, col: 5, offset: 67494},
+				pos: position{line: 1725, col: 5, offset: 67424},
 				run: (*parser).callonNormalBlockElement1,
 				expr: &seqExpr{
-					pos: position{line: 1728, col: 5, offset: 67494},
+					pos: position{line: 1725, col: 5, offset: 67424},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1728, col: 5, offset: 67494},
+							pos: position{line: 1725, col: 5, offset: 67424},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1728, col: 6, offset: 67495},
+								pos:  position{line: 1725, col: 6, offset: 67425},
 								name: "EOF",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1728, col: 10, offset: 67499},
+							pos:   position{line: 1725, col: 10, offset: 67429},
 							label: "element",
 							expr: &choiceExpr{
-								pos: position{line: 1728, col: 19, offset: 67508},
+								pos: position{line: 1725, col: 19, offset: 67438},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1728, col: 19, offset: 67508},
+										pos:  position{line: 1725, col: 19, offset: 67438},
 										name: "BlankLine",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1729, col: 15, offset: 67534},
+										pos:  position{line: 1726, col: 15, offset: 67464},
 										name: "FileInclusion",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1730, col: 15, offset: 67563},
+										pos:  position{line: 1727, col: 15, offset: 67493},
 										name: "ImageBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1731, col: 15, offset: 67590},
+										pos:  position{line: 1728, col: 15, offset: 67520},
 										name: "OrderedListItem",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1732, col: 15, offset: 67622},
+										pos:  position{line: 1729, col: 15, offset: 67552},
 										name: "UnorderedListItem",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1733, col: 15, offset: 67656},
+										pos:  position{line: 1730, col: 15, offset: 67586},
 										name: "LabeledListItem",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1734, col: 15, offset: 67688},
+										pos:  position{line: 1731, col: 15, offset: 67618},
 										name: "ContinuedListItemElement",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1735, col: 15, offset: 67728},
+										pos:  position{line: 1732, col: 15, offset: 67658},
 										name: "DelimitedBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1736, col: 15, offset: 67758},
+										pos:  position{line: 1733, col: 15, offset: 67688},
 										name: "LiteralBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1737, col: 15, offset: 67787},
+										pos:  position{line: 1734, col: 15, offset: 67717},
 										name: "AttributeDeclaration",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1738, col: 15, offset: 67824},
+										pos:  position{line: 1735, col: 15, offset: 67754},
 										name: "AttributeReset",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1739, col: 15, offset: 67855},
+										pos:  position{line: 1736, col: 15, offset: 67785},
 										name: "TableOfContentsPlaceHolder",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1740, col: 15, offset: 67897},
+										pos:  position{line: 1737, col: 15, offset: 67827},
 										name: "Paragraph",
 									},
 								},
@@ -12610,43 +12602,43 @@ var g = &grammar{
 		},
 		{
 			name: "VerseBlockContent",
-			pos:  position{line: 1744, col: 1, offset: 67950},
+			pos:  position{line: 1741, col: 1, offset: 67880},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1744, col: 22, offset: 67971},
+				pos: position{line: 1741, col: 22, offset: 67901},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1744, col: 22, offset: 67971},
+					pos:  position{line: 1741, col: 22, offset: 67901},
 					name: "VerseBlockElement",
 				},
 			},
 		},
 		{
 			name: "VerseBlockElement",
-			pos:  position{line: 1746, col: 1, offset: 67993},
+			pos:  position{line: 1743, col: 1, offset: 67923},
 			expr: &actionExpr{
-				pos: position{line: 1746, col: 22, offset: 68014},
+				pos: position{line: 1743, col: 22, offset: 67944},
 				run: (*parser).callonVerseBlockElement1,
 				expr: &seqExpr{
-					pos: position{line: 1746, col: 22, offset: 68014},
+					pos: position{line: 1743, col: 22, offset: 67944},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1746, col: 22, offset: 68014},
+							pos: position{line: 1743, col: 22, offset: 67944},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1746, col: 23, offset: 68015},
+								pos:  position{line: 1743, col: 23, offset: 67945},
 								name: "EOF",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1746, col: 27, offset: 68019},
+							pos:   position{line: 1743, col: 27, offset: 67949},
 							label: "element",
 							expr: &choiceExpr{
-								pos: position{line: 1746, col: 36, offset: 68028},
+								pos: position{line: 1743, col: 36, offset: 67958},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1746, col: 36, offset: 68028},
+										pos:  position{line: 1743, col: 36, offset: 67958},
 										name: "BlankLine",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1746, col: 48, offset: 68040},
+										pos:  position{line: 1743, col: 48, offset: 67970},
 										name: "VerseBlockParagraph",
 									},
 								},
@@ -12658,17 +12650,17 @@ var g = &grammar{
 		},
 		{
 			name: "VerseBlockParagraph",
-			pos:  position{line: 1750, col: 1, offset: 68094},
+			pos:  position{line: 1747, col: 1, offset: 68024},
 			expr: &actionExpr{
-				pos: position{line: 1750, col: 24, offset: 68117},
+				pos: position{line: 1747, col: 24, offset: 68047},
 				run: (*parser).callonVerseBlockParagraph1,
 				expr: &labeledExpr{
-					pos:   position{line: 1750, col: 24, offset: 68117},
+					pos:   position{line: 1747, col: 24, offset: 68047},
 					label: "lines",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 1750, col: 30, offset: 68123},
+						pos: position{line: 1747, col: 30, offset: 68053},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1750, col: 31, offset: 68124},
+							pos:  position{line: 1747, col: 31, offset: 68054},
 							name: "VerseBlockParagraphLine",
 						},
 					},
@@ -12677,26 +12669,26 @@ var g = &grammar{
 		},
 		{
 			name: "VerseBlockParagraphLine",
-			pos:  position{line: 1754, col: 1, offset: 68218},
+			pos:  position{line: 1751, col: 1, offset: 68148},
 			expr: &actionExpr{
-				pos: position{line: 1754, col: 28, offset: 68245},
+				pos: position{line: 1751, col: 28, offset: 68175},
 				run: (*parser).callonVerseBlockParagraphLine1,
 				expr: &seqExpr{
-					pos: position{line: 1754, col: 28, offset: 68245},
+					pos: position{line: 1751, col: 28, offset: 68175},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1754, col: 28, offset: 68245},
+							pos:   position{line: 1751, col: 28, offset: 68175},
 							label: "elements",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1754, col: 37, offset: 68254},
+								pos: position{line: 1751, col: 37, offset: 68184},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1754, col: 38, offset: 68255},
+									pos:  position{line: 1751, col: 38, offset: 68185},
 									name: "InlineElement",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1754, col: 54, offset: 68271},
+							pos:  position{line: 1751, col: 54, offset: 68201},
 							name: "EOL",
 						},
 					},
@@ -12705,59 +12697,59 @@ var g = &grammar{
 		},
 		{
 			name: "Table",
-			pos:  position{line: 1761, col: 1, offset: 68520},
+			pos:  position{line: 1758, col: 1, offset: 68450},
 			expr: &actionExpr{
-				pos: position{line: 1761, col: 10, offset: 68529},
+				pos: position{line: 1758, col: 10, offset: 68459},
 				run: (*parser).callonTable1,
 				expr: &seqExpr{
-					pos: position{line: 1761, col: 10, offset: 68529},
+					pos: position{line: 1758, col: 10, offset: 68459},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1761, col: 10, offset: 68529},
+							pos:   position{line: 1758, col: 10, offset: 68459},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1761, col: 21, offset: 68540},
+								pos: position{line: 1758, col: 21, offset: 68470},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1761, col: 22, offset: 68541},
+									pos:  position{line: 1758, col: 22, offset: 68471},
 									name: "Attributes",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1761, col: 35, offset: 68554},
+							pos:  position{line: 1758, col: 35, offset: 68484},
 							name: "TableDelimiter",
 						},
 						&labeledExpr{
-							pos:   position{line: 1762, col: 5, offset: 68574},
+							pos:   position{line: 1759, col: 5, offset: 68504},
 							label: "header",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1762, col: 12, offset: 68581},
+								pos: position{line: 1759, col: 12, offset: 68511},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1762, col: 13, offset: 68582},
+									pos:  position{line: 1759, col: 13, offset: 68512},
 									name: "TableLineHeader",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1763, col: 5, offset: 68605},
+							pos:   position{line: 1760, col: 5, offset: 68535},
 							label: "lines",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1763, col: 11, offset: 68611},
+								pos: position{line: 1760, col: 11, offset: 68541},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1763, col: 12, offset: 68612},
+									pos:  position{line: 1760, col: 12, offset: 68542},
 									name: "TableLine",
 								},
 							},
 						},
 						&choiceExpr{
-							pos: position{line: 1764, col: 6, offset: 68630},
+							pos: position{line: 1761, col: 6, offset: 68560},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 1764, col: 6, offset: 68630},
+									pos:  position{line: 1761, col: 6, offset: 68560},
 									name: "TableDelimiter",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1764, col: 23, offset: 68647},
+									pos:  position{line: 1761, col: 23, offset: 68577},
 									name: "EOF",
 								},
 							},
@@ -12768,20 +12760,20 @@ var g = &grammar{
 		},
 		{
 			name: "TableCellSeparator",
-			pos:  position{line: 1768, col: 1, offset: 68766},
+			pos:  position{line: 1765, col: 1, offset: 68696},
 			expr: &seqExpr{
-				pos: position{line: 1768, col: 23, offset: 68788},
+				pos: position{line: 1765, col: 23, offset: 68718},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1768, col: 23, offset: 68788},
+						pos:        position{line: 1765, col: 23, offset: 68718},
 						val:        "|",
 						ignoreCase: false,
 						want:       "\"|\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1768, col: 27, offset: 68792},
+						pos: position{line: 1765, col: 27, offset: 68722},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1768, col: 27, offset: 68792},
+							pos:  position{line: 1765, col: 27, offset: 68722},
 							name: "Space",
 						},
 					},
@@ -12790,25 +12782,25 @@ var g = &grammar{
 		},
 		{
 			name: "TableDelimiter",
-			pos:  position{line: 1770, col: 1, offset: 68802},
+			pos:  position{line: 1767, col: 1, offset: 68732},
 			expr: &seqExpr{
-				pos: position{line: 1770, col: 19, offset: 68820},
+				pos: position{line: 1767, col: 19, offset: 68750},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1770, col: 19, offset: 68820},
+						pos:        position{line: 1767, col: 19, offset: 68750},
 						val:        "|===",
 						ignoreCase: false,
 						want:       "\"|===\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1770, col: 26, offset: 68827},
+						pos: position{line: 1767, col: 26, offset: 68757},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1770, col: 26, offset: 68827},
+							pos:  position{line: 1767, col: 26, offset: 68757},
 							name: "Space",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1770, col: 33, offset: 68834},
+						pos:  position{line: 1767, col: 33, offset: 68764},
 						name: "EOL",
 					},
 				},
@@ -12816,37 +12808,37 @@ var g = &grammar{
 		},
 		{
 			name: "TableLineHeader",
-			pos:  position{line: 1773, col: 1, offset: 68905},
+			pos:  position{line: 1770, col: 1, offset: 68835},
 			expr: &actionExpr{
-				pos: position{line: 1773, col: 20, offset: 68924},
+				pos: position{line: 1770, col: 20, offset: 68854},
 				run: (*parser).callonTableLineHeader1,
 				expr: &seqExpr{
-					pos: position{line: 1773, col: 20, offset: 68924},
+					pos: position{line: 1770, col: 20, offset: 68854},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1773, col: 20, offset: 68924},
+							pos: position{line: 1770, col: 20, offset: 68854},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1773, col: 21, offset: 68925},
+								pos:  position{line: 1770, col: 21, offset: 68855},
 								name: "TableDelimiter",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1773, col: 36, offset: 68940},
+							pos:   position{line: 1770, col: 36, offset: 68870},
 							label: "cells",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1773, col: 42, offset: 68946},
+								pos: position{line: 1770, col: 42, offset: 68876},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1773, col: 43, offset: 68947},
+									pos:  position{line: 1770, col: 43, offset: 68877},
 									name: "TableCell",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1773, col: 55, offset: 68959},
+							pos:  position{line: 1770, col: 55, offset: 68889},
 							name: "EOL",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1773, col: 59, offset: 68963},
+							pos:  position{line: 1770, col: 59, offset: 68893},
 							name: "BlankLine",
 						},
 					},
@@ -12855,39 +12847,39 @@ var g = &grammar{
 		},
 		{
 			name: "TableLine",
-			pos:  position{line: 1777, col: 1, offset: 69035},
+			pos:  position{line: 1774, col: 1, offset: 68965},
 			expr: &actionExpr{
-				pos: position{line: 1777, col: 14, offset: 69048},
+				pos: position{line: 1774, col: 14, offset: 68978},
 				run: (*parser).callonTableLine1,
 				expr: &seqExpr{
-					pos: position{line: 1777, col: 14, offset: 69048},
+					pos: position{line: 1774, col: 14, offset: 68978},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1777, col: 14, offset: 69048},
+							pos: position{line: 1774, col: 14, offset: 68978},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1777, col: 15, offset: 69049},
+								pos:  position{line: 1774, col: 15, offset: 68979},
 								name: "TableDelimiter",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1777, col: 30, offset: 69064},
+							pos:   position{line: 1774, col: 30, offset: 68994},
 							label: "cells",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1777, col: 36, offset: 69070},
+								pos: position{line: 1774, col: 36, offset: 69000},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1777, col: 37, offset: 69071},
+									pos:  position{line: 1774, col: 37, offset: 69001},
 									name: "TableCell",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1777, col: 49, offset: 69083},
+							pos:  position{line: 1774, col: 49, offset: 69013},
 							name: "EOL",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1777, col: 53, offset: 69087},
+							pos: position{line: 1774, col: 53, offset: 69017},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1777, col: 53, offset: 69087},
+								pos:  position{line: 1774, col: 53, offset: 69017},
 								name: "BlankLine",
 							},
 						},
@@ -12897,54 +12889,54 @@ var g = &grammar{
 		},
 		{
 			name: "TableCell",
-			pos:  position{line: 1781, col: 1, offset: 69160},
+			pos:  position{line: 1778, col: 1, offset: 69090},
 			expr: &actionExpr{
-				pos: position{line: 1781, col: 14, offset: 69173},
+				pos: position{line: 1778, col: 14, offset: 69103},
 				run: (*parser).callonTableCell1,
 				expr: &seqExpr{
-					pos: position{line: 1781, col: 14, offset: 69173},
+					pos: position{line: 1778, col: 14, offset: 69103},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1781, col: 14, offset: 69173},
+							pos:  position{line: 1778, col: 14, offset: 69103},
 							name: "TableCellSeparator",
 						},
 						&labeledExpr{
-							pos:   position{line: 1781, col: 33, offset: 69192},
+							pos:   position{line: 1778, col: 33, offset: 69122},
 							label: "elements",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1781, col: 42, offset: 69201},
+								pos: position{line: 1778, col: 42, offset: 69131},
 								expr: &seqExpr{
-									pos: position{line: 1781, col: 43, offset: 69202},
+									pos: position{line: 1778, col: 43, offset: 69132},
 									exprs: []interface{}{
 										&notExpr{
-											pos: position{line: 1781, col: 43, offset: 69202},
+											pos: position{line: 1778, col: 43, offset: 69132},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1781, col: 44, offset: 69203},
+												pos:  position{line: 1778, col: 44, offset: 69133},
 												name: "TableCellSeparator",
 											},
 										},
 										&notExpr{
-											pos: position{line: 1781, col: 63, offset: 69222},
+											pos: position{line: 1778, col: 63, offset: 69152},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1781, col: 64, offset: 69223},
+												pos:  position{line: 1778, col: 64, offset: 69153},
 												name: "EOL",
 											},
 										},
 										&zeroOrMoreExpr{
-											pos: position{line: 1781, col: 68, offset: 69227},
+											pos: position{line: 1778, col: 68, offset: 69157},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1781, col: 68, offset: 69227},
+												pos:  position{line: 1778, col: 68, offset: 69157},
 												name: "Space",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1781, col: 75, offset: 69234},
+											pos:  position{line: 1778, col: 75, offset: 69164},
 											name: "InlineElement",
 										},
 										&zeroOrMoreExpr{
-											pos: position{line: 1781, col: 89, offset: 69248},
+											pos: position{line: 1778, col: 89, offset: 69178},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1781, col: 89, offset: 69248},
+												pos:  position{line: 1778, col: 89, offset: 69178},
 												name: "Space",
 											},
 										},
@@ -12958,25 +12950,25 @@ var g = &grammar{
 		},
 		{
 			name: "CommentBlockDelimiter",
-			pos:  position{line: 1788, col: 1, offset: 69504},
+			pos:  position{line: 1785, col: 1, offset: 69434},
 			expr: &seqExpr{
-				pos: position{line: 1788, col: 26, offset: 69529},
+				pos: position{line: 1785, col: 26, offset: 69459},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1788, col: 26, offset: 69529},
+						pos:        position{line: 1785, col: 26, offset: 69459},
 						val:        "////",
 						ignoreCase: false,
 						want:       "\"////\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1788, col: 33, offset: 69536},
+						pos: position{line: 1785, col: 33, offset: 69466},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1788, col: 33, offset: 69536},
+							pos:  position{line: 1785, col: 33, offset: 69466},
 							name: "Space",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1788, col: 40, offset: 69543},
+						pos:  position{line: 1785, col: 40, offset: 69473},
 						name: "EOL",
 					},
 				},
@@ -12984,25 +12976,25 @@ var g = &grammar{
 		},
 		{
 			name: "CommentBlockStartDelimiter",
-			pos:  position{line: 1790, col: 1, offset: 69550},
+			pos:  position{line: 1787, col: 1, offset: 69480},
 			expr: &seqExpr{
-				pos: position{line: 1790, col: 31, offset: 69580},
+				pos: position{line: 1787, col: 31, offset: 69510},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1790, col: 31, offset: 69580},
+						pos:        position{line: 1787, col: 31, offset: 69510},
 						val:        "////",
 						ignoreCase: false,
 						want:       "\"////\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1790, col: 38, offset: 69587},
+						pos: position{line: 1787, col: 38, offset: 69517},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1790, col: 38, offset: 69587},
+							pos:  position{line: 1787, col: 38, offset: 69517},
 							name: "Space",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1790, col: 45, offset: 69594},
+						pos:  position{line: 1787, col: 45, offset: 69524},
 						name: "EOL",
 					},
 				},
@@ -13010,34 +13002,34 @@ var g = &grammar{
 		},
 		{
 			name: "CommentBlockEndDelimiter",
-			pos:  position{line: 1792, col: 1, offset: 69601},
+			pos:  position{line: 1789, col: 1, offset: 69531},
 			expr: &choiceExpr{
-				pos: position{line: 1792, col: 29, offset: 69629},
+				pos: position{line: 1789, col: 29, offset: 69559},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 1792, col: 30, offset: 69630},
+						pos: position{line: 1789, col: 30, offset: 69560},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 1792, col: 30, offset: 69630},
+								pos:        position{line: 1789, col: 30, offset: 69560},
 								val:        "////",
 								ignoreCase: false,
 								want:       "\"////\"",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 1792, col: 37, offset: 69637},
+								pos: position{line: 1789, col: 37, offset: 69567},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1792, col: 37, offset: 69637},
+									pos:  position{line: 1789, col: 37, offset: 69567},
 									name: "Space",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1792, col: 44, offset: 69644},
+								pos:  position{line: 1789, col: 44, offset: 69574},
 								name: "EOL",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1792, col: 51, offset: 69651},
+						pos:  position{line: 1789, col: 51, offset: 69581},
 						name: "EOF",
 					},
 				},
@@ -13045,27 +13037,27 @@ var g = &grammar{
 		},
 		{
 			name: "CommentBlock",
-			pos:  position{line: 1794, col: 1, offset: 69658},
+			pos:  position{line: 1791, col: 1, offset: 69588},
 			expr: &actionExpr{
-				pos: position{line: 1794, col: 17, offset: 69674},
+				pos: position{line: 1791, col: 17, offset: 69604},
 				run: (*parser).callonCommentBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1794, col: 17, offset: 69674},
+					pos: position{line: 1791, col: 17, offset: 69604},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1794, col: 17, offset: 69674},
+							pos:  position{line: 1791, col: 17, offset: 69604},
 							name: "CommentBlockStartDelimiter",
 						},
 						&labeledExpr{
-							pos:   position{line: 1794, col: 44, offset: 69701},
+							pos:   position{line: 1791, col: 44, offset: 69631},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1794, col: 53, offset: 69710},
+								pos:  position{line: 1791, col: 53, offset: 69640},
 								name: "CommentBlockVerbatimContent",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1794, col: 83, offset: 69740},
+							pos:  position{line: 1791, col: 83, offset: 69670},
 							name: "CommentBlockEndDelimiter",
 						},
 					},
@@ -13074,27 +13066,27 @@ var g = &grammar{
 		},
 		{
 			name: "CommentBlockVerbatimContent",
-			pos:  position{line: 1798, col: 1, offset: 69854},
+			pos:  position{line: 1795, col: 1, offset: 69784},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1798, col: 32, offset: 69885},
+				pos: position{line: 1795, col: 32, offset: 69815},
 				expr: &actionExpr{
-					pos: position{line: 1798, col: 33, offset: 69886},
+					pos: position{line: 1795, col: 33, offset: 69816},
 					run: (*parser).callonCommentBlockVerbatimContent2,
 					expr: &seqExpr{
-						pos: position{line: 1798, col: 33, offset: 69886},
+						pos: position{line: 1795, col: 33, offset: 69816},
 						exprs: []interface{}{
 							&notExpr{
-								pos: position{line: 1798, col: 33, offset: 69886},
+								pos: position{line: 1795, col: 33, offset: 69816},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1798, col: 34, offset: 69887},
+									pos:  position{line: 1795, col: 34, offset: 69817},
 									name: "CommentBlockEndDelimiter",
 								},
 							},
 							&labeledExpr{
-								pos:   position{line: 1798, col: 59, offset: 69912},
+								pos:   position{line: 1795, col: 59, offset: 69842},
 								label: "content",
 								expr: &ruleRefExpr{
-									pos:  position{line: 1798, col: 68, offset: 69921},
+									pos:  position{line: 1795, col: 68, offset: 69851},
 									name: "VerbatimContent",
 								},
 							},
@@ -13105,43 +13097,43 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineComment",
-			pos:  position{line: 1802, col: 1, offset: 70066},
+			pos:  position{line: 1799, col: 1, offset: 69996},
 			expr: &actionExpr{
-				pos: position{line: 1802, col: 22, offset: 70087},
+				pos: position{line: 1799, col: 22, offset: 70017},
 				run: (*parser).callonSingleLineComment1,
 				expr: &seqExpr{
-					pos: position{line: 1802, col: 22, offset: 70087},
+					pos: position{line: 1799, col: 22, offset: 70017},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1802, col: 22, offset: 70087},
+							pos: position{line: 1799, col: 22, offset: 70017},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1802, col: 23, offset: 70088},
+								pos:  position{line: 1799, col: 23, offset: 70018},
 								name: "CommentBlockDelimiter",
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1802, col: 45, offset: 70110},
+							pos: position{line: 1799, col: 45, offset: 70040},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1802, col: 45, offset: 70110},
+								pos:  position{line: 1799, col: 45, offset: 70040},
 								name: "Space",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1802, col: 52, offset: 70117},
+							pos:        position{line: 1799, col: 52, offset: 70047},
 							val:        "//",
 							ignoreCase: false,
 							want:       "\"//\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1802, col: 57, offset: 70122},
+							pos:   position{line: 1799, col: 57, offset: 70052},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1802, col: 66, offset: 70131},
+								pos:  position{line: 1799, col: 66, offset: 70061},
 								name: "SingleLineCommentContent",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1802, col: 92, offset: 70157},
+							pos:  position{line: 1799, col: 92, offset: 70087},
 							name: "EOL",
 						},
 					},
@@ -13150,14 +13142,14 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineCommentContent",
-			pos:  position{line: 1806, col: 1, offset: 70226},
+			pos:  position{line: 1803, col: 1, offset: 70156},
 			expr: &actionExpr{
-				pos: position{line: 1806, col: 29, offset: 70254},
+				pos: position{line: 1803, col: 29, offset: 70184},
 				run: (*parser).callonSingleLineCommentContent1,
 				expr: &zeroOrMoreExpr{
-					pos: position{line: 1806, col: 29, offset: 70254},
+					pos: position{line: 1803, col: 29, offset: 70184},
 					expr: &charClassMatcher{
-						pos:        position{line: 1806, col: 29, offset: 70254},
+						pos:        position{line: 1803, col: 29, offset: 70184},
 						val:        "[^\\r\\n]",
 						chars:      []rune{'\r', '\n'},
 						ignoreCase: false,
@@ -13168,20 +13160,20 @@ var g = &grammar{
 		},
 		{
 			name: "LiteralBlock",
-			pos:  position{line: 1814, col: 1, offset: 70575},
+			pos:  position{line: 1811, col: 1, offset: 70505},
 			expr: &choiceExpr{
-				pos: position{line: 1814, col: 17, offset: 70591},
+				pos: position{line: 1811, col: 17, offset: 70521},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1814, col: 17, offset: 70591},
+						pos:  position{line: 1811, col: 17, offset: 70521},
 						name: "ParagraphWithLiteralAttribute",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1814, col: 49, offset: 70623},
+						pos:  position{line: 1811, col: 49, offset: 70553},
 						name: "ParagraphWithHeadingSpaces",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1814, col: 78, offset: 70652},
+						pos:  position{line: 1811, col: 78, offset: 70582},
 						name: "ParagraphWithLiteralBlockDelimiter",
 					},
 				},
@@ -13189,9 +13181,9 @@ var g = &grammar{
 		},
 		{
 			name: "LiteralBlockDelimiter",
-			pos:  position{line: 1816, col: 1, offset: 70690},
+			pos:  position{line: 1813, col: 1, offset: 70620},
 			expr: &litMatcher{
-				pos:        position{line: 1816, col: 26, offset: 70715},
+				pos:        position{line: 1813, col: 26, offset: 70645},
 				val:        "....",
 				ignoreCase: false,
 				want:       "\"....\"",
@@ -13199,29 +13191,29 @@ var g = &grammar{
 		},
 		{
 			name: "ParagraphWithHeadingSpaces",
-			pos:  position{line: 1819, col: 1, offset: 70790},
+			pos:  position{line: 1816, col: 1, offset: 70720},
 			expr: &actionExpr{
-				pos: position{line: 1819, col: 31, offset: 70820},
+				pos: position{line: 1816, col: 31, offset: 70750},
 				run: (*parser).callonParagraphWithHeadingSpaces1,
 				expr: &seqExpr{
-					pos: position{line: 1819, col: 31, offset: 70820},
+					pos: position{line: 1816, col: 31, offset: 70750},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1819, col: 31, offset: 70820},
+							pos:   position{line: 1816, col: 31, offset: 70750},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1819, col: 42, offset: 70831},
+								pos: position{line: 1816, col: 42, offset: 70761},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1819, col: 43, offset: 70832},
+									pos:  position{line: 1816, col: 43, offset: 70762},
 									name: "Attributes",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1819, col: 56, offset: 70845},
+							pos:   position{line: 1816, col: 56, offset: 70775},
 							label: "lines",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1819, col: 63, offset: 70852},
+								pos:  position{line: 1816, col: 63, offset: 70782},
 								name: "ParagraphWithHeadingSpacesLines",
 							},
 						},
@@ -13231,33 +13223,33 @@ var g = &grammar{
 		},
 		{
 			name: "ParagraphWithHeadingSpacesLines",
-			pos:  position{line: 1824, col: 1, offset: 71087},
+			pos:  position{line: 1821, col: 1, offset: 71017},
 			expr: &actionExpr{
-				pos: position{line: 1825, col: 5, offset: 71128},
+				pos: position{line: 1822, col: 5, offset: 71058},
 				run: (*parser).callonParagraphWithHeadingSpacesLines1,
 				expr: &seqExpr{
-					pos: position{line: 1825, col: 5, offset: 71128},
+					pos: position{line: 1822, col: 5, offset: 71058},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1825, col: 5, offset: 71128},
+							pos:   position{line: 1822, col: 5, offset: 71058},
 							label: "firstLine",
 							expr: &actionExpr{
-								pos: position{line: 1825, col: 16, offset: 71139},
+								pos: position{line: 1822, col: 16, offset: 71069},
 								run: (*parser).callonParagraphWithHeadingSpacesLines4,
 								expr: &seqExpr{
-									pos: position{line: 1825, col: 16, offset: 71139},
+									pos: position{line: 1822, col: 16, offset: 71069},
 									exprs: []interface{}{
 										&oneOrMoreExpr{
-											pos: position{line: 1825, col: 16, offset: 71139},
+											pos: position{line: 1822, col: 16, offset: 71069},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1825, col: 16, offset: 71139},
+												pos:  position{line: 1822, col: 16, offset: 71069},
 												name: "Space",
 											},
 										},
 										&oneOrMoreExpr{
-											pos: position{line: 1825, col: 23, offset: 71146},
+											pos: position{line: 1822, col: 23, offset: 71076},
 											expr: &charClassMatcher{
-												pos:        position{line: 1825, col: 23, offset: 71146},
+												pos:        position{line: 1822, col: 23, offset: 71076},
 												val:        "[^\\r\\n]",
 												chars:      []rune{'\r', '\n'},
 												ignoreCase: false,
@@ -13269,37 +13261,37 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1827, col: 8, offset: 71201},
+							pos:  position{line: 1824, col: 8, offset: 71131},
 							name: "EOL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1828, col: 5, offset: 71265},
+							pos:   position{line: 1825, col: 5, offset: 71195},
 							label: "otherLines",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1828, col: 16, offset: 71276},
+								pos: position{line: 1825, col: 16, offset: 71206},
 								expr: &actionExpr{
-									pos: position{line: 1829, col: 9, offset: 71287},
+									pos: position{line: 1826, col: 9, offset: 71217},
 									run: (*parser).callonParagraphWithHeadingSpacesLines13,
 									expr: &seqExpr{
-										pos: position{line: 1829, col: 9, offset: 71287},
+										pos: position{line: 1826, col: 9, offset: 71217},
 										exprs: []interface{}{
 											&notExpr{
-												pos: position{line: 1829, col: 9, offset: 71287},
+												pos: position{line: 1826, col: 9, offset: 71217},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1829, col: 10, offset: 71288},
+													pos:  position{line: 1826, col: 10, offset: 71218},
 													name: "BlankLine",
 												},
 											},
 											&labeledExpr{
-												pos:   position{line: 1830, col: 9, offset: 71308},
+												pos:   position{line: 1827, col: 9, offset: 71238},
 												label: "otherLine",
 												expr: &actionExpr{
-													pos: position{line: 1830, col: 20, offset: 71319},
+													pos: position{line: 1827, col: 20, offset: 71249},
 													run: (*parser).callonParagraphWithHeadingSpacesLines18,
 													expr: &oneOrMoreExpr{
-														pos: position{line: 1830, col: 20, offset: 71319},
+														pos: position{line: 1827, col: 20, offset: 71249},
 														expr: &charClassMatcher{
-															pos:        position{line: 1830, col: 20, offset: 71319},
+															pos:        position{line: 1827, col: 20, offset: 71249},
 															val:        "[^\\r\\n]",
 															chars:      []rune{'\r', '\n'},
 															ignoreCase: false,
@@ -13309,7 +13301,7 @@ var g = &grammar{
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1832, col: 12, offset: 71382},
+												pos:  position{line: 1829, col: 12, offset: 71312},
 												name: "EOL",
 											},
 										},
@@ -13323,72 +13315,72 @@ var g = &grammar{
 		},
 		{
 			name: "ParagraphWithLiteralBlockDelimiter",
-			pos:  position{line: 1839, col: 1, offset: 71619},
+			pos:  position{line: 1836, col: 1, offset: 71549},
 			expr: &actionExpr{
-				pos: position{line: 1839, col: 39, offset: 71657},
+				pos: position{line: 1836, col: 39, offset: 71587},
 				run: (*parser).callonParagraphWithLiteralBlockDelimiter1,
 				expr: &seqExpr{
-					pos: position{line: 1839, col: 39, offset: 71657},
+					pos: position{line: 1836, col: 39, offset: 71587},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1839, col: 39, offset: 71657},
+							pos:   position{line: 1836, col: 39, offset: 71587},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1839, col: 50, offset: 71668},
+								pos: position{line: 1836, col: 50, offset: 71598},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1839, col: 51, offset: 71669},
+									pos:  position{line: 1836, col: 51, offset: 71599},
 									name: "Attributes",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1840, col: 9, offset: 71691},
+							pos:  position{line: 1837, col: 9, offset: 71621},
 							name: "LiteralBlockDelimiter",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1840, col: 31, offset: 71713},
+							pos: position{line: 1837, col: 31, offset: 71643},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1840, col: 31, offset: 71713},
+								pos:  position{line: 1837, col: 31, offset: 71643},
 								name: "Space",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1840, col: 38, offset: 71720},
+							pos:  position{line: 1837, col: 38, offset: 71650},
 							name: "Newline",
 						},
 						&labeledExpr{
-							pos:   position{line: 1840, col: 46, offset: 71728},
+							pos:   position{line: 1837, col: 46, offset: 71658},
 							label: "lines",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1840, col: 53, offset: 71735},
+								pos:  position{line: 1837, col: 53, offset: 71665},
 								name: "ParagraphWithLiteralBlockDelimiterLines",
 							},
 						},
 						&choiceExpr{
-							pos: position{line: 1840, col: 95, offset: 71777},
+							pos: position{line: 1837, col: 95, offset: 71707},
 							alternatives: []interface{}{
 								&seqExpr{
-									pos: position{line: 1840, col: 96, offset: 71778},
+									pos: position{line: 1837, col: 96, offset: 71708},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 1840, col: 96, offset: 71778},
+											pos:  position{line: 1837, col: 96, offset: 71708},
 											name: "LiteralBlockDelimiter",
 										},
 										&zeroOrMoreExpr{
-											pos: position{line: 1840, col: 118, offset: 71800},
+											pos: position{line: 1837, col: 118, offset: 71730},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1840, col: 118, offset: 71800},
+												pos:  position{line: 1837, col: 118, offset: 71730},
 												name: "Space",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1840, col: 125, offset: 71807},
+											pos:  position{line: 1837, col: 125, offset: 71737},
 											name: "EOL",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1840, col: 132, offset: 71814},
+									pos:  position{line: 1837, col: 132, offset: 71744},
 									name: "EOF",
 								},
 							},
@@ -13399,17 +13391,17 @@ var g = &grammar{
 		},
 		{
 			name: "ParagraphWithLiteralBlockDelimiterLines",
-			pos:  position{line: 1845, col: 1, offset: 71978},
+			pos:  position{line: 1842, col: 1, offset: 71908},
 			expr: &actionExpr{
-				pos: position{line: 1845, col: 44, offset: 72021},
+				pos: position{line: 1842, col: 44, offset: 71951},
 				run: (*parser).callonParagraphWithLiteralBlockDelimiterLines1,
 				expr: &labeledExpr{
-					pos:   position{line: 1845, col: 44, offset: 72021},
+					pos:   position{line: 1842, col: 44, offset: 71951},
 					label: "lines",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 1845, col: 50, offset: 72027},
+						pos: position{line: 1842, col: 50, offset: 71957},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1845, col: 51, offset: 72028},
+							pos:  position{line: 1842, col: 51, offset: 71958},
 							name: "ParagraphWithLiteralBlockDelimiterLine",
 						},
 					},
@@ -13418,33 +13410,33 @@ var g = &grammar{
 		},
 		{
 			name: "ParagraphWithLiteralBlockDelimiterLine",
-			pos:  position{line: 1849, col: 1, offset: 72116},
+			pos:  position{line: 1846, col: 1, offset: 72046},
 			expr: &actionExpr{
-				pos: position{line: 1850, col: 5, offset: 72172},
+				pos: position{line: 1847, col: 5, offset: 72102},
 				run: (*parser).callonParagraphWithLiteralBlockDelimiterLine1,
 				expr: &seqExpr{
-					pos: position{line: 1850, col: 5, offset: 72172},
+					pos: position{line: 1847, col: 5, offset: 72102},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1850, col: 5, offset: 72172},
+							pos:   position{line: 1847, col: 5, offset: 72102},
 							label: "line",
 							expr: &actionExpr{
-								pos: position{line: 1850, col: 11, offset: 72178},
+								pos: position{line: 1847, col: 11, offset: 72108},
 								run: (*parser).callonParagraphWithLiteralBlockDelimiterLine4,
 								expr: &seqExpr{
-									pos: position{line: 1850, col: 11, offset: 72178},
+									pos: position{line: 1847, col: 11, offset: 72108},
 									exprs: []interface{}{
 										&notExpr{
-											pos: position{line: 1850, col: 11, offset: 72178},
+											pos: position{line: 1847, col: 11, offset: 72108},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1850, col: 12, offset: 72179},
+												pos:  position{line: 1847, col: 12, offset: 72109},
 												name: "LiteralBlockDelimiter",
 											},
 										},
 										&zeroOrMoreExpr{
-											pos: position{line: 1850, col: 34, offset: 72201},
+											pos: position{line: 1847, col: 34, offset: 72131},
 											expr: &charClassMatcher{
-												pos:        position{line: 1850, col: 34, offset: 72201},
+												pos:        position{line: 1847, col: 34, offset: 72131},
 												val:        "[^\\r\\n]",
 												chars:      []rune{'\r', '\n'},
 												ignoreCase: false,
@@ -13456,7 +13448,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1852, col: 8, offset: 72256},
+							pos:  position{line: 1849, col: 8, offset: 72186},
 							name: "EOL",
 						},
 					},
@@ -13465,33 +13457,33 @@ var g = &grammar{
 		},
 		{
 			name: "ParagraphWithLiteralAttribute",
-			pos:  position{line: 1857, col: 1, offset: 72387},
+			pos:  position{line: 1854, col: 1, offset: 72317},
 			expr: &actionExpr{
-				pos: position{line: 1858, col: 5, offset: 72426},
+				pos: position{line: 1855, col: 5, offset: 72356},
 				run: (*parser).callonParagraphWithLiteralAttribute1,
 				expr: &seqExpr{
-					pos: position{line: 1858, col: 5, offset: 72426},
+					pos: position{line: 1855, col: 5, offset: 72356},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1858, col: 5, offset: 72426},
+							pos:   position{line: 1855, col: 5, offset: 72356},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1858, col: 16, offset: 72437},
+								pos: position{line: 1855, col: 16, offset: 72367},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1858, col: 17, offset: 72438},
+									pos:  position{line: 1855, col: 17, offset: 72368},
 									name: "Attributes",
 								},
 							},
 						},
 						&andCodeExpr{
-							pos: position{line: 1859, col: 5, offset: 72456},
+							pos: position{line: 1856, col: 5, offset: 72386},
 							run: (*parser).callonParagraphWithLiteralAttribute6,
 						},
 						&labeledExpr{
-							pos:   position{line: 1866, col: 5, offset: 72670},
+							pos:   position{line: 1863, col: 5, offset: 72600},
 							label: "lines",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1866, col: 12, offset: 72677},
+								pos:  position{line: 1863, col: 12, offset: 72607},
 								name: "ParagraphWithLiteralAttributeLines",
 							},
 						},
@@ -13501,12 +13493,12 @@ var g = &grammar{
 		},
 		{
 			name: "LiteralKind",
-			pos:  position{line: 1870, col: 1, offset: 72831},
+			pos:  position{line: 1867, col: 1, offset: 72761},
 			expr: &actionExpr{
-				pos: position{line: 1870, col: 16, offset: 72846},
+				pos: position{line: 1867, col: 16, offset: 72776},
 				run: (*parser).callonLiteralKind1,
 				expr: &litMatcher{
-					pos:        position{line: 1870, col: 16, offset: 72846},
+					pos:        position{line: 1867, col: 16, offset: 72776},
 					val:        "literal",
 					ignoreCase: false,
 					want:       "\"literal\"",
@@ -13515,17 +13507,17 @@ var g = &grammar{
 		},
 		{
 			name: "ParagraphWithLiteralAttributeLines",
-			pos:  position{line: 1875, col: 1, offset: 72934},
+			pos:  position{line: 1872, col: 1, offset: 72864},
 			expr: &actionExpr{
-				pos: position{line: 1875, col: 39, offset: 72972},
+				pos: position{line: 1872, col: 39, offset: 72902},
 				run: (*parser).callonParagraphWithLiteralAttributeLines1,
 				expr: &labeledExpr{
-					pos:   position{line: 1875, col: 39, offset: 72972},
+					pos:   position{line: 1872, col: 39, offset: 72902},
 					label: "lines",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 1875, col: 45, offset: 72978},
+						pos: position{line: 1872, col: 45, offset: 72908},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1875, col: 46, offset: 72979},
+							pos:  position{line: 1872, col: 46, offset: 72909},
 							name: "ParagraphWithLiteralAttributeLine",
 						},
 					},
@@ -13534,30 +13526,30 @@ var g = &grammar{
 		},
 		{
 			name: "ParagraphWithLiteralAttributeLine",
-			pos:  position{line: 1879, col: 1, offset: 73063},
+			pos:  position{line: 1876, col: 1, offset: 72993},
 			expr: &actionExpr{
-				pos: position{line: 1879, col: 38, offset: 73100},
+				pos: position{line: 1876, col: 38, offset: 73030},
 				run: (*parser).callonParagraphWithLiteralAttributeLine1,
 				expr: &seqExpr{
-					pos: position{line: 1879, col: 38, offset: 73100},
+					pos: position{line: 1876, col: 38, offset: 73030},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1879, col: 38, offset: 73100},
+							pos: position{line: 1876, col: 38, offset: 73030},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1879, col: 39, offset: 73101},
+								pos:  position{line: 1876, col: 39, offset: 73031},
 								name: "BlankLine",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1879, col: 49, offset: 73111},
+							pos:   position{line: 1876, col: 49, offset: 73041},
 							label: "content",
 							expr: &actionExpr{
-								pos: position{line: 1879, col: 58, offset: 73120},
+								pos: position{line: 1876, col: 58, offset: 73050},
 								run: (*parser).callonParagraphWithLiteralAttributeLine6,
 								expr: &oneOrMoreExpr{
-									pos: position{line: 1879, col: 58, offset: 73120},
+									pos: position{line: 1876, col: 58, offset: 73050},
 									expr: &charClassMatcher{
-										pos:        position{line: 1879, col: 58, offset: 73120},
+										pos:        position{line: 1876, col: 58, offset: 73050},
 										val:        "[^\\r\\n]",
 										chars:      []rune{'\r', '\n'},
 										ignoreCase: false,
@@ -13567,7 +13559,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1881, col: 4, offset: 73167},
+							pos:  position{line: 1878, col: 4, offset: 73097},
 							name: "EOL",
 						},
 					},
@@ -13576,29 +13568,29 @@ var g = &grammar{
 		},
 		{
 			name: "IndexTerm",
-			pos:  position{line: 1888, col: 1, offset: 73360},
+			pos:  position{line: 1885, col: 1, offset: 73290},
 			expr: &actionExpr{
-				pos: position{line: 1888, col: 14, offset: 73373},
+				pos: position{line: 1885, col: 14, offset: 73303},
 				run: (*parser).callonIndexTerm1,
 				expr: &seqExpr{
-					pos: position{line: 1888, col: 14, offset: 73373},
+					pos: position{line: 1885, col: 14, offset: 73303},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1888, col: 14, offset: 73373},
+							pos:        position{line: 1885, col: 14, offset: 73303},
 							val:        "((",
 							ignoreCase: false,
 							want:       "\"((\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1888, col: 19, offset: 73378},
+							pos:   position{line: 1885, col: 19, offset: 73308},
 							label: "term",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1888, col: 25, offset: 73384},
+								pos:  position{line: 1885, col: 25, offset: 73314},
 								name: "IndexTermContent",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1888, col: 43, offset: 73402},
+							pos:        position{line: 1885, col: 43, offset: 73332},
 							val:        "))",
 							ignoreCase: false,
 							want:       "\"))\"",
@@ -13609,51 +13601,51 @@ var g = &grammar{
 		},
 		{
 			name: "IndexTermContent",
-			pos:  position{line: 1892, col: 1, offset: 73471},
+			pos:  position{line: 1889, col: 1, offset: 73401},
 			expr: &actionExpr{
-				pos: position{line: 1892, col: 21, offset: 73491},
+				pos: position{line: 1889, col: 21, offset: 73421},
 				run: (*parser).callonIndexTermContent1,
 				expr: &labeledExpr{
-					pos:   position{line: 1892, col: 21, offset: 73491},
+					pos:   position{line: 1889, col: 21, offset: 73421},
 					label: "elements",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 1892, col: 30, offset: 73500},
+						pos: position{line: 1889, col: 30, offset: 73430},
 						expr: &choiceExpr{
-							pos: position{line: 1892, col: 31, offset: 73501},
+							pos: position{line: 1889, col: 31, offset: 73431},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 1892, col: 31, offset: 73501},
+									pos:  position{line: 1889, col: 31, offset: 73431},
 									name: "Word",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1892, col: 38, offset: 73508},
+									pos:  position{line: 1889, col: 38, offset: 73438},
 									name: "QuotedText",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1892, col: 51, offset: 73521},
+									pos:  position{line: 1889, col: 51, offset: 73451},
 									name: "QuotedString",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1892, col: 66, offset: 73536},
+									pos:  position{line: 1889, col: 66, offset: 73466},
 									name: "Space",
 								},
 								&actionExpr{
-									pos: position{line: 1892, col: 74, offset: 73544},
+									pos: position{line: 1889, col: 74, offset: 73474},
 									run: (*parser).callonIndexTermContent9,
 									expr: &seqExpr{
-										pos: position{line: 1892, col: 75, offset: 73545},
+										pos: position{line: 1889, col: 75, offset: 73475},
 										exprs: []interface{}{
 											&notExpr{
-												pos: position{line: 1892, col: 75, offset: 73545},
+												pos: position{line: 1889, col: 75, offset: 73475},
 												expr: &litMatcher{
-													pos:        position{line: 1892, col: 76, offset: 73546},
+													pos:        position{line: 1889, col: 76, offset: 73476},
 													val:        "))",
 													ignoreCase: false,
 													want:       "\"))\"",
 												},
 											},
 											&anyMatcher{
-												line: 1892, col: 81, offset: 73551,
+												line: 1889, col: 81, offset: 73481,
 											},
 										},
 									},
@@ -13666,63 +13658,63 @@ var g = &grammar{
 		},
 		{
 			name: "ConcealedIndexTerm",
-			pos:  position{line: 1898, col: 1, offset: 73663},
+			pos:  position{line: 1895, col: 1, offset: 73593},
 			expr: &actionExpr{
-				pos: position{line: 1898, col: 23, offset: 73685},
+				pos: position{line: 1895, col: 23, offset: 73615},
 				run: (*parser).callonConcealedIndexTerm1,
 				expr: &seqExpr{
-					pos: position{line: 1898, col: 23, offset: 73685},
+					pos: position{line: 1895, col: 23, offset: 73615},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1898, col: 23, offset: 73685},
+							pos:        position{line: 1895, col: 23, offset: 73615},
 							val:        "(((",
 							ignoreCase: false,
 							want:       "\"(((\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1898, col: 29, offset: 73691},
+							pos:   position{line: 1895, col: 29, offset: 73621},
 							label: "term1",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1898, col: 36, offset: 73698},
+								pos:  position{line: 1895, col: 36, offset: 73628},
 								name: "ConcealedIndexTermContent",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1899, col: 5, offset: 73731},
+							pos:   position{line: 1896, col: 5, offset: 73661},
 							label: "term2",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1899, col: 11, offset: 73737},
+								pos: position{line: 1896, col: 11, offset: 73667},
 								expr: &actionExpr{
-									pos: position{line: 1899, col: 12, offset: 73738},
+									pos: position{line: 1896, col: 12, offset: 73668},
 									run: (*parser).callonConcealedIndexTerm8,
 									expr: &seqExpr{
-										pos: position{line: 1899, col: 12, offset: 73738},
+										pos: position{line: 1896, col: 12, offset: 73668},
 										exprs: []interface{}{
 											&zeroOrMoreExpr{
-												pos: position{line: 1899, col: 12, offset: 73738},
+												pos: position{line: 1896, col: 12, offset: 73668},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1899, col: 12, offset: 73738},
+													pos:  position{line: 1896, col: 12, offset: 73668},
 													name: "Space",
 												},
 											},
 											&litMatcher{
-												pos:        position{line: 1899, col: 19, offset: 73745},
+												pos:        position{line: 1896, col: 19, offset: 73675},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&zeroOrMoreExpr{
-												pos: position{line: 1899, col: 23, offset: 73749},
+												pos: position{line: 1896, col: 23, offset: 73679},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1899, col: 23, offset: 73749},
+													pos:  position{line: 1896, col: 23, offset: 73679},
 													name: "Space",
 												},
 											},
 											&labeledExpr{
-												pos:   position{line: 1899, col: 30, offset: 73756},
+												pos:   position{line: 1896, col: 30, offset: 73686},
 												label: "content",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1899, col: 39, offset: 73765},
+													pos:  position{line: 1896, col: 39, offset: 73695},
 													name: "ConcealedIndexTermContent",
 												},
 											},
@@ -13732,41 +13724,41 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1900, col: 5, offset: 73824},
+							pos:   position{line: 1897, col: 5, offset: 73754},
 							label: "term3",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1900, col: 11, offset: 73830},
+								pos: position{line: 1897, col: 11, offset: 73760},
 								expr: &actionExpr{
-									pos: position{line: 1900, col: 12, offset: 73831},
+									pos: position{line: 1897, col: 12, offset: 73761},
 									run: (*parser).callonConcealedIndexTerm19,
 									expr: &seqExpr{
-										pos: position{line: 1900, col: 12, offset: 73831},
+										pos: position{line: 1897, col: 12, offset: 73761},
 										exprs: []interface{}{
 											&zeroOrMoreExpr{
-												pos: position{line: 1900, col: 12, offset: 73831},
+												pos: position{line: 1897, col: 12, offset: 73761},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1900, col: 12, offset: 73831},
+													pos:  position{line: 1897, col: 12, offset: 73761},
 													name: "Space",
 												},
 											},
 											&litMatcher{
-												pos:        position{line: 1900, col: 19, offset: 73838},
+												pos:        position{line: 1897, col: 19, offset: 73768},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&zeroOrMoreExpr{
-												pos: position{line: 1900, col: 23, offset: 73842},
+												pos: position{line: 1897, col: 23, offset: 73772},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1900, col: 23, offset: 73842},
+													pos:  position{line: 1897, col: 23, offset: 73772},
 													name: "Space",
 												},
 											},
 											&labeledExpr{
-												pos:   position{line: 1900, col: 30, offset: 73849},
+												pos:   position{line: 1897, col: 30, offset: 73779},
 												label: "content",
 												expr: &ruleRefExpr{
-													pos:  position{line: 1900, col: 39, offset: 73858},
+													pos:  position{line: 1897, col: 39, offset: 73788},
 													name: "ConcealedIndexTermContent",
 												},
 											},
@@ -13776,7 +13768,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1901, col: 5, offset: 73917},
+							pos:        position{line: 1898, col: 5, offset: 73847},
 							val:        ")))",
 							ignoreCase: false,
 							want:       "\")))\"",
@@ -13787,21 +13779,21 @@ var g = &grammar{
 		},
 		{
 			name: "ConcealedIndexTermContent",
-			pos:  position{line: 1905, col: 1, offset: 74000},
+			pos:  position{line: 1902, col: 1, offset: 73930},
 			expr: &actionExpr{
-				pos: position{line: 1905, col: 30, offset: 74029},
+				pos: position{line: 1902, col: 30, offset: 73959},
 				run: (*parser).callonConcealedIndexTermContent1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1905, col: 30, offset: 74029},
+					pos: position{line: 1902, col: 30, offset: 73959},
 					expr: &choiceExpr{
-						pos: position{line: 1905, col: 31, offset: 74030},
+						pos: position{line: 1902, col: 31, offset: 73960},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 1905, col: 31, offset: 74030},
+								pos:  position{line: 1902, col: 31, offset: 73960},
 								name: "Alphanum",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1905, col: 42, offset: 74041},
+								pos:  position{line: 1902, col: 42, offset: 73971},
 								name: "Space",
 							},
 						},
@@ -13811,29 +13803,29 @@ var g = &grammar{
 		},
 		{
 			name: "BlankLine",
-			pos:  position{line: 1912, col: 1, offset: 74197},
+			pos:  position{line: 1909, col: 1, offset: 74127},
 			expr: &actionExpr{
-				pos: position{line: 1912, col: 14, offset: 74210},
+				pos: position{line: 1909, col: 14, offset: 74140},
 				run: (*parser).callonBlankLine1,
 				expr: &seqExpr{
-					pos: position{line: 1912, col: 14, offset: 74210},
+					pos: position{line: 1909, col: 14, offset: 74140},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1912, col: 14, offset: 74210},
+							pos: position{line: 1909, col: 14, offset: 74140},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1912, col: 15, offset: 74211},
+								pos:  position{line: 1909, col: 15, offset: 74141},
 								name: "EOF",
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1912, col: 19, offset: 74215},
+							pos: position{line: 1909, col: 19, offset: 74145},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1912, col: 19, offset: 74215},
+								pos:  position{line: 1909, col: 19, offset: 74145},
 								name: "Space",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1912, col: 26, offset: 74222},
+							pos:  position{line: 1909, col: 26, offset: 74152},
 							name: "EOL",
 						},
 					},
@@ -13842,9 +13834,9 @@ var g = &grammar{
 		},
 		{
 			name: "Alphanum",
-			pos:  position{line: 1919, col: 1, offset: 74376},
+			pos:  position{line: 1916, col: 1, offset: 74306},
 			expr: &charClassMatcher{
-				pos:        position{line: 1919, col: 13, offset: 74388},
+				pos:        position{line: 1916, col: 13, offset: 74318},
 				val:        "[\\pL0-9]",
 				ranges:     []rune{'0', '9'},
 				classes:    []*unicode.RangeTable{rangeTable("L")},
@@ -13854,42 +13846,42 @@ var g = &grammar{
 		},
 		{
 			name: "Parenthesis",
-			pos:  position{line: 1921, col: 1, offset: 74400},
+			pos:  position{line: 1918, col: 1, offset: 74330},
 			expr: &choiceExpr{
-				pos: position{line: 1921, col: 16, offset: 74415},
+				pos: position{line: 1918, col: 16, offset: 74345},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1921, col: 16, offset: 74415},
+						pos:        position{line: 1918, col: 16, offset: 74345},
 						val:        "(",
 						ignoreCase: false,
 						want:       "\"(\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1921, col: 22, offset: 74421},
+						pos:        position{line: 1918, col: 22, offset: 74351},
 						val:        ")",
 						ignoreCase: false,
 						want:       "\")\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1921, col: 28, offset: 74427},
+						pos:        position{line: 1918, col: 28, offset: 74357},
 						val:        "[",
 						ignoreCase: false,
 						want:       "\"[\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1921, col: 34, offset: 74433},
+						pos:        position{line: 1918, col: 34, offset: 74363},
 						val:        "]",
 						ignoreCase: false,
 						want:       "\"]\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1921, col: 40, offset: 74439},
+						pos:        position{line: 1918, col: 40, offset: 74369},
 						val:        "{",
 						ignoreCase: false,
 						want:       "\"{\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1921, col: 46, offset: 74445},
+						pos:        position{line: 1918, col: 46, offset: 74375},
 						val:        "}",
 						ignoreCase: false,
 						want:       "\"}\"",
@@ -13899,14 +13891,14 @@ var g = &grammar{
 		},
 		{
 			name: "Alphanums",
-			pos:  position{line: 1923, col: 1, offset: 74453},
+			pos:  position{line: 1920, col: 1, offset: 74383},
 			expr: &actionExpr{
-				pos: position{line: 1923, col: 14, offset: 74466},
+				pos: position{line: 1920, col: 14, offset: 74396},
 				run: (*parser).callonAlphanums1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1923, col: 14, offset: 74466},
+					pos: position{line: 1920, col: 14, offset: 74396},
 					expr: &charClassMatcher{
-						pos:        position{line: 1923, col: 14, offset: 74466},
+						pos:        position{line: 1920, col: 14, offset: 74396},
 						val:        "[\\pL0-9]",
 						ranges:     []rune{'0', '9'},
 						classes:    []*unicode.RangeTable{rangeTable("L")},
@@ -13918,20 +13910,20 @@ var g = &grammar{
 		},
 		{
 			name: "Word",
-			pos:  position{line: 1927, col: 1, offset: 74516},
+			pos:  position{line: 1924, col: 1, offset: 74446},
 			expr: &choiceExpr{
-				pos: position{line: 1931, col: 5, offset: 74847},
+				pos: position{line: 1928, col: 5, offset: 74777},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1931, col: 5, offset: 74847},
+						pos: position{line: 1928, col: 5, offset: 74777},
 						run: (*parser).callonWord2,
 						expr: &seqExpr{
-							pos: position{line: 1931, col: 5, offset: 74847},
+							pos: position{line: 1928, col: 5, offset: 74777},
 							exprs: []interface{}{
 								&oneOrMoreExpr{
-									pos: position{line: 1931, col: 5, offset: 74847},
+									pos: position{line: 1928, col: 5, offset: 74777},
 									expr: &charClassMatcher{
-										pos:        position{line: 1931, col: 5, offset: 74847},
+										pos:        position{line: 1928, col: 5, offset: 74777},
 										val:        "[\\pL0-9]",
 										ranges:     []rune{'0', '9'},
 										classes:    []*unicode.RangeTable{rangeTable("L")},
@@ -13940,19 +13932,19 @@ var g = &grammar{
 									},
 								},
 								&andExpr{
-									pos: position{line: 1931, col: 15, offset: 74857},
+									pos: position{line: 1928, col: 15, offset: 74787},
 									expr: &choiceExpr{
-										pos: position{line: 1931, col: 17, offset: 74859},
+										pos: position{line: 1928, col: 17, offset: 74789},
 										alternatives: []interface{}{
 											&charClassMatcher{
-												pos:        position{line: 1931, col: 17, offset: 74859},
+												pos:        position{line: 1928, col: 17, offset: 74789},
 												val:        "[\\r\\n ,\\]]",
 												chars:      []rune{'\r', '\n', ' ', ',', ']'},
 												ignoreCase: false,
 												inverted:   false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1931, col: 30, offset: 74872},
+												pos:  position{line: 1928, col: 30, offset: 74802},
 												name: "EOF",
 											},
 										},
@@ -13962,15 +13954,15 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1933, col: 9, offset: 74944},
+						pos: position{line: 1930, col: 9, offset: 74874},
 						run: (*parser).callonWord10,
 						expr: &seqExpr{
-							pos: position{line: 1933, col: 9, offset: 74944},
+							pos: position{line: 1930, col: 9, offset: 74874},
 							exprs: []interface{}{
 								&oneOrMoreExpr{
-									pos: position{line: 1933, col: 9, offset: 74944},
+									pos: position{line: 1930, col: 9, offset: 74874},
 									expr: &charClassMatcher{
-										pos:        position{line: 1933, col: 9, offset: 74944},
+										pos:        position{line: 1930, col: 9, offset: 74874},
 										val:        "[\\pL0-9]",
 										ranges:     []rune{'0', '9'},
 										classes:    []*unicode.RangeTable{rangeTable("L")},
@@ -13979,21 +13971,21 @@ var g = &grammar{
 									},
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1933, col: 19, offset: 74954},
+									pos: position{line: 1930, col: 19, offset: 74884},
 									expr: &seqExpr{
-										pos: position{line: 1933, col: 20, offset: 74955},
+										pos: position{line: 1930, col: 20, offset: 74885},
 										exprs: []interface{}{
 											&charClassMatcher{
-												pos:        position{line: 1933, col: 20, offset: 74955},
+												pos:        position{line: 1930, col: 20, offset: 74885},
 												val:        "[=*_`]",
 												chars:      []rune{'=', '*', '_', '`'},
 												ignoreCase: false,
 												inverted:   false,
 											},
 											&oneOrMoreExpr{
-												pos: position{line: 1933, col: 27, offset: 74962},
+												pos: position{line: 1930, col: 27, offset: 74892},
 												expr: &charClassMatcher{
-													pos:        position{line: 1933, col: 27, offset: 74962},
+													pos:        position{line: 1930, col: 27, offset: 74892},
 													val:        "[\\pL0-9]",
 													ranges:     []rune{'0', '9'},
 													classes:    []*unicode.RangeTable{rangeTable("L")},
@@ -14012,20 +14004,20 @@ var g = &grammar{
 		},
 		{
 			name: "InlineWord",
-			pos:  position{line: 1937, col: 1, offset: 75042},
+			pos:  position{line: 1934, col: 1, offset: 74972},
 			expr: &choiceExpr{
-				pos: position{line: 1938, col: 5, offset: 75124},
+				pos: position{line: 1935, col: 5, offset: 75054},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1938, col: 5, offset: 75124},
+						pos: position{line: 1935, col: 5, offset: 75054},
 						run: (*parser).callonInlineWord2,
 						expr: &seqExpr{
-							pos: position{line: 1938, col: 5, offset: 75124},
+							pos: position{line: 1935, col: 5, offset: 75054},
 							exprs: []interface{}{
 								&oneOrMoreExpr{
-									pos: position{line: 1938, col: 5, offset: 75124},
+									pos: position{line: 1935, col: 5, offset: 75054},
 									expr: &charClassMatcher{
-										pos:        position{line: 1938, col: 5, offset: 75124},
+										pos:        position{line: 1935, col: 5, offset: 75054},
 										val:        "[\\pL0-9,.?!;]",
 										chars:      []rune{',', '.', '?', '!', ';'},
 										ranges:     []rune{'0', '9'},
@@ -14035,19 +14027,19 @@ var g = &grammar{
 									},
 								},
 								&andExpr{
-									pos: position{line: 1938, col: 20, offset: 75139},
+									pos: position{line: 1935, col: 20, offset: 75069},
 									expr: &choiceExpr{
-										pos: position{line: 1938, col: 22, offset: 75141},
+										pos: position{line: 1935, col: 22, offset: 75071},
 										alternatives: []interface{}{
 											&charClassMatcher{
-												pos:        position{line: 1938, col: 22, offset: 75141},
+												pos:        position{line: 1935, col: 22, offset: 75071},
 												val:        "[\\r\\n ]",
 												chars:      []rune{'\r', '\n', ' '},
 												ignoreCase: false,
 												inverted:   false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1938, col: 32, offset: 75151},
+												pos:  position{line: 1935, col: 32, offset: 75081},
 												name: "EOF",
 											},
 										},
@@ -14057,7 +14049,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1940, col: 9, offset: 75223},
+						pos:  position{line: 1937, col: 9, offset: 75153},
 						name: "Word",
 					},
 				},
@@ -14065,12 +14057,12 @@ var g = &grammar{
 		},
 		{
 			name: "AnyChar",
-			pos:  position{line: 1943, col: 1, offset: 75326},
+			pos:  position{line: 1940, col: 1, offset: 75256},
 			expr: &actionExpr{
-				pos: position{line: 1943, col: 12, offset: 75337},
+				pos: position{line: 1940, col: 12, offset: 75267},
 				run: (*parser).callonAnyChar1,
 				expr: &charClassMatcher{
-					pos:        position{line: 1943, col: 12, offset: 75337},
+					pos:        position{line: 1940, col: 12, offset: 75267},
 					val:        "[^\\r\\n]",
 					chars:      []rune{'\r', '\n'},
 					ignoreCase: false,
@@ -14080,24 +14072,24 @@ var g = &grammar{
 		},
 		{
 			name: "FileLocation",
-			pos:  position{line: 1947, col: 1, offset: 75406},
+			pos:  position{line: 1944, col: 1, offset: 75336},
 			expr: &actionExpr{
-				pos: position{line: 1947, col: 17, offset: 75422},
+				pos: position{line: 1944, col: 17, offset: 75352},
 				run: (*parser).callonFileLocation1,
 				expr: &labeledExpr{
-					pos:   position{line: 1947, col: 17, offset: 75422},
+					pos:   position{line: 1944, col: 17, offset: 75352},
 					label: "path",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 1947, col: 22, offset: 75427},
+						pos: position{line: 1944, col: 22, offset: 75357},
 						expr: &choiceExpr{
-							pos: position{line: 1947, col: 23, offset: 75428},
+							pos: position{line: 1944, col: 23, offset: 75358},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 1947, col: 23, offset: 75428},
+									pos:  position{line: 1944, col: 23, offset: 75358},
 									name: "FILENAME",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1947, col: 34, offset: 75439},
+									pos:  position{line: 1944, col: 34, offset: 75369},
 									name: "AttributeSubstitution",
 								},
 							},
@@ -14108,17 +14100,17 @@ var g = &grammar{
 		},
 		{
 			name: "ResolvedFileLocation",
-			pos:  position{line: 1951, col: 1, offset: 75527},
+			pos:  position{line: 1948, col: 1, offset: 75457},
 			expr: &actionExpr{
-				pos: position{line: 1951, col: 25, offset: 75551},
+				pos: position{line: 1948, col: 25, offset: 75481},
 				run: (*parser).callonResolvedFileLocation1,
 				expr: &labeledExpr{
-					pos:   position{line: 1951, col: 25, offset: 75551},
+					pos:   position{line: 1948, col: 25, offset: 75481},
 					label: "path",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 1951, col: 30, offset: 75556},
+						pos: position{line: 1948, col: 30, offset: 75486},
 						expr: &charClassMatcher{
-							pos:        position{line: 1951, col: 31, offset: 75557},
+							pos:        position{line: 1948, col: 31, offset: 75487},
 							val:        "[^\\r\\n []",
 							chars:      []rune{'\r', '\n', ' ', '['},
 							ignoreCase: false,
@@ -14130,38 +14122,38 @@ var g = &grammar{
 		},
 		{
 			name: "Location",
-			pos:  position{line: 1955, col: 1, offset: 75633},
+			pos:  position{line: 1952, col: 1, offset: 75563},
 			expr: &actionExpr{
-				pos: position{line: 1955, col: 13, offset: 75645},
+				pos: position{line: 1952, col: 13, offset: 75575},
 				run: (*parser).callonLocation1,
 				expr: &seqExpr{
-					pos: position{line: 1955, col: 13, offset: 75645},
+					pos: position{line: 1952, col: 13, offset: 75575},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1955, col: 13, offset: 75645},
+							pos:   position{line: 1952, col: 13, offset: 75575},
 							label: "scheme",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1955, col: 20, offset: 75652},
+								pos: position{line: 1952, col: 20, offset: 75582},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1955, col: 21, offset: 75653},
+									pos:  position{line: 1952, col: 21, offset: 75583},
 									name: "URL_SCHEME",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1955, col: 34, offset: 75666},
+							pos:   position{line: 1952, col: 34, offset: 75596},
 							label: "path",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1955, col: 39, offset: 75671},
+								pos: position{line: 1952, col: 39, offset: 75601},
 								expr: &choiceExpr{
-									pos: position{line: 1955, col: 40, offset: 75672},
+									pos: position{line: 1952, col: 40, offset: 75602},
 									alternatives: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 1955, col: 40, offset: 75672},
+											pos:  position{line: 1952, col: 40, offset: 75602},
 											name: "FILENAME",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1955, col: 51, offset: 75683},
+											pos:  position{line: 1952, col: 51, offset: 75613},
 											name: "AttributeSubstitution",
 										},
 									},
@@ -14174,35 +14166,35 @@ var g = &grammar{
 		},
 		{
 			name: "LocationWithScheme",
-			pos:  position{line: 1959, col: 1, offset: 75775},
+			pos:  position{line: 1956, col: 1, offset: 75705},
 			expr: &actionExpr{
-				pos: position{line: 1959, col: 23, offset: 75797},
+				pos: position{line: 1956, col: 23, offset: 75727},
 				run: (*parser).callonLocationWithScheme1,
 				expr: &seqExpr{
-					pos: position{line: 1959, col: 23, offset: 75797},
+					pos: position{line: 1956, col: 23, offset: 75727},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1959, col: 23, offset: 75797},
+							pos:   position{line: 1956, col: 23, offset: 75727},
 							label: "scheme",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1959, col: 31, offset: 75805},
+								pos:  position{line: 1956, col: 31, offset: 75735},
 								name: "URL_SCHEME",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1959, col: 43, offset: 75817},
+							pos:   position{line: 1956, col: 43, offset: 75747},
 							label: "path",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1959, col: 48, offset: 75822},
+								pos: position{line: 1956, col: 48, offset: 75752},
 								expr: &choiceExpr{
-									pos: position{line: 1959, col: 49, offset: 75823},
+									pos: position{line: 1956, col: 49, offset: 75753},
 									alternatives: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 1959, col: 49, offset: 75823},
+											pos:  position{line: 1956, col: 49, offset: 75753},
 											name: "FILENAME",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1959, col: 60, offset: 75834},
+											pos:  position{line: 1956, col: 60, offset: 75764},
 											name: "AttributeSubstitution",
 										},
 									},
@@ -14215,11 +14207,11 @@ var g = &grammar{
 		},
 		{
 			name: "FILENAME",
-			pos:  position{line: 1963, col: 1, offset: 75926},
+			pos:  position{line: 1960, col: 1, offset: 75856},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 1963, col: 13, offset: 75938},
+				pos: position{line: 1960, col: 13, offset: 75868},
 				expr: &charClassMatcher{
-					pos:        position{line: 1963, col: 14, offset: 75939},
+					pos:        position{line: 1960, col: 14, offset: 75869},
 					val:        "[^\\r\\n{}[\\] ]",
 					chars:      []rune{'\r', '\n', '{', '}', '[', ']', ' '},
 					ignoreCase: false,
@@ -14229,26 +14221,26 @@ var g = &grammar{
 		},
 		{
 			name: "ResolvedLocation",
-			pos:  position{line: 1965, col: 1, offset: 76075},
+			pos:  position{line: 1962, col: 1, offset: 76005},
 			expr: &actionExpr{
-				pos: position{line: 1965, col: 21, offset: 76095},
+				pos: position{line: 1962, col: 21, offset: 76025},
 				run: (*parser).callonResolvedLocation1,
 				expr: &seqExpr{
-					pos: position{line: 1965, col: 21, offset: 76095},
+					pos: position{line: 1962, col: 21, offset: 76025},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1965, col: 21, offset: 76095},
+							pos:   position{line: 1962, col: 21, offset: 76025},
 							label: "scheme",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1965, col: 29, offset: 76103},
+								pos:  position{line: 1962, col: 29, offset: 76033},
 								name: "URL_SCHEME",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1965, col: 41, offset: 76115},
+							pos:   position{line: 1962, col: 41, offset: 76045},
 							label: "path",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1965, col: 47, offset: 76121},
+								pos:  position{line: 1962, col: 47, offset: 76051},
 								name: "RESOLVED_FILENAME",
 							},
 						},
@@ -14258,11 +14250,11 @@ var g = &grammar{
 		},
 		{
 			name: "RESOLVED_FILENAME",
-			pos:  position{line: 1970, col: 1, offset: 76374},
+			pos:  position{line: 1967, col: 1, offset: 76304},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 1970, col: 22, offset: 76395},
+				pos: position{line: 1967, col: 22, offset: 76325},
 				expr: &charClassMatcher{
-					pos:        position{line: 1970, col: 23, offset: 76396},
+					pos:        position{line: 1967, col: 23, offset: 76326},
 					val:        "[^\\r\\n[\\] ]",
 					chars:      []rune{'\r', '\n', '[', ']', ' '},
 					ignoreCase: false,
@@ -14272,14 +14264,14 @@ var g = &grammar{
 		},
 		{
 			name: "URL",
-			pos:  position{line: 1972, col: 1, offset: 76530},
+			pos:  position{line: 1969, col: 1, offset: 76460},
 			expr: &actionExpr{
-				pos: position{line: 1972, col: 9, offset: 76538},
+				pos: position{line: 1969, col: 9, offset: 76468},
 				run: (*parser).callonURL1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1972, col: 9, offset: 76538},
+					pos: position{line: 1969, col: 9, offset: 76468},
 					expr: &charClassMatcher{
-						pos:        position{line: 1972, col: 9, offset: 76538},
+						pos:        position{line: 1969, col: 9, offset: 76468},
 						val:        "[^\\r\\n[\\]]",
 						chars:      []rune{'\r', '\n', '[', ']'},
 						ignoreCase: false,
@@ -14290,36 +14282,36 @@ var g = &grammar{
 		},
 		{
 			name: "URL_SCHEME",
-			pos:  position{line: 1976, col: 1, offset: 76590},
+			pos:  position{line: 1973, col: 1, offset: 76520},
 			expr: &choiceExpr{
-				pos: position{line: 1976, col: 15, offset: 76604},
+				pos: position{line: 1973, col: 15, offset: 76534},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1976, col: 15, offset: 76604},
+						pos:        position{line: 1973, col: 15, offset: 76534},
 						val:        "http://",
 						ignoreCase: false,
 						want:       "\"http://\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1976, col: 27, offset: 76616},
+						pos:        position{line: 1973, col: 27, offset: 76546},
 						val:        "https://",
 						ignoreCase: false,
 						want:       "\"https://\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1976, col: 40, offset: 76629},
+						pos:        position{line: 1973, col: 40, offset: 76559},
 						val:        "ftp://",
 						ignoreCase: false,
 						want:       "\"ftp://\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1976, col: 51, offset: 76640},
+						pos:        position{line: 1973, col: 51, offset: 76570},
 						val:        "irc://",
 						ignoreCase: false,
 						want:       "\"irc://\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1976, col: 62, offset: 76651},
+						pos:        position{line: 1973, col: 62, offset: 76581},
 						val:        "mailto:",
 						ignoreCase: false,
 						want:       "\"mailto:\"",
@@ -14329,14 +14321,14 @@ var g = &grammar{
 		},
 		{
 			name: "ID",
-			pos:  position{line: 1978, col: 1, offset: 76664},
+			pos:  position{line: 1975, col: 1, offset: 76594},
 			expr: &actionExpr{
-				pos: position{line: 1978, col: 7, offset: 76670},
+				pos: position{line: 1975, col: 7, offset: 76600},
 				run: (*parser).callonID1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1978, col: 7, offset: 76670},
+					pos: position{line: 1975, col: 7, offset: 76600},
 					expr: &charClassMatcher{
-						pos:        position{line: 1978, col: 7, offset: 76670},
+						pos:        position{line: 1975, col: 7, offset: 76600},
 						val:        "[^[\\]<>,]",
 						chars:      []rune{'[', ']', '<', '>', ','},
 						ignoreCase: false,
@@ -14347,12 +14339,12 @@ var g = &grammar{
 		},
 		{
 			name: "DIGIT",
-			pos:  position{line: 1982, col: 1, offset: 76799},
+			pos:  position{line: 1979, col: 1, offset: 76729},
 			expr: &actionExpr{
-				pos: position{line: 1982, col: 10, offset: 76808},
+				pos: position{line: 1979, col: 10, offset: 76738},
 				run: (*parser).callonDIGIT1,
 				expr: &charClassMatcher{
-					pos:        position{line: 1982, col: 10, offset: 76808},
+					pos:        position{line: 1979, col: 10, offset: 76738},
 					val:        "[0-9]",
 					ranges:     []rune{'0', '9'},
 					ignoreCase: false,
@@ -14362,26 +14354,26 @@ var g = &grammar{
 		},
 		{
 			name: "NUMBER",
-			pos:  position{line: 1986, col: 1, offset: 76854},
+			pos:  position{line: 1983, col: 1, offset: 76784},
 			expr: &actionExpr{
-				pos: position{line: 1986, col: 11, offset: 76864},
+				pos: position{line: 1983, col: 11, offset: 76794},
 				run: (*parser).callonNUMBER1,
 				expr: &seqExpr{
-					pos: position{line: 1986, col: 11, offset: 76864},
+					pos: position{line: 1983, col: 11, offset: 76794},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 1986, col: 11, offset: 76864},
+							pos: position{line: 1983, col: 11, offset: 76794},
 							expr: &litMatcher{
-								pos:        position{line: 1986, col: 11, offset: 76864},
+								pos:        position{line: 1983, col: 11, offset: 76794},
 								val:        "-",
 								ignoreCase: false,
 								want:       "\"-\"",
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 1986, col: 16, offset: 76869},
+							pos: position{line: 1983, col: 16, offset: 76799},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1986, col: 16, offset: 76869},
+								pos:  position{line: 1983, col: 16, offset: 76799},
 								name: "DIGIT",
 							},
 						},
@@ -14391,21 +14383,21 @@ var g = &grammar{
 		},
 		{
 			name: "Space",
-			pos:  position{line: 1990, col: 1, offset: 76925},
+			pos:  position{line: 1987, col: 1, offset: 76855},
 			expr: &choiceExpr{
-				pos: position{line: 1990, col: 10, offset: 76934},
+				pos: position{line: 1987, col: 10, offset: 76864},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1990, col: 10, offset: 76934},
+						pos:        position{line: 1987, col: 10, offset: 76864},
 						val:        " ",
 						ignoreCase: false,
 						want:       "\" \"",
 					},
 					&actionExpr{
-						pos: position{line: 1990, col: 16, offset: 76940},
+						pos: position{line: 1987, col: 16, offset: 76870},
 						run: (*parser).callonSpace3,
 						expr: &litMatcher{
-							pos:        position{line: 1990, col: 16, offset: 76940},
+							pos:        position{line: 1987, col: 16, offset: 76870},
 							val:        "\t",
 							ignoreCase: false,
 							want:       "\"\\t\"",
@@ -14416,24 +14408,24 @@ var g = &grammar{
 		},
 		{
 			name: "Newline",
-			pos:  position{line: 1994, col: 1, offset: 76985},
+			pos:  position{line: 1991, col: 1, offset: 76915},
 			expr: &choiceExpr{
-				pos: position{line: 1994, col: 12, offset: 76996},
+				pos: position{line: 1991, col: 12, offset: 76926},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1994, col: 12, offset: 76996},
+						pos:        position{line: 1991, col: 12, offset: 76926},
 						val:        "\r\n",
 						ignoreCase: false,
 						want:       "\"\\r\\n\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1994, col: 21, offset: 77005},
+						pos:        position{line: 1991, col: 21, offset: 76935},
 						val:        "\r",
 						ignoreCase: false,
 						want:       "\"\\r\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1994, col: 28, offset: 77012},
+						pos:        position{line: 1991, col: 28, offset: 76942},
 						val:        "\n",
 						ignoreCase: false,
 						want:       "\"\\n\"",
@@ -14443,26 +14435,26 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 1996, col: 1, offset: 77020},
+			pos:  position{line: 1993, col: 1, offset: 76950},
 			expr: &notExpr{
-				pos: position{line: 1996, col: 8, offset: 77027},
+				pos: position{line: 1993, col: 8, offset: 76957},
 				expr: &anyMatcher{
-					line: 1996, col: 9, offset: 77028,
+					line: 1993, col: 9, offset: 76958,
 				},
 			},
 		},
 		{
 			name: "EOL",
-			pos:  position{line: 1998, col: 1, offset: 77033},
+			pos:  position{line: 1995, col: 1, offset: 76963},
 			expr: &choiceExpr{
-				pos: position{line: 1998, col: 8, offset: 77040},
+				pos: position{line: 1995, col: 8, offset: 76970},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1998, col: 8, offset: 77040},
+						pos:  position{line: 1995, col: 8, offset: 76970},
 						name: "Newline",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1998, col: 18, offset: 77050},
+						pos:  position{line: 1995, col: 18, offset: 76980},
 						name: "EOF",
 					},
 				},
@@ -15194,20 +15186,9 @@ func (p *parser) callonStandaloneAttributes1() (interface{}, error) {
 	return p.cur.onStandaloneAttributes1(stack["attributes"])
 }
 
-func (c *current) onQuotedString1(qs interface{}) (interface{}, error) {
-
-	return qs, nil
-}
-
-func (p *parser) callonQuotedString1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onQuotedString1(stack["qs"])
-}
-
 func (c *current) onSingleQuotedString1(elements interface{}) (interface{}, error) {
 
-	return types.QuotedString{Kind: types.SingleQuote, Elements: elements.([]interface{})}, nil
+	return types.NewQuotedString(types.SingleQuote, elements.([]interface{}))
 }
 
 func (p *parser) callonSingleQuotedString1() (interface{}, error) {
@@ -15251,7 +15232,7 @@ func (p *parser) callonSingleQuotedStringFallbackCharacter3() (interface{}, erro
 
 func (c *current) onDoubleQuotedString1(elements interface{}) (interface{}, error) {
 
-	return types.QuotedString{Kind: types.DoubleQuote, Elements: elements.([]interface{})}, nil
+	return types.NewQuotedString(types.DoubleQuote, elements.([]interface{}))
 }
 
 func (p *parser) callonDoubleQuotedString1() (interface{}, error) {

--- a/pkg/parser/parser.peg
+++ b/pkg/parser/parser.peg
@@ -364,6 +364,81 @@ StandaloneAttributes <- attributes:(ElementAttribute)+ BlankLine* EOF { // stand
 }
 
 // ------------------------------------------
+// Quoted Strings (between curly single or double quotes)
+// ------------------------------------------
+
+QuotedString <- qs:(SingleQuotedString / DoubleQuotedString) {
+    return qs, nil
+}
+
+SingleQuotedString <- "'`" elements:SingleQuotedStringElements "`'" {
+    return types.QuotedString{ Kind: types.SingleQuote, Elements: elements.([]interface{})}, nil
+}
+
+SingleQuotedStringElements <- elements:(SingleQuotedStringElement+) {
+    return types.NewInlineElements(elements)
+}
+
+// We have to treat this one special, because of ambiguity with monospace markup.
+SingleQuotedStringElement <- element:(
+        LineBreak // must be before spaces
+        / Space+
+        / InlineIcon
+        / InlineImage
+        / InlineFootnote
+        / InlinePassthrough
+        / Link
+        / AttributeSubstitution
+        / BoldText
+        / ItalicText
+        / MarkedText
+        / SubscriptText
+        / SuperscriptText
+        / !"`'" MonospaceText
+        / DoubleQuotedString
+        / SingleQuotedStringFallbackCharacter) {
+    return element, nil
+}
+
+SingleQuotedStringFallbackCharacter <-  [^\r\n`] / "`" !"'" {
+    return types.NewStringElement(string(c.text))
+}
+
+DoubleQuotedString <- "\"`" elements:DoubleQuotedStringElements "`\"" {
+
+    return types.QuotedString{ Kind: types.DoubleQuote, Elements: elements.([]interface{})}, nil
+}
+
+DoubleQuotedStringElements <- elements:(DoubleQuotedStringElement+) {
+    return types.NewInlineElements(elements)
+}
+
+// We have to treat this one special, because of ambiguity with monospace markup.
+DoubleQuotedStringElement <- element:(
+        LineBreak // must be before spaces
+        // Space+
+        / InlineIcon
+        / InlineImage
+        / InlineFootnote
+        / InlinePassthrough
+        / Link
+        / AttributeSubstitution
+        / BoldText
+        / ItalicText
+        / MarkedText
+        / SubscriptText
+        / SuperscriptText
+        / !"`\"" MonospaceText
+        / SingleQuotedString
+        / DoubleQuotedStringFallbackCharacter) {
+            return element, nil
+}
+
+DoubleQuotedStringFallbackCharacter <-  ([^\r\n`] / "`" !"\"") {
+    return types.NewStringElement(string(c.text))
+}
+
+// ------------------------------------------
 // Sections
 // ------------------------------------------
 Section <- attributes:(Attributes)?
@@ -392,6 +467,7 @@ TitleElement <- element:(Word
         / InlineImage
         / Link
         / InlineFootnote
+        / QuotedString
         / QuotedText
         / AttributeSubstitution
         / AnyChar) {
@@ -723,6 +799,7 @@ LabeledListItemTermElement <- element:(Word
         / InlineImage 
         / Link
         / InlineFootnote
+        / QuotedString
         / QuotedText
         / AttributeSubstitution
         / AnyChar ) {
@@ -882,8 +959,9 @@ InlineElement <-
     element:(InlineWord // more permissive than words
         / LineBreak // must be before spaces
         / Space+ 
-        / !EOL ( 
-            QuotedText
+        / !EOL (
+            QuotedString
+            / QuotedText
             / InlineIcon
             / InlineImage 
             / Link 
@@ -911,9 +989,9 @@ LineBreak <- Space "+" Space* &EOL {
 // ----------------------------------------------------------------------------
 QuotedText <- UnconstrainedQuotedText / ConstrainedQuotedText / EscapedQuotedText
 
-ConstrainedQuotedTextMarker <- "*" !"*" / "_" !"_" / "`" !"`" 
+ConstrainedQuotedTextMarker <- "*" !"*" / "_" !"_" / "#" !"#" / "`" !"`"
 
-UnconstrainedQuotedTextPrefix <- "**" / "__" / "``" / "^" / "~"
+UnconstrainedQuotedTextPrefix <- "**" / "__" / "``" / "##" / "^" / "~"
 
 ConstrainedQuotedText <- text:(SingleQuoteBoldText 
             / SingleQuoteItalicText
@@ -969,9 +1047,10 @@ DoubleQuoteBoldTextElement <- Word
         / SubscriptText
         / SuperscriptText
         / InlineIcon
-        / InlineImage 
-        / Link 
-        / InlinePassthrough 
+        / InlineImage
+        / Link
+        / InlinePassthrough
+        / QuotedString
         / AttributeSubstitution
         / DoubleQuoteBoldTextStringElement
         / DoubleQuoteBoldTextFallbackCharacter
@@ -1006,7 +1085,8 @@ SingleQuoteBoldTextElement <- Word
         / InlineIcon
         / InlineImage 
         / Link  
-        / InlinePassthrough 
+        / InlinePassthrough
+        / QuotedString
         / AttributeSubstitution
         / SingleQuoteBoldTextStringElement
         / SingleQuoteBoldTextFallbackCharacter
@@ -1053,7 +1133,8 @@ DoubleQuoteItalicTextElement <- Word
         / InlineIcon
         / InlineImage 
         / Link 
-        / InlinePassthrough 
+        / InlinePassthrough
+        / QuotedString
         / DoubleQuoteItalicTextStringElement
         / DoubleQuoteItalicTextFallbackCharacter
 
@@ -1087,6 +1168,7 @@ SingleQuoteItalicTextElement <- Word
         / InlineImage 
         / Link  
         / InlinePassthrough 
+        / QuotedString
         / AttributeSubstitution
         / SingleQuoteItalicTextStringElement
         / SingleQuoteItalicTextFallbackCharacter
@@ -1133,6 +1215,7 @@ DoubleQuoteMonospaceTextElement <- Word
         / InlineImage
         / Link
         / InlinePassthrough 
+        / QuotedString
         / DoubleQuoteMonospaceTextStringElement
         / DoubleQuoteMonospaceTextFallbackCharacter
 
@@ -1167,6 +1250,7 @@ SingleQuoteMonospaceTextElement <-  Word
         / InlineImage 
         / Link 
         / InlinePassthrough 
+        / QuotedString
         / AttributeSubstitution
         / SingleQuoteMonospaceTextStringElement
         / SingleQuoteMonospaceTextFallbackCharacter
@@ -1214,6 +1298,7 @@ DoubleQuoteMarkedTextElement <- Word
         / InlineImage
         / Link
         / InlinePassthrough
+        / QuotedString
         / DoubleQuoteMarkedTextStringElement
         / DoubleQuoteMarkedTextFallbackCharacter
 
@@ -1247,6 +1332,7 @@ SingleQuoteMarkedTextElement <- Word
         / InlineImage
         / Link
         / InlinePassthrough
+        / QuotedString
         / AttributeSubstitution
         / SingleQuoteMarkedTextStringElement
         / SingleQuoteMarkedTextFallbackCharacter
@@ -1377,11 +1463,11 @@ LinkAttributes <- "[" firstAttr:(FirstLinkAttributeElement)*
 
 FirstLinkAttributeElement <- element:(
     // surrounded with double quotes
-    ("\"" elements:(QuotedText / QuotedAttributeChar)+ "\"" &(!"=") ","? {
+    ("\"" elements:(QuotedString / QuotedText / QuotedAttributeChar)+ "\"" &(!"=") ","? {
         return types.NewInlineElements(elements.([]interface{}))
     }) /
     // not surrounded with double quotes
-    (elements:(QuotedText / UnquotedAttributeChar)+ &(!"=") ","? {
+    (elements:(QuotedString / QuotedText / UnquotedAttributeChar)+ &(!"=") ","? {
         return types.NewInlineElements(elements.([]interface{}))
     }))  {
         return element, nil
@@ -1803,7 +1889,7 @@ IndexTerm <- "((" term:(IndexTermContent) "))" {
        return types.NewIndexTerm(term.([]interface{}))
 }
 
-IndexTermContent <- elements:(Word / QuotedText / Space / (!"))" .) {
+IndexTermContent <- elements:(Word / QuotedText / QuotedString / Space / (!"))" .) {
     return string(c.text), nil
 })+ {
     return types.NewInlineElements(elements.([]interface{}))

--- a/pkg/parser/parser.peg
+++ b/pkg/parser/parser.peg
@@ -367,12 +367,10 @@ StandaloneAttributes <- attributes:(ElementAttribute)+ BlankLine* EOF { // stand
 // Quoted Strings (between curly single or double quotes)
 // ------------------------------------------
 
-QuotedString <- qs:(SingleQuotedString / DoubleQuotedString) {
-    return qs, nil
-}
+QuotedString <- SingleQuotedString / DoubleQuotedString
 
 SingleQuotedString <- "'`" elements:SingleQuotedStringElements "`'" {
-    return types.QuotedString{ Kind: types.SingleQuote, Elements: elements.([]interface{})}, nil
+    return types.NewQuotedString(types.SingleQuote, elements.([]interface{}))
 }
 
 SingleQuotedStringElements <- elements:(SingleQuotedStringElement+) {
@@ -405,8 +403,7 @@ SingleQuotedStringFallbackCharacter <-  [^\r\n`] / "`" !"'" {
 }
 
 DoubleQuotedString <- "\"`" elements:DoubleQuotedStringElements "`\"" {
-
-    return types.QuotedString{ Kind: types.DoubleQuote, Elements: elements.([]interface{})}, nil
+    return types.NewQuotedString(types.DoubleQuote, elements.([]interface{}))
 }
 
 DoubleQuotedStringElements <- elements:(DoubleQuotedStringElement+) {

--- a/pkg/parser/quoted_string_test.go
+++ b/pkg/parser/quoted_string_test.go
@@ -1,0 +1,1009 @@
+package parser_test
+
+import (
+	"github.com/bytesparadise/libasciidoc/pkg/types"
+	. "github.com/bytesparadise/libasciidoc/testsupport"
+
+	. "github.com/onsi/ginkgo" //nolint golint
+	. "github.com/onsi/gomega" //nolint golint
+)
+
+var _ = Describe("quoted strings", func() {
+
+	Context("draft document", func() {
+		It("simple single quoted string", func() {
+			source := "'`curly was single`'"
+			expected := types.DraftDocument{
+				Blocks: []interface{}{
+					types.Paragraph{
+						Lines: [][]interface{}{
+							{
+								types.QuotedString{
+									Kind: types.SingleQuote,
+									Elements: []interface{}{
+										types.StringElement{Content: "curly was single"},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
+		})
+		It("spaces with single quoted string", func() {
+			source := "'` curly was single `'"
+			expected := types.DraftDocument{
+				Blocks: []interface{}{
+					types.Paragraph{
+						Lines: [][]interface{}{
+							{
+								types.QuotedString{
+									Kind: types.SingleQuote,
+									Elements: []interface{}{
+										types.StringElement{Content: " curly was single "},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
+		})
+
+		It("bold in single quoted string", func() {
+			source := "'`curly *was* single`'"
+			expected := types.DraftDocument{
+				Blocks: []interface{}{
+					types.Paragraph{
+						Lines: [][]interface{}{
+							{
+								types.QuotedString{
+									Kind: types.SingleQuote,
+									Elements: []interface{}{
+										types.StringElement{Content: "curly "},
+										types.QuotedText{
+											Kind: types.Bold,
+											Elements: []interface{}{
+												types.StringElement{Content: "was"},
+											},
+										},
+										types.StringElement{Content: " single"},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
+		})
+
+		It("italics in single quoted string", func() {
+			source := "'`curly _was_ single`'"
+			expected := types.DraftDocument{
+				Blocks: []interface{}{
+					types.Paragraph{
+						Lines: [][]interface{}{
+							{
+								types.QuotedString{
+									Kind: types.SingleQuote,
+									Elements: []interface{}{
+										types.StringElement{Content: "curly "},
+										types.QuotedText{
+											Kind: types.Italic,
+											Elements: []interface{}{
+												types.StringElement{Content: "was"},
+											},
+										},
+										types.StringElement{Content: " single"},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
+		})
+		It("span in single quoted string", func() {
+			source := "'`curly [strikeout]#was#_is_ single`'"
+			expected := types.DraftDocument{
+				Blocks: []interface{}{
+					types.Paragraph{
+						Lines: [][]interface{}{
+							{
+								types.QuotedString{
+									Kind: types.SingleQuote,
+									Elements: []interface{}{
+										types.StringElement{Content: "curly "},
+										types.QuotedText{
+											Kind:       types.Marked,
+											Attributes: types.Attributes{types.AttrRole: "strikeout"},
+											Elements: []interface{}{
+												types.StringElement{Content: "was"},
+											},
+										},
+										types.QuotedText{
+											Kind: types.Italic,
+											Elements: []interface{}{
+												types.StringElement{Content: "is"},
+											},
+										},
+
+										types.StringElement{Content: " single"},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
+		})
+		It("curly in monospace  string", func() {
+			source := "'`curly `is` single`'"
+			expected := types.DraftDocument{
+				Blocks: []interface{}{
+					types.Paragraph{
+						Lines: [][]interface{}{
+							{
+								types.QuotedString{
+									Kind: types.SingleQuote,
+									Elements: []interface{}{
+										types.StringElement{Content: "curly "},
+										types.QuotedText{
+											Kind: types.Monospace,
+											Elements: []interface{}{
+												types.StringElement{Content: "is"},
+											},
+										},
+										types.StringElement{Content: " single"},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
+		})
+		It("curly as monospace string", func() {
+			source := "'``curly``'"
+			expected := types.DraftDocument{
+				Blocks: []interface{}{
+					types.Paragraph{
+						Lines: [][]interface{}{
+							{
+								types.QuotedString{
+									Kind: types.SingleQuote,
+									Elements: []interface{}{
+										types.QuotedText{
+											Kind: types.Monospace,
+											Elements: []interface{}{
+												types.StringElement{Content: "curly"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
+		})
+
+		It("curly with nested double curly", func() {
+			source := "'`single\"`double`\"`'"
+			expected := types.DraftDocument{
+				Blocks: []interface{}{
+					types.Paragraph{
+						Lines: [][]interface{}{
+							{
+								types.QuotedString{
+									Kind: types.SingleQuote,
+									Elements: []interface{}{
+										types.StringElement{Content: "single"},
+										types.QuotedString{
+											Kind: types.DoubleQuote,
+											Elements: []interface{}{
+												types.StringElement{Content: "double"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
+		})
+
+		It("curly in monospace string", func() {
+			source := "`'`curly`'`"
+			expected := types.DraftDocument{
+				Blocks: []interface{}{
+					types.Paragraph{
+						Lines: [][]interface{}{
+							{
+								types.QuotedText{
+									Kind: types.Monospace,
+									Elements: []interface{}{
+										types.QuotedString{
+											Kind: types.SingleQuote,
+											Elements: []interface{}{
+												types.StringElement{Content: "curly"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
+		})
+		It("curly in italics", func() {
+			source := "_'`curly`'_"
+			expected := types.DraftDocument{
+				Blocks: []interface{}{
+					types.Paragraph{
+						Lines: [][]interface{}{
+							{
+								types.QuotedText{
+									Kind: types.Italic,
+									Elements: []interface{}{
+										types.QuotedString{
+											Kind: types.SingleQuote,
+											Elements: []interface{}{
+												types.StringElement{Content: "curly"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
+		})
+		It("curly in bold", func() {
+			source := "*'`curly`'*"
+			expected := types.DraftDocument{
+				Blocks: []interface{}{
+					types.Paragraph{
+						Lines: [][]interface{}{
+							{
+								types.QuotedText{
+									Kind: types.Bold,
+									Elements: []interface{}{
+										types.QuotedString{
+											Kind: types.SingleQuote,
+											Elements: []interface{}{
+												types.StringElement{Content: "curly"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
+		})
+
+		It("curly in title", func() {
+			source := "== a '`curly`' episode"
+			expected := types.DraftDocument{
+				Blocks: []interface{}{
+					types.Section{
+						Level: 1,
+						Title: []interface{}{
+							types.StringElement{Content: "a "},
+							types.QuotedString{
+								Kind: types.SingleQuote,
+								Elements: []interface{}{
+									types.StringElement{Content: "curly"},
+								},
+							},
+							types.StringElement{Content: " episode"},
+						},
+						Elements: []interface{}{},
+					},
+				},
+			}
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
+		})
+
+		It("curly in list element", func() {
+			source := "* a '`curly`' episode"
+			expected := types.DraftDocument{
+				Blocks: []interface{}{
+					types.UnorderedListItem{
+						Level:       1,
+						CheckStyle:  types.NoCheck,
+						BulletStyle: types.OneAsterisk,
+						Elements: []interface{}{
+							types.Paragraph{
+								Lines: [][]interface{}{
+									{
+										types.StringElement{Content: "a "},
+										types.QuotedString{
+											Kind: types.SingleQuote,
+											Elements: []interface{}{
+												types.StringElement{Content: "curly"},
+											},
+										},
+										types.StringElement{Content: " episode"},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
+		})
+
+		It("curly in labeled list", func() {
+			source := "'`term`':: something '`quoted`'"
+			expected := types.DraftDocument{
+				Blocks: []interface{}{
+					types.LabeledListItem{
+						Level: 1,
+						Term: []interface{}{
+							types.StringElement{Content: "'`term`'"}, // parsed later
+						},
+						Elements: []interface{}{
+							types.Paragraph{
+								Lines: [][]interface{}{
+									{
+										types.StringElement{Content: "something "},
+										types.QuotedString{
+											Kind: types.SingleQuote,
+											Elements: []interface{}{
+												types.StringElement{Content: "quoted"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
+		})
+
+		It("curly in link", func() {
+			source := "https://www.example.com/a['`example`']"
+			expected := types.DraftDocument{
+				Blocks: []interface{}{
+					types.Paragraph{
+						Lines: [][]interface{}{
+							{
+								types.InlineLink{
+									Location: types.Location{
+										Scheme: "https://",
+										Path: []interface{}{
+											types.StringElement{Content: "www.example.com/a"},
+										},
+									},
+									Attributes: types.Attributes{
+										"positional-1": []interface{}{
+											types.QuotedString{
+												Kind: types.SingleQuote,
+												Elements: []interface{}{
+													types.StringElement{
+														Content: "example",
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
+		})
+		It("curly in quoted link", func() {
+			source := "https://www.example.com/a[\"an '`example`'\"]"
+			expected := types.DraftDocument{
+				Blocks: []interface{}{
+					types.Paragraph{
+						Lines: [][]interface{}{
+							{
+								types.InlineLink{
+									Location: types.Location{
+										Scheme: "https://",
+										Path: []interface{}{
+											types.StringElement{Content: "www.example.com/a"},
+										},
+									},
+									Attributes: types.Attributes{
+										"positional-1": []interface{}{
+											types.StringElement{
+												Content: "an ",
+											},
+											types.QuotedString{
+												Kind: types.SingleQuote,
+												Elements: []interface{}{
+													types.StringElement{
+														Content: "example",
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
+		})
+
+		It("image in curly", func() {
+			source := "'`a image:foo.png[]`'"
+			expected := types.DraftDocument{
+				Blocks: []interface{}{
+					types.Paragraph{
+						Lines: [][]interface{}{
+							{
+								types.QuotedString{
+									Kind: types.SingleQuote,
+									Elements: []interface{}{
+										types.StringElement{Content: "a "},
+										types.InlineImage{
+											Location: types.Location{
+												Path: []interface{}{
+													types.StringElement{
+														Content: "foo.png",
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
+		})
+
+		It("icon in curly", func() {
+			source := "'`a icon:note[]`'"
+			expected := types.DraftDocument{
+				Blocks: []interface{}{
+					types.Paragraph{
+						Lines: [][]interface{}{
+							{
+								types.QuotedString{
+									Kind: types.SingleQuote,
+									Elements: []interface{}{
+										types.StringElement{Content: "a "},
+										types.Icon{
+											Class: "note",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
+		})
+
+		It("simple double quoted string", func() {
+			source := "\"`curly was single`\""
+			expected := types.DraftDocument{
+				Blocks: []interface{}{
+					types.Paragraph{
+						Lines: [][]interface{}{
+							{
+								types.QuotedString{
+									Kind: types.DoubleQuote,
+									Elements: []interface{}{
+										types.StringElement{Content: "curly was single"},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
+		})
+
+		It("spaces with double quoted string", func() {
+			source := "\"` curly was single `\""
+			expected := types.DraftDocument{
+				Blocks: []interface{}{
+					types.Paragraph{
+						Lines: [][]interface{}{
+							{
+								types.QuotedString{
+									Kind: types.DoubleQuote,
+									Elements: []interface{}{
+										types.StringElement{Content: " curly was single "},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
+		})
+		It("bold in double quoted string", func() {
+			source := "\"`curly *was* single`\""
+			expected := types.DraftDocument{
+				Blocks: []interface{}{
+					types.Paragraph{
+						Lines: [][]interface{}{
+							{
+								types.QuotedString{
+									Kind: types.DoubleQuote,
+									Elements: []interface{}{
+										types.StringElement{Content: "curly "},
+										types.QuotedText{
+											Kind: types.Bold,
+											Elements: []interface{}{
+												types.StringElement{Content: "was"},
+											},
+										},
+										types.StringElement{Content: " single"},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
+		})
+		It("italics in double quoted string", func() {
+			source := "\"`curly _was_ single`\""
+			expected := types.DraftDocument{
+				Blocks: []interface{}{
+					types.Paragraph{
+						Lines: [][]interface{}{
+							{
+								types.QuotedString{
+									Kind: types.DoubleQuote,
+									Elements: []interface{}{
+										types.StringElement{Content: "curly "},
+										types.QuotedText{
+											Kind: types.Italic,
+											Elements: []interface{}{
+												types.StringElement{Content: "was"},
+											},
+										},
+										types.StringElement{Content: " single"},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
+		})
+
+		It("span in double quoted string", func() {
+			source := "\"`curly [strikeout]#was#_is_ single`\""
+			expected := types.DraftDocument{
+				Blocks: []interface{}{
+					types.Paragraph{
+						Lines: [][]interface{}{
+							{
+								types.QuotedString{
+									Kind: types.DoubleQuote,
+									Elements: []interface{}{
+										types.StringElement{Content: "curly "},
+										types.QuotedText{
+											Kind:       types.Marked,
+											Attributes: types.Attributes{types.AttrRole: "strikeout"},
+											Elements: []interface{}{
+												types.StringElement{Content: "was"},
+											},
+										},
+										types.QuotedText{
+											Kind: types.Italic,
+											Elements: []interface{}{
+												types.StringElement{Content: "is"},
+											},
+										},
+
+										types.StringElement{Content: " single"},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
+		})
+
+		It("double curly in monospace string", func() {
+			source := "\"`curly `is` single`\""
+			expected := types.DraftDocument{
+				Blocks: []interface{}{
+					types.Paragraph{
+						Lines: [][]interface{}{
+							{
+								types.QuotedString{
+									Kind: types.DoubleQuote,
+									Elements: []interface{}{
+										types.StringElement{Content: "curly "},
+										types.QuotedText{
+											Kind: types.Monospace,
+											Elements: []interface{}{
+												types.StringElement{Content: "is"},
+											},
+										},
+										types.StringElement{Content: " single"},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
+		})
+		It("double curly as monospace string", func() {
+			source := "\"``curly``\""
+			expected := types.DraftDocument{
+				Blocks: []interface{}{
+					types.Paragraph{
+						Lines: [][]interface{}{
+							{
+								types.QuotedString{
+									Kind: types.DoubleQuote,
+									Elements: []interface{}{
+										types.QuotedText{
+											Kind: types.Monospace,
+											Elements: []interface{}{
+												types.StringElement{Content: "curly"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
+		})
+		It("double curly with nested single curly", func() {
+			source := "\"`double'`single`'`\""
+			expected := types.DraftDocument{
+				Blocks: []interface{}{
+					types.Paragraph{
+						Lines: [][]interface{}{
+							{
+								types.QuotedString{
+									Kind: types.DoubleQuote,
+									Elements: []interface{}{
+										types.StringElement{Content: "double"},
+										types.QuotedString{
+											Kind: types.SingleQuote,
+											Elements: []interface{}{
+												types.StringElement{Content: "single"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
+		})
+		It("double curly in monospace string", func() {
+			source := "`\"`curly`\"`"
+			expected := types.DraftDocument{
+				Blocks: []interface{}{
+					types.Paragraph{
+						Lines: [][]interface{}{
+							{
+								types.QuotedText{
+									Kind: types.Monospace,
+									Elements: []interface{}{
+										types.QuotedString{
+											Kind: types.DoubleQuote,
+											Elements: []interface{}{
+												types.StringElement{Content: "curly"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
+		})
+		It("double curly in italics", func() {
+			source := "_\"`curly`\"_"
+			expected := types.DraftDocument{
+				Blocks: []interface{}{
+					types.Paragraph{
+						Lines: [][]interface{}{
+							{
+								types.QuotedText{
+									Kind: types.Italic,
+									Elements: []interface{}{
+										types.QuotedString{
+											Kind: types.DoubleQuote,
+											Elements: []interface{}{
+												types.StringElement{Content: "curly"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
+		})
+		It("double curly in bold", func() {
+			source := "*\"`curly`\"*"
+			expected := types.DraftDocument{
+				Blocks: []interface{}{
+					types.Paragraph{
+						Lines: [][]interface{}{
+							{
+								types.QuotedText{
+									Kind: types.Bold,
+									Elements: []interface{}{
+										types.QuotedString{
+											Kind: types.DoubleQuote,
+											Elements: []interface{}{
+												types.StringElement{Content: "curly"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
+		})
+
+		It("double curly in title", func() {
+			source := "== a \"`curly`\" episode"
+			expected := types.DraftDocument{
+				Blocks: []interface{}{
+					types.Section{
+						Level: 1,
+						Title: []interface{}{
+							types.StringElement{Content: "a "},
+							types.QuotedString{
+								Kind: types.DoubleQuote,
+								Elements: []interface{}{
+									types.StringElement{Content: "curly"},
+								},
+							},
+							types.StringElement{Content: " episode"},
+						},
+						Elements: []interface{}{},
+					},
+				},
+			}
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
+		})
+
+		It("double in list element", func() {
+			source := "* a \"`curly`\" episode"
+			expected := types.DraftDocument{
+				Blocks: []interface{}{
+					types.UnorderedListItem{
+						Level:       1,
+						CheckStyle:  types.NoCheck,
+						BulletStyle: types.OneAsterisk,
+						Elements: []interface{}{
+							types.Paragraph{
+								Lines: [][]interface{}{
+									{
+										types.StringElement{Content: "a "},
+										types.QuotedString{
+											Kind: types.DoubleQuote,
+											Elements: []interface{}{
+												types.StringElement{Content: "curly"},
+											},
+										},
+										types.StringElement{Content: " episode"},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
+		})
+		It("double curly in labeled list", func() {
+			source := "\"`term`\":: something \"`quoted`\""
+			expected := types.DraftDocument{
+				Blocks: []interface{}{
+					types.LabeledListItem{
+						Level: 1,
+						Term: []interface{}{
+							types.StringElement{Content: "\"`term`\""}, // parsed later
+						},
+						Elements: []interface{}{
+							types.Paragraph{
+								Lines: [][]interface{}{
+									{
+										types.StringElement{Content: "something "},
+										types.QuotedString{
+											Kind: types.DoubleQuote,
+											Elements: []interface{}{
+												types.StringElement{Content: "quoted"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
+		})
+
+		// In a link, the quotes are ambiguous, and we default to assuming they are for enclosing
+		// the link text.  Nest them explicitly if this is needed.
+		It("double curly in link (becomes mono)", func() {
+			source := "https://www.example.com/a[\"`example`\"]"
+			expected := types.DraftDocument{
+				Blocks: []interface{}{
+					types.Paragraph{
+						Lines: [][]interface{}{
+							{
+								types.InlineLink{
+									Location: types.Location{
+										Scheme: "https://",
+										Path: []interface{}{
+											types.StringElement{Content: "www.example.com/a"},
+										},
+									},
+									Attributes: types.Attributes{
+										"positional-1": []interface{}{
+											types.QuotedText{
+												Kind: types.Monospace,
+												Elements: []interface{}{
+													types.StringElement{
+														Content: "example",
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
+		})
+
+		// This is the unambiguous form.
+		It("curly in quoted link", func() {
+			source := "https://www.example.com/a[\"\"`example`\"\"]"
+			expected := types.DraftDocument{
+				Blocks: []interface{}{
+					types.Paragraph{
+						Lines: [][]interface{}{
+							{
+								types.InlineLink{
+									Location: types.Location{
+										Scheme: "https://",
+										Path: []interface{}{
+											types.StringElement{Content: "www.example.com/a"},
+										},
+									},
+									Attributes: types.Attributes{
+										"positional-1": []interface{}{
+											types.QuotedString{
+												Kind: types.DoubleQuote,
+												Elements: []interface{}{
+													types.StringElement{
+														Content: "example",
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
+		})
+		It("image in double curly", func() {
+			source := "\"`a image:foo.png[]`\""
+			expected := types.DraftDocument{
+				Blocks: []interface{}{
+					types.Paragraph{
+						Lines: [][]interface{}{
+							{
+								types.QuotedString{
+									Kind: types.DoubleQuote,
+									Elements: []interface{}{
+										types.StringElement{Content: "a "},
+										types.InlineImage{
+											Location: types.Location{
+												Path: []interface{}{
+													types.StringElement{
+														Content: "foo.png",
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
+		})
+		It("icon in double curly", func() {
+			source := "\"`a icon:note[]`\""
+			expected := types.DraftDocument{
+				Blocks: []interface{}{
+					types.Paragraph{
+						Lines: [][]interface{}{
+							{
+								types.QuotedString{
+									Kind: types.DoubleQuote,
+									Elements: []interface{}{
+										types.StringElement{Content: "a "},
+										types.Icon{
+											Class: "note",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
+		})
+
+	})
+})
+
+/*
+		})
+	})
+*/

--- a/pkg/renderer/sgml/elements.go
+++ b/pkg/renderer/sgml/elements.go
@@ -135,6 +135,8 @@ func (r *sgmlRenderer) renderElement(ctx *renderer.Context, element interface{})
 		return r.renderConcealedIndexTerm(e)
 	case types.VerbatimLine:
 		return r.renderVerbatimLine(e)
+	case types.QuotedString:
+		return r.renderQuotedString(ctx, e)
 	default:
 		return nil, errors.Errorf("unsupported type of element: %T", element)
 	}
@@ -163,6 +165,8 @@ func (r *sgmlRenderer) renderPlainText(ctx *renderer.Context, element interface{
 		return []byte("\n\n"), nil
 	case types.StringElement:
 		return []byte(element.Content), nil
+	case types.QuotedString:
+		return r.renderQuotedStringPlain(ctx, element)
 	case types.Paragraph:
 		return r.renderLines(ctx, element.Lines, r.withPlainText())
 	case types.FootnoteReference:

--- a/pkg/renderer/sgml/html5/quoted_string_test.go
+++ b/pkg/renderer/sgml/html5/quoted_string_test.go
@@ -1,0 +1,328 @@
+package html5_test
+
+import (
+	. "github.com/bytesparadise/libasciidoc/testsupport"
+
+	. "github.com/onsi/ginkgo" //nolint golint
+	. "github.com/onsi/gomega" //nolint golint
+)
+
+var _ = Describe("quoted strings", func() {
+
+	Context("quoted strings", func() {
+
+		It("bold content alone", func() {
+			source := "*bold content*"
+			expected := `<div class="paragraph">
+<p><strong>bold content</strong></p>
+</div>`
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+		})
+
+		It("simple single quoted string", func() {
+			source := "'`curly was single`'"
+			expected := `<div class="paragraph">
+<p>&#8216;curly was single&#8217;</p>
+</div>`
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+		})
+		It("spaces with single quoted string", func() {
+			source := "'` curly was single `' or so they say"
+			expected := `<div class="paragraph">
+<p>&#8216; curly was single &#8217; or so they say</p>
+</div>`
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+		})
+
+		It("bold in single quoted string", func() {
+			source := "'`curly *was* single`'"
+			expected := `<div class="paragraph">
+<p>&#8216;curly <strong>was</strong> single&#8217;</p>
+</div>`
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+		})
+
+		It("italics in single quoted string", func() {
+			source := "'`curly _was_ single`'"
+			expected := `<div class="paragraph">
+<p>&#8216;curly <em>was</em> single&#8217;</p>
+</div>`
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+
+		})
+		It("span in single quoted string", func() {
+			source := "'`curly [strikeout]#was#_is_ single`'"
+			expected := `<div class="paragraph">
+<p>&#8216;curly <span class="strikeout">was</span><em>is</em> single&#8217;</p>
+</div>`
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+
+		})
+		It("curly in monospace  string", func() {
+			source := "'`curly `is` single`'"
+			expected := `<div class="paragraph">
+<p>&#8216;curly <code>is</code> single&#8217;</p>
+</div>`
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+		})
+		It("curly as monospace string", func() {
+			source := "'``curly``'"
+			expected := `<div class="paragraph">
+<p>&#8216;<code>curly</code>&#8217;</p>
+</div>`
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+		})
+
+		It("curly with nested double curly", func() {
+			source := "'`single\"`double`\"`'"
+			expected := `<div class="paragraph">
+<p>&#8216;single&#8220;double&#8221;&#8217;</p>
+</div>`
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+		})
+
+		It("curly in monospace string", func() {
+			source := "`'`curly`'`"
+			expected := `<div class="paragraph">
+<p><code>&#8216;curly&#8217;</code></p>
+</div>`
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+		})
+		It("curly in italics", func() {
+			source := "_'`curly`'_"
+			expected := `<div class="paragraph">
+<p><em>&#8216;curly&#8217;</em></p>
+</div>`
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+
+		})
+		It("curly in bold", func() {
+			source := "*'`curly`'*"
+			expected := `<div class="paragraph">
+<p><strong>&#8216;curly&#8217;</strong></p>
+</div>`
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+		})
+
+		It("curly in title", func() {
+			source := "== a '`curly`' episode"
+			expected := `<div class="sect1">
+<h2 id="_a_episode">a &#8216;curly&#8217; episode</h2>
+<div class="sectionbody">
+</div>
+</div>`
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+		})
+
+		It("curly in list element", func() {
+			source := "* a '`curly`' episode"
+			expected := `<div class="ulist">
+<ul>
+<li>
+<p>a &#8216;curly&#8217; episode</p>
+</li>
+</ul>
+</div>`
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+		})
+
+		It("curly in labeled list", func() {
+			source := "'`term`':: something '`quoted`'"
+			expected := `<div class="dlist">
+<dl>
+<dt class="hdlist1">&#8216;term&#8217;</dt>
+<dd>
+<p>something &#8216;quoted&#8217;</p>
+</dd>
+</dl>
+</div>`
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+		})
+
+		It("curly in link", func() {
+			source := "https://www.example.com/a['`example`']"
+			expected := `<div class="paragraph">
+<p><a href="https://www.example.com/a">&#8216;example&#8217;</a></p>
+</div>`
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+		})
+		It("curly in quoted link", func() {
+			source := "https://www.example.com/a[\"an '`example`'\"]"
+			expected := `<div class="paragraph">
+<p><a href="https://www.example.com/a">an &#8216;example&#8217;</a></p>
+</div>`
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+		})
+
+		It("image in curly", func() {
+			source := "'`a image:foo.png[]`'"
+			expected := `<div class="paragraph">
+<p>&#8216;a <span class="image"><img src="foo.png" alt=""></span>&#8217;</p>
+</div>`
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+		})
+
+		It("icon in curly", func() {
+			source := ":icons: font\n\n'`a icon:note[]`'"
+			expected := `<div class="paragraph">
+<p>&#8216;a <span class="icon"><i class="fa fa-note"></i></span>&#8217;</p>
+</div>`
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+		})
+
+		It("simple single quoted string", func() {
+			source := "\"`curly was single`\""
+			expected := `<div class="paragraph">
+<p>&#8220;curly was single&#8221;</p>
+</div>`
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+
+		})
+
+		It("spaces with double quoted string", func() {
+			source := "\"` curly was single `\""
+			expected := `<div class="paragraph">
+<p>&#8220; curly was single &#8221;</p>
+</div>`
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+		})
+		It("bold in double quoted string", func() {
+			source := "\"`curly *was* single`\""
+			expected := `<div class="paragraph">
+<p>&#8220;curly <strong>was</strong> single&#8221;</p>
+</div>`
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+
+		})
+		It("italics in double quoted string", func() {
+			source := "\"`curly _was_ single`\""
+			expected := `<div class="paragraph">
+<p>&#8220;curly <em>was</em> single&#8221;</p>
+</div>`
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+		})
+
+		It("span in double quoted string", func() {
+			source := "\"`curly [strikeout]#was#_is_ single`\""
+			expected := `<div class="paragraph">
+<p>&#8220;curly <span class="strikeout">was</span><em>is</em> single&#8221;</p>
+</div>`
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+		})
+
+		It("double curly in monospace string", func() {
+			source := "\"`curly `is` single`\""
+			expected := `<div class="paragraph">
+<p>&#8220;curly <code>is</code> single&#8221;</p>
+</div>`
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+		})
+
+		It("double curly as monospace string", func() {
+			source := "\"``curly``\""
+			expected := `<div class="paragraph">
+<p>&#8220;<code>curly</code>&#8221;</p>
+</div>`
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+		})
+		It("double curly with nested single curly", func() {
+			source := "\"`double'`single`'`\""
+			expected := `<div class="paragraph">
+<p>&#8220;double&#8216;single&#8217;&#8221;</p>
+</div>`
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+		})
+		It("double curly in monospace string", func() {
+			source := "`\"`curly`\"`"
+			expected := `<div class="paragraph">
+<p><code>&#8220;curly&#8221;</code></p>
+</div>`
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+		})
+		It("double curly in italics", func() {
+			source := "_\"`curly`\"_"
+			expected := `<div class="paragraph">
+<p><em>&#8220;curly&#8221;</em></p>
+</div>`
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+
+		})
+		It("double curly in bold", func() {
+			source := "*\"`curly`\"*"
+			expected := `<div class="paragraph">
+<p><strong>&#8220;curly&#8221;</strong></p>
+</div>`
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+
+		})
+
+		It("double curly in title", func() {
+			source := "== a \"`curly`\" episode"
+			expected := `<div class="sect1">
+<h2 id="_a_episode">a &#8220;curly&#8221; episode</h2>
+<div class="sectionbody">
+</div>
+</div>`
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+		})
+
+		It("double in list element", func() {
+			source := "* a \"`curly`\" episode"
+			expected := `<div class="ulist">
+<ul>
+<li>
+<p>a &#8220;curly&#8221; episode</p>
+</li>
+</ul>
+</div>`
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+
+		})
+		It("double curly in labeled list", func() {
+			source := "\"`term`\":: something \"`quoted`\""
+			expected := `<div class="dlist">
+<dl>
+<dt class="hdlist1">&#8220;term&#8221;</dt>
+<dd>
+<p>something &#8220;quoted&#8221;</p>
+</dd>
+</dl>
+</div>`
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+		})
+
+		// In a link, the quotes are ambiguous, and we default to assuming they are for enclosing
+		// the link text.  Nest them explicitly if this is needed.
+		It("double curly in link (becomes mono)", func() {
+			source := "https://www.example.com/a[\"`example`\"]"
+			expected := `<div class="paragraph">
+<p><a href="https://www.example.com/a"><code>example</code></a></p>
+</div>`
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+		})
+
+		// This is the unambiguous form.
+		It("curly in quoted link", func() {
+			source := "https://www.example.com/a[\"\"`example`\"\"]"
+			expected := `<div class="paragraph">
+<p><a href="https://www.example.com/a">&#8220;example&#8221;</a></p>
+</div>`
+
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+		})
+		It("image in double curly", func() {
+			source := "\"`a image:foo.png[]`\""
+			expected := `<div class="paragraph">
+<p>&#8220;a <span class="image"><img src="foo.png" alt=""></span>&#8221;</p>
+</div>`
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+		})
+		It("icon in double curly", func() {
+			source := ":icons: font\n\n\"`a icon:note[]`\""
+			expected := `<div class="paragraph">
+<p>&#8220;a <span class="icon"><i class="fa fa-note"></i></span>&#8221;</p>
+</div>`
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+		})
+	})
+})

--- a/pkg/renderer/sgml/string.go
+++ b/pkg/renderer/sgml/string.go
@@ -9,6 +9,43 @@ import (
 	"github.com/pkg/errors"
 )
 
+var quotes = map[types.QuotedStringKind]struct {
+	Open  string
+	Close string
+	Plain string
+}{
+	types.SingleQuote: {
+		Open:  "&#8216;",
+		Close: "&#8217;",
+		Plain: "'",
+	},
+	types.DoubleQuote: {
+		Open:  "&#8220;",
+		Close: "&#8221;",
+		Plain: `"`,
+	},
+}
+
+func (r *sgmlRenderer) renderQuotedStringPlain(ctx *renderer.Context, s types.QuotedString) ([]byte, error) {
+	buf := &bytes.Buffer{}
+	b, err := r.renderPlainText(ctx, s.Elements)
+	if err != nil {
+		return []byte{}, err
+	}
+	buf.WriteString(quotes[s.Kind].Plain)
+	buf.Write(b)
+	buf.WriteString(quotes[s.Kind].Plain)
+	return buf.Bytes(), nil
+}
+
+func (r *sgmlRenderer) renderQuotedString(ctx *renderer.Context, s types.QuotedString) ([]byte, error) {
+	elements := append([]interface{}{
+		types.StringElement{Content: quotes[s.Kind].Open},
+	}, s.Elements...)
+	elements = append(elements, types.StringElement{Content: quotes[s.Kind].Close})
+	return r.renderInlineElements(ctx, elements)
+}
+
 func (r *sgmlRenderer) renderStringElement(_ *renderer.Context, str types.StringElement) ([]byte, error) {
 	buf := &bytes.Buffer{}
 	err := r.stringElement.Execute(buf, str.Content)

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -1835,6 +1835,10 @@ type QuotedString struct {
 	Elements []interface{}
 }
 
+func NewQuotedString(kind QuotedStringKind, elements []interface{}) (QuotedString, error) {
+	return QuotedString{Kind: kind, Elements: elements}, nil
+}
+
 // ------------------------------------------
 // InlinePassthrough
 // ------------------------------------------

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -1778,6 +1778,16 @@ const (
 	Superscript
 )
 
+// QuotedStringKind indicates whether this is 'single' or "double" quoted.
+type QuotedStringKind int
+
+const (
+	// SingleQuote means single quotes (')
+	SingleQuote QuotedStringKind = iota
+	// DoubleQuote means double quotes (")
+	DoubleQuote
+)
+
 // NewQuotedText initializes a new `QuotedText` from the given kind and content
 func NewQuotedText(kind QuotedTextKind, attributes interface{}, elements ...interface{}) (QuotedText, error) {
 	attrs, err := NewQuotedTextAttributes(attributes)
@@ -1818,6 +1828,11 @@ func NewEscapedQuotedText(backslashes string, punctuation string, content interf
 			Content: punctuation,
 		},
 	}, nil
+}
+
+type QuotedString struct {
+	Kind     QuotedStringKind
+	Elements []interface{}
 }
 
 // ------------------------------------------


### PR DESCRIPTION
This adds support for the "`double`" and '`single`' types of
quoted strings.  These are inline enclosed elements, which is
necessary to prevent confusion with code blocks.  It also
matches asciidoctor.

Fixes #620

(PR NOTE: I did find a few bugs in the asciidoctor parser here; I have not attempted to be 100% bug compatible with asciidoctor.  This does conform to the documented, and what I believe, intended syntax was.  The PR is big mostly because of the large number of tests.  I will be following up with a fix for #176 once this PR integrates -- this PR is a bit more important to me than #176 as the fallback rendering for #176 is arguably still reasonable, but the fallback for this is not and quite ugly.)