### PR TITLE
bug(renderer): Wrong code for (TM)

### DIFF
--- a/pkg/renderer/sgml/html5/string_test.go
+++ b/pkg/renderer/sgml/html5/string_test.go
@@ -28,7 +28,7 @@ var _ = Describe("strings", func() {
 	It("text with trademark", func() {
 		source := `TheRightThing(TM)`
 		expected := `<div class="paragraph">
-<p>TheRightThing&#153;</p>
+<p>TheRightThing&#8482;</p>
 </div>`
 		Expect(RenderHTML(source)).To(MatchHTML(expected))
 	})

--- a/pkg/renderer/sgml/string.go
+++ b/pkg/renderer/sgml/string.go
@@ -67,7 +67,7 @@ func copyright(source string) string {
 }
 
 func trademark(source string) string {
-	return strings.Replace(source, "(TM)", "&#153;", -1)
+	return strings.Replace(source, "(TM)", "&#8482;", -1)
 }
 
 func registered(source string) string {

--- a/pkg/renderer/sgml/xhtml5/string_test.go
+++ b/pkg/renderer/sgml/xhtml5/string_test.go
@@ -28,7 +28,7 @@ var _ = Describe("strings", func() {
 	It("text with trademark", func() {
 		source := `TheRightThing(TM)`
 		expected := `<div class="paragraph">
-<p>TheRightThing&#153;</p>
+<p>TheRightThing&#8482;</p>
 </div>`
 		Expect(RenderXHTML(source)).To(MatchHTML(expected))
 	})


### PR DESCRIPTION
We were using the code 153, which is not the same value used by
asciidoctor, and doesn't uniformly render as the trademark
symbol.

Fixes #641


(This PR should be mergeable/rebaseable as is, because it's changes are fairly isolated from other PRs currently outstanding.)