### PR TITLE
Bug450

### DIFF
--- a/pkg/parser/link_test.go
+++ b/pkg/parser/link_test.go
@@ -1564,13 +1564,13 @@ a link to {scheme}://{path} and https://foo.baz`
 						"path":   "foo.bar",
 					},
 					ElementReferences: types.ElementReferences{
-						"_a_title_to_https_foo_bar_and_https_foo_baz": title,
+						"_a_title_to_httpsfoo_bar_and_httpsfoo_baz": title,
 					},
 					Elements: []interface{}{
 						types.Section{
 							Level: 0,
 							Attributes: types.Attributes{
-								types.AttrID: "_a_title_to_https_foo_bar_and_https_foo_baz",
+								types.AttrID: "_a_title_to_httpsfoo_bar_and_httpsfoo_baz",
 							},
 							Title:    title,
 							Elements: []interface{}{},
@@ -1616,13 +1616,13 @@ a link to {scheme}://{path} and https://foo.baz`
 						"path":   "foo.bar",
 					},
 					ElementReferences: types.ElementReferences{
-						"_a_title_to_https_foo_bar_and_https_foo_baz": title,
+						"_a_title_to_httpsfoo_bar_and_httpsfoo_baz": title,
 					},
 					Elements: []interface{}{
 						types.Section{
 							Level: 1,
 							Attributes: types.Attributes{
-								types.AttrID: "_a_title_to_https_foo_bar_and_https_foo_baz",
+								types.AttrID: "_a_title_to_httpsfoo_bar_and_httpsfoo_baz",
 							},
 							Title:    title,
 							Elements: []interface{}{},

--- a/pkg/renderer/sgml/html5/link_test.go
+++ b/pkg/renderer/sgml/html5/link_test.go
@@ -116,7 +116,7 @@ a link to {scheme}://{path}`
 	
 == a title to {scheme}://{path} and https://foo.baz`
 				expected := `<div class="sect1">
-<h2 id="_a_title_to_https_foo_bar_and_https_foo_baz">a title to <a href="https://foo.bar" class="bare">https://foo.bar</a> and <a href="https://foo.baz" class="bare">https://foo.baz</a></h2>
+<h2 id="_a_title_to_httpsfoo_bar_and_httpsfoo_baz">a title to <a href="https://foo.bar" class="bare">https://foo.bar</a> and <a href="https://foo.baz" class="bare">https://foo.baz</a></h2>
 <div class="sectionbody">
 </div>
 </div>`

--- a/pkg/renderer/sgml/xhtml5/link_test.go
+++ b/pkg/renderer/sgml/xhtml5/link_test.go
@@ -116,7 +116,7 @@ a link to {scheme}://{path}`
 	
 == a title to {scheme}://{path} and https://foo.baz`
 				expected := `<div class="sect1">
-<h2 id="_a_title_to_https_foo_bar_and_https_foo_baz">a title to <a href="https://foo.bar" class="bare">https://foo.bar</a> and <a href="https://foo.baz" class="bare">https://foo.baz</a></h2>
+<h2 id="_a_title_to_httpsfoo_bar_and_httpsfoo_baz">a title to <a href="https://foo.bar" class="bare">https://foo.bar</a> and <a href="https://foo.baz" class="bare">https://foo.baz</a></h2>
 <div class="sectionbody">
 </div>
 </div>`

--- a/pkg/types/non_alphanumeric_replacement_test.go
+++ b/pkg/types/non_alphanumeric_replacement_test.go
@@ -74,6 +74,6 @@ var _ = Describe("normalizing string", func() {
 				},
 			},
 		}
-		Expect(types.ReplaceNonAlphanumerics(source, "_")).To(Equal("link_to_https_foo_bar")) // asciidoctor will return `_link_to_https_foo_bar`
+		Expect(types.ReplaceNonAlphanumerics(source, "_")).To(Equal("link_to_httpsfoo_bar")) // asciidoctor will return `_link_to_https_foo_bar`
 	})
 })

--- a/pkg/types/non_alphanumerics_replacement.go
+++ b/pkg/types/non_alphanumerics_replacement.go
@@ -53,6 +53,10 @@ func ReplaceNonAlphanumerics(elements []interface{}, replacement string) (string
 func replaceNonAlphanumerics(content, replacement string) (string, error) {
 	buf := bytes.NewBuffer(nil)
 	lastCharIsSpace := false
+
+	// Drop the :// from links.
+	content = strings.ReplaceAll(content, "://", "")
+
 	for _, r := range strings.TrimLeft(content, " ") { // ignore header spaces
 		if unicode.Is(unicode.Letter, r) || unicode.Is(unicode.Number, r) {
 			_, err := buf.WriteString(strings.ToLower(string(r)))

--- a/pkg/types/types_test.go
+++ b/pkg/types/types_test.go
@@ -770,7 +770,7 @@ var _ = Describe("element id resolution", func() {
 				})
 				// then
 				Expect(err).NotTo(HaveOccurred())
-				Expect(section.Attributes[types.AttrID]).To(Equal("_a_link_to_https_foo_com")) // TODO: should be `httpsfoo`
+				Expect(section.Attributes[types.AttrID]).To(Equal("_a_link_to_httpsfoo_com")) // TODO: should be `httpsfoo`
 			})
 		})
 
@@ -831,7 +831,7 @@ var _ = Describe("element id resolution", func() {
 				})
 				// then
 				Expect(err).NotTo(HaveOccurred())
-				Expect(section.Attributes[types.AttrID]).To(Equal("custom_a_link_to_https_foo_com")) // TODO: should be `httpsfoo`
+				Expect(section.Attributes[types.AttrID]).To(Equal("custom_a_link_to_httpsfoo_com")) // TODO: should be `httpsfoo`
 			})
 		})
 


### PR DESCRIPTION
Please only look at the last commit in this PR.  The first two commits are related to PRs already submitted.

To be completely honest, I prefer the libasciidoc behavior as it is, without this change; but some folks might have style sheets which reference the proposed change (for asciidoctor) so this makes it more compatible.

Were compatibility with asciidoctor stylesheets not a concern, I'd recommend declining this change.