### PR TITLE
chore(docs): Update the installation instructions

### DIFF
--- a/CONTRIBUTE.adoc
+++ b/CONTRIBUTE.adoc
@@ -29,6 +29,23 @@ Don’t get discouraged if you don't get an immediate response, this is a side-p
 
 Testing existing features is a good way to contribute to the project, too!
 
+== Modifying The Grammar
+
+If you're working on the code, and want to modify the grammar (parser/parser.peg), you
+will need to install the https://github.com/mna/pigeon[pigeon] grammar generator:
+
+    $ go get -u github.com/mna/pigeon
+
+Then if you're updating the grammar, you then will need to use go generate:
+
+   $ go generate ./...
+
+(This is made possible by the pkg/parser/generate.go file.
+See that file for details on the flags used with pigeon.)
+
+Then you can go build as per normal:
+
+   $ go build ./...
 
 == Benchmarking
 

--- a/README.adoc
+++ b/README.adoc
@@ -77,11 +77,11 @@ Libasciidoc provides 2 functions to convert an Asciidoc content into HTML:
 
 1. Converting an `io.Reader` into an HTML document:
 
-    ConvertToHTML(r io.Reader, output io.Writer, config configuration.Configuration) (types.Metadata, error) 
+    Convert(r io.Reader, output io.Writer, config configuration.Configuration) (types.Metadata, error) 
 
 2. Converting a file (given its name) into an HTML document:
 
-   ConvertFileToHTML(output io.Writer, config configuration.Configuration) (types.Metadata, error)
+   ConvertFile(output io.Writer, config configuration.Configuration) (types.Metadata, error)
 
 where the returned `types.Metadata` object contains the document's title which is not part of the generated HTML `<body>` part, as well as the other attributes of the source document.
 
@@ -104,7 +104,7 @@ var tmpl = template.Must(t.Parse(tmplStr))
 
 output := &strings.Builder{}
 content := strings.NewReader(`example::hello world[suffix=!!!!!]`)
-libasciidoc.ConvertToHTML(context.Background(), content, output, renderer.WithMacroTemplate(tmpl.Name(), tmpl))
+libasciidoc.Convert(content, output, renderer.WithMacroTemplate(tmpl.Name(), tmpl))
 ```
 
 == How to contribute

--- a/README.adoc
+++ b/README.adoc
@@ -53,8 +53,11 @@ Using `-b` (or `--backend`) the following formats are supported:
 
 == Installation
 
+This is a standard Go package, and it installs like you might expect.
+
+To install it in your `$GOPATH` (assuming `$GOPATH/bin` is on your path), just use `go install`:
+
     $ go get -u github.com/bytesparadise/libasciidoc
-    $ make install
 
 == Usage
 

--- a/make/go.mk
+++ b/make/go.mk
@@ -41,9 +41,7 @@ generate: install-pigeon
 ## generate the .go file based on the asciidoc grammar
 generate-optimized: install-pigeon
 	@echo "generating the parser (optimized)..."
-	@pigeon -optimize-parser \
-		-alternate-entrypoints AsciidocRawDocument,RawFile,TextDocument,DocumentRawBlock,FileLocation,IncludedFileLine,InlineLinks,LabeledListItemTerm,NormalBlockContent,NormalParagraphContent,VerseBlockContent,MarkdownQuoteBlockAttribution,InlineElements \
-		-o ./pkg/parser/parser.go ./pkg/parser/parser.peg
+	@go generate ./...
 
 .PHONY: build
 ## build the binary executable from CLI

--- a/pkg/parser/generate.go
+++ b/pkg/parser/generate.go
@@ -1,0 +1,3 @@
+package parser
+
+//go:generate pigeon -optimize-parser -alternate-entrypoints AsciidocRawDocument,RawFile,TextDocument,DocumentRawBlock,FileLocation,IncludedFileLine,InlineLinks,LabeledListItemTerm,NormalBlockContent,NormalParagraphContent,VerseBlockContent,MarkdownQuoteBlockAttribution,InlineElements -o parser.go parser.peg


### PR DESCRIPTION
chore(build): Use go generate

This provides a simpler go generate (meaning developers no longer
need to use "make", which is a qualify of life improvement for
developers working on non-UNIX systems), and updates the instructions
to reflect the trivial installation steps.  (Also details about using
go generate for developers are added to the CONTRIBUTING document.)

This also coincidentally includes updates to the latest dependencies,
which has the benefit of eliminating the protobuf dependency.

Fixes https://github.com/bytesparadise/libasciidoc/issues/638