### PR TITLE
feature(renderer): Tables should honor table-caption attribute

### DIFF
--- a/pkg/renderer/sgml/html5/table.go
+++ b/pkg/renderer/sgml/html5/table.go
@@ -27,8 +27,6 @@ const (
 
 	tableRowTmpl = "<tr>\n{{ .Content }}</tr>\n"
 
-	tableCaptionTmpl = "Table {{ .TableNumber }}. "
-
 	tableHeaderCellTmpl = "<th class=\"tableblock halign-{{ .HAlign }} valign-{{ .VAlign }}\">{{ .Content }}</th>\n"
 
 	tableCellTmpl = "<td class=\"tableblock halign-{{ .HAlign }} valign-{{ .VAlign }}\"><p class=\"tableblock\">{{ .Content }}</p></td>\n"

--- a/pkg/renderer/sgml/html5/templates.go
+++ b/pkg/renderer/sgml/html5/templates.go
@@ -69,7 +69,6 @@ var templates = sgml.Templates{
 	SuperscriptText:           superscriptTextTmpl,
 	Table:                     tableTmpl,
 	TableBody:                 tableBodyTmpl,
-	TableCaption:              tableCaptionTmpl,
 	TableCell:                 tableCellTmpl,
 	TableHeader:               tableHeaderTmpl,
 	TableHeaderCell:           tableHeaderCellTmpl,

--- a/pkg/renderer/sgml/sgml_renderer.go
+++ b/pkg/renderer/sgml/sgml_renderer.go
@@ -69,7 +69,6 @@ type sgmlRenderer struct {
 	superscriptText           *textTemplate
 	table                     *textTemplate
 	tableBody                 *textTemplate
-	tableCaption              *textTemplate
 	tableCell                 *textTemplate
 	tableHeader               *textTemplate
 	tableHeaderCell           *textTemplate
@@ -149,7 +148,6 @@ func (r *sgmlRenderer) prepareTemplates() error {
 		r.superscriptText, err = r.newTemplate("superscript", tmpls.SuperscriptText, err)
 		r.table, err = r.newTemplate("table", tmpls.Table, err)
 		r.tableBody, err = r.newTemplate("table-body", tmpls.TableBody, err)
-		r.tableCaption, err = r.newTemplate("table-caption", tmpls.TableCaption, err)
 		r.tableCell, err = r.newTemplate("table-cell", tmpls.TableCell, err)
 		r.tableHeader, err = r.newTemplate("table-header", tmpls.TableHeader, err)
 		r.tableHeaderCell, err = r.newTemplate("table-header-cell", tmpls.TableHeaderCell, err)

--- a/pkg/renderer/sgml/templates.go
+++ b/pkg/renderer/sgml/templates.go
@@ -62,7 +62,6 @@ type Templates struct {
 	SuperscriptText           string
 	Table                     string
 	TableBody                 string
-	TableCaption              string
 	TableCell                 string
 	TableHeader               string
 	TableHeaderCell           string

--- a/pkg/renderer/sgml/xhtml5/table_test.go
+++ b/pkg/renderer/sgml/xhtml5/table_test.go
@@ -175,6 +175,48 @@ var _ = Describe("tables", func() {
 		Expect(RenderXHTML(source)).To(MatchHTML(expected))
 	})
 
+	It("2 tables with no caption label", func() {
+		source := `:table-caption!:
+
+.Title 1
+|===
+| foo | bar
+|===
+
+.Title 2
+|===
+| foo | bar
+|===`
+		expected := `<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Title 1</caption>
+<colgroup>
+<col style="width: 50%;"/>
+<col style="width: 50%;"/>
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">foo</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">bar</p></td>
+</tr>
+</tbody>
+</table>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Title 2</caption>
+<colgroup>
+<col style="width: 50%;"/>
+<col style="width: 50%;"/>
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">foo</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">bar</p></td>
+</tr>
+</tbody>
+</table>
+`
+		Expect(RenderXHTML(source)).To(MatchHTML(expected))
+	})
+
 	It("2 tables with 2 counters", func() {
 		source := `.Title 1
 |===

--- a/pkg/types/attributes.go
+++ b/pkg/types/attributes.go
@@ -111,6 +111,8 @@ const (
 	AttrPositional3 = "@3"
 	// AttrVersionLabel labels the version number in the document
 	AttrVersionLabel = "version-label"
+	// AttrTableCaption is the table caption
+	AttrTableCaption = "table-caption"
 )
 
 // NewElementID initializes a new attribute map with a single entry for the ID using the given value
@@ -327,13 +329,6 @@ func (a Attributes) AppendString(key string, value interface{}) {
 		case []string:
 			a[key] = append(v, value...)
 		}
-	}
-}
-
-// NilSafeSet sets the key/value pair unless the value is nil or empty
-func (a Attributes) NilSafeSet(key string, value interface{}) {
-	if value != nil && value != "" {
-		a[key] = value
 	}
 }
 

--- a/pkg/types/predefined_attributes.go
+++ b/pkg/types/predefined_attributes.go
@@ -35,5 +35,6 @@ func init() {
 		"two-semicolons": ";",
 		"cpp":            "C++",
 		AttrVersionLabel: "version",
+		AttrTableCaption: "Table {counter:table-counter}. ",
 	}
 }

--- a/pkg/types/types_utils.go
+++ b/pkg/types/types_utils.go
@@ -6,14 +6,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-// NilSafe returns a new slice if the given elements is nil, otherwise it returns the given elements
-func NilSafe(elements []interface{}) []interface{} {
-	if elements != nil {
-		return elements
-	}
-	return make([]interface{}, 0)
-}
-
 // Merge merge string elements together
 func Merge(elements ...interface{}) []interface{} {
 	result := make([]interface{}, 0)


### PR DESCRIPTION
This uses a kind of hack to make Table captions work mostly as
they are documented to, so that {counter:table-number} seems to
act like a substitution.  This hack should be removed when full
attribute value substitution is done.  (This approach has the
benefit of localizing this hack until it can be replaced.)

Of course, this will be incompatible with other uses of the
table-counter counter (because it isn't actually the same counter),
and won't support anything beyond the most trivial substitutions.

While here removed a couple of unused functions.

Fixes #712