### PR TITLE
feature(renderer): version-label not honored

### DIFF
--- a/pkg/parser/document_attributes_test.go
+++ b/pkg/parser/document_attributes_test.go
@@ -1188,7 +1188,9 @@ a paragraph written by {author}.`
 a paragraph written by {author}.`
 				expected := types.Document{
 					Attributes: types.Attributes{
-						"author": "Xavier",
+						"author":  "Xavier",
+						"author1": nil,
+						"author2": nil,
 					},
 					Elements: []interface{}{
 						types.Paragraph{

--- a/pkg/parser/document_processing_apply_substitutions.go
+++ b/pkg/parser/document_processing_apply_substitutions.go
@@ -80,7 +80,7 @@ func applyAttributeSubstitutionsOnElement(element interface{}, attrs types.Attri
 		attrs.Set(e.Name, e.Value)
 		return e, false, nil
 	case types.AttributeReset:
-		attrs.Delete(e.Name)
+		attrs.Set(e.Name, nil) // This allows us to test for a reset vs. undefined.
 		return e, false, nil
 	case types.AttributeSubstitution:
 		if value, ok := attrs.GetAsString(e.Name); ok {

--- a/pkg/parser/link_test.go
+++ b/pkg/parser/link_test.go
@@ -740,6 +740,7 @@ a link to {scheme}://{path} and https://foo.baz`
 					expected := types.Document{
 						Attributes: types.Attributes{
 							"scheme": "https",
+							"path":   nil,
 						},
 						Elements: []interface{}{
 							types.Paragraph{
@@ -1193,6 +1194,7 @@ a link to {scheme}:{path}[] and https://foo.baz`
 				expected := types.Document{
 					Attributes: types.Attributes{
 						"scheme": "link",
+						"path":   nil,
 					},
 					Elements: []interface{}{
 						types.Paragraph{

--- a/pkg/renderer/sgml/document_details.go
+++ b/pkg/renderer/sgml/document_details.go
@@ -2,6 +2,7 @@ package sgml
 
 import (
 	"bytes"
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -17,20 +18,24 @@ func (r *sgmlRenderer) renderDocumentDetails(ctx *renderer.Context) (*sanitized,
 			return nil, errors.Wrap(err, "error while rendering the document details")
 		}
 		documentDetailsBuff := &bytes.Buffer{}
+		revLabel, _ := ctx.Attributes.GetAsString("version-label")
 		revNumber, _ := ctx.Attributes.GetAsString("revnumber")
 		revDate, _ := ctx.Attributes.GetAsString("revdate")
 		revRemark, _ := ctx.Attributes.GetAsString("revremark")
 		err = r.documentDetails.Execute(documentDetailsBuff, struct {
 			Authors   sanitized
+			RevLabel  string
 			RevNumber string
 			RevDate   string
 			RevRemark string
 		}{
 			Authors:   *authors,
+			RevLabel:  revLabel,
 			RevNumber: revNumber,
 			RevDate:   revDate,
 			RevRemark: revRemark,
 		})
+		fmt.Printf("DEBUG: REVISION: %q\n", revLabel)
 		if err != nil {
 			return nil, errors.Wrap(err, "error while rendering the document details")
 		}

--- a/pkg/renderer/sgml/html5/document_details.go
+++ b/pkg/renderer/sgml/html5/document_details.go
@@ -3,7 +3,7 @@ package html5
 const (
 	documentDetailsTmpl = `<div class="details">{{ if .Authors }}
 {{ .Authors }}{{ end }}{{ if .RevNumber }}
-<span id="revnumber">version {{ .RevNumber }}{{ if .RevDate }},{{ end }}</span>{{ end }}{{ if .RevDate }}
+<span id="revnumber">{{ if .RevLabel }}{{ .RevLabel }} {{ end }}{{ .RevNumber }}{{ if .RevDate }},{{ end }}</span>{{ end }}{{ if .RevDate }}
 <span id="revdate">{{ .RevDate }}</span>{{ end }}{{ if .RevRemark }}
 <br><span id="revremark">{{ .RevRemark }}</span>{{ end }}
 </div>

--- a/pkg/renderer/sgml/xhtml5/document_details.go
+++ b/pkg/renderer/sgml/xhtml5/document_details.go
@@ -3,7 +3,7 @@ package xhtml5
 const (
 	documentDetailsTmpl = `<div class="details">{{ if .Authors }}
 {{ .Authors }}{{ end }}{{ if .RevNumber }}
-<span id="revnumber">version {{ .RevNumber }}{{ if .RevDate }},{{ end }}</span>{{ end }}{{ if .RevDate }}
+<span id="revnumber">{{ if .RevLabel }}{{ .RevLabel }} {{ end }}{{ .RevNumber }}{{ if .RevDate }},{{ end }}</span>{{ end }}{{ if .RevDate }}
 <span id="revdate">{{ .RevDate }}</span>{{ end }}{{ if .RevRemark }}
 <br/><span id="revremark">{{ .RevRemark }}</span>{{ end }}
 </div>

--- a/pkg/renderer/sgml/xhtml5/document_details_test.go
+++ b/pkg/renderer/sgml/xhtml5/document_details_test.go
@@ -173,6 +173,92 @@ a paragraph`
 			)).To(MatchHTMLTemplate(expected, now))
 		})
 
+		It("with author and version label reset", func() {
+			source := `= Document Title
+Joe Blow <joe.blow@example.com>
+1.5, May 21, 1999
+:version-label!:
+
+a paragraph`
+			expected := `<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+<head>
+<meta charset="UTF-8"/>
+<meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+<meta name="generator" content="libasciidoc"/>
+<meta name="author" content="Joe Blow"/>
+<title>Document Title</title>
+</head>
+<body class="article">
+<div id="header">
+<h1>Document Title</h1>
+<div class="details">
+<span id="author" class="author">Joe Blow</span><br/>
+<span id="email" class="email"><a href="mailto:joe.blow@example.com">joe.blow@example.com</a></span><br/>
+<span id="revnumber">1.5,</span>
+<span id="revdate">May 21, 1999</span>
+</div>
+</div>
+<div id="content">
+<div class="paragraph">
+<p>a paragraph</p>
+</div>
+</div>
+</body>
+</html>`
+			Expect(RenderXHTML(source,
+				configuration.WithHeaderFooter(true),
+				configuration.WithLastUpdated(now),
+				configuration.WithAttributes(map[string]string{
+					types.AttrNoFooter: "",
+				}),
+			)).To(MatchHTMLTemplate(expected, now))
+		})
+
+		It("with author and custom version label only", func() {
+			source := `= Document Title
+Joe Blow <joe.blow@example.com>
+1.0, May 21, 1999
+:version-label: Edition
+
+a paragraph`
+			expected := `<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+<head>
+<meta charset="UTF-8"/>
+<meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+<meta name="generator" content="libasciidoc"/>
+<meta name="author" content="Joe Blow"/>
+<title>Document Title</title>
+</head>
+<body class="article">
+<div id="header">
+<h1>Document Title</h1>
+<div class="details">
+<span id="author" class="author">Joe Blow</span><br/>
+<span id="email" class="email"><a href="mailto:joe.blow@example.com">joe.blow@example.com</a></span><br/>
+<span id="revnumber">Edition 1.0,</span>
+<span id="revdate">May 21, 1999</span>
+</div>
+</div>
+<div id="content">
+<div class="paragraph">
+<p>a paragraph</p>
+</div>
+</div>
+</body>
+</html>`
+			Expect(RenderXHTML(source,
+				configuration.WithHeaderFooter(true),
+				configuration.WithLastUpdated(now),
+				configuration.WithAttributes(map[string]string{
+					types.AttrNoFooter: "",
+				}),
+			)).To(MatchHTMLTemplate(expected, now))
+		})
+
 		It("without header and with footer", func() {
 			source := `= Document Title
 
@@ -238,6 +324,5 @@ a paragraph`
 				}),
 			)).To(MatchHTMLTemplate(expected, now))
 		})
-
 	})
 })

--- a/pkg/types/attributes.go
+++ b/pkg/types/attributes.go
@@ -109,6 +109,8 @@ const (
 	AttrPositional2 = "@2"
 	// AttrPositional3 positional parameter 3
 	AttrPositional3 = "@3"
+	// AttrVersionLabel labels the version number in the document
+	AttrVersionLabel = "version-label"
 )
 
 // NewElementID initializes a new attribute map with a single entry for the ID using the given value
@@ -338,16 +340,19 @@ func (a Attributes) NilSafeSet(key string, value interface{}) {
 // GetAsString gets the string value for the given key (+ `true`),
 // or empty string (+ `false`) if none was found
 func (a Attributes) GetAsString(key string) (string, bool) {
-	// check in predefined attributes
-	if value, found := Predefined[key]; found {
-		return value, true
-	}
 	if value, found := a[key]; found {
+		if value == nil {
+			return "", false // nil here means attribute was reset
+		}
 		if value, ok := value.(string); ok {
 			return value, true
 		} else if v, ok := a[key]; ok {
 			return fmt.Sprintf("%v", v), true
 		}
+	}
+	// check in predefined attributes
+	if value, found := Predefined[key]; found {
+		return value, true
 	}
 	return "", false
 }
@@ -355,14 +360,17 @@ func (a Attributes) GetAsString(key string) (string, bool) {
 // GetAsStringWithDefault gets the string value for the given key,
 // or returns the given default value
 func (a Attributes) GetAsStringWithDefault(key, defaultValue string) string {
-	// check in predefined attributes
-	if value, found := Predefined[key]; found {
-		return value
-	}
 	if value, found := a[key]; found {
+		if value == nil {
+			return "" // nil present means attribute was reset
+		}
 		if value, ok := value.(string); ok {
 			return value
 		}
+	}
+	// check in predefined attributes
+	if value, found := Predefined[key]; found {
+		return value
 	}
 	return defaultValue
 }

--- a/pkg/types/document_attributes_overrides.go
+++ b/pkg/types/document_attributes_overrides.go
@@ -33,11 +33,6 @@ func (a AttributesWithOverrides) Add(attrs map[string]interface{}) {
 	}
 }
 
-// Delete deletes the given attribute
-func (a AttributesWithOverrides) Delete(key string) {
-	delete(a.Content, key)
-}
-
 // GetAsString gets the string value for the given key (+ `true`),
 // or empty string (+ `false`) if none was found
 func (a AttributesWithOverrides) GetAsString(key string) (string, bool) {

--- a/pkg/types/predefined_attributes.go
+++ b/pkg/types/predefined_attributes.go
@@ -34,5 +34,6 @@ func init() {
 		"two-colons":     "::",
 		"two-semicolons": ";",
 		"cpp":            "C++",
+		AttrVersionLabel: "version",
 	}
 }

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -272,20 +272,10 @@ type AttributeDeclaration struct {
 
 // NewAttributeDeclaration initializes a new AttributeDeclaration with the given name and optional value
 func NewAttributeDeclaration(name string, value interface{}) (AttributeDeclaration, error) {
-	var attrName, attrValue string
-	attrName = Apply(name,
-		func(s string) string {
-			return strings.TrimSpace(s)
-		})
-	if value, ok := value.(string); ok {
-		attrValue = Apply(value,
-			func(s string) string {
-				return strings.TrimSpace(s)
-			})
-	}
-	log.Debugf("initialized a new AttributeDeclaration: '%s' -> '%s'", attrName, attrValue)
+	attrValue, _ := value.(string)
+	log.Debugf("initialized a new AttributeDeclaration: '%s' -> '%s'", name, attrValue)
 	return AttributeDeclaration{
-		Name:  attrName,
+		Name:  name,
 		Value: attrValue,
 	}, nil
 }


### PR DESCRIPTION
This supports the version-label be changed, or even reset
for document attributes.

To support resetting this label, the initial value is located
in the Predefined attributes, and a reset of the attribute is
stored as a nil attribute value instead of deleting it from the
attributes.  This allows us to distinguish a reset as an override.

This approach will be used for other predefined text values in
follow ups.

Fixes #710