### PR TITLE
bug(renderer): Section ID should include the icon class

### DIFF
--- a/pkg/parser/icon_test.go
+++ b/pkg/parser/icon_test.go
@@ -138,7 +138,7 @@ var _ = Describe("icons", func() {
 					Blocks: []interface{}{
 						types.Section{
 							Attributes: types.Attributes{
-								types.AttrID: "_a_from_me", // TODO: missing icon class
+								types.AttrID: "_a_note_from_me",
 							},
 							Level: 1,
 							Title: []interface{}{
@@ -166,7 +166,7 @@ var _ = Describe("icons", func() {
 						types.Section{
 							Level: 0,
 							Attributes: types.Attributes{
-								types.AttrID: "_or_what_to_do", // TODO: should be "_warning_or_what_note_to_do"
+								types.AttrID: "_warning_or_what_note_to_do",
 							},
 							Title: []interface{}{
 								types.Icon{Class: "warning"},

--- a/pkg/types/non_alphanumerics_replacement.go
+++ b/pkg/types/non_alphanumerics_replacement.go
@@ -41,6 +41,16 @@ func ReplaceNonAlphanumerics(elements []interface{}, replacement string) (string
 				buf.WriteString(replacement)
 			}
 			buf.WriteString(r)
+		case Icon:
+			s := element.Attributes.GetAsStringWithDefault(AttrImageAlt, element.Class)
+			r, err := replaceNonAlphanumerics(s, replacement)
+			if err != nil {
+				return "", err
+			}
+			if buf.Len() > 0 {
+				buf.WriteString(replacement)
+			}
+			buf.WriteString(r)
 		default:
 			// other types are ignored
 		}


### PR DESCRIPTION
Fixes #691

(This also honors alt if its set on the icon, and uses that instead of the icon class).