### PR TITLE
refactor(parser/renderer): Support section and document roles

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -3817,11 +3817,11 @@ var g = &grammar{
 						&labeledExpr{
 							pos:   position{line: 503, col: 12, offset: 17042},
 							label: "attributes",
-							expr: &zeroOrOneExpr{
+							expr: &zeroOrMoreExpr{
 								pos: position{line: 503, col: 23, offset: 17053},
 								expr: &ruleRefExpr{
 									pos:  position{line: 503, col: 24, offset: 17054},
-									name: "Attributes",
+									name: "BlockAttrs",
 								},
 							},
 						},

--- a/pkg/parser/parser.peg
+++ b/pkg/parser/parser.peg
@@ -500,7 +500,7 @@ DoubleQuotedStringFallbackCharacter <-  ([^\r\n\t `] / "`" !"\"") {
 // ------------------------------------------
 // Sections
 // ------------------------------------------
-Section <- attributes:(Attributes)?
+Section <- attributes:(BlockAttrs)*
     level:(("=")+ {   
         // `=` is level 0, etc.
         return (len(c.text)-1), nil 

--- a/pkg/renderer/sgml/html5/html5.go
+++ b/pkg/renderer/sgml/html5/html5.go
@@ -12,7 +12,7 @@ const (
 <link type="text/css" rel="stylesheet" href="{{ .CSS }}">{{ end }}
 <title>{{ .Title }}</title>
 </head>
-<body class="{{ .Doctype }}{{ if .Role }} {{ .Role }}{{ end }}">{{ if .IncludeHeader }}
+<body{{ if .ID }} id="{{ .ID }}"{{ end }} class="{{ .Doctype }}{{ if .Roles }} {{ .Roles }}{{ end }}">{{ if .IncludeHeader }}
 {{ .Header }}{{ end }}
 <div id="content">
 {{ .Content }}

--- a/pkg/renderer/sgml/html5/html5_test.go
+++ b/pkg/renderer/sgml/html5/html5_test.go
@@ -80,6 +80,40 @@ Last updated {{.LastUpdated}}
 			To(MatchHTMLTemplate(expected, now))
 	})
 
+	It("header with multple roles and id", func() {
+		source := `[.role1#anchor.role2]
+= My Title`
+		expected := `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="generator" content="libasciidoc">
+<link type="text/css" rel="stylesheet" href="/path/to/style.css">
+<title>My Title</title>
+</head>
+<body id="anchor" class="article role1 role2">
+<div id="header">
+<h1>My Title</h1>
+</div>
+<div id="content">
+
+</div>
+<div id="footer">
+<div id="footer-text">
+Last updated {{.LastUpdated}}
+</div>
+</div>
+</body>
+</html>`
+		now := time.Now()
+		Expect(RenderHTML(source, configuration.WithHeaderFooter(true),
+			configuration.WithCSS("/path/to/style.css"),
+			configuration.WithLastUpdated(now))).
+			To(MatchHTMLTemplate(expected, now))
+	})
+
 	It("should include adoc file without leveloffset from relative file", func() {
 		source := "include::../../../../../test/includes/grandchild-include.adoc[]" // with filename `tmp/foo.adoc`, we are virtually in a subfolder
 		expectedContent := `<div class="sect1">

--- a/pkg/renderer/sgml/html5/section.go
+++ b/pkg/renderer/sgml/html5/section.go
@@ -2,11 +2,12 @@ package html5
 
 // initializes the sgml
 const (
-	preambleTmpl = "{{ if .Wrapper }}<div id=\"preamble\">\n<div class=\"sectionbody\">\n{{ end }}" +
+	preambleTmpl = "{{ if .Wrapper }}<div id=\"preamble\">\n" +
+		"<div class=\"sectionbody\">\n{{ end }}" +
 		`{{ .Content }}` +
 		"{{ if .Wrapper }}\n</div>\n</div>{{ end }}"
 
-	sectionContentTmpl = "<div class=\"sect{{ .Level }}\">\n" +
+	sectionContentTmpl = "<div class=\"sect{{ .Level }}{{ if .Roles }} {{ .Roles }}{{ end }}\">\n" +
 		"{{ .Header }}" +
 		"{{ if eq .Level 1 }}\n<div class=\"sectionbody\">{{ end }}" +
 		"{{ if .Content }}\n{{ .Content }}{{ end }}\n" +

--- a/pkg/renderer/sgml/html5/section_test.go
+++ b/pkg/renderer/sgml/html5/section_test.go
@@ -31,6 +31,18 @@ var _ = Describe("sections", func() {
 			Expect(RenderHTML(source)).To(MatchHTML(expected))
 		})
 
+		It("section level 1 alone with roles and id", func() {
+			source := "[.role1#anchor.role2]\n== a title with *bold* content"
+			// top-level section is not rendered per-say,
+			// but the section will be used to set the HTML page's <title> element
+			expected := `<div class="sect1 role1 role2">
+<h2 id="anchor">a title with <strong>bold</strong> content</h2>
+<div class="sectionbody">
+</div>
+</div>`
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+		})
+
 		It("section level 2 alone", func() {
 			source := "=== a title"
 			// top-level section is not rendered per-say,

--- a/pkg/renderer/sgml/section.go
+++ b/pkg/renderer/sgml/section.go
@@ -53,12 +53,16 @@ func (r *sgmlRenderer) renderSection(ctx *renderer.Context, s types.Section) (st
 		Header   sanitized
 		Content  sanitized
 		Elements []interface{}
+		ID       sanitized
+		Roles    sanitized
 		Level    int
 	}{
 		Context:  ctx,
 		Header:   title,
 		Level:    s.Level,
 		Elements: s.Elements,
+		ID:       r.renderElementID(s.Attributes),
+		Roles:    r.renderElementRoles(s.Attributes),
 		Content:  sanitized(content),
 	})
 	if err != nil {
@@ -79,11 +83,13 @@ func (r *sgmlRenderer) renderSectionTitle(ctx *renderer.Context, s types.Section
 		Level        int
 		LevelPlusOne int
 		ID           sanitized
+		Roles        sanitized
 		Content      string
 	}{
 		Level:        s.Level,
 		LevelPlusOne: s.Level + 1, // Level 1 is <h2>.
 		ID:           r.renderElementID(s.Attributes),
+		Roles:        r.renderElementRoles(s.Attributes),
 		Content:      renderedContentStr,
 	})
 	if err != nil {

--- a/pkg/renderer/sgml/xhtml5/section_test.go
+++ b/pkg/renderer/sgml/xhtml5/section_test.go
@@ -31,6 +31,18 @@ var _ = Describe("sections", func() {
 			Expect(RenderXHTML(source)).To(MatchHTML(expected))
 		})
 
+		It("section level 1 alone with roles and id", func() {
+			source := "[.role1#anchor.role2]\n== a title with *bold* content"
+			// top-level section is not rendered per-say,
+			// but the section will be used to set the HTML page's <title> element
+			expected := `<div class="sect1 role1 role2">
+<h2 id="anchor">a title with <strong>bold</strong> content</h2>
+<div class="sectionbody">
+</div>
+</div>`
+			Expect(RenderXHTML(source)).To(MatchHTML(expected))
+		})
+
 		It("section level 2 alone", func() {
 			source := "=== a title"
 			// top-level section is not rendered per-say,

--- a/pkg/renderer/sgml/xhtml5/xhtml5.go
+++ b/pkg/renderer/sgml/xhtml5/xhtml5.go
@@ -12,7 +12,7 @@ const (
 <link type="text/css" rel="stylesheet" href="{{ .CSS }}"/>{{ end }}
 <title>{{ .Title }}</title>
 </head>
-<body class="{{ .Doctype }}{{ if .Role }} {{ .Role }}{{ end }}">{{ if .IncludeHeader }}
+<body{{ if .ID }} id="{{ .ID }}"{{ end }} class="{{ .Doctype }}{{ if .Roles }} {{ .Roles }}{{ end }}">{{ if .IncludeHeader }}
 {{ .Header }}{{ end }}
 <div id="content">
 {{ .Content }}

--- a/pkg/renderer/sgml/xhtml5/xhtml5_test.go
+++ b/pkg/renderer/sgml/xhtml5/xhtml5_test.go
@@ -80,6 +80,40 @@ Last updated {{.LastUpdated}}
 			To(MatchHTMLTemplate(expected, now))
 	})
 
+	It("header with multple roles and id", func() {
+		source := `[.role1#anchor.role2]
+= My Title`
+		expected := `<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+<head>
+<meta charset="UTF-8"/>
+<meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+<meta name="generator" content="libasciidoc"/>
+<link type="text/css" rel="stylesheet" href="/path/to/style.css"/>
+<title>My Title</title>
+</head>
+<body id="anchor" class="article role1 role2">
+<div id="header">
+<h1>My Title</h1>
+</div>
+<div id="content">
+
+</div>
+<div id="footer">
+<div id="footer-text">
+Last updated {{.LastUpdated}}
+</div>
+</div>
+</body>
+</html>`
+		now := time.Now()
+		Expect(RenderXHTML(source, configuration.WithHeaderFooter(true),
+			configuration.WithCSS("/path/to/style.css"),
+			configuration.WithLastUpdated(now))).
+			To(MatchHTMLTemplate(expected, now))
+	})
+
 	It("should include adoc file without leveloffset from relative file", func() {
 		source := "include::../../../../../test/includes/grandchild-include.adoc[]" // with filename `tmp/foo.adoc`, we are virtually in a subfolder
 		expectedContent := `<div class="sect1">


### PR DESCRIPTION
This adds support for both sections and the top-level document
(section0 elements) to have multiple roles.  It also adds the
support for the ID element for documents, in a way that precisely
emulates what asciidoctor does (only custom IDs are emitted).