### PR TITLE
feature(renderer): htmlEscape should escape quotes

### DIFF
--- a/libasciidoc_test.go
+++ b/libasciidoc_test.go
@@ -296,7 +296,7 @@ Free use of this software is granted under the terms of the MIT License.`
 
 				expectedContent := `<h2 id="_name">Name</h2>
 <div class="sectionbody">
-<p>eve - analyzes an image to determine if it's a picture of a life form</p>
+<p>eve - analyzes an image to determine if it&#39;s a picture of a life form</p>
 </div>
 <div class="sect1">
 <h2 id="_synopsis">Synopsis</h2>
@@ -355,7 +355,7 @@ Free use of this software is granted under the terms of the MIT License.`
 <h1>eve(1) Manual Page</h1>
 <h2 id="_name">Name</h2>
 <div class="sectionbody">
-<p>eve - analyzes an image to determine if it's a picture of a life form</p>
+<p>eve - analyzes an image to determine if it&#39;s a picture of a life form</p>
 </div>
 </div>
 <div id="content">
@@ -434,7 +434,7 @@ Free use of this software is granted under the terms of the MIT License.`
 <h2 id="_foo">Foo</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p>eve - analyzes an image to determine if it's a picture of a life form</p>
+<p>eve - analyzes an image to determine if it&#39;s a picture of a life form</p>
 </div>
 </div>
 </div>

--- a/pkg/renderer/sgml/html5/delimited_block_test.go
+++ b/pkg/renderer/sgml/html5/delimited_block_test.go
@@ -230,10 +230,10 @@ end
 ----`
 			expected := `<div class="listingblock">
 <div class="content">
-<pre class="highlight"><code>require 'sinatra'
+<pre class="highlight"><code>require &#39;sinatra&#39;
 
-get '/hi' do
-  "Hello World!"
+get &#39;/hi&#39; do
+  &#34;Hello World!&#34;
 end</code></pre>
 </div>
 </div>`
@@ -254,10 +254,10 @@ end
 			expected := `<div class="listingblock">
 <div class="title">Source block title</div>
 <div class="content">
-<pre class="highlight"><code class="language-ruby" data-lang="ruby">require 'sinatra'
+<pre class="highlight"><code class="language-ruby" data-lang="ruby">require &#39;sinatra&#39;
 
-get '/hi' do
-  "Hello World!"
+get &#39;/hi&#39; do
+  &#34;Hello World!&#34;
 end</code></pre>
 </div>
 </div>`
@@ -278,10 +278,10 @@ end
 			expected := `<div class="listingblock">
 <div class="title">Source block title</div>
 <div class="content">
-<pre class="highlight"><code class="language-ruby" data-lang="ruby">require 'sinatra'
+<pre class="highlight"><code class="language-ruby" data-lang="ruby">require &#39;sinatra&#39;
 
-get '/hi' do
-  "Hello World!"
+get &#39;/hi&#39; do
+  &#34;Hello World!&#34;
 end</code></pre>
 </div>
 </div>`
@@ -302,10 +302,10 @@ end
 			expected := `<div id="id-for-source-block" class="listingblock">
 <div class="title">app.rb</div>
 <div class="content">
-<pre class="highlight"><code class="language-ruby" data-lang="ruby">require 'sinatra'
+<pre class="highlight"><code class="language-ruby" data-lang="ruby">require &#39;sinatra&#39;
 
-get '/hi' do
-  "Hello World!"
+get &#39;/hi&#39; do
+  &#34;Hello World!&#34;
 end</code></pre>
 </div>
 </div>`
@@ -372,13 +372,13 @@ public class GreetingResourceTest {
 
     @Test
     public void testHelloEndpoint() {
-        Mockito.when(greetingService.hello()).thenReturn("hello from mockito");
+        Mockito.when(greetingService.hello()).thenReturn(&#34;hello from mockito&#34;);
 
         given()
-          .when().get("/hello")
+          .when().get(&#34;/hello&#34;)
           .then()
              .statusCode(200)
-             .body(is("hello from mockito"));
+             .body(is(&#34;hello from mockito&#34;));
     }
 
 }</code></pre>
@@ -454,7 +454,7 @@ and "more" content
 <p><strong>bold content</strong></p>
 </div>
 <div class="paragraph">
-<p>and "more" content</p>
+<p>and &#34;more&#34; content</p>
 </div>
 </div>
 </div>`

--- a/pkg/renderer/sgml/html5/file_inclusion_test.go
+++ b/pkg/renderer/sgml/html5/file_inclusion_test.go
@@ -234,11 +234,11 @@ include::../../../../test/includes/hello_world.go.txt[]`
 <p>package includes</p>
 </div>
 <div class="paragraph">
-<p>import "fmt"</p>
+<p>import &#34;fmt&#34;</p>
 </div>
 <div class="paragraph">
 <p>func helloworld() {
-	fmt.Println("hello, world!")
+	fmt.Println(&#34;hello, world!&#34;)
 }</p>
 </div>`
 		Expect(RenderHTML(source)).To(MatchHTML(expected))
@@ -285,11 +285,11 @@ include::../../../../test/includes/hello_world.go.txt[]`
 <p>package includes</p>
 </div>
 <div class="paragraph">
-<p>import "fmt"</p>
+<p>import &#34;fmt&#34;</p>
 </div>
 <div class="paragraph">
 <p>func helloworld() {
-	fmt.Println("hello, world!")
+	fmt.Println(&#34;hello, world!&#34;)
 }</p>
 </div>
 </div>
@@ -455,10 +455,10 @@ include::../../../../test/includes/hello_world.go.txt[]
 <div class="content">
 <pre>package includes
 
-import "fmt"
+import &#34;fmt&#34;
 
 func helloworld() {
-	fmt.Println("hello, world!")
+	fmt.Println(&#34;hello, world!&#34;)
 }</pre>
 </div>
 </div>`
@@ -473,10 +473,10 @@ func helloworld() {
 <div class="content">
 <pre class="highlight"><code>package includes
 
-import "fmt"
+import &#34;fmt&#34;
 
 func helloworld() {
-	fmt.Println("hello, world!")
+	fmt.Println(&#34;hello, world!&#34;)
 }</code></pre>
 </div>
 </div>`
@@ -493,11 +493,11 @@ include::../../../../test/includes/hello_world.go.txt[]
 <p>package includes</p>
 </div>
 <div class="paragraph">
-<p>import "fmt"</p>
+<p>import &#34;fmt&#34;</p>
 </div>
 <div class="paragraph">
 <p>func helloworld() {
-	fmt.Println("hello, world!")
+	fmt.Println(&#34;hello, world!&#34;)
 }</p>
 </div>
 </div>
@@ -515,11 +515,11 @@ ____`
 <p>package includes</p>
 </div>
 <div class="paragraph">
-<p>import "fmt"</p>
+<p>import &#34;fmt&#34;</p>
 </div>
 <div class="paragraph">
 <p>func helloworld() {
-	fmt.Println("hello, world!")
+	fmt.Println(&#34;hello, world!&#34;)
 }</p>
 </div>
 </blockquote>
@@ -535,10 +535,10 @@ ____`
 				expected := `<div class="verseblock">
 <pre class="content">package includes
 
-import "fmt"
+import &#34;fmt&#34;
 
 func helloworld() {
-	fmt.Println("hello, world!")
+	fmt.Println(&#34;hello, world!&#34;)
 }</pre>
 </div>`
 				Expect(RenderHTML(source)).To(MatchHTML(expected))
@@ -554,11 +554,11 @@ include::../../../../test/includes/hello_world.go.txt[]
 <p>package includes</p>
 </div>
 <div class="paragraph">
-<p>import "fmt"</p>
+<p>import &#34;fmt&#34;</p>
 </div>
 <div class="paragraph">
 <p>func helloworld() {
-	fmt.Println("hello, world!")
+	fmt.Println(&#34;hello, world!&#34;)
 }</p>
 </div>
 </div>
@@ -584,7 +584,7 @@ include::../../../../test/includes/hello_world.go.txt[]
 				source := `include::../../../../test/includes/hello_world.go.txt[lines=5..7]`
 				expected := `<div class="paragraph">
 <p>func helloworld() {
-	fmt.Println("hello, world!")
+	fmt.Println(&#34;hello, world!&#34;)
 }</p>
 </div>`
 				Expect(RenderHTML(source)).To(MatchHTML(expected))
@@ -597,7 +597,7 @@ include::../../../../test/includes/hello_world.go.txt[]
 </div>
 <div class="paragraph">
 <p>func helloworld() {
-	fmt.Println("hello, world!")
+	fmt.Println(&#34;hello, world!&#34;)
 }</p>
 </div>`
 				Expect(RenderHTML(source)).To(MatchHTML(expected))
@@ -625,7 +625,7 @@ include::../../../../test/includes/hello_world.go.txt[lines=5..7]
 				expected := `<div class="listingblock">
 <div class="content">
 <pre>func helloworld() {
-	fmt.Println("hello, world!")
+	fmt.Println(&#34;hello, world!&#34;)
 }</pre>
 </div>
 </div>`
@@ -641,7 +641,7 @@ include::../../../../test/includes/hello_world.go.txt[lines=1..2;5..7]
 <pre>package includes
 
 func helloworld() {
-	fmt.Println("hello, world!")
+	fmt.Println(&#34;hello, world!&#34;)
 }</pre>
 </div>
 </div>`

--- a/pkg/renderer/sgml/html5/html5_test.go
+++ b/pkg/renderer/sgml/html5/html5_test.go
@@ -214,7 +214,7 @@ Free use of this software is granted under the terms of the MIT License.`
 <h1>eve(1) Manual Page</h1>
 <h2 id="_name">Name</h2>
 <div class="sectionbody">
-<p>eve - analyzes an image to determine if it's a picture of a life form</p>
+<p>eve - analyzes an image to determine if it&#39;s a picture of a life form</p>
 </div>
 </div>
 <div id="content">
@@ -237,7 +237,7 @@ Free use of this software is granted under the terms of the MIT License.`
 </dd>
 <dt class="hdlist1"><strong>-c, --capture</strong></dt>
 <dd>
-<p>Capture specimen if it's a picture of a life form.</p>
+<p>Capture specimen if it&#39;s a picture of a life form.</p>
 </dd>
 </dl>
 </div>
@@ -342,7 +342,7 @@ Free use of this software is granted under the terms of the MIT License.`
 
 		expected := `<h2 id="_name">Name</h2>
 <div class="sectionbody">
-<p>eve - analyzes an image to determine if it's a picture of a life form</p>
+<p>eve - analyzes an image to determine if it&#39;s a picture of a life form</p>
 </div>
 <div class="sect1">
 <h2 id="_synopsis">Synopsis</h2>
@@ -363,7 +363,7 @@ Free use of this software is granted under the terms of the MIT License.`
 </dd>
 <dt class="hdlist1"><strong>-c, --capture</strong></dt>
 <dd>
-<p>Capture specimen if it's a picture of a life form.</p>
+<p>Capture specimen if it&#39;s a picture of a life form.</p>
 </dd>
 </dl>
 </div>

--- a/pkg/renderer/sgml/html5/labeled_list_test.go
+++ b/pkg/renderer/sgml/html5/labeled_list_test.go
@@ -95,7 +95,7 @@ item 2:: description 2.`
 <dl>
 <dt class="hdlist1">item 1</dt>
 <dd>
-<p>&lt;script&gt;alert("foo!")&lt;/script&gt;</p>
+<p>&lt;script&gt;alert(&#34;foo!&#34;)&lt;/script&gt;</p>
 </dd>
 </dl>
 </div>`

--- a/pkg/renderer/sgml/html5/ordered_list_test.go
+++ b/pkg/renderer/sgml/html5/ordered_list_test.go
@@ -367,7 +367,7 @@ print("one")
 <p></p>
 <div class="listingblock">
 <div class="content">
-<pre>print("one")</pre>
+<pre>print(&#34;one&#34;)</pre>
 </div>
 </div>
 </li>
@@ -375,7 +375,7 @@ print("one")
 <p></p>
 <div class="listingblock">
 <div class="content">
-<pre>print("one")</pre>
+<pre>print(&#34;one&#34;)</pre>
 </div>
 </div>
 </li>

--- a/pkg/renderer/sgml/html5/paragraph_test.go
+++ b/pkg/renderer/sgml/html5/paragraph_test.go
@@ -61,7 +61,7 @@ and here another paragraph
 		It("paragraph with single quotes", func() {
 			source := `a 'subsection' paragraph.`
 			expected := `<div class="paragraph">
-<p>a 'subsection' paragraph.</p>
+<p>a &#39;subsection&#39; paragraph.</p>
 </div>`
 			Expect(RenderHTML(source)).To(MatchHTML(expected))
 		})

--- a/pkg/renderer/sgml/html5/quoted_string_test.go
+++ b/pkg/renderer/sgml/html5/quoted_string_test.go
@@ -37,7 +37,7 @@ var _ = Describe("quoted strings", func() {
 		It("interior spaces with single quoted string", func() {
 			source := "'` curly was single `' or so they say"
 			expected := "<div class=\"paragraph\">\n" +
-				"<p>'` curly was single `' or so they say</p>\n" +
+				"<p>&#39;` curly was single `&#39; or so they say</p>\n" +
 				"</div>"
 			Expect(RenderHTML(source)).To(MatchHTML(expected))
 		})
@@ -190,7 +190,7 @@ var _ = Describe("quoted strings", func() {
 		It("spaces with double quoted string", func() {
 			source := "\"` curly was single `\""
 			expected := "<div class=\"paragraph\">\n" +
-				"<p>\"` curly was single `\"</p>\n" +
+				"<p>&#34;` curly was single `&#34;</p>\n" +
 				"</div>"
 			Expect(RenderHTML(source)).To(MatchHTML(expected))
 		})

--- a/pkg/renderer/sgml/html_escape.go
+++ b/pkg/renderer/sgml/html_escape.go
@@ -19,7 +19,6 @@ var htmlEscaper = strings.NewReplacer(
 	`&`, "&amp;",
 	`<`, "&lt;",
 	`>`, "&gt;",
-	// TODO: These two should be substituted as well.  The elements here could wind up in attributes.
-	// `'`, "&#39;", // "&#39;" is shorter than "&apos;" and apos was not in HTML until HTML5.
-	// `"`, "&#34;", // "&#34;" is shorter than "&quot;".
+	`'`, "&#39;", // "&#39;" is shorter than "&apos;" and apos was not in HTML until HTML5.
+	`"`, "&#34;", // "&#34;" is shorter than "&quot;".
 )

--- a/pkg/renderer/sgml/xhtml5/delimited_block_test.go
+++ b/pkg/renderer/sgml/xhtml5/delimited_block_test.go
@@ -230,10 +230,10 @@ end
 ----`
 			expected := `<div class="listingblock">
 <div class="content">
-<pre class="highlight"><code>require 'sinatra'
+<pre class="highlight"><code>require &#39;sinatra&#39;
 
-get '/hi' do
-  "Hello World!"
+get &#39;/hi&#39; do
+  &#34;Hello World!&#34;
 end</code></pre>
 </div>
 </div>`
@@ -254,10 +254,10 @@ end
 			expected := `<div class="listingblock">
 <div class="title">Source block title</div>
 <div class="content">
-<pre class="highlight"><code class="language-ruby" data-lang="ruby">require 'sinatra'
+<pre class="highlight"><code class="language-ruby" data-lang="ruby">require &#39;sinatra&#39;
 
-get '/hi' do
-  "Hello World!"
+get &#39;/hi&#39; do
+  &#34;Hello World!&#34;
 end</code></pre>
 </div>
 </div>`
@@ -278,10 +278,10 @@ end
 			expected := `<div class="listingblock">
 <div class="title">Source block title</div>
 <div class="content">
-<pre class="highlight"><code class="language-ruby" data-lang="ruby">require 'sinatra'
+<pre class="highlight"><code class="language-ruby" data-lang="ruby">require &#39;sinatra&#39;
 
-get '/hi' do
-  "Hello World!"
+get &#39;/hi&#39; do
+  &#34;Hello World!&#34;
 end</code></pre>
 </div>
 </div>`
@@ -302,10 +302,10 @@ end
 			expected := `<div id="id-for-source-block" class="listingblock">
 <div class="title">app.rb</div>
 <div class="content">
-<pre class="highlight"><code class="language-ruby" data-lang="ruby">require 'sinatra'
+<pre class="highlight"><code class="language-ruby" data-lang="ruby">require &#39;sinatra&#39;
 
-get '/hi' do
-  "Hello World!"
+get &#39;/hi&#39; do
+  &#34;Hello World!&#34;
 end</code></pre>
 </div>
 </div>`
@@ -372,13 +372,13 @@ public class GreetingResourceTest {
 
     @Test
     public void testHelloEndpoint() {
-        Mockito.when(greetingService.hello()).thenReturn("hello from mockito");
+        Mockito.when(greetingService.hello()).thenReturn(&#34;hello from mockito&#34;);
 
         given()
-          .when().get("/hello")
+          .when().get(&#34;/hello&#34;)
           .then()
              .statusCode(200)
-             .body(is("hello from mockito"));
+             .body(is(&#34;hello from mockito&#34;));
     }
 
 }</code></pre>
@@ -454,7 +454,7 @@ and "more" content
 <p><strong>bold content</strong></p>
 </div>
 <div class="paragraph">
-<p>and "more" content</p>
+<p>and &#34;more&#34; content</p>
 </div>
 </div>
 </div>`

--- a/pkg/renderer/sgml/xhtml5/file_inclusion_test.go
+++ b/pkg/renderer/sgml/xhtml5/file_inclusion_test.go
@@ -234,11 +234,11 @@ include::../../../../test/includes/hello_world.go.txt[]`
 <p>package includes</p>
 </div>
 <div class="paragraph">
-<p>import "fmt"</p>
+<p>import &#34;fmt&#34;</p>
 </div>
 <div class="paragraph">
 <p>func helloworld() {
-	fmt.Println("hello, world!")
+	fmt.Println(&#34;hello, world!&#34;)
 }</p>
 </div>`
 		Expect(RenderXHTML(source)).To(MatchHTML(expected))
@@ -285,11 +285,11 @@ include::../../../../test/includes/hello_world.go.txt[]`
 <p>package includes</p>
 </div>
 <div class="paragraph">
-<p>import "fmt"</p>
+<p>import &#34;fmt&#34;</p>
 </div>
 <div class="paragraph">
 <p>func helloworld() {
-	fmt.Println("hello, world!")
+	fmt.Println(&#34;hello, world!&#34;)
 }</p>
 </div>
 </div>
@@ -455,10 +455,10 @@ include::../../../../test/includes/hello_world.go.txt[]
 <div class="content">
 <pre>package includes
 
-import "fmt"
+import &#34;fmt&#34;
 
 func helloworld() {
-	fmt.Println("hello, world!")
+	fmt.Println(&#34;hello, world!&#34;)
 }</pre>
 </div>
 </div>`
@@ -473,10 +473,10 @@ func helloworld() {
 <div class="content">
 <pre class="highlight"><code>package includes
 
-import "fmt"
+import &#34;fmt&#34;
 
 func helloworld() {
-	fmt.Println("hello, world!")
+	fmt.Println(&#34;hello, world!&#34;)
 }</code></pre>
 </div>
 </div>`
@@ -493,11 +493,11 @@ include::../../../../test/includes/hello_world.go.txt[]
 <p>package includes</p>
 </div>
 <div class="paragraph">
-<p>import "fmt"</p>
+<p>import &#34;fmt&#34;</p>
 </div>
 <div class="paragraph">
 <p>func helloworld() {
-	fmt.Println("hello, world!")
+	fmt.Println(&#34;hello, world!&#34;)
 }</p>
 </div>
 </div>
@@ -515,11 +515,11 @@ ____`
 <p>package includes</p>
 </div>
 <div class="paragraph">
-<p>import "fmt"</p>
+<p>import &#34;fmt&#34;</p>
 </div>
 <div class="paragraph">
 <p>func helloworld() {
-	fmt.Println("hello, world!")
+	fmt.Println(&#34;hello, world!&#34;)
 }</p>
 </div>
 </blockquote>
@@ -535,10 +535,10 @@ ____`
 				expected := `<div class="verseblock">
 <pre class="content">package includes
 
-import "fmt"
+import &#34;fmt&#34;
 
 func helloworld() {
-	fmt.Println("hello, world!")
+	fmt.Println(&#34;hello, world!&#34;)
 }</pre>
 </div>`
 				Expect(RenderXHTML(source)).To(MatchHTML(expected))
@@ -554,11 +554,11 @@ include::../../../../test/includes/hello_world.go.txt[]
 <p>package includes</p>
 </div>
 <div class="paragraph">
-<p>import "fmt"</p>
+<p>import &#34;fmt&#34;</p>
 </div>
 <div class="paragraph">
 <p>func helloworld() {
-	fmt.Println("hello, world!")
+	fmt.Println(&#34;hello, world!&#34;)
 }</p>
 </div>
 </div>
@@ -584,7 +584,7 @@ include::../../../../test/includes/hello_world.go.txt[]
 				source := `include::../../../../test/includes/hello_world.go.txt[lines=5..7]`
 				expected := `<div class="paragraph">
 <p>func helloworld() {
-	fmt.Println("hello, world!")
+	fmt.Println(&#34;hello, world!&#34;)
 }</p>
 </div>`
 				Expect(RenderXHTML(source)).To(MatchHTML(expected))
@@ -597,7 +597,7 @@ include::../../../../test/includes/hello_world.go.txt[]
 </div>
 <div class="paragraph">
 <p>func helloworld() {
-	fmt.Println("hello, world!")
+	fmt.Println(&#34;hello, world!&#34;)
 }</p>
 </div>`
 				Expect(RenderXHTML(source)).To(MatchHTML(expected))
@@ -625,7 +625,7 @@ include::../../../../test/includes/hello_world.go.txt[lines=5..7]
 				expected := `<div class="listingblock">
 <div class="content">
 <pre>func helloworld() {
-	fmt.Println("hello, world!")
+	fmt.Println(&#34;hello, world!&#34;)
 }</pre>
 </div>
 </div>`
@@ -641,7 +641,7 @@ include::../../../../test/includes/hello_world.go.txt[lines=1..2;5..7]
 <pre>package includes
 
 func helloworld() {
-	fmt.Println("hello, world!")
+	fmt.Println(&#34;hello, world!&#34;)
 }</pre>
 </div>
 </div>`

--- a/pkg/renderer/sgml/xhtml5/labeled_list_test.go
+++ b/pkg/renderer/sgml/xhtml5/labeled_list_test.go
@@ -95,7 +95,7 @@ item 2:: description 2.`
 <dl>
 <dt class="hdlist1">item 1</dt>
 <dd>
-<p>&lt;script&gt;alert("foo!")&lt;/script&gt;</p>
+<p>&lt;script&gt;alert(&#34;foo!&#34;)&lt;/script&gt;</p>
 </dd>
 </dl>
 </div>`

--- a/pkg/renderer/sgml/xhtml5/ordered_list_test.go
+++ b/pkg/renderer/sgml/xhtml5/ordered_list_test.go
@@ -367,7 +367,7 @@ print("one")
 <p></p>
 <div class="listingblock">
 <div class="content">
-<pre>print("one")</pre>
+<pre>print(&#34;one&#34;)</pre>
 </div>
 </div>
 </li>
@@ -375,7 +375,7 @@ print("one")
 <p></p>
 <div class="listingblock">
 <div class="content">
-<pre>print("one")</pre>
+<pre>print(&#34;one&#34;)</pre>
 </div>
 </div>
 </li>

--- a/pkg/renderer/sgml/xhtml5/paragraph_test.go
+++ b/pkg/renderer/sgml/xhtml5/paragraph_test.go
@@ -61,7 +61,7 @@ and here another paragraph
 		It("paragraph with single quotes", func() {
 			source := `a 'subsection' paragraph.`
 			expected := `<div class="paragraph">
-<p>a 'subsection' paragraph.</p>
+<p>a &#39;subsection&#39; paragraph.</p>
 </div>`
 			Expect(RenderXHTML(source)).To(MatchHTML(expected))
 		})

--- a/pkg/renderer/sgml/xhtml5/quoted_string_test.go
+++ b/pkg/renderer/sgml/xhtml5/quoted_string_test.go
@@ -29,7 +29,7 @@ var _ = Describe("quoted strings", func() {
 		It("spaces with single quoted string", func() {
 			source := "'` curly was single `' or so they say"
 			expected := "<div class=\"paragraph\">\n" +
-				"<p>'` curly was single `' or so they say</p>\n" +
+				"<p>&#39;` curly was single `&#39; or so they say</p>\n" +
 				"</div>"
 			Expect(RenderXHTML(source)).To(MatchHTML(expected))
 		})
@@ -182,7 +182,7 @@ var _ = Describe("quoted strings", func() {
 		It("spaces with double quoted string", func() {
 			source := "\"` curly was single `\""
 			expected := "<div class=\"paragraph\">\n" +
-				"<p>\"` curly was single `\"</p>\n" +
+				"<p>&#34;` curly was single `&#34;</p>\n" +
 				"</div>"
 			Expect(RenderXHTML(source)).To(MatchHTML(expected))
 		})

--- a/pkg/renderer/sgml/xhtml5/xhtml5_test.go
+++ b/pkg/renderer/sgml/xhtml5/xhtml5_test.go
@@ -214,7 +214,7 @@ Free use of this software is granted under the terms of the MIT License.`
 <h1>eve(1) Manual Page</h1>
 <h2 id="_name">Name</h2>
 <div class="sectionbody">
-<p>eve - analyzes an image to determine if it's a picture of a life form</p>
+<p>eve - analyzes an image to determine if it&#39;s a picture of a life form</p>
 </div>
 </div>
 <div id="content">
@@ -237,7 +237,7 @@ Free use of this software is granted under the terms of the MIT License.`
 </dd>
 <dt class="hdlist1"><strong>-c, --capture</strong></dt>
 <dd>
-<p>Capture specimen if it's a picture of a life form.</p>
+<p>Capture specimen if it&#39;s a picture of a life form.</p>
 </dd>
 </dl>
 </div>
@@ -342,7 +342,7 @@ Free use of this software is granted under the terms of the MIT License.`
 
 		expected := `<h2 id="_name">Name</h2>
 <div class="sectionbody">
-<p>eve - analyzes an image to determine if it's a picture of a life form</p>
+<p>eve - analyzes an image to determine if it&#39;s a picture of a life form</p>
 </div>
 <div class="sect1">
 <h2 id="_synopsis">Synopsis</h2>
@@ -363,7 +363,7 @@ Free use of this software is granted under the terms of the MIT License.`
 </dd>
 <dt class="hdlist1"><strong>-c, --capture</strong></dt>
 <dd>
-<p>Capture specimen if it's a picture of a life form.</p>
+<p>Capture specimen if it&#39;s a picture of a life form.</p>
 </dd>
 </dl>
 </div>

--- a/test/fixtures/supported/basic.html
+++ b/test/fixtures/supported/basic.html
@@ -20,7 +20,7 @@
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight"><code class="language-ruby" data-lang="ruby">puts "Hello, World!"</code></pre>
+<pre class="highlight"><code class="language-ruby" data-lang="ruby">puts &#34;Hello, World!&#34;</code></pre>
 </div>
 </div>
 </div>

--- a/test/fixtures/supported/lists.html
+++ b/test/fixtures/supported/lists.html
@@ -309,7 +309,7 @@ This is test, only a test.
 <p>level 3
 This is a new line inside an unordered list using &#43; symbol.
 We can even force content to start on a separate line&#8230;&#8203;<br>
-Amazing, isn't it?</p>
+Amazing, isn&#39;t it?</p>
 <div class="ulist">
 <ul>
 <li>

--- a/test/fixtures/supported/sample.html
+++ b/test/fixtures/supported/sample.html
@@ -26,7 +26,7 @@ This is test, only a test.
 <div class="sect2">
 <h3 id="id_section_a_subsection">Section A Subsection</h3>
 <div class="paragraph">
-<p><strong>Section A</strong> 'subsection' paragraph.</p>
+<p><strong>Section A</strong> &#39;subsection&#39; paragraph.</p>
 </div>
 </div>
 </div>


### PR DESCRIPTION
This makes all single and double quotes escaped in SGML content,
improving the safety of using these characters inline.

Fixes #644 