### PR TITLE
refactor(renderer): Use string instead of []byte internally …

### DIFF
--- a/pkg/renderer/sgml/blank_line.go
+++ b/pkg/renderer/sgml/blank_line.go
@@ -1,29 +1,29 @@
 package sgml
 
 import (
-	"bytes"
+	"strings"
 
 	"github.com/bytesparadise/libasciidoc/pkg/types"
 
 	log "github.com/sirupsen/logrus"
 )
 
-func (r *sgmlRenderer) renderBlankLine(ctx *Context, _ types.BlankLine) ([]byte, error) {
+func (r *sgmlRenderer) renderBlankLine(ctx *Context, _ types.BlankLine) (string, error) {
 	if ctx.IncludeBlankLine {
-		buf := &bytes.Buffer{}
+		buf := &strings.Builder{}
 		if err := r.blankLine.Execute(buf, nil); err != nil {
-			return nil, err
+			return "", err
 		}
 		log.Debug("rendering blank line")
-		return buf.Bytes(), nil
+		return buf.String(), nil
 	}
-	return []byte{}, nil
+	return "", nil
 }
 
-func (r *sgmlRenderer) renderLineBreak() ([]byte, error) {
-	buf := &bytes.Buffer{}
+func (r *sgmlRenderer) renderLineBreak() (string, error) {
+	buf := &strings.Builder{}
 	if err := r.lineBreak.Execute(buf, nil); err != nil {
-		return nil, err
+		return "", err
 	}
-	return buf.Bytes(), nil
+	return buf.String(), nil
 }

--- a/pkg/renderer/sgml/callout_list.go
+++ b/pkg/renderer/sgml/callout_list.go
@@ -1,15 +1,15 @@
 package sgml
 
 import (
-	"bytes"
+	"strings"
 
 	"github.com/bytesparadise/libasciidoc/pkg/renderer"
 	"github.com/bytesparadise/libasciidoc/pkg/types"
 	"github.com/pkg/errors"
 )
 
-func (r *sgmlRenderer) renderCalloutList(ctx *renderer.Context, l types.CalloutList) ([]byte, error) {
-	result := &bytes.Buffer{}
+func (r *sgmlRenderer) renderCalloutList(ctx *renderer.Context, l types.CalloutList) (string, error) {
+	result := &strings.Builder{}
 	err := r.calloutList.Execute(result, ContextualPipeline{
 		Context: ctx,
 		Data: struct {
@@ -25,7 +25,7 @@ func (r *sgmlRenderer) renderCalloutList(ctx *renderer.Context, l types.CalloutL
 		},
 	})
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to render callout list")
+		return "", errors.Wrap(err, "unable to render callout list")
 	}
-	return result.Bytes(), nil
+	return result.String(), nil
 }

--- a/pkg/renderer/sgml/document_details.go
+++ b/pkg/renderer/sgml/document_details.go
@@ -3,6 +3,7 @@ package sgml
 import (
 	"bytes"
 	"strconv"
+	"strings"
 
 	"github.com/bytesparadise/libasciidoc/pkg/renderer"
 	"github.com/bytesparadise/libasciidoc/pkg/types"
@@ -40,7 +41,7 @@ func (r *sgmlRenderer) renderDocumentDetails(ctx *renderer.Context) (*sanitized,
 }
 
 func (r *sgmlRenderer) renderDocumentAuthorsDetails(ctx *renderer.Context) (*sanitized, error) { // TODO: use  `types.DocumentAuthor` attribute in context
-	authorsDetailsBuff := &bytes.Buffer{}
+	authorsDetailsBuff := &strings.Builder{}
 	i := 1
 	for {
 		var authorKey string
@@ -57,9 +58,11 @@ func (r *sgmlRenderer) renderDocumentAuthorsDetails(ctx *renderer.Context) (*san
 		}
 		// having at least one author is the minimal requirement for document details
 		if author, ok := ctx.Attributes.GetAsString(authorKey); ok {
-			authorDetailsBuff := &bytes.Buffer{}
+			if i > 1 {
+				authorsDetailsBuff.WriteString("\n")
+			}
 			email, _ := ctx.Attributes.GetAsString(emailKey)
-			err := r.documentAuthorDetails.Execute(authorDetailsBuff, struct {
+			err := r.documentAuthorDetails.Execute(authorsDetailsBuff, struct {
 				Index string
 				Name  string
 				Email string
@@ -72,10 +75,6 @@ func (r *sgmlRenderer) renderDocumentAuthorsDetails(ctx *renderer.Context) (*san
 				return nil, errors.Wrap(err, "error while rendering the document author")
 			}
 			// if there were authors before, need to insert a `\n`
-			if i > 1 {
-				authorsDetailsBuff.WriteString("\n")
-			}
-			authorsDetailsBuff.Write(authorDetailsBuff.Bytes())
 			i++
 		} else {
 			break

--- a/pkg/renderer/sgml/footnote_reference.go
+++ b/pkg/renderer/sgml/footnote_reference.go
@@ -1,7 +1,6 @@
 package sgml
 
 import (
-	"bytes"
 	"fmt"
 	"strings"
 
@@ -18,8 +17,8 @@ func (r *sgmlRenderer) renderFootnote(ctx *renderer.Context, elements []interfac
 	return strings.TrimSpace(string(result)), nil
 }
 
-func (r *sgmlRenderer) renderFootnoteReference(note types.FootnoteReference) ([]byte, error) {
-	result := &bytes.Buffer{}
+func (r *sgmlRenderer) renderFootnoteReference(note types.FootnoteReference) (string, error) {
+	result := &strings.Builder{}
 	if note.ID != types.InvalidFootnoteReference && !note.Duplicate {
 		// valid case for a footnote with content, with our without an explicit reference
 		err := r.footnote.Execute(result, struct {
@@ -30,7 +29,7 @@ func (r *sgmlRenderer) renderFootnoteReference(note types.FootnoteReference) ([]
 			Ref: note.Ref,
 		})
 		if err != nil {
-			return nil, errors.Wrapf(err, "unable to render footnote")
+			return "", errors.Wrap(err, "unable to render footnote")
 		}
 	} else if note.Duplicate {
 		// valid case for a footnote with content, with our without an explicit reference
@@ -42,7 +41,7 @@ func (r *sgmlRenderer) renderFootnoteReference(note types.FootnoteReference) ([]
 			Ref: note.Ref,
 		})
 		if err != nil {
-			return nil, errors.Wrapf(err, "unable to render footnote")
+			return "", errors.Wrap(err, "unable to render footnote")
 		}
 	} else {
 		// invalid footnote
@@ -52,14 +51,14 @@ func (r *sgmlRenderer) renderFootnoteReference(note types.FootnoteReference) ([]
 			Ref: note.Ref,
 		})
 		if err != nil {
-			return nil, errors.Wrapf(err, "unable to render missing footnote")
+			return "", errors.Wrap(err, "unable to render missing footnote")
 		}
 	}
-	return result.Bytes(), nil
+	return result.String(), nil
 }
 
-func (r *sgmlRenderer) renderFootnoteReferencePlainText(note types.FootnoteReference) ([]byte, error) {
-	result := &bytes.Buffer{}
+func (r *sgmlRenderer) renderFootnoteReferencePlainText(note types.FootnoteReference) (string, error) {
+	result := &strings.Builder{}
 	if note.ID != types.InvalidFootnoteReference {
 		// valid case for a footnote with content, with our without an explicit reference
 		err := r.footnoteRefPlain.Execute(result, struct {
@@ -70,20 +69,20 @@ func (r *sgmlRenderer) renderFootnoteReferencePlainText(note types.FootnoteRefer
 			Class: "footnote",
 		})
 		if err != nil {
-			return nil, errors.Wrapf(err, "unable to render footnote")
+			return "", errors.Wrap(err, "unable to render footnote")
 		}
 	} else {
-		return nil, fmt.Errorf("unable to render missing footnote")
+		return "", fmt.Errorf("unable to render missing footnote")
 	}
-	return result.Bytes(), nil
+	return result.String(), nil
 }
 
-func (r *sgmlRenderer) renderFootnotes(ctx *renderer.Context, notes []types.Footnote) ([]byte, error) {
+func (r *sgmlRenderer) renderFootnotes(ctx *renderer.Context, notes []types.Footnote) (string, error) {
 	// skip if there's no foot note in the doc
 	if len(notes) == 0 {
-		return []byte{}, nil
+		return "", nil
 	}
-	result := &bytes.Buffer{}
+	result := &strings.Builder{}
 	err := r.footnotes.Execute(result,
 		ContextualPipeline{
 			Context: ctx,
@@ -94,7 +93,7 @@ func (r *sgmlRenderer) renderFootnotes(ctx *renderer.Context, notes []types.Foot
 			},
 		})
 	if err != nil {
-		return []byte{}, errors.Wrapf(err, "failed to render footnotes")
+		return "", errors.Wrap(err, "failed to render footnotes")
 	}
-	return result.Bytes(), nil
+	return result.String(), nil
 }

--- a/pkg/renderer/sgml/html5/callout_list.go
+++ b/pkg/renderer/sgml/html5/callout_list.go
@@ -6,7 +6,7 @@ const (
 {{ if .Title }}<div class="title">{{ escape .Title }}</div>
 {{ end }}<ol>
 {{ range $itemIndex, $item := $items }}<li>
-{{ renderList $ctx $item.Elements | printf "%s" }}
+{{ renderList $ctx $item.Elements }}
 </li>
 {{ end }}</ol>
 </div>{{ end }}`

--- a/pkg/renderer/sgml/html5/delimited_block.go
+++ b/pkg/renderer/sgml/html5/delimited_block.go
@@ -4,14 +4,14 @@ const (
 	fencedBlockTmpl = `{{ $ctx := .Context }}{{ with .Data }}<div {{ if .ID }}id="{{ .ID }}" {{ end }}class="listingblock">{{ if .Title }}
 <div class="title">{{ escape .Title }}</div>{{ end }}
 <div class="content">
-<pre class="highlight"><code>{{ render $ctx .Elements | printf "%s" }}</code></pre>
+<pre class="highlight"><code>{{ render $ctx .Elements }}</code></pre>
 </div>
 </div>{{ end }}`
 
 	listingBlockTmpl = `{{ $ctx := .Context }}{{ with .Data }}<div {{ if .ID }}id="{{ .ID }}" {{ end }}class="listingblock">{{ if .Title }}
 <div class="title">{{ escape .Title }}</div>{{ end }}
 <div class="content">
-<pre>{{ renderElements $ctx .Elements | printf "%s" }}</pre>
+<pre>{{ renderElements $ctx .Elements }}</pre>
 </div>
 </div>{{ end }}`
 
@@ -22,19 +22,19 @@ const (
 </div>
 </div>`
 
-	sourceBlockContentTmpl = `{{ $ctx := .Context }}{{ with .Data }}{{ render $ctx .Elements | printf "%s" }}{{ end }}`
+	sourceBlockContentTmpl = `{{ $ctx := .Context }}{{ with .Data }}{{ render $ctx .Elements }}{{ end }}`
 
 	exampleBlockTmpl = `{{ $ctx := .Context }}{{ with .Data }}<div {{ if .ID }}id="{{ .ID }}" {{ end }}class="exampleblock">{{ if .Title }}
 <div class="title">{{ escape .Title }}</div>{{ end }}
 <div class="content">
-{{ renderElements $ctx .Elements | printf "%s" }}
+{{ renderElements $ctx .Elements }}
 </div>
 </div>{{ end }}`
 
 	quoteBlockTmpl = `{{ $ctx := .Context }}{{ with .Data }}<div {{ if .ID }}id="{{ .ID }}" {{ end }}class="quoteblock">{{ if .Title }}
 <div class="title">{{ escape .Title }}</div>{{ end }}
 <blockquote>
-{{ renderElements $ctx .Elements | printf "%s" }}
+{{ renderElements $ctx .Elements }}
 </blockquote>{{ if .Attribution.First }}
 <div class="attribution">
 &#8212; {{ .Attribution.First }}{{ if .Attribution.Second }}<br>
@@ -44,14 +44,14 @@ const (
 
 	verseBlockTmpl = `{{ $ctx := .Context }}{{ with .Data }}<div {{ if .ID }}id="{{ .ID }}" {{ end }}class="verseblock">{{ if .Title }}
 <div class="title">{{ escape .Title }}</div>{{ end }}
-<pre class="content">{{ range $index, $element := .Elements }}{{ renderVerse $ctx $element | printf "%s" }}{{ end }}</pre>{{ if .Attribution.First }}
+<pre class="content">{{ range $index, $element := .Elements }}{{ renderVerse $ctx $element }}{{ end }}</pre>{{ if .Attribution.First }}
 <div class="attribution">
 &#8212; {{ .Attribution.First }}{{ if .Attribution.Second }}<br>
 <cite>{{ .Attribution.Second }}</cite>{{ end }}
 </div>{{ end }}
 </div>{{ end }}`
 
-	verseBlockParagraphTmpl = `{{ $ctx := .Context }}{{ with .Data }}{{ renderLines $ctx .Lines | printf "%s" }}{{ end }}`
+	verseBlockParagraphTmpl = `{{ $ctx := .Context }}{{ with .Data }}{{ renderLines $ctx .Lines }}{{ end }}`
 
 	admonitionBlockTmpl = `{{ $ctx := .Context }}{{ with .Data }}<div {{ if .ID }}id="{{ .ID}}" {{ end }}class="admonitionblock {{ .Class }}">
 <table>
@@ -61,7 +61,7 @@ const (
 </td>
 <td class="content">
 {{ if .Title }}<div class="title">{{ escape .Title }}</div>
-{{ end }}{{ renderElements $ctx .Elements | printf "%s" }}
+{{ end }}{{ renderElements $ctx .Elements }}
 </td>
 </tr>
 </table>
@@ -70,10 +70,10 @@ const (
 	sidebarBlockTmpl = `{{ $ctx := .Context }}{{ with .Data }}<div {{ if .ID }}id="{{ .ID }}" {{ end }}class="sidebarblock">
 <div class="content">{{ if .Title }}
 <div class="title">{{ escape .Title }}</div>{{ end }}
-{{ renderElements $ctx .Elements | printf "%s" }}
+{{ renderElements $ctx .Elements }}
 </div>
 </div>{{ end }}`
 
 	// the name here is weird because "pass" as a prefix triggers a false security warning
-	pssThroughBlock = `{{ $ctx := .Context }}{{ with .Data }}{{ render $ctx .Elements | printf "%s" }}{{ end }}`
+	pssThroughBlock = `{{ $ctx := .Context }}{{ with .Data }}{{ render $ctx .Elements }}{{ end }}`
 )

--- a/pkg/renderer/sgml/html5/labeled_list.go
+++ b/pkg/renderer/sgml/html5/labeled_list.go
@@ -4,9 +4,9 @@ const (
 	labeledListTmpl = `{{ $ctx := .Context }}{{ with .Data }}<div{{ if .ID }} id="{{ .ID }}"{{ end }} class="dlist{{ if .Role }} {{ .Role }}{{ end }}">
 {{ if .Title }}<div class="title">{{ escape .Title }}</div>
 {{ end }}<dl>
-{{ $items := .Items }}{{ range $itemIndex, $item := $items }}<dt class="hdlist1">{{ renderInline $ctx $item.Term | printf "%s" }}</dt>{{ if $item.Elements }}
+{{ $items := .Items }}{{ range $itemIndex, $item := $items }}<dt class="hdlist1">{{ renderInline $ctx $item.Term }}</dt>{{ if $item.Elements }}
 <dd>
-{{ renderList $ctx $item.Elements | printf "%s" }}
+{{ renderList $ctx $item.Elements }}
 </dd>{{ end }}
 {{ end }}</dl>
 </div>{{ end }}`
@@ -16,10 +16,10 @@ const (
 {{ end }}<table>
 <tr>
 <td class="hdlist1">{{ $items := .Items }}{{ range $itemIndex, $item := $items }}
-{{ renderInline $ctx $item.Term | printf "%s" }}
+{{ renderInline $ctx $item.Term }}
 {{ if $item.Elements }}</td>
 <td class="hdlist2">
-{{ renderList $ctx $item.Elements | printf "%s" }}
+{{ renderList $ctx $item.Elements }}
 {{ if includeNewline $ctx $itemIndex $items }}</td>
 </tr>
 <tr>
@@ -32,8 +32,8 @@ const (
 {{ if .Title }}<div class="title">{{ escape .Title }}</div>
 {{ end }}<ol>
 {{ $items := .Items }}{{ range $itemIndex, $item := $items }}<li>
-<p><em>{{ renderInline $ctx $item.Term | printf "%s" }}</em></p>
-{{ if $item.Elements }}{{ renderList $ctx $item.Elements | printf "%s" }}{{ end }}
+<p><em>{{ renderInline $ctx $item.Term }}</em></p>
+{{ if $item.Elements }}{{ renderList $ctx $item.Elements }}{{ end }}
 </li>
 {{ end }}</ol>
 </div>{{ end }}`

--- a/pkg/renderer/sgml/html5/ordered_list.go
+++ b/pkg/renderer/sgml/html5/ordered_list.go
@@ -5,7 +5,7 @@ const (
 {{ if .Title }}<div class="title">{{ escape .Title }}</div>
 {{ end }}<ol class="{{ .NumberingStyle }}"{{ .ListStyle }}{{ if .Start }} start="{{ .Start }}"{{ end }}>
 {{ range $itemIndex, $item := $items }}<li>
-{{ renderList $ctx $item.Elements | printf "%s" }}
+{{ renderList $ctx $item.Elements }}
 </li>
 {{ end }}</ol>
 </div>{{ end }}`

--- a/pkg/renderer/sgml/html5/paragraph.go
+++ b/pkg/renderer/sgml/html5/paragraph.go
@@ -1,12 +1,12 @@
 package html5
 
 const (
-	paragraphTmpl = `{{ $ctx := .Context }}{{ with .Data }}{{ $renderedLines := renderLines $ctx .Lines .HardBreaks | printf "%s" }}<div {{ if ne .ID "" }}id="{{ .ID }}" {{ end }}class="{{ .Class }}">{{ if ne .Title "" }}
+	paragraphTmpl = `{{ $ctx := .Context }}{{ with .Data }}{{ $renderedLines := renderLines $ctx .Lines .HardBreaks }}<div {{ if ne .ID "" }}id="{{ .ID }}" {{ end }}class="{{ .Class }}">{{ if ne .Title "" }}
 <div class="doctitle">{{ escape .Title }}</div>{{ end }}
 <p>{{ $renderedLines }}</p>
 </div>{{ end }}`
 
-	admonitionParagraphTmpl = `{{ $ctx := .Context }}{{ with .Data }}{{ $renderedLines := renderLines $ctx .Lines | printf "%s" }}{{ if ne $renderedLines "" }}<div {{ if .ID }}id="{{ .ID }}" {{ end }}class="admonitionblock {{ .Class }}">
+	admonitionParagraphTmpl = `{{ $ctx := .Context }}{{ with .Data }}{{ $renderedLines := renderLines $ctx .Lines }}{{ if ne $renderedLines "" }}<div {{ if .ID }}id="{{ .ID }}" {{ end }}class="admonitionblock {{ .Class }}">
 <table>
 <tr>
 <td class="icon">
@@ -20,17 +20,17 @@ const (
 </table>
 </div>{{ end }}{{ end }}`
 
-	delimitedBlockParagraphTmpl = `{{ $ctx := .Context }}{{ with .Data }}<p>{{ .CheckStyle }}{{ renderLines $ctx .Lines | printf "%s" }}</p>{{ end }}`
+	delimitedBlockParagraphTmpl = `{{ $ctx := .Context }}{{ with .Data }}<p>{{ .CheckStyle }}{{ renderLines $ctx .Lines }}</p>{{ end }}`
 
 	sourceParagraphTmpl = `{{ $ctx := .Context }}{{ with .Data }}<div class="listingblock">
 <div class="content">
-<pre class="highlight">{{ if .Language }}<code class="language-{{ .Language }}" data-lang="{{ .Language }}">{{ else }}<code>{{ end }}{{ renderLines $ctx .Lines | printf "%s" }}</code></pre>
+<pre class="highlight">{{ if .Language }}<code class="language-{{ .Language }}" data-lang="{{ .Language }}">{{ else }}<code>{{ end }}{{ renderLines $ctx .Lines }}</code></pre>
 </div>
 </div>{{ end }}`
 
 	verseParagraphTmpl = `{{ $ctx := .Context }}{{ with .Data }}<div {{ if .ID }}id="{{ .ID }}" {{ end }}class="verseblock">{{ if .Title }}
 <div class="title">{{ escape .Title }}</div>{{ end }}
-<pre class="content">{{ renderLines $ctx .Lines plainText | printf "%s" }}</pre>{{ if .Attribution.First }}
+<pre class="content">{{ renderLines $ctx .Lines plainText }}</pre>{{ if .Attribution.First }}
 <div class="attribution">
 &#8212; {{ .Attribution.First }}{{ if .Attribution.Second }}<br>
 <cite>{{ .Attribution.Second }}</cite>{{ end }}
@@ -40,7 +40,7 @@ const (
 	quoteParagraphTmpl = `{{ $ctx := .Context }}{{ with .Data }}<div {{ if .ID }}id="{{ .ID }}" {{ end }}class="quoteblock">{{ if .Title }}
 <div class="title">{{ escape .Title }}</div>{{ end }}
 <blockquote>
-{{ renderLines $ctx .Lines | printf "%s" }}
+{{ renderLines $ctx .Lines }}
 </blockquote>{{ if .Attribution.First }}
 <div class="attribution">
 &#8212; {{ .Attribution.First }}{{ if .Attribution.Second }}<br>
@@ -48,5 +48,5 @@ const (
 </div>{{ end }}
 </div>{{ end }}`
 
-	manpageNameParagraphTmpl = `{{ $ctx := .Context }}{{ with .Data }}{{ $renderedLines := renderLines $ctx .Lines | printf "%s" }}<p>{{ $renderedLines }}</p>{{ end }}`
+	manpageNameParagraphTmpl = `{{ $ctx := .Context }}{{ with .Data }}{{ $renderedLines := renderLines $ctx .Lines }}<p>{{ $renderedLines }}</p>{{ end }}`
 )

--- a/pkg/renderer/sgml/html5/section.go
+++ b/pkg/renderer/sgml/html5/section.go
@@ -4,19 +4,19 @@ package html5
 const (
 	preambleTmpl = `{{ $ctx := .Context }}{{ with .Data }}{{ if .Wrapper }}<div id="preamble">
 <div class="sectionbody">
-{{ end }}{{ renderElements $ctx .Elements | printf "%s" }}{{ if .Wrapper }}
+{{ end }}{{ renderElements $ctx .Elements }}{{ if .Wrapper }}
 </div>
 </div>{{ end }}{{ end }}`
 
 	sectionOneTmpl = `{{ $ctx := .Context }}{{ with .Data }}<div class="{{ .Class }}">
 {{ .SectionTitle }}
-<div class="sectionbody">{{ $elements := renderElements $ctx .Elements | printf "%s" }}{{ if $elements }}
+<div class="sectionbody">{{ $elements := renderElements $ctx .Elements }}{{ if $elements }}
 {{ $elements }}{{ end }}
 </div>
 </div>{{ end }}`
 
 	sectionContentTmpl = `{{ $ctx := .Context }}{{ with .Data }}<div class="{{ .Class }}">
-{{ .SectionTitle }}{{ $elements := renderElements $ctx .Elements | printf "%s" }}{{ if $elements }}
+{{ .SectionTitle }}{{ $elements := renderElements $ctx .Elements }}{{ if $elements }}
 {{ $elements }}{{ end }}
 </div>{{ end }}`
 

--- a/pkg/renderer/sgml/html5/table.go
+++ b/pkg/renderer/sgml/html5/table.go
@@ -8,12 +8,12 @@ const (
 </colgroup>
 {{ if .Header }}{{ if .Header.Cells }}<thead>
 <tr>
-{{ $headerCells := .Header.Cells }}{{ range $index, $cell := $headerCells }}<th class="tableblock halign-left valign-top">{{ renderInline $ctx $cell | printf "%s" }}</th>{{ includeNewline $ctx $index $headerCells }}{{ end }}
+{{ $headerCells := .Header.Cells }}{{ range $index, $cell := $headerCells }}<th class="tableblock halign-left valign-top">{{ renderInline $ctx $cell }}</th>{{ includeNewline $ctx $index $headerCells }}{{ end }}
 </tr>
 </thead>
 {{ end }}{{ end }}<tbody>
 {{ range $indexLine, $line := .Lines }}<tr>
-{{ range $indexCells, $cell := $line.Cells }}<td class="tableblock halign-left valign-top"><p class="tableblock">{{ renderInline $ctx $cell | printf "%s" }}</p></td>{{ includeNewline $ctx $indexCells $line.Cells }}{{ end }}
+{{ range $indexCells, $cell := $line.Cells }}<td class="tableblock halign-left valign-top"><p class="tableblock">{{ renderInline $ctx $cell }}</p></td>{{ includeNewline $ctx $indexCells $line.Cells }}{{ end }}
 </tr>
 {{ end }}</tbody>{{ end }}
 </table>{{ end }}`

--- a/pkg/renderer/sgml/html5/unordered_list.go
+++ b/pkg/renderer/sgml/html5/unordered_list.go
@@ -5,7 +5,7 @@ const (
 {{ if .Title }}<div class="title">{{ escape .Title }}</div>
 {{ end }}<ul{{ if .Checklist }} class="checklist"{{ end }}>
 {{ $items := .Items }}{{ range $itemIndex, $item := $items }}<li>
-{{ $elements := $item.Elements }}{{ renderList $ctx $elements | printf "%s" }}
+{{ $elements := $item.Elements }}{{ renderList $ctx $elements }}
 </li>
 {{ end }}</ul>
 </div>{{ end }}`

--- a/pkg/renderer/sgml/icon.go
+++ b/pkg/renderer/sgml/icon.go
@@ -1,7 +1,6 @@
 package sgml
 
 import (
-	"bytes"
 	fmt "fmt"
 	"github.com/bytesparadise/libasciidoc/pkg/renderer"
 	"github.com/bytesparadise/libasciidoc/pkg/types"
@@ -10,15 +9,15 @@ import (
 	"strings"
 )
 
-func (r *sgmlRenderer) renderInlineIcon(ctx *renderer.Context, icon types.Icon) ([]byte, error) {
-	result := &bytes.Buffer{}
+func (r *sgmlRenderer) renderInlineIcon(ctx *renderer.Context, icon types.Icon) (string, error) {
+	result := &strings.Builder{}
 
 	iconStr, err := r.renderIcon(ctx, types.Icon{
 		Class:      icon.Class,
 		Attributes: icon.Attributes,
 	}, false)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 	err = r.inlineIcon.Execute(result, struct {
 		Class  string
@@ -37,9 +36,9 @@ func (r *sgmlRenderer) renderInlineIcon(ctx *renderer.Context, icon types.Icon) 
 	})
 
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to render inline image")
+		return "", errors.Wrap(err, "unable to render inline image")
 	}
-	return result.Bytes(), nil
+	return result.String(), nil
 }
 
 func (r *sgmlRenderer) renderIcon(ctx *renderer.Context, icon types.Icon, admonition bool) (sanitized, error) {

--- a/pkg/renderer/sgml/image.go
+++ b/pkg/renderer/sgml/image.go
@@ -1,16 +1,16 @@
 package sgml
 
 import (
-	"bytes"
 	"strconv"
+	"strings"
 
 	"github.com/bytesparadise/libasciidoc/pkg/renderer"
 	"github.com/bytesparadise/libasciidoc/pkg/types"
 	"github.com/pkg/errors"
 )
 
-func (r *sgmlRenderer) renderImageBlock(ctx *renderer.Context, img types.ImageBlock) ([]byte, error) {
-	result := &bytes.Buffer{}
+func (r *sgmlRenderer) renderImageBlock(ctx *renderer.Context, img types.ImageBlock) (string, error) {
+	result := &strings.Builder{}
 	title := ""
 	if t, found := img.Attributes.GetAsString(types.AttrTitle); found {
 		title = "Figure " + strconv.Itoa(ctx.GetAndIncrementImageCounter()) + ". " + EscapeString(t)
@@ -36,14 +36,14 @@ func (r *sgmlRenderer) renderImageBlock(ctx *renderer.Context, img types.ImageBl
 	})
 
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to render block image")
+		return "", errors.Wrap(err, "unable to render block image")
 	}
 	// log.Debugf("rendered block image: %s", result.Bytes())
-	return result.Bytes(), nil
+	return result.String(), nil
 }
 
-func (r *sgmlRenderer) renderInlineImage(img types.InlineImage) ([]byte, error) {
-	result := &bytes.Buffer{}
+func (r *sgmlRenderer) renderInlineImage(img types.InlineImage) (string, error) {
+	result := &strings.Builder{}
 	err := r.inlineImage.Execute(result, struct {
 		Role   string
 		Title  string
@@ -62,8 +62,8 @@ func (r *sgmlRenderer) renderInlineImage(img types.InlineImage) ([]byte, error) 
 	})
 
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to render inline image")
+		return "", errors.Wrap(err, "unable to render inline image")
 	}
 	// log.Debugf("rendered inline image: %s", result.Bytes())
-	return result.Bytes(), nil
+	return result.String(), nil
 }

--- a/pkg/renderer/sgml/index_term.go
+++ b/pkg/renderer/sgml/index_term.go
@@ -5,10 +5,10 @@ import (
 	"github.com/bytesparadise/libasciidoc/pkg/types"
 )
 
-func (r *sgmlRenderer) renderIndexTerm(ctx *renderer.Context, t types.IndexTerm) ([]byte, error) {
+func (r *sgmlRenderer) renderIndexTerm(ctx *renderer.Context, t types.IndexTerm) (string, error) {
 	return r.renderInlineElements(ctx, t.Term)
 }
 
-func (r *sgmlRenderer) renderConcealedIndexTerm(_ types.ConcealedIndexTerm) ([]byte, error) {
-	return []byte{}, nil // do not render
+func (r *sgmlRenderer) renderConcealedIndexTerm(_ types.ConcealedIndexTerm) (string, error) {
+	return "", nil // do not render
 }

--- a/pkg/renderer/sgml/inline_elements.go
+++ b/pkg/renderer/sgml/inline_elements.go
@@ -1,7 +1,6 @@
 package sgml
 
 import (
-	"bytes"
 	"strings"
 
 	"github.com/bytesparadise/libasciidoc/pkg/renderer"
@@ -22,9 +21,9 @@ func (r *sgmlRenderer) withVerbatim() renderLinesOption {
 	}
 }
 
-func (r *sgmlRenderer) renderInlineElements(ctx *renderer.Context, elements []interface{}, options ...renderLinesOption) ([]byte, error) {
+func (r *sgmlRenderer) renderInlineElements(ctx *renderer.Context, elements []interface{}, options ...renderLinesOption) (string, error) {
 	if len(elements) == 0 {
-		return []byte{}, nil
+		return "", nil
 	}
 	log.Debugf("rendering line with %d element(s)...", len(elements))
 	lr := linesRenderer{
@@ -34,11 +33,11 @@ func (r *sgmlRenderer) renderInlineElements(ctx *renderer.Context, elements []in
 		apply(&lr)
 	}
 	// first pass or rendering, using the provided `renderElementFunc`:
-	buf := &bytes.Buffer{}
+	buf := &strings.Builder{}
 	for i, element := range elements {
 		renderedElement, err := lr.render(ctx, element)
 		if err != nil {
-			return nil, errors.Wrapf(err, "unable to render line")
+			return "", errors.Wrapf(err, "unable to render line")
 		}
 		if i == len(elements)-1 {
 			if _, ok := element.(types.StringElement); ok { // TODO: only for StringElement? or for any kind of element?
@@ -46,16 +45,16 @@ func (r *sgmlRenderer) renderInlineElements(ctx *renderer.Context, elements []in
 				buf.WriteString(strings.TrimRight(string(renderedElement), " "))
 				log.Debugf("trimmed spaces on '%v'", string(renderedElement))
 			} else {
-				buf.Write(renderedElement)
+				buf.WriteString(renderedElement)
 			}
 		} else {
-			buf.Write(renderedElement)
+			buf.WriteString(renderedElement)
 		}
 	}
 	if log.IsLevelEnabled(log.DebugLevel) {
 		log.Debugf("rendered inline elements: '%s'", buf.String())
 	}
-	return buf.Bytes(), nil
+	return buf.String(), nil
 }
 
-type renderFunc func(*renderer.Context, interface{}) ([]byte, error)
+type renderFunc func(*renderer.Context, interface{}) (string, error)

--- a/pkg/renderer/sgml/labeled_list.go
+++ b/pkg/renderer/sgml/labeled_list.go
@@ -1,20 +1,20 @@
 package sgml
 
 import (
-	"bytes"
+	"strings"
 
 	"github.com/bytesparadise/libasciidoc/pkg/renderer"
 	"github.com/bytesparadise/libasciidoc/pkg/types"
 	"github.com/pkg/errors"
 )
 
-func (r *sgmlRenderer) renderLabeledList(ctx *renderer.Context, l types.LabeledList) ([]byte, error) {
+func (r *sgmlRenderer) renderLabeledList(ctx *renderer.Context, l types.LabeledList) (string, error) {
 	tmpl, err := r.getLabeledListTmpl(l)
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to render labeled list")
+		return "", errors.Wrap(err, "unable to render labeled list")
 	}
 
-	result := &bytes.Buffer{}
+	result := &strings.Builder{}
 	// here we must preserve the HTML tags
 	err = tmpl.Execute(result, ContextualPipeline{
 		Context: ctx,
@@ -31,10 +31,10 @@ func (r *sgmlRenderer) renderLabeledList(ctx *renderer.Context, l types.LabeledL
 		},
 	})
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to render labeled list")
+		return "", errors.Wrap(err, "unable to render labeled list")
 	}
 	// log.Debugf("rendered labeled list: %s", result.Bytes())
-	return result.Bytes(), nil
+	return result.String(), nil
 }
 
 func (r *sgmlRenderer) getLabeledListTmpl(l types.LabeledList) (*textTemplate, error) {

--- a/pkg/renderer/sgml/link.go
+++ b/pkg/renderer/sgml/link.go
@@ -1,7 +1,7 @@
 package sgml
 
 import (
-	"bytes"
+	"strings"
 
 	"github.com/bytesparadise/libasciidoc/pkg/renderer"
 	"github.com/bytesparadise/libasciidoc/pkg/types"
@@ -9,30 +9,30 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func (r *sgmlRenderer) renderLink(ctx *renderer.Context, l types.InlineLink) ([]byte, error) { //nolint: unparam
-	result := &bytes.Buffer{}
+func (r *sgmlRenderer) renderLink(ctx *renderer.Context, l types.InlineLink) (string, error) { //nolint: unparam
+	result := &strings.Builder{}
 	location := l.Location.String()
-	var text []byte
+	text := ""
 	class := ""
 	var err error
 	// TODO; support `mailto:` positional attributes
 	positionals := l.Attributes.Positionals()
 	if len(positionals) > 0 {
-		buf := &bytes.Buffer{}
+		buf := &strings.Builder{}
 		for i, arg := range positionals {
 			t, err := r.renderInlineElements(ctx, arg)
 			if err != nil {
-				return nil, errors.Wrapf(err, "unable to render external link")
+				return "", errors.Wrap(err, "unable to render external link")
 			}
-			buf.Write(t)
+			buf.WriteString(t)
 			if i < len(positionals)-1 {
 				buf.WriteString(",")
 			}
 		}
-		text = buf.Bytes()
+		text = buf.String()
 	} else {
 		class = "bare"
-		text = []byte(location)
+		text = location
 	}
 	err = r.link.Execute(result, struct {
 		URL   string
@@ -40,12 +40,12 @@ func (r *sgmlRenderer) renderLink(ctx *renderer.Context, l types.InlineLink) ([]
 		Class string
 	}{
 		URL:   location,
-		Text:  string(text),
+		Text:  text,
 		Class: class,
 	})
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to render external link")
+		return "", errors.Wrap(err, "unable to render external link")
 	}
-	log.Debugf("rendered external link: %s", result.Bytes())
-	return result.Bytes(), nil
+	log.Debugf("rendered external link: %s", result.String())
+	return result.String(), nil
 }

--- a/pkg/renderer/sgml/literal_blocks.go
+++ b/pkg/renderer/sgml/literal_blocks.go
@@ -1,7 +1,6 @@
 package sgml
 
 import (
-	"bytes"
 	"math"
 	"strings"
 
@@ -11,7 +10,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func (r *sgmlRenderer) renderLiteralBlock(ctx *renderer.Context, b types.LiteralBlock) ([]byte, error) {
+func (r *sgmlRenderer) renderLiteralBlock(ctx *renderer.Context, b types.LiteralBlock) (string, error) {
 	log.Debugf("rendering delimited block with content: %s", b.Lines)
 	var lines []string
 	if t, found := b.Attributes.GetAsString(types.AttrLiteralBlockType); found && t == types.LiteralBlockWithSpacesOnFirstLine {
@@ -40,7 +39,7 @@ func (r *sgmlRenderer) renderLiteralBlock(ctx *renderer.Context, b types.Literal
 	} else {
 		lines = b.Lines
 	}
-	result := &bytes.Buffer{}
+	result := &strings.Builder{}
 	err := r.literalBlock.Execute(result, ContextualPipeline{
 		Context: ctx,
 		Data: struct {
@@ -53,7 +52,7 @@ func (r *sgmlRenderer) renderLiteralBlock(ctx *renderer.Context, b types.Literal
 			Lines: lines,
 		}})
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to render delimited block")
+		return "", errors.Wrap(err, "unable to render delimited block")
 	}
-	return result.Bytes(), nil
+	return result.String(), nil
 }

--- a/pkg/renderer/sgml/ordered_list.go
+++ b/pkg/renderer/sgml/ordered_list.go
@@ -1,15 +1,15 @@
 package sgml
 
 import (
-	"bytes"
+	"strings"
 
 	"github.com/bytesparadise/libasciidoc/pkg/renderer"
 	"github.com/bytesparadise/libasciidoc/pkg/types"
 	"github.com/pkg/errors"
 )
 
-func (r *sgmlRenderer) renderOrderedList(ctx *renderer.Context, l types.OrderedList) ([]byte, error) {
-	result := &bytes.Buffer{}
+func (r *sgmlRenderer) renderOrderedList(ctx *renderer.Context, l types.OrderedList) (string, error) {
+	result := &strings.Builder{}
 	err := r.orderedList.Execute(result, ContextualPipeline{
 		Context: ctx,
 		Data: struct {
@@ -31,9 +31,9 @@ func (r *sgmlRenderer) renderOrderedList(ctx *renderer.Context, l types.OrderedL
 		},
 	})
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to render ordered list")
+		return "", errors.Wrap(err, "unable to render ordered list")
 	}
-	return result.Bytes(), nil
+	return result.String(), nil
 }
 
 func getNumberingStyle(l types.OrderedList) string {

--- a/pkg/renderer/sgml/section.go
+++ b/pkg/renderer/sgml/section.go
@@ -1,7 +1,6 @@
 package sgml
 
 import (
-	"bytes"
 	"strconv"
 	"strings"
 
@@ -11,9 +10,9 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func (r *sgmlRenderer) renderPreamble(ctx *renderer.Context, p types.Preamble) ([]byte, error) {
+func (r *sgmlRenderer) renderPreamble(ctx *renderer.Context, p types.Preamble) (string, error) {
 	log.Debugf("rendering preamble...")
-	result := &bytes.Buffer{}
+	result := &strings.Builder{}
 	// the <div id="preamble"> wrapper is only necessary
 	// if the document has a section 0
 	err := r.preamble.Execute(result, ContextualPipeline{
@@ -27,19 +26,19 @@ func (r *sgmlRenderer) renderPreamble(ctx *renderer.Context, p types.Preamble) (
 		},
 	})
 	if err != nil {
-		return nil, errors.Wrapf(err, "error while rendering preamble")
+		return "", errors.Wrap(err, "error while rendering preamble")
 	}
 	// log.Debugf("rendered preamble: %s", result.Bytes())
-	return result.Bytes(), nil
+	return result.String(), nil
 }
 
-func (r *sgmlRenderer) renderSection(ctx *renderer.Context, s types.Section) ([]byte, error) {
+func (r *sgmlRenderer) renderSection(ctx *renderer.Context, s types.Section) (string, error) {
 	log.Debugf("rendering section level %d", s.Level)
 	renderedSectionTitle, err := r.renderSectionTitle(ctx, s)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error while rendering section")
+		return "", errors.Wrap(err, "error while rendering section")
 	}
-	result := &bytes.Buffer{}
+	result := &strings.Builder{}
 	// select the appropriate template for the section
 	var tmpl *textTemplate
 	if s.Level == 1 {
@@ -59,19 +58,19 @@ func (r *sgmlRenderer) renderSection(ctx *renderer.Context, s types.Section) ([]
 			Elements:     s.Elements,
 		}})
 	if err != nil {
-		return nil, errors.Wrapf(err, "error while rendering section")
+		return "", errors.Wrap(err, "error while rendering section")
 	}
 	// log.Debugf("rendered section: %s", result.Bytes())
-	return result.Bytes(), nil
+	return result.String(), nil
 }
 
 func (r *sgmlRenderer) renderSectionTitle(ctx *renderer.Context, s types.Section) (string, error) {
-	result := &bytes.Buffer{}
+	result := &strings.Builder{}
 	renderedContent, err := r.renderInlineElements(ctx, s.Title)
 	if err != nil {
-		return "", errors.Wrapf(err, "error while rendering sectionTitle content")
+		return "", errors.Wrap(err, "error while rendering sectionTitle content")
 	}
-	renderedContentStr := strings.TrimSpace(string(renderedContent))
+	renderedContentStr := strings.TrimSpace(renderedContent)
 	id := r.renderElementID(s.Attributes)
 	err = r.sectionHeader.Execute(result, struct {
 		Level   int

--- a/pkg/renderer/sgml/string.go
+++ b/pkg/renderer/sgml/string.go
@@ -1,7 +1,6 @@
 package sgml
 
 import (
-	"bytes"
 	"strings"
 
 	"github.com/bytesparadise/libasciidoc/pkg/renderer"
@@ -26,19 +25,19 @@ var quotes = map[types.QuotedStringKind]struct {
 	},
 }
 
-func (r *sgmlRenderer) renderQuotedStringPlain(ctx *renderer.Context, s types.QuotedString) ([]byte, error) {
-	buf := &bytes.Buffer{}
+func (r *sgmlRenderer) renderQuotedStringPlain(ctx *renderer.Context, s types.QuotedString) (string, error) {
+	buf := &strings.Builder{}
 	b, err := r.renderPlainText(ctx, s.Elements)
 	if err != nil {
-		return []byte{}, err
+		return "", err
 	}
 	buf.WriteString(quotes[s.Kind].Plain)
-	buf.Write(b)
+	buf.WriteString(b)
 	buf.WriteString(quotes[s.Kind].Plain)
-	return buf.Bytes(), nil
+	return buf.String(), nil
 }
 
-func (r *sgmlRenderer) renderQuotedString(ctx *renderer.Context, s types.QuotedString) ([]byte, error) {
+func (r *sgmlRenderer) renderQuotedString(ctx *renderer.Context, s types.QuotedString) (string, error) {
 	elements := append([]interface{}{
 		types.StringElement{Content: quotes[s.Kind].Open},
 	}, s.Elements...)
@@ -46,17 +45,17 @@ func (r *sgmlRenderer) renderQuotedString(ctx *renderer.Context, s types.QuotedS
 	return r.renderInlineElements(ctx, elements)
 }
 
-func (r *sgmlRenderer) renderStringElement(_ *renderer.Context, str types.StringElement) ([]byte, error) {
-	buf := &bytes.Buffer{}
+func (r *sgmlRenderer) renderStringElement(_ *renderer.Context, str types.StringElement) (string, error) {
+	buf := &strings.Builder{}
 	err := r.stringElement.Execute(buf, str.Content)
 	if err != nil {
-		return []byte{}, errors.Wrapf(err, "unable to render string")
+		return "", errors.Wrap(err, "unable to render string")
 	}
 
 	// NB: For all SGML flavors we are aware of, the numeric entities from
 	// Unicode are supported.  We generally avoid named entities.
 	result := convert(buf.String(), ellipsis, copyright, trademark, registered)
-	return []byte(result), nil
+	return result, nil
 }
 
 func ellipsis(source string) string {

--- a/pkg/renderer/sgml/table.go
+++ b/pkg/renderer/sgml/table.go
@@ -1,10 +1,10 @@
 package sgml
 
 import (
-	"bytes"
 	"fmt"
 	"math"
 	"strconv"
+	"strings"
 
 	"github.com/bytesparadise/libasciidoc/pkg/renderer"
 	"github.com/bytesparadise/libasciidoc/pkg/types"
@@ -12,8 +12,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func (r *sgmlRenderer) renderTable(ctx *renderer.Context, t types.Table) ([]byte, error) {
-	result := &bytes.Buffer{}
+func (r *sgmlRenderer) renderTable(ctx *renderer.Context, t types.Table) (string, error) {
+	result := &strings.Builder{}
 	// inspect first line to obtain cell width ratio
 	widths := []string{}
 	if len(t.Lines) > 0 {
@@ -51,9 +51,9 @@ func (r *sgmlRenderer) renderTable(ctx *renderer.Context, t types.Table) ([]byte
 		},
 	})
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to render table")
+		return "", errors.Wrap(err, "failed to render table")
 	}
-	return result.Bytes(), nil
+	return result.String(), nil
 }
 
 type formatColumnWidthOption func(float64) float64

--- a/pkg/renderer/sgml/table_of_contents.go
+++ b/pkg/renderer/sgml/table_of_contents.go
@@ -1,8 +1,8 @@
 package sgml
 
 import (
-	"bytes"
 	"strconv"
+	"strings"
 
 	"github.com/bytesparadise/libasciidoc/pkg/renderer"
 	"github.com/bytesparadise/libasciidoc/pkg/types"
@@ -10,30 +10,30 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func (r *sgmlRenderer) renderTableOfContents(ctx *renderer.Context, toc types.TableOfContents) ([]byte, error) {
+func (r *sgmlRenderer) renderTableOfContents(ctx *renderer.Context, toc types.TableOfContents) (string, error) {
 	log.Debug("rendering table of contents...")
 	renderedSections, err := r.renderTableOfContentsSections(ctx, toc.Sections)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error while rendering table of contents")
+		return "", errors.Wrap(err, "error while rendering table of contents")
 	}
 	if renderedSections == "" {
 		// nothing to render (document has no section)
-		return []byte{}, nil
+		return "", nil
 	}
-	result := &bytes.Buffer{}
+	result := &strings.Builder{}
 	err = r.tocRoot.Execute(result, renderedSections)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error while rendering table of contents")
+		return "", errors.Wrap(err, "error while rendering table of contents")
 	}
 	// log.Debugf("rendered ToC: %s", result.Bytes())
-	return result.Bytes(), nil
+	return result.String(), nil
 }
 
 func (r *sgmlRenderer) renderTableOfContentsSections(ctx *renderer.Context, sections []types.ToCSection) (sanitized, error) {
 	if len(sections) == 0 {
 		return "", nil
 	}
-	resultBuf := &bytes.Buffer{}
+	resultBuf := &strings.Builder{}
 	err := r.tocSection.Execute(resultBuf, ContextualPipeline{
 		Context: ctx,
 		Data: struct {

--- a/pkg/renderer/sgml/unordered_list.go
+++ b/pkg/renderer/sgml/unordered_list.go
@@ -1,14 +1,14 @@
 package sgml
 
 import (
-	"bytes"
+	"strings"
 
 	"github.com/bytesparadise/libasciidoc/pkg/renderer"
 	"github.com/bytesparadise/libasciidoc/pkg/types"
 	"github.com/pkg/errors"
 )
 
-func (r *sgmlRenderer) renderUnorderedList(ctx *renderer.Context, l types.UnorderedList) ([]byte, error) {
+func (r *sgmlRenderer) renderUnorderedList(ctx *renderer.Context, l types.UnorderedList) (string, error) {
 	// make sure nested elements are aware of that their rendering occurs within a list
 	checkList := false
 	if len(l.Items) > 0 {
@@ -16,7 +16,7 @@ func (r *sgmlRenderer) renderUnorderedList(ctx *renderer.Context, l types.Unorde
 			checkList = true
 		}
 	}
-	result := &bytes.Buffer{}
+	result := &strings.Builder{}
 	// here we must preserve the HTML tags
 	err := r.unorderedList.Execute(result, ContextualPipeline{
 		Context: ctx,
@@ -35,7 +35,7 @@ func (r *sgmlRenderer) renderUnorderedList(ctx *renderer.Context, l types.Unorde
 		},
 	})
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to render unordered list")
+		return "", errors.Wrap(err, "unable to render unordered list")
 	}
-	return result.Bytes(), nil
+	return result.String(), nil
 }

--- a/pkg/renderer/sgml/user_macro.go
+++ b/pkg/renderer/sgml/user_macro.go
@@ -1,14 +1,14 @@
 package sgml
 
 import (
-	"bytes"
+	"strings"
 
 	"github.com/bytesparadise/libasciidoc/pkg/renderer"
 	"github.com/bytesparadise/libasciidoc/pkg/types"
 )
 
-func (r *sgmlRenderer) renderUserMacro(ctx *renderer.Context, um types.UserMacro) ([]byte, error) {
-	buf := &bytes.Buffer{}
+func (r *sgmlRenderer) renderUserMacro(ctx *renderer.Context, um types.UserMacro) (string, error) {
+	buf := &strings.Builder{}
 	macro, err := ctx.Config.MacroTemplate(um.Name)
 	if err != nil {
 		if um.Kind == types.BlockMacro {
@@ -26,8 +26,8 @@ func (r *sgmlRenderer) renderUserMacro(ctx *renderer.Context, um types.UserMacro
 		err = macro.Execute(buf, um)
 	}
 	if err != nil {
-		return nil, err
+		return "", err
 	}
-	return buf.Bytes(), nil
+	return buf.String(), nil
 
 }

--- a/pkg/renderer/sgml/verbatim_line.go
+++ b/pkg/renderer/sgml/verbatim_line.go
@@ -1,15 +1,15 @@
 package sgml
 
 import (
-	"bytes"
+	"strings"
 
 	"github.com/bytesparadise/libasciidoc/pkg/types"
 )
 
-func (r *sgmlRenderer) renderVerbatimLine(l types.VerbatimLine) ([]byte, error) {
-	result := &bytes.Buffer{}
+func (r *sgmlRenderer) renderVerbatimLine(l types.VerbatimLine) (string, error) {
+	result := &strings.Builder{}
 	if err := r.verbatimLine.Execute(result, l); err != nil {
-		return nil, err
+		return "", err
 	}
-	return result.Bytes(), nil
+	return result.String(), nil
 }

--- a/pkg/renderer/sgml/xhtml5/delimited_block.go
+++ b/pkg/renderer/sgml/xhtml5/delimited_block.go
@@ -4,7 +4,7 @@ const (
 	quoteBlockTmpl = `{{ $ctx := .Context }}{{ with .Data }}<div {{ if .ID }}id="{{ .ID }}" {{ end }}class="quoteblock">{{ if .Title }}
 <div class="title">{{ escape .Title }}</div>{{ end }}
 <blockquote>
-{{ renderElements $ctx .Elements | printf "%s" }}
+{{ renderElements $ctx .Elements }}
 </blockquote>{{ if .Attribution.First }}
 <div class="attribution">
 &#8212; {{ .Attribution.First }}{{ if .Attribution.Second }}<br/>
@@ -14,7 +14,7 @@ const (
 
 	verseBlockTmpl = `{{ $ctx := .Context }}{{ with .Data }}<div {{ if .ID }}id="{{ .ID }}" {{ end }}class="verseblock">{{ if .Title }}
 <div class="title">{{ escape .Title }}</div>{{ end }}
-<pre class="content">{{ range $index, $element := .Elements }}{{ renderVerse $ctx $element | printf "%s" }}{{ end }}</pre>{{ if .Attribution.First }}
+<pre class="content">{{ range $index, $element := .Elements }}{{ renderVerse $ctx $element }}{{ end }}</pre>{{ if .Attribution.First }}
 <div class="attribution">
 &#8212; {{ .Attribution.First }}{{ if .Attribution.Second }}<br/>
 <cite>{{ .Attribution.Second }}</cite>{{ end }}

--- a/pkg/renderer/sgml/xhtml5/labeled_list.go
+++ b/pkg/renderer/sgml/xhtml5/labeled_list.go
@@ -6,10 +6,10 @@ const (
 {{ end }}<table>
 <tr>
 <td class="hdlist1">{{ $items := .Items }}{{ range $itemIndex, $item := $items }}
-{{ renderInline $ctx $item.Term | printf "%s" }}
+{{ renderInline $ctx $item.Term }}
 {{ if $item.Elements }}</td>
 <td class="hdlist2">
-{{ renderList $ctx $item.Elements | printf "%s" }}
+{{ renderList $ctx $item.Elements }}
 {{ if includeNewline $ctx $itemIndex $items }}</td>
 </tr>
 <tr>

--- a/pkg/renderer/sgml/xhtml5/paragraph.go
+++ b/pkg/renderer/sgml/xhtml5/paragraph.go
@@ -3,7 +3,7 @@ package xhtml5
 const (
 	verseParagraphTmpl = `{{ $ctx := .Context }}{{ with .Data }}<div {{ if .ID }}id="{{ .ID }}" {{ end }}class="verseblock">{{ if .Title }}
 <div class="title">{{ escape .Title }}</div>{{ end }}
-<pre class="content">{{ renderLines $ctx .Lines plainText | printf "%s" }}</pre>{{ if .Attribution.First }}
+<pre class="content">{{ renderLines $ctx .Lines plainText }}</pre>{{ if .Attribution.First }}
 <div class="attribution">
 &#8212; {{ .Attribution.First }}{{ if .Attribution.Second }}<br/>
 <cite>{{ .Attribution.Second }}</cite>{{ end }}
@@ -13,7 +13,7 @@ const (
 	quoteParagraphTmpl = `{{ $ctx := .Context }}{{ with .Data }}<div {{ if .ID }}id="{{ .ID }}" {{ end }}class="quoteblock">{{ if .Title }}
 <div class="title">{{ escape .Title }}</div>{{ end }}
 <blockquote>
-{{ renderLines $ctx .Lines | printf "%s" }}
+{{ renderLines $ctx .Lines }}
 </blockquote>{{ if .Attribution.First }}
 <div class="attribution">
 &#8212; {{ .Attribution.First }}{{ if .Attribution.Second }}<br/>

--- a/pkg/renderer/sgml/xhtml5/table.go
+++ b/pkg/renderer/sgml/xhtml5/table.go
@@ -8,12 +8,12 @@ const (
 </colgroup>
 {{ if .Header }}{{ if .Header.Cells }}<thead>
 <tr>
-{{ $headerCells := .Header.Cells }}{{ range $index, $cell := $headerCells }}<th class="tableblock halign-left valign-top">{{ renderInline $ctx $cell | printf "%s" }}</th>{{ includeNewline $ctx $index $headerCells }}{{ end }}
+{{ $headerCells := .Header.Cells }}{{ range $index, $cell := $headerCells }}<th class="tableblock halign-left valign-top">{{ renderInline $ctx $cell }}</th>{{ includeNewline $ctx $index $headerCells }}{{ end }}
 </tr>
 </thead>
 {{ end }}{{ end }}<tbody>
 {{ range $indexLine, $line := .Lines }}<tr>
-{{ range $indexCells, $cell := $line.Cells }}<td class="tableblock halign-left valign-top"><p class="tableblock">{{ renderInline $ctx $cell | printf "%s" }}</p></td>{{ includeNewline $ctx $indexCells $line.Cells }}{{ end }}
+{{ range $indexCells, $cell := $line.Cells }}<td class="tableblock halign-left valign-top"><p class="tableblock">{{ renderInline $ctx $cell }}</p></td>{{ includeNewline $ctx $indexCells $line.Cells }}{{ end }}
 </tr>
 {{ end }}</tbody>{{ end }}
 </table>{{ end }}`


### PR DESCRIPTION
NB: This PR is based upon the PR for 623, as I anticipate that that PR will be merged first.

This internal refactoring is phase 1, and gets rid of the | printf "%s" nonsense in the templates.

I anticipate doing further refactoring of the templates to make them nicer and easier to work with, and easier to modify.  (For example removing Contextual Pipeline intermediate object and the need to do with $Data.)

Note that I did not have to modify any of the test code for this -- there are no changes to outputs.