### PR TITLE
bug(renderer): Remove stray debugging message

### DIFF
--- a/pkg/renderer/sgml/document_details.go
+++ b/pkg/renderer/sgml/document_details.go
@@ -2,7 +2,6 @@ package sgml
 
 import (
 	"bytes"
-	"fmt"
 	"strconv"
 	"strings"
 
@@ -35,7 +34,6 @@ func (r *sgmlRenderer) renderDocumentDetails(ctx *renderer.Context) (*sanitized,
 			RevDate:   revDate,
 			RevRemark: revRemark,
 		})
-		fmt.Printf("DEBUG: REVISION: %q\n", revLabel)
 		if err != nil {
 			return nil, errors.Wrap(err, "error while rendering the document details")
 		}


### PR DESCRIPTION
A printf message used during testing accidentally was left in
the commit submitted for 711.  This removes that.

(Sorry, I should have caught this before the PR was submitted!)