### PR TITLE
feature(renderer): Add image float, align, and capture support.

### DIFF
--- a/LIMITATIONS.adoc
+++ b/LIMITATIONS.adoc
@@ -88,7 +88,8 @@ Interactive checklists are not supported.
 
 Interactive SVG support is missing, as is support for inline SVG.
 
-Float, alignment, and caption attributes have no effect.
+The global figure-caption attribute is not honored.
+Use per-image caption attributes for more control if needed.
 
 == Multimedia
 

--- a/pkg/renderer/sgml/element_role.go
+++ b/pkg/renderer/sgml/element_role.go
@@ -17,3 +17,22 @@ func (r *sgmlRenderer) renderElementRoles(attrs types.Attributes) sanitized {
 		return ""
 	}
 }
+
+// Image roles add float and alignment attributes -- we turn these into roles.
+func (r *sgmlRenderer) renderImageRoles(attrs types.Attributes) sanitized {
+	var roles []string
+
+	if val, ok := attrs.GetAsString(types.AttrImageFloat); ok {
+		roles = append(roles, val)
+	}
+	if val, ok := attrs.GetAsString(types.AttrImageAlign); ok {
+		roles = append(roles, "text-"+val)
+	}
+	switch r := attrs[types.AttrRole].(type) {
+	case []string:
+		roles = append(roles, r...)
+	case string:
+		roles = append(roles, r)
+	}
+	return sanitized(template.HTMLEscapeString(strings.Join(roles, " ")))
+}

--- a/pkg/renderer/sgml/html5/image.go
+++ b/pkg/renderer/sgml/html5/image.go
@@ -5,8 +5,10 @@ const (
 <div class="content">
 {{ if ne .Href "" }}<a class="image" href="{{ .Href }}">{{ end }}<img src="{{ .Path }}" alt="{{ .Alt }}"{{ if .Width }} width="{{ .Width }}"{{ end }}{{ if .Height }} height="{{ .Height }}"{{ end }}>{{ if ne .Href "" }}</a>{{ end }}
 </div>{{ if .Title }}
-<div class="title">Figure {{ .ImageNumber }}. {{ .Title }}</div>
+<div class="title">{{ .Caption }}{{ .Title }}</div>
 {{ else }}
 {{ end }}</div>`
 	inlineImageTmpl = `<span class="image{{ if .Roles }} {{ .Roles }}{{ end }}"><img src="{{ .Path }}" alt="{{ .Alt }}"{{ if .Width }} width="{{ .Width }}"{{ end }}{{ if .Height }} height="{{ .Height }}"{{ end }}{{ if .Title }} title="{{ .Title }}"{{ end }}></span>`
+
+	imageCaptionTmpl = "Figure {{ .ImageNumber }}. "
 )

--- a/pkg/renderer/sgml/html5/image_test.go
+++ b/pkg/renderer/sgml/html5/image_test.go
@@ -44,6 +44,29 @@ var _ = Describe("images", func() {
 			Expect(RenderHTML(source)).To(MatchHTML(expected))
 		})
 
+		It("block image with alt and dimensions, float, align", func() {
+
+			source := "image::foo.png[foo image, 600, 400,float=left,align=center]"
+			expected := `<div class="imageblock left text-center">
+<div class="content">
+<img src="foo.png" alt="foo image" width="600" height="400">
+</div>
+</div>`
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+		})
+
+		It("block image with custom caption", func() {
+
+			source := ".Image Title\nimage::foo.png[foo image, 600, 400,caption=\"Bar A. \"]"
+			expected := `<div class="imageblock">
+<div class="content">
+<img src="foo.png" alt="foo image" width="600" height="400">
+</div>
+<div class="title">Bar A. Image Title</div>
+</div>`
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+		})
+
 		It("block image with alt and dimensions and multiple roles", func() {
 
 			source := "[.role1.role2]\nimage::foo.png[foo image, 600, 400]"

--- a/pkg/renderer/sgml/html5/templates.go
+++ b/pkg/renderer/sgml/html5/templates.go
@@ -32,6 +32,7 @@ var templates = sgml.Templates{
 	IconFont:                  iconFontTmpl,
 	IconImage:                 iconImageTmpl,
 	IconText:                  iconTextTmpl,
+	ImageCaption:              imageCaptionTmpl,
 	InlineIcon:                inlineIconTmpl,
 	InlineImage:               inlineImageTmpl,
 	InternalCrossReference:    internalCrossReferenceTmpl,

--- a/pkg/renderer/sgml/image.go
+++ b/pkg/renderer/sgml/image.go
@@ -10,14 +10,36 @@ import (
 
 func (r *sgmlRenderer) renderImageBlock(ctx *renderer.Context, img types.ImageBlock) (string, error) {
 	result := &strings.Builder{}
+	caption := &strings.Builder{}
 	number := 0
+	title := r.renderElementTitle(img.Attributes)
+
+	// Matching asciidoctor behavior, we increment the counter if we have a title,
+	// regardless if we have a number or not. This will probably lead to confusion
+	// if mixed custom and stock captioning is used.
 	if _, found := img.Attributes.GetAsString(types.AttrTitle); found {
 		number = ctx.GetAndIncrementImageCounter()
+
+		if s, ok := img.Attributes.GetAsString(types.AttrImageCaption); ok {
+			caption.WriteString(s)
+		} else {
+			err := r.imageCaption.Execute(caption, struct {
+				ImageNumber int
+				Title       sanitized
+			}{
+				ImageNumber: number,
+				Title:       title,
+			})
+			if err != nil {
+				return "", errors.Wrap(err, "unable to format image caption")
+			}
+		}
 	}
 	err := r.blockImage.Execute(result, struct {
 		ID          sanitized
 		Title       sanitized
 		ImageNumber int
+		Caption     string
 		Roles       sanitized
 		Href        string
 		Alt         string
@@ -26,9 +48,10 @@ func (r *sgmlRenderer) renderImageBlock(ctx *renderer.Context, img types.ImageBl
 		Path        string
 	}{
 		ID:          r.renderElementID(img.Attributes),
-		Title:       r.renderElementTitle(img.Attributes),
+		Title:       title,
 		ImageNumber: number,
-		Roles:       r.renderElementRoles(img.Attributes),
+		Caption:     caption.String(),
+		Roles:       r.renderImageRoles(img.Attributes),
 		Href:        img.Attributes.GetAsStringWithDefault(types.AttrInlineLink, ""),
 		Alt:         img.Attributes.GetAsStringWithDefault(types.AttrImageAlt, ""),
 		Width:       img.Attributes.GetAsStringWithDefault(types.AttrImageWidth, ""),
@@ -55,7 +78,7 @@ func (r *sgmlRenderer) renderInlineImage(img types.InlineImage) (string, error) 
 		Path   string
 	}{
 		Title:  r.renderElementTitle(img.Attributes),
-		Roles:  r.renderElementRoles(img.Attributes),
+		Roles:  r.renderImageRoles(img.Attributes),
 		Alt:    img.Attributes.GetAsStringWithDefault(types.AttrImageAlt, ""),
 		Width:  img.Attributes.GetAsStringWithDefault(types.AttrImageWidth, ""),
 		Height: img.Attributes.GetAsStringWithDefault(types.AttrImageHeight, ""),

--- a/pkg/renderer/sgml/sgml_renderer.go
+++ b/pkg/renderer/sgml/sgml_renderer.go
@@ -32,6 +32,7 @@ type sgmlRenderer struct {
 	iconFont                  *textTemplate
 	iconImage                 *textTemplate
 	iconText                  *textTemplate
+	imageCaption              *textTemplate
 	inlineIcon                *textTemplate
 	inlineImage               *textTemplate
 	internalCrossReference    *textTemplate
@@ -110,6 +111,7 @@ func (r *sgmlRenderer) prepareTemplates() error {
 		r.iconFont, err = r.newTemplate("icon-font", tmpls.IconFont, err)
 		r.iconImage, err = r.newTemplate("icon-image", tmpls.IconImage, err)
 		r.iconText, err = r.newTemplate("icon-text", tmpls.IconText, err)
+		r.imageCaption, err = r.newTemplate("image-caption", tmpls.ImageCaption, err)
 		r.inlineIcon, err = r.newTemplate("inline-icon", tmpls.InlineIcon, err)
 		r.inlineImage, err = r.newTemplate("inline-image", tmpls.InlineImage, err)
 		r.internalCrossReference, err = r.newTemplate("internal-xref", tmpls.InternalCrossReference, err)

--- a/pkg/renderer/sgml/templates.go
+++ b/pkg/renderer/sgml/templates.go
@@ -25,6 +25,7 @@ type Templates struct {
 	IconFont                  string
 	IconImage                 string
 	IconText                  string
+	ImageCaption              string
 	InlineIcon                string
 	InlineImage               string
 	InternalCrossReference    string

--- a/pkg/renderer/sgml/xhtml5/image.go
+++ b/pkg/renderer/sgml/xhtml5/image.go
@@ -1,17 +1,18 @@
 package xhtml5
 
 const (
-	blockImageTmpl = `<div{{ if .ID }} id="{{ .ID }}"{{ end }} class="imageblock{{ if .Roles }} {{ .Roles }}{{ end }}">
-<div class="content">
-{{ if ne .Href "" }}<a class="image" href="{{ .Href }}">{{ end }}` +
+	blockImageTmpl = "<div" +
+		"{{ if .ID }} id=\"{{ .ID }}\"{{ end }}" +
+		" class=\"imageblock{{ if .Roles }} {{ .Roles }}{{ end }}\">\n" +
+		"<div class=\"content\">\n" +
+		`{{ if .Href }}<a class="image" href="{{ .Href }}">{{ end }}` +
 		`<img src="{{ .Path }}" alt="{{ .Alt }}"` +
 		`{{ if .Width }} width="{{ .Width }}"{{ end }}` +
 		`{{ if .Height }} height="{{ .Height }}"{{ end }}` +
-		`/>{{ if ne .Href "" }}</a>{{ end }}
-</div>{{ if .Title }}
-<div class="title">Figure {{ .ImageNumber }}. {{ .Title }}</div>
-{{ else }}
-{{ end }}</div>`
+		"/>{{ if .Href }}</a>{{ end }}\n" +
+		"</div>\n" +
+		"{{ if .Title }}<div class=\"title\">{{ .Caption }}{{ .Title }}</div>\n{{ end }}" +
+		"</div>"
 
 	inlineImageTmpl = `<span class="image{{ if .Roles }} {{ .Roles }}{{ end }}">` +
 		`<img src="{{ .Path }}" alt="{{ .Alt }}"` +

--- a/pkg/renderer/sgml/xhtml5/image_test.go
+++ b/pkg/renderer/sgml/xhtml5/image_test.go
@@ -44,6 +44,29 @@ var _ = Describe("images", func() {
 			Expect(RenderXHTML(source)).To(MatchHTML(expected))
 		})
 
+		It("block image with alt and dimensions, float, align", func() {
+
+			source := "image::foo.png[foo image, 600, 400,float=left,align=center]"
+			expected := `<div class="imageblock left text-center">
+<div class="content">
+<img src="foo.png" alt="foo image" width="600" height="400"/>
+</div>
+</div>`
+			Expect(RenderXHTML(source)).To(MatchHTML(expected))
+		})
+
+		It("block image with custom caption", func() {
+
+			source := ".Image Title\nimage::foo.png[foo image, 600, 400,caption=\"Bar A. \"]"
+			expected := `<div class="imageblock">
+<div class="content">
+<img src="foo.png" alt="foo image" width="600" height="400"/>
+</div>
+<div class="title">Bar A. Image Title</div>
+</div>`
+			Expect(RenderXHTML(source)).To(MatchHTML(expected))
+		})
+
 		It("block image with title, alt and dimensions", func() {
 			source := `[#img-foobar]
 .A title to foobar

--- a/pkg/types/attributes.go
+++ b/pkg/types/attributes.go
@@ -79,6 +79,12 @@ const (
 	AttrImageTitle = "title"
 	// AttrImageWindow the `window` attribute, which becomes the target for the link
 	AttrImageWindow = "window"
+	// AttrImageCaption is the image caption for block images
+	AttrImageCaption = "caption"
+	// AttrImageFloat is for image float
+	AttrImageFloat = "float"
+	// AttrImageAlign is for image alignment
+	AttrImageAlign = "align"
 	// AttrIconSize the icon `size`, and can be one of 1x, 2x, 3x, 4x, 5x, lg, fw
 	AttrIconSize = "size"
 	// AttrIconRotate the icon `rotate` attribute, and can be one of 90, 180, or 270


### PR DESCRIPTION
Note that the global figure-caption override is still not honored.

(Text below is not in the git history).

I have changes to support figure-caption, but they require adding new default attributes at document root.  This will require updating ever test in the parser suite -- > 350 when I looked -- to add these stock attributes.  As this is going to be such a large job, I'd rather not do it multiple times as we add other global caption attributes (e.g. for TIP, CAUTION, and Example blocks, etc.)   Instead I'd like to do those later, all at once.   Unless someone has a better idea how to deal with "unsetting" default attributes (i.e. the main use of figure-caption is in a disable -- :figure-caption!:  block.