### PR TITLE
refactor(renderer): Clean up/simplify title handling

### DIFF
--- a/pkg/renderer/sgml/callout_list.go
+++ b/pkg/renderer/sgml/callout_list.go
@@ -23,7 +23,7 @@ func (r *sgmlRenderer) renderCalloutList(ctx *renderer.Context, l types.CalloutL
 	err := r.calloutList.Execute(result, struct {
 		Context *renderer.Context
 		ID      sanitized
-		Title   string
+		Title   sanitized
 		Roles   sanitized
 		Content sanitized
 		Items   []types.CalloutListItem

--- a/pkg/renderer/sgml/delimited_block.go
+++ b/pkg/renderer/sgml/delimited_block.go
@@ -58,7 +58,7 @@ func (r *sgmlRenderer) renderFencedBlock(ctx *renderer.Context, b types.Delimite
 	err = r.fencedBlock.Execute(result, struct {
 		Context  *renderer.Context
 		ID       sanitized
-		Title    string
+		Title    sanitized
 		Roles    sanitized
 		Content  sanitized
 		Elements []interface{}
@@ -92,7 +92,7 @@ func (r *sgmlRenderer) renderListingBlock(ctx *renderer.Context, b types.Delimit
 	err = r.listingBlock.Execute(result, struct {
 		Context  *renderer.Context
 		ID       sanitized
-		Title    string
+		Title    sanitized
 		Roles    sanitized
 		Content  sanitized
 		Elements []interface{}
@@ -164,7 +164,7 @@ func (r *sgmlRenderer) renderSourceBlock(ctx *renderer.Context, b types.Delimite
 	result := &bytes.Buffer{}
 	err = r.sourceBlock.Execute(result, struct {
 		ID                sanitized
-		Title             string
+		Title             sanitized
 		Roles             sanitized
 		Language          string
 		SyntaxHighlighter string
@@ -195,7 +195,7 @@ func (r *sgmlRenderer) renderAdmonitionBlock(ctx *renderer.Context, b types.Deli
 	err = r.admonitionBlock.Execute(result, struct {
 		Context  *renderer.Context
 		ID       sanitized
-		Title    string
+		Title    sanitized
 		Kind     types.AdmonitionKind
 		Roles    sanitized
 		Icon     sanitized
@@ -230,7 +230,7 @@ func (r *sgmlRenderer) renderExampleBlock(ctx *renderer.Context, b types.Delimit
 	err = r.exampleBlock.Execute(result, struct {
 		Context       *renderer.Context
 		ID            sanitized
-		Title         string
+		Title         sanitized
 		Roles         sanitized
 		ExampleNumber int
 		Content       sanitized
@@ -258,7 +258,7 @@ func (r *sgmlRenderer) renderQuoteBlock(ctx *renderer.Context, b types.Delimited
 	err = r.quoteBlock.Execute(result, struct {
 		Context     *renderer.Context
 		ID          sanitized
-		Title       string
+		Title       sanitized
 		Roles       sanitized
 		Attribution Attribution
 		Content     sanitized
@@ -290,7 +290,7 @@ func (r *sgmlRenderer) renderVerseBlock(ctx *renderer.Context, b types.Delimited
 	err := r.verseBlock.Execute(result, struct {
 		Context     *renderer.Context
 		ID          sanitized
-		Title       string
+		Title       sanitized
 		Roles       sanitized
 		Attribution Attribution
 		Content     sanitized
@@ -335,7 +335,7 @@ func (r *sgmlRenderer) renderSidebarBlock(ctx *renderer.Context, b types.Delimit
 	err = r.sidebarBlock.Execute(result, struct {
 		Context  *renderer.Context
 		ID       sanitized
-		Title    string
+		Title    sanitized
 		Roles    sanitized
 		Content  sanitized
 		Elements []interface{}

--- a/pkg/renderer/sgml/html5/callout_list.go
+++ b/pkg/renderer/sgml/html5/callout_list.go
@@ -5,7 +5,7 @@ const (
 	calloutListTmpl = `<div` +
 		`{{ if .ID }} id="{{ .ID }}"{{ end }} ` +
 		"class=\"colist arabic{{ if .Roles }} {{ .Roles }}{{ end}}\">\n" +
-		"{{ if .Title }}<div class=\"title\">{{ escape .Title }}</div>\n{{ end }}" +
+		"{{ if .Title }}<div class=\"title\">{{ .Title }}</div>\n{{ end }}" +
 		"<ol>\n" +
 		"{{ .Content }}" +
 		"</ol>\n</div>"

--- a/pkg/renderer/sgml/html5/delimited_block.go
+++ b/pkg/renderer/sgml/html5/delimited_block.go
@@ -3,7 +3,7 @@ package html5
 const (
 	fencedBlockTmpl = `<div {{ if .ID }}id="{{ .ID }}" {{ end }}` +
 		"class=\"listingblock{{ if .Roles }} {{ .Roles }}{{ end }}\">\n" +
-		"{{ if .Title }}<div class=\"title\">{{ escape .Title }}</div>\n{{ end }}" +
+		"{{ if .Title }}<div class=\"title\">{{ .Title }}</div>\n{{ end }}" +
 		"<div class=\"content\">\n" +
 		"<pre class=\"highlight\"><code>{{ .Content }}</code></pre>\n" +
 		"</div>\n" +
@@ -11,7 +11,7 @@ const (
 
 	listingBlockTmpl = `<div {{ if .ID }}id="{{ .ID }}" {{ end }}` +
 		"class=\"listingblock{{ if .Roles }} {{ .Roles }}{{ end }}\">\n" +
-		"{{ if .Title }}<div class=\"title\">{{ escape .Title }}</div>\n{{ end }}" +
+		"{{ if .Title }}<div class=\"title\">{{ .Title }}</div>\n{{ end }}" +
 		"<div class=\"content\">\n" +
 		"<pre>{{ .Content }}</pre>\n" +
 		"</div>\n" +
@@ -19,7 +19,7 @@ const (
 
 	sourceBlockTmpl = `<div {{ if .ID }}id="{{ .ID }}" {{ end }}` +
 		"class=\"listingblock{{ if .Roles }} {{ .Roles }}{{ end }}\">\n" +
-		"{{ if .Title }}<div class=\"title\">{{ escape .Title }}</div>\n{{ end }}" +
+		"{{ if .Title }}<div class=\"title\">{{ .Title }}</div>\n{{ end }}" +
 		"<div class=\"content\">\n" +
 		"<pre class=\"" +
 		`{{ if .SyntaxHighlighter }}{{ .SyntaxHighlighter }} {{ end }}` +
@@ -32,7 +32,7 @@ const (
 
 	exampleBlockTmpl = `<div {{ if .ID }}id="{{ .ID }}" {{ end }}` +
 		"class=\"exampleblock{{ if .Roles }} {{ .Roles }}{{ end }}\">\n" +
-		"{{ if .Title }}<div class=\"title\">Example {{ .ExampleNumber }}. {{ escape .Title }}</div>\n{{ end }}" +
+		"{{ if .Title }}<div class=\"title\">Example {{ .ExampleNumber }}. {{ .Title }}</div>\n{{ end }}" +
 		"<div class=\"content\">\n" +
 		"{{ .Content }}\n" +
 		"</div>\n" +
@@ -40,7 +40,7 @@ const (
 
 	quoteBlockTmpl = `<div {{ if .ID }}id="{{ .ID }}" {{ end }}` +
 		"class=\"quoteblock{{ if .Roles }} {{ .Roles }}{{ end }}\">\n" +
-		"{{ if .Title }}<div class=\"title\">{{ escape .Title }}</div>\n{{ end }}" +
+		"{{ if .Title }}<div class=\"title\">{{ .Title }}</div>\n{{ end }}" +
 		"<blockquote>\n" +
 		"{{ .Content }}\n" +
 		"</blockquote>\n" +
@@ -52,7 +52,7 @@ const (
 
 	verseBlockTmpl = `<div {{ if .ID }}id="{{ .ID }}" {{ end }}` +
 		"class=\"verseblock{{ if .Roles }} {{ .Roles }}{{ end }}\">\n" +
-		"{{ if .Title }}<div class=\"title\">{{ escape .Title }}</div>\n{{ end }}" +
+		"{{ if .Title }}<div class=\"title\">{{ .Title }}</div>\n{{ end }}" +
 		"<pre class=\"content\">{{ .Content }}</pre>\n" +
 		"{{ if .Attribution.First }}<div class=\"attribution\">\n&#8212; {{ .Attribution.First }}" +
 		"{{ if .Attribution.Second }}<br>\n<cite>{{ .Attribution.Second }}</cite>{{ end }}\n" +
@@ -65,14 +65,14 @@ const (
 		"<tr>\n" +
 		"<td class=\"icon\">\n{{ .Icon }}\n</td>\n" +
 		"<td class=\"content\">\n" +
-		"{{ if .Title }}<div class=\"title\">{{ escape .Title }}</div>\n{{ end }}" +
+		"{{ if .Title }}<div class=\"title\">{{ .Title }}</div>\n{{ end }}" +
 		"{{ .Content }}\n" +
 		"</td>\n</tr>\n</table>\n</div>"
 
 	sidebarBlockTmpl = "<div {{ if .ID }}id=\"{{ .ID }}\" {{ end }}" +
 		"class=\"sidebarblock{{ if .Roles }} {{ .Roles }}{{ end }}\">\n" +
 		"<div class=\"content\">\n" +
-		"{{ if .Title }}<div class=\"title\">{{ escape .Title }}</div>\n{{ end }}" +
+		"{{ if .Title }}<div class=\"title\">{{ .Title }}</div>\n{{ end }}" +
 		"{{ .Content }}\n" +
 		"</div>\n" +
 		"</div>"

--- a/pkg/renderer/sgml/html5/html5.go
+++ b/pkg/renderer/sgml/html5/html5.go
@@ -10,7 +10,7 @@ const (
 <meta name="generator" content="{{ .Generator }}">{{ end }}{{ if .Authors }}
 <meta name="author" content="{{ .Authors }}">{{ end }}{{ if .CSS}}
 <link type="text/css" rel="stylesheet" href="{{ .CSS }}">{{ end }}
-<title>{{ escape .Title }}</title>
+<title>{{ .Title }}</title>
 </head>
 <body class="{{ .Doctype }}{{ if .Role }} {{ .Role }}{{ end }}">{{ if .IncludeHeader }}
 {{ .Header }}{{ end }}

--- a/pkg/renderer/sgml/html5/image.go
+++ b/pkg/renderer/sgml/html5/image.go
@@ -5,8 +5,8 @@ const (
 <div class="content">
 {{ if ne .Href "" }}<a class="image" href="{{ .Href }}">{{ end }}<img src="{{ .Path }}" alt="{{ .Alt }}"{{ if .Width }} width="{{ .Width }}"{{ end }}{{ if .Height }} height="{{ .Height }}"{{ end }}>{{ if ne .Href "" }}</a>{{ end }}
 </div>{{ if .Title }}
-<div class="title">{{ escape .Title }}</div>
+<div class="title">{{ .Title }}</div>
 {{ else }}
 {{ end }}</div>`
-	inlineImageTmpl = `<span class="image{{ if .Role }} {{ .Role }}{{ end }}"><img src="{{ .Path }}" alt="{{ .Alt }}"{{ if .Width }} width="{{ .Width }}"{{ end }}{{ if .Height }} height="{{ .Height }}"{{ end }}{{ if .Title }} title="{{ escape .Title }}"{{ end }}></span>`
+	inlineImageTmpl = `<span class="image{{ if .Role }} {{ .Role }}{{ end }}"><img src="{{ .Path }}" alt="{{ .Alt }}"{{ if .Width }} width="{{ .Width }}"{{ end }}{{ if .Height }} height="{{ .Height }}"{{ end }}{{ if .Title }} title="{{ .Title }}"{{ end }}></span>`
 )

--- a/pkg/renderer/sgml/html5/labeled_list.go
+++ b/pkg/renderer/sgml/html5/labeled_list.go
@@ -4,7 +4,7 @@ const (
 	labeledListTmpl = `<div` +
 		`{{ if .ID }} id="{{ .ID }}"{{ end }}` +
 		" class=\"dlist{{ if .Roles }} {{ .Roles }}{{ end }}\">\n" +
-		"{{ if .Title }}<div class=\"title\">{{ escape .Title }}</div>\n{{ end }}" +
+		"{{ if .Title }}<div class=\"title\">{{ .Title }}</div>\n{{ end }}" +
 		"<dl>\n{{ .Content }}</dl>\n</div>"
 
 	labeledListItemTmpl = "<dt class=\"hdlist1\">{{ .Term }}</dt>\n" +
@@ -13,7 +13,7 @@ const (
 	labeledListHorizontalTmpl = `<div` +
 		`{{ if .ID }} id="{{ .ID }}"{{ end }} ` +
 		"class=\"hdlist{{ if .Roles }} {{ .Roles }}{{ end }}\">\n" +
-		"{{ if .Title }}<div class=\"title\">{{ escape .Title }}</div>\n{{ end }}" +
+		"{{ if .Title }}<div class=\"title\">{{ .Title }}</div>\n{{ end }}" +
 		"<table>\n{{ .Content }}</table>\n</div>"
 
 	// Continuation items (multiple terms sharing a single definition) make this a bit more complex.
@@ -25,7 +25,7 @@ const (
 	qAndAListTmpl = "<div{{ if .ID }} id=\"{{ .ID }}\"{{ end }} " +
 		"class=\"qlist qanda{{ if .Roles }} {{ .Roles }}{{ end }}\"" +
 		">\n" +
-		"{{ if .Title }}<div class=\"title\">{{ escape .Title }}</div>\n{{ end }}" +
+		"{{ if .Title }}<div class=\"title\">{{ .Title }}</div>\n{{ end }}" +
 		"<ol>\n{{ .Content }}</ol>\n</div>"
 
 	qAndAListItemTmpl = "<li>\n<p><em>{{ .Term }}</em></p>\n{{ .Content }}\n</li>\n"

--- a/pkg/renderer/sgml/html5/literal_blocks.go
+++ b/pkg/renderer/sgml/html5/literal_blocks.go
@@ -3,7 +3,7 @@ package html5
 const (
 	literalBlockTmpl = `<div {{ if .ID }}id="{{ .ID }}" {{ end }}` +
 		"class=\"literalblock\"{{ if .Roles }} {{ .Roles }}{{ end }}>\n" +
-		"{{ if .Title }}<div class=\"title\">{{ escape .Title }}</div>\n{{ end }}" +
+		"{{ if .Title }}<div class=\"title\">{{ .Title }}</div>\n{{ end }}" +
 		"<div class=\"content\">\n" +
 		"<pre>{{ .Content }}</pre>\n" +
 		"</div>\n" +

--- a/pkg/renderer/sgml/html5/ordered_list.go
+++ b/pkg/renderer/sgml/html5/ordered_list.go
@@ -5,7 +5,7 @@ const (
 		` class="olist {{ .NumberingStyle }}` +
 		`{{ if .Roles }} {{ .Roles }}{{ end }}"` +
 		">\n" +
-		"{{ if .Title }}<div class=\"title\">{{ escape .Title }}</div>\n{{ end }}" +
+		"{{ if .Title }}<div class=\"title\">{{ .Title }}</div>\n{{ end }}" +
 		`<ol` +
 		` class="{{ .NumberingStyle }}"` +
 		`{{ if .ListStyle }} type="{{ .ListStyle }}"{{ end }}` +

--- a/pkg/renderer/sgml/html5/paragraph.go
+++ b/pkg/renderer/sgml/html5/paragraph.go
@@ -3,7 +3,7 @@ package html5
 const (
 	paragraphTmpl = "<div{{ if .ID }} id=\"{{ .ID }}\"{{ end }}" +
 		" class=\"paragraph{{ if .Roles }} {{ .Roles }}{{ end }}\">\n" +
-		"{{ if .Title  }}<div class=\"doctitle\">{{ escape .Title }}</div>\n{{ end }}" +
+		"{{ if .Title  }}<div class=\"doctitle\">{{ .Title }}</div>\n{{ end }}" +
 		"<p>{{ .Content }}</p>\n" +
 		"</div>"
 
@@ -14,7 +14,7 @@ const (
 		"{{ if .Icon }}{{ .Icon }}{{ end }}\n" +
 		"</td>\n" +
 		"<td class=\"content\">\n" +
-		"{{ if .Title }}<div class=\"title\">{{ escape .Title }}</div>\n{{ end }}" +
+		"{{ if .Title }}<div class=\"title\">{{ .Title }}</div>\n{{ end }}" +
 		"{{ .Content }}\n" +
 		"</td>\n</tr>\n</table>\n</div>{{ end }}"
 
@@ -30,14 +30,14 @@ const (
 		"</div>"
 
 	verseParagraphTmpl = "<div {{ if .ID }}id=\"{{ .ID }}\" {{ end }}class=\"verseblock\">\n" +
-		"{{ if .Title }}<div class=\"title\">{{ escape .Title }}</div>\n{{ end }}" +
+		"{{ if .Title }}<div class=\"title\">{{ .Title }}</div>\n{{ end }}" +
 		"<pre class=\"content\">{{ .Content }}</pre>\n" +
 		"{{ if .Attribution.First }}<div class=\"attribution\">\n&#8212; {{ .Attribution.First }}" +
 		"{{ if .Attribution.Second }}<br>\n<cite>{{ .Attribution.Second }}</cite>\n{{ else }}\n{{ end }}" +
 		"</div>\n{{ end }}</div>"
 
 	quoteParagraphTmpl = "<div {{ if .ID }}id=\"{{ .ID }}\" {{ end }}class=\"quoteblock\">\n" +
-		"{{ if .Title }}<div class=\"title\">{{ escape .Title }}</div>\n{{ end }}" +
+		"{{ if .Title }}<div class=\"title\">{{ .Title }}</div>\n{{ end }}" +
 		"<blockquote>\n" +
 		"{{ .Content }}\n" +
 		"</blockquote>\n" +

--- a/pkg/renderer/sgml/html5/table.go
+++ b/pkg/renderer/sgml/html5/table.go
@@ -3,7 +3,7 @@ package html5
 const (
 	// TODO: These class settings need to be overridable via attributes
 	tableTmpl = "<table class=\"tableblock frame-all grid-all stretch{{ if .Roles }} {{ .Roles }}{{ end }}\">\n" +
-		"{{ if .Title }}<caption class=\"title\">Table {{ .TableNumber }}. {{ escape .Title }}</caption>\n{{ end }}" +
+		"{{ if .Title }}<caption class=\"title\">Table {{ .TableNumber }}. {{ .Title }}</caption>\n{{ end }}" +
 		"{{ if .Body }}" +
 		"<colgroup>\n" +
 		"{{ range $i, $w := .CellWidths }}<col style=\"width: {{ $w }}%;\">\n{{ end}}" +

--- a/pkg/renderer/sgml/html5/unordered_list.go
+++ b/pkg/renderer/sgml/html5/unordered_list.go
@@ -5,7 +5,7 @@ const (
 		` class="ulist{{ if .Checklist }} checklist{{ end }}` +
 		`{{ if .Roles }} {{ .Roles }}{{ end }}"` +
 		">\n" +
-		"{{ if .Title }}<div class=\"title\">{{ escape .Title }}</div>\n{{ end }}" +
+		"{{ if .Title }}<div class=\"title\">{{ .Title }}</div>\n{{ end }}" +
 		"<ul{{ if .Checklist }} class=\"checklist\"{{ end }}>\n" +
 		"{{ .Content }}</ul>\n</div>"
 

--- a/pkg/renderer/sgml/html_escape.go
+++ b/pkg/renderer/sgml/html_escape.go
@@ -19,6 +19,7 @@ var htmlEscaper = strings.NewReplacer(
 	`&`, "&amp;",
 	`<`, "&lt;",
 	`>`, "&gt;",
+	// TODO: These two should be substituted as well.  The elements here could wind up in attributes.
 	// `'`, "&#39;", // "&#39;" is shorter than "&apos;" and apos was not in HTML until HTML5.
 	// `"`, "&#34;", // "&#34;" is shorter than "&quot;".
 )

--- a/pkg/renderer/sgml/image.go
+++ b/pkg/renderer/sgml/image.go
@@ -11,13 +11,14 @@ import (
 
 func (r *sgmlRenderer) renderImageBlock(ctx *renderer.Context, img types.ImageBlock) (string, error) {
 	result := &strings.Builder{}
-	title := ""
+	title := sanitized("")
 	if t, found := img.Attributes.GetAsString(types.AttrTitle); found {
-		title = "Figure " + strconv.Itoa(ctx.GetAndIncrementImageCounter()) + ". " + EscapeString(t)
+		// TODO: This should be moved to the template
+		title = sanitized("Figure " + strconv.Itoa(ctx.GetAndIncrementImageCounter()) + ". " + EscapeString(t))
 	}
 	err := r.blockImage.Execute(result, struct {
 		ID     sanitized
-		Title  string
+		Title  sanitized
 		Role   string
 		Href   string
 		Alt    string
@@ -46,7 +47,7 @@ func (r *sgmlRenderer) renderInlineImage(img types.InlineImage) (string, error) 
 	result := &strings.Builder{}
 	err := r.inlineImage.Execute(result, struct {
 		Role   string
-		Title  string
+		Title  sanitized
 		Href   string
 		Alt    string
 		Width  string

--- a/pkg/renderer/sgml/labeled_list.go
+++ b/pkg/renderer/sgml/labeled_list.go
@@ -28,7 +28,7 @@ func (r *sgmlRenderer) renderLabeledList(ctx *renderer.Context, l types.LabeledL
 	err = tmpl.Execute(result, struct {
 		Context *renderer.Context
 		ID      sanitized
-		Title   string
+		Title   sanitized
 		Roles   sanitized
 		Content sanitized
 		Items   []types.LabeledListItem

--- a/pkg/renderer/sgml/literal_blocks.go
+++ b/pkg/renderer/sgml/literal_blocks.go
@@ -43,7 +43,7 @@ func (r *sgmlRenderer) renderLiteralBlock(ctx *renderer.Context, b types.Literal
 	err := r.literalBlock.Execute(result, struct {
 		Context *renderer.Context
 		ID      sanitized
-		Title   string
+		Title   sanitized
 		Roles   sanitized
 		Content string
 		Lines   []string

--- a/pkg/renderer/sgml/ordered_list.go
+++ b/pkg/renderer/sgml/ordered_list.go
@@ -22,7 +22,7 @@ func (r *sgmlRenderer) renderOrderedList(ctx *renderer.Context, l types.OrderedL
 	err := r.orderedList.Execute(result, struct {
 		Context        *renderer.Context
 		ID             sanitized
-		Title          string
+		Title          sanitized
 		Roles          sanitized
 		NumberingStyle string
 		ListStyle      string

--- a/pkg/renderer/sgml/paragraph.go
+++ b/pkg/renderer/sgml/paragraph.go
@@ -35,7 +35,7 @@ func (r *sgmlRenderer) renderParagraph(ctx *renderer.Context, p types.Paragraph)
 			Context *renderer.Context
 			ID      sanitized
 			Roles   sanitized
-			Title   string
+			Title   sanitized
 			Lines   [][]interface{}
 			Content sanitized
 		}{
@@ -72,7 +72,7 @@ func (r *sgmlRenderer) renderAdmonitionParagraph(ctx *renderer.Context, p types.
 	err = r.admonitionParagraph.Execute(result, struct {
 		Context *renderer.Context
 		ID      sanitized
-		Title   string
+		Title   sanitized
 		Roles   sanitized
 		Icon    sanitized
 		Kind    sanitized
@@ -103,7 +103,7 @@ func (r *sgmlRenderer) renderSourceParagraph(ctx *renderer.Context, p types.Para
 	err = r.sourceParagraph.Execute(result, struct {
 		Context  *renderer.Context
 		ID       sanitized
-		Title    string
+		Title    sanitized
 		Language string
 		Content  sanitized
 		Lines    [][]interface{}
@@ -130,7 +130,7 @@ func (r *sgmlRenderer) renderVerseParagraph(ctx *renderer.Context, p types.Parag
 	err = r.verseParagraph.Execute(result, struct {
 		Context     *renderer.Context
 		ID          sanitized
-		Title       string
+		Title       sanitized
 		Attribution Attribution
 		Content     sanitized
 		Lines       [][]interface{}
@@ -157,7 +157,7 @@ func (r *sgmlRenderer) renderQuoteParagraph(ctx *renderer.Context, p types.Parag
 	err = r.quoteParagraph.Execute(result, struct {
 		Context     *renderer.Context
 		ID          sanitized
-		Title       string
+		Title       sanitized
 		Attribution Attribution
 		Content     sanitized
 		Lines       [][]interface{}
@@ -205,7 +205,7 @@ func (r *sgmlRenderer) renderDelimitedBlockParagraph(ctx *renderer.Context, p ty
 	err = r.delimitedBlockParagraph.Execute(result, struct {
 		Context    *renderer.Context
 		ID         sanitized
-		Title      string
+		Title      sanitized
 		CheckStyle string
 		Content    sanitized
 		Lines      [][]interface{}
@@ -231,9 +231,9 @@ func renderCheckStyle(style interface{}) string {
 	}
 }
 
-func (r *sgmlRenderer) renderElementTitle(attrs types.Attributes) string {
+func (r *sgmlRenderer) renderElementTitle(attrs types.Attributes) sanitized {
 	if title, found := attrs.GetAsString(types.AttrTitle); found {
-		return strings.TrimSpace(title)
+		return sanitized(EscapeString(strings.TrimSpace(title)))
 	}
 	return ""
 }

--- a/pkg/renderer/sgml/renderer.go
+++ b/pkg/renderer/sgml/renderer.go
@@ -112,7 +112,7 @@ func (r *sgmlRenderer) Render(ctx *renderer.Context, doc types.Document, output 
 		err = r.article.Execute(output, struct {
 			Generator     string
 			Doctype       string
-			Title         string
+			Title         sanitized
 			Authors       string
 			Header        string
 			Role          string
@@ -146,7 +146,7 @@ func (r *sgmlRenderer) Render(ctx *renderer.Context, doc types.Document, output 
 		}
 	}
 	// generate the metadata to be returned to the caller
-	md.Title = renderedTitle
+	md.Title = string(renderedTitle)
 	// arguably this should be a time.Time for use in Go
 	md.LastUpdated = ctx.Config.LastUpdated.Format(configuration.LastUpdatedFormat)
 	md.TableOfContents = ctx.TableOfContents
@@ -240,13 +240,14 @@ func (r *sgmlRenderer) renderAuthors(doc types.Document) string {
 	return strings.Join(authorStrs, "; ")
 }
 
-func (r *sgmlRenderer) renderDocumentTitle(ctx *renderer.Context, doc types.Document) (string, error) {
+func (r *sgmlRenderer) renderDocumentTitle(ctx *renderer.Context, doc types.Document) (sanitized, error) {
 	if header, found := doc.Header(); found {
+		// TODO: This feels wrong.  The title should not need markup.
 		title, err := r.renderPlainText(ctx, header.Title)
 		if err != nil {
 			return "", errors.Wrap(err, "unable to render document title")
 		}
-		return title, nil
+		return sanitized(title), nil
 	}
 	return "", nil
 }

--- a/pkg/renderer/sgml/table.go
+++ b/pkg/renderer/sgml/table.go
@@ -49,7 +49,7 @@ func (r *sgmlRenderer) renderTable(ctx *renderer.Context, t types.Table) (string
 
 	err = r.table.Execute(result, struct {
 		Context     *renderer.Context
-		Title       string
+		Title       sanitized
 		CellWidths  []string
 		TableNumber int
 		Roles       sanitized

--- a/pkg/renderer/sgml/unordered_list.go
+++ b/pkg/renderer/sgml/unordered_list.go
@@ -29,7 +29,7 @@ func (r *sgmlRenderer) renderUnorderedList(ctx *renderer.Context, l types.Unorde
 	err := r.unorderedList.Execute(result, struct {
 		Context   *renderer.Context
 		ID        sanitized
-		Title     string
+		Title     sanitized
 		Roles     sanitized
 		Checklist bool
 		Items     []types.UnorderedListItem

--- a/pkg/renderer/sgml/xhtml5/delimited_block.go
+++ b/pkg/renderer/sgml/xhtml5/delimited_block.go
@@ -3,7 +3,7 @@ package xhtml5
 const (
 	quoteBlockTmpl = `<div {{ if .ID }}id="{{ .ID }}" {{ end }}` +
 		"class=\"quoteblock{{ if .Roles }} {{ .Roles }}{{ end }}\">\n" +
-		"{{ if .Title }}<div class=\"title\">{{ escape .Title }}</div>\n{{ end }}" +
+		"{{ if .Title }}<div class=\"title\">{{ .Title }}</div>\n{{ end }}" +
 		"<blockquote>\n" +
 		"{{ .Content }}\n" +
 		"</blockquote>\n" +
@@ -15,7 +15,7 @@ const (
 
 	verseBlockTmpl = `<div {{ if .ID }}id="{{ .ID }}" {{ end }}` +
 		"class=\"verseblock{{ if .Roles }} {{ .Roles }}{{ end }}\">\n" +
-		"{{ if .Title }}<div class=\"title\">{{ escape .Title }}</div>\n{{ end }}" +
+		"{{ if .Title }}<div class=\"title\">{{ .Title }}</div>\n{{ end }}" +
 		"<pre class=\"content\">{{ .Content }}</pre>\n" +
 		"{{ if .Attribution.First }}<div class=\"attribution\">\n&#8212; {{ .Attribution.First }}" +
 		"{{ if .Attribution.Second }}<br/>\n<cite>{{ .Attribution.Second }}</cite>{{ end }}\n" +

--- a/pkg/renderer/sgml/xhtml5/image.go
+++ b/pkg/renderer/sgml/xhtml5/image.go
@@ -9,7 +9,7 @@ const (
 		`{{ if .Height }} height="{{ .Height }}"{{ end }}` +
 		`/>{{ if ne .Href "" }}</a>{{ end }}
 </div>{{ if .Title }}
-<div class="title">{{ escape .Title }}</div>
+<div class="title">{{ .Title }}</div>
 {{ else }}
 {{ end }}</div>`
 
@@ -17,6 +17,6 @@ const (
 		`<img src="{{ .Path }}" alt="{{ .Alt }}"` +
 		`{{ if .Width }} width="{{ .Width }}"{{ end }}` +
 		`{{ if .Height }} height="{{ .Height }}"{{ end }}` +
-		`{{ if .Title }} title="{{ escape .Title }}"{{ end }}` +
+		`{{ if .Title }} title="{{ .Title }}"{{ end }}` +
 		`/></span>`
 )

--- a/pkg/renderer/sgml/xhtml5/paragraph.go
+++ b/pkg/renderer/sgml/xhtml5/paragraph.go
@@ -2,14 +2,14 @@ package xhtml5
 
 const (
 	verseParagraphTmpl = "<div {{ if .ID }}id=\"{{ .ID }}\" {{ end }}class=\"verseblock\">\n" +
-		"{{ if .Title }}<div class=\"title\">{{ escape .Title }}</div>\n{{ end }}" +
+		"{{ if .Title }}<div class=\"title\">{{ .Title }}</div>\n{{ end }}" +
 		"<pre class=\"content\">{{ .Content }}</pre>\n" +
 		"{{ if .Attribution.First }}<div class=\"attribution\">\n&#8212; {{ .Attribution.First }}" +
 		"{{ if .Attribution.Second }}<br/>\n<cite>{{ .Attribution.Second }}</cite>\n{{ else }}\n{{ end }}" +
 		"</div>\n{{ end }}</div>"
 
 	quoteParagraphTmpl = "<div {{ if .ID }}id=\"{{ .ID }}\" {{ end }}class=\"quoteblock\">\n" +
-		"{{ if .Title }}<div class=\"title\">{{ escape .Title }}</div>\n{{ end }}" +
+		"{{ if .Title }}<div class=\"title\">{{ .Title }}</div>\n{{ end }}" +
 		"<blockquote>\n" +
 		"{{ .Content }}\n" +
 		"</blockquote>\n" +

--- a/pkg/renderer/sgml/xhtml5/table.go
+++ b/pkg/renderer/sgml/xhtml5/table.go
@@ -2,7 +2,7 @@ package xhtml5
 
 const (
 	tableTmpl = "<table class=\"tableblock frame-all grid-all stretch{{ if .Roles }} {{ .Roles }}{{ end }}\">\n" +
-		"{{ if .Title }}<caption class=\"title\">Table {{ .TableNumber }}. {{ escape .Title }}</caption>\n{{ end }}" +
+		"{{ if .Title }}<caption class=\"title\">Table {{ .TableNumber }}. {{ .Title }}</caption>\n{{ end }}" +
 		"{{ if .Body }}" +
 		"<colgroup>\n" +
 		"{{ range $i, $w := .CellWidths }}<col style=\"width: {{ $w }}%;\"/>\n{{ end}}" +

--- a/pkg/renderer/sgml/xhtml5/xhtml5.go
+++ b/pkg/renderer/sgml/xhtml5/xhtml5.go
@@ -10,7 +10,7 @@ const (
 <meta name="generator" content="{{ .Generator }}"/>{{ end }}{{ if .Authors }}
 <meta name="author" content="{{ .Authors }}"/>{{ end }}{{ if .CSS}}
 <link type="text/css" rel="stylesheet" href="{{ .CSS }}"/>{{ end }}
-<title>{{ escape .Title }}</title>
+<title>{{ .Title }}</title>
 </head>
 <body class="{{ .Doctype }}{{ if .Role }} {{ .Role }}{{ end }}">{{ if .IncludeHeader }}
 {{ .Header }}{{ end }}


### PR DESCRIPTION
This eliminates the needs for templates to call escape.

Fixes #640