### PR TITLE
refactor(parser/renderer): predefined attributes

### DIFF
--- a/pkg/parser/delimited_block_test.go
+++ b/pkg/parser/delimited_block_test.go
@@ -678,13 +678,13 @@ import <a>
 							Lines: []interface{}{
 								[]interface{}{
 									types.SpecialCharacter{
-										Content: "<",
+										Name: "<",
 									},
 									types.StringElement{
 										Content: "a",
 									},
 									types.SpecialCharacter{
-										Content: ">",
+										Name: ">",
 									},
 									types.StringElement{
 										Content: " an import",
@@ -2591,13 +2591,13 @@ import <a>
 							Lines: []interface{}{
 								[]interface{}{
 									types.SpecialCharacter{
-										Content: "<",
+										Name: "<",
 									},
 									types.StringElement{
 										Content: "a",
 									},
 									types.SpecialCharacter{
-										Content: ">",
+										Name: ">",
 									},
 									types.StringElement{
 										Content: " an import",

--- a/pkg/parser/labeled_list_test.go
+++ b/pkg/parser/labeled_list_test.go
@@ -1813,7 +1813,7 @@ level 2::: description 2`
 									types.Paragraph{
 										Lines: []interface{}{
 											[]interface{}{
-												types.SpecialCharacter{Content: "&"},
+												types.PredefinedAttribute{Name: "amp"},
 											},
 										},
 									},

--- a/pkg/parser/ordered_list_test.go
+++ b/pkg/parser/ordered_list_test.go
@@ -856,7 +856,7 @@ print("one")
 . {blank}
 +
 ----
-print("one")
+print("two")
 ----`
 				expected := types.DraftDocument{
 					Blocks: []interface{}{
@@ -866,7 +866,9 @@ print("one")
 							Elements: []interface{}{
 								types.Paragraph{
 									Lines: []interface{}{
-										[]interface{}{}, // empty line
+										[]interface{}{
+											types.PredefinedAttribute{Name: "blank"},
+										},
 									},
 								},
 							},
@@ -888,7 +890,9 @@ print("one")
 							Elements: []interface{}{
 								types.Paragraph{
 									Lines: []interface{}{
-										[]interface{}{}, // empty line
+										[]interface{}{
+											types.PredefinedAttribute{Name: "blank"},
+										},
 									},
 								},
 							},
@@ -899,7 +903,7 @@ print("one")
 								Kind: types.Listing,
 								Elements: []interface{}{
 									types.VerbatimLine{
-										Content: "print(\"one\")",
+										Content: "print(\"two\")",
 									},
 								},
 							},
@@ -1048,7 +1052,7 @@ print("one")
 										types.Paragraph{
 											Lines: []interface{}{
 												[]interface{}{
-													types.SpecialCharacter{Content: "&"},
+													types.PredefinedAttribute{Name: "amp"},
 												},
 											},
 										},
@@ -1906,7 +1910,7 @@ print("one")
 . {blank}
 +
 ----
-print("one")
+print("two")
 ----`
 				expected := types.Document{
 					Elements: []interface{}{
@@ -1917,7 +1921,11 @@ print("one")
 									Style: types.Arabic,
 									Elements: []interface{}{
 										types.Paragraph{
-											Lines: []interface{}{},
+											Lines: []interface{}{
+												[]interface{}{
+													types.PredefinedAttribute{Name: "blank"},
+												},
+											},
 										},
 										types.DelimitedBlock{
 											Kind: types.Listing,
@@ -1934,13 +1942,17 @@ print("one")
 									Style: types.Arabic,
 									Elements: []interface{}{
 										types.Paragraph{
-											Lines: []interface{}{},
+											Lines: []interface{}{
+												[]interface{}{
+													types.PredefinedAttribute{Name: "blank"},
+												},
+											},
 										},
 										types.DelimitedBlock{
 											Kind: types.Listing,
 											Elements: []interface{}{
 												types.VerbatimLine{
-													Content: "print(\"one\")",
+													Content: "print(\"two\")",
 												},
 											},
 										},

--- a/pkg/parser/paragraph_test.go
+++ b/pkg/parser/paragraph_test.go
@@ -160,9 +160,7 @@ foo`
 						types.Paragraph{
 							Lines: []interface{}{
 								[]interface{}{
-									types.StringElement{Content: "C"},
-									types.SpecialCharacter{Content: "+"},
-									types.SpecialCharacter{Content: "+"},
+									types.StringElement{Content: "C++"},
 								},
 								[]interface{}{
 									types.StringElement{Content: "foo"},
@@ -406,9 +404,9 @@ another one using attribute substitution: {github-url}[]...
 								Lines: []interface{}{
 									[]interface{}{
 										types.StringElement{Content: "a link to https://github.com[] "},
-										types.SpecialCharacter{Content: "<"},
+										types.SpecialCharacter{Name: "<"},
 										types.StringElement{Content: "using the *inline link macro*"},
-										types.SpecialCharacter{Content: ">"},
+										types.SpecialCharacter{Name: ">"},
 									},
 									[]interface{}{
 										types.StringElement{Content: "another one using attribute substitution: {github-url}[]..."},
@@ -1193,7 +1191,13 @@ a paragraph`
 				expected := types.Document{
 					Elements: []interface{}{
 						types.Paragraph{
-							Lines: []interface{}{},
+							Lines: []interface{}{
+								[]interface{}{
+									types.PredefinedAttribute{
+										Name: "blank",
+									},
+								},
+							},
 						},
 					},
 				}
@@ -1208,7 +1212,7 @@ a paragraph`
 							Lines: []interface{}{
 								[]interface{}{
 									types.StringElement{Content: "hello "},
-									types.SpecialCharacter{Content: "+"},
+									types.PredefinedAttribute{Name: "plus"},
 									types.StringElement{Content: " world"},
 								},
 							},
@@ -1310,13 +1314,13 @@ a *link* to {github-url} <here>`
 											Content: " ",
 										},
 										types.SpecialCharacter{
-											Content: "<",
+											Name: "<",
 										},
 										types.StringElement{
 											Content: "here",
 										},
 										types.SpecialCharacter{
-											Content: ">",
+											Name: ">",
 										},
 									},
 								},

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -16128,21 +16128,15 @@ var g = &grammar{
 							ignoreCase: false,
 							want:       "\"&\"",
 						},
-						&litMatcher{
-							pos:        position{line: 2232, col: 40, offset: 81909},
-							val:        "+",
-							ignoreCase: false,
-							want:       "\"+\"",
-						},
 					},
 				},
 			},
 		},
 		{
 			name: "Alphanum",
-			pos:  position{line: 2239, col: 1, offset: 82201},
+			pos:  position{line: 2239, col: 1, offset: 82073},
 			expr: &charClassMatcher{
-				pos:        position{line: 2239, col: 13, offset: 82213},
+				pos:        position{line: 2239, col: 13, offset: 82085},
 				val:        "[\\pL0-9]",
 				ranges:     []rune{'0', '9'},
 				classes:    []*unicode.RangeTable{rangeTable("L")},
@@ -16152,42 +16146,42 @@ var g = &grammar{
 		},
 		{
 			name: "Parenthesis",
-			pos:  position{line: 2241, col: 1, offset: 82223},
+			pos:  position{line: 2241, col: 1, offset: 82095},
 			expr: &choiceExpr{
-				pos: position{line: 2241, col: 16, offset: 82238},
+				pos: position{line: 2241, col: 16, offset: 82110},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 2241, col: 16, offset: 82238},
+						pos:        position{line: 2241, col: 16, offset: 82110},
 						val:        "(",
 						ignoreCase: false,
 						want:       "\"(\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2241, col: 22, offset: 82244},
+						pos:        position{line: 2241, col: 22, offset: 82116},
 						val:        ")",
 						ignoreCase: false,
 						want:       "\")\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2241, col: 28, offset: 82250},
+						pos:        position{line: 2241, col: 28, offset: 82122},
 						val:        "[",
 						ignoreCase: false,
 						want:       "\"[\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2241, col: 34, offset: 82256},
+						pos:        position{line: 2241, col: 34, offset: 82128},
 						val:        "]",
 						ignoreCase: false,
 						want:       "\"]\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2241, col: 40, offset: 82262},
+						pos:        position{line: 2241, col: 40, offset: 82134},
 						val:        "{",
 						ignoreCase: false,
 						want:       "\"{\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2241, col: 46, offset: 82268},
+						pos:        position{line: 2241, col: 46, offset: 82140},
 						val:        "}",
 						ignoreCase: false,
 						want:       "\"}\"",
@@ -16197,14 +16191,14 @@ var g = &grammar{
 		},
 		{
 			name: "Alphanums",
-			pos:  position{line: 2243, col: 1, offset: 82274},
+			pos:  position{line: 2243, col: 1, offset: 82146},
 			expr: &actionExpr{
-				pos: position{line: 2243, col: 14, offset: 82287},
+				pos: position{line: 2243, col: 14, offset: 82159},
 				run: (*parser).callonAlphanums1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 2243, col: 14, offset: 82287},
+					pos: position{line: 2243, col: 14, offset: 82159},
 					expr: &charClassMatcher{
-						pos:        position{line: 2243, col: 14, offset: 82287},
+						pos:        position{line: 2243, col: 14, offset: 82159},
 						val:        "[\\pL0-9]",
 						ranges:     []rune{'0', '9'},
 						classes:    []*unicode.RangeTable{rangeTable("L")},
@@ -16216,20 +16210,20 @@ var g = &grammar{
 		},
 		{
 			name: "Word",
-			pos:  position{line: 2247, col: 1, offset: 82333},
+			pos:  position{line: 2247, col: 1, offset: 82205},
 			expr: &choiceExpr{
-				pos: position{line: 2251, col: 5, offset: 82660},
+				pos: position{line: 2251, col: 5, offset: 82532},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 2251, col: 5, offset: 82660},
+						pos: position{line: 2251, col: 5, offset: 82532},
 						run: (*parser).callonWord2,
 						expr: &seqExpr{
-							pos: position{line: 2251, col: 5, offset: 82660},
+							pos: position{line: 2251, col: 5, offset: 82532},
 							exprs: []interface{}{
 								&oneOrMoreExpr{
-									pos: position{line: 2251, col: 5, offset: 82660},
+									pos: position{line: 2251, col: 5, offset: 82532},
 									expr: &charClassMatcher{
-										pos:        position{line: 2251, col: 5, offset: 82660},
+										pos:        position{line: 2251, col: 5, offset: 82532},
 										val:        "[\\pL0-9]",
 										ranges:     []rune{'0', '9'},
 										classes:    []*unicode.RangeTable{rangeTable("L")},
@@ -16238,19 +16232,19 @@ var g = &grammar{
 									},
 								},
 								&andExpr{
-									pos: position{line: 2251, col: 15, offset: 82670},
+									pos: position{line: 2251, col: 15, offset: 82542},
 									expr: &choiceExpr{
-										pos: position{line: 2251, col: 17, offset: 82672},
+										pos: position{line: 2251, col: 17, offset: 82544},
 										alternatives: []interface{}{
 											&charClassMatcher{
-												pos:        position{line: 2251, col: 17, offset: 82672},
+												pos:        position{line: 2251, col: 17, offset: 82544},
 												val:        "[\\r\\n ,\\]]",
 												chars:      []rune{'\r', '\n', ' ', ',', ']'},
 												ignoreCase: false,
 												inverted:   false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2251, col: 30, offset: 82685},
+												pos:  position{line: 2251, col: 30, offset: 82557},
 												name: "EOF",
 											},
 										},
@@ -16260,15 +16254,15 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2253, col: 9, offset: 82755},
+						pos: position{line: 2253, col: 9, offset: 82627},
 						run: (*parser).callonWord10,
 						expr: &seqExpr{
-							pos: position{line: 2253, col: 9, offset: 82755},
+							pos: position{line: 2253, col: 9, offset: 82627},
 							exprs: []interface{}{
 								&oneOrMoreExpr{
-									pos: position{line: 2253, col: 9, offset: 82755},
+									pos: position{line: 2253, col: 9, offset: 82627},
 									expr: &charClassMatcher{
-										pos:        position{line: 2253, col: 9, offset: 82755},
+										pos:        position{line: 2253, col: 9, offset: 82627},
 										val:        "[\\pL0-9]",
 										ranges:     []rune{'0', '9'},
 										classes:    []*unicode.RangeTable{rangeTable("L")},
@@ -16277,21 +16271,21 @@ var g = &grammar{
 									},
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 2253, col: 19, offset: 82765},
+									pos: position{line: 2253, col: 19, offset: 82637},
 									expr: &seqExpr{
-										pos: position{line: 2253, col: 20, offset: 82766},
+										pos: position{line: 2253, col: 20, offset: 82638},
 										exprs: []interface{}{
 											&charClassMatcher{
-												pos:        position{line: 2253, col: 20, offset: 82766},
+												pos:        position{line: 2253, col: 20, offset: 82638},
 												val:        "[=*_`]",
 												chars:      []rune{'=', '*', '_', '`'},
 												ignoreCase: false,
 												inverted:   false,
 											},
 											&oneOrMoreExpr{
-												pos: position{line: 2253, col: 27, offset: 82773},
+												pos: position{line: 2253, col: 27, offset: 82645},
 												expr: &charClassMatcher{
-													pos:        position{line: 2253, col: 27, offset: 82773},
+													pos:        position{line: 2253, col: 27, offset: 82645},
 													val:        "[\\pL0-9]",
 													ranges:     []rune{'0', '9'},
 													classes:    []*unicode.RangeTable{rangeTable("L")},
@@ -16310,20 +16304,20 @@ var g = &grammar{
 		},
 		{
 			name: "InlineWord",
-			pos:  position{line: 2257, col: 1, offset: 82849},
+			pos:  position{line: 2257, col: 1, offset: 82721},
 			expr: &choiceExpr{
-				pos: position{line: 2258, col: 5, offset: 82930},
+				pos: position{line: 2258, col: 5, offset: 82802},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 2258, col: 5, offset: 82930},
+						pos: position{line: 2258, col: 5, offset: 82802},
 						run: (*parser).callonInlineWord2,
 						expr: &seqExpr{
-							pos: position{line: 2258, col: 5, offset: 82930},
+							pos: position{line: 2258, col: 5, offset: 82802},
 							exprs: []interface{}{
 								&oneOrMoreExpr{
-									pos: position{line: 2258, col: 5, offset: 82930},
+									pos: position{line: 2258, col: 5, offset: 82802},
 									expr: &charClassMatcher{
-										pos:        position{line: 2258, col: 5, offset: 82930},
+										pos:        position{line: 2258, col: 5, offset: 82802},
 										val:        "[\\pL0-9,?!;]",
 										chars:      []rune{',', '?', '!', ';'},
 										ranges:     []rune{'0', '9'},
@@ -16333,19 +16327,19 @@ var g = &grammar{
 									},
 								},
 								&andExpr{
-									pos: position{line: 2258, col: 19, offset: 82944},
+									pos: position{line: 2258, col: 19, offset: 82816},
 									expr: &choiceExpr{
-										pos: position{line: 2258, col: 21, offset: 82946},
+										pos: position{line: 2258, col: 21, offset: 82818},
 										alternatives: []interface{}{
 											&charClassMatcher{
-												pos:        position{line: 2258, col: 21, offset: 82946},
+												pos:        position{line: 2258, col: 21, offset: 82818},
 												val:        "[\\r\\n ]",
 												chars:      []rune{'\r', '\n', ' '},
 												ignoreCase: false,
 												inverted:   false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2258, col: 31, offset: 82956},
+												pos:  position{line: 2258, col: 31, offset: 82828},
 												name: "EOF",
 											},
 										},
@@ -16355,7 +16349,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2260, col: 9, offset: 83025},
+						pos:  position{line: 2260, col: 9, offset: 82897},
 						name: "Word",
 					},
 				},
@@ -16363,12 +16357,12 @@ var g = &grammar{
 		},
 		{
 			name: "AnyChar",
-			pos:  position{line: 2263, col: 1, offset: 83125},
+			pos:  position{line: 2263, col: 1, offset: 82997},
 			expr: &actionExpr{
-				pos: position{line: 2263, col: 12, offset: 83136},
+				pos: position{line: 2263, col: 12, offset: 83008},
 				run: (*parser).callonAnyChar1,
 				expr: &charClassMatcher{
-					pos:        position{line: 2263, col: 12, offset: 83136},
+					pos:        position{line: 2263, col: 12, offset: 83008},
 					val:        "[^\\r\\n]",
 					chars:      []rune{'\r', '\n'},
 					ignoreCase: false,
@@ -16378,24 +16372,24 @@ var g = &grammar{
 		},
 		{
 			name: "FileLocation",
-			pos:  position{line: 2267, col: 1, offset: 83201},
+			pos:  position{line: 2267, col: 1, offset: 83073},
 			expr: &actionExpr{
-				pos: position{line: 2267, col: 17, offset: 83217},
+				pos: position{line: 2267, col: 17, offset: 83089},
 				run: (*parser).callonFileLocation1,
 				expr: &labeledExpr{
-					pos:   position{line: 2267, col: 17, offset: 83217},
+					pos:   position{line: 2267, col: 17, offset: 83089},
 					label: "path",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 2267, col: 22, offset: 83222},
+						pos: position{line: 2267, col: 22, offset: 83094},
 						expr: &choiceExpr{
-							pos: position{line: 2267, col: 23, offset: 83223},
+							pos: position{line: 2267, col: 23, offset: 83095},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 2267, col: 23, offset: 83223},
+									pos:  position{line: 2267, col: 23, offset: 83095},
 									name: "FILENAME",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2267, col: 34, offset: 83234},
+									pos:  position{line: 2267, col: 34, offset: 83106},
 									name: "AttributeSubstitution",
 								},
 							},
@@ -16406,17 +16400,17 @@ var g = &grammar{
 		},
 		{
 			name: "ResolvedFileLocation",
-			pos:  position{line: 2271, col: 1, offset: 83318},
+			pos:  position{line: 2271, col: 1, offset: 83190},
 			expr: &actionExpr{
-				pos: position{line: 2271, col: 25, offset: 83342},
+				pos: position{line: 2271, col: 25, offset: 83214},
 				run: (*parser).callonResolvedFileLocation1,
 				expr: &labeledExpr{
-					pos:   position{line: 2271, col: 25, offset: 83342},
+					pos:   position{line: 2271, col: 25, offset: 83214},
 					label: "path",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 2271, col: 30, offset: 83347},
+						pos: position{line: 2271, col: 30, offset: 83219},
 						expr: &charClassMatcher{
-							pos:        position{line: 2271, col: 31, offset: 83348},
+							pos:        position{line: 2271, col: 31, offset: 83220},
 							val:        "[^\\r\\n []",
 							chars:      []rune{'\r', '\n', ' ', '['},
 							ignoreCase: false,
@@ -16428,38 +16422,38 @@ var g = &grammar{
 		},
 		{
 			name: "Location",
-			pos:  position{line: 2275, col: 1, offset: 83420},
+			pos:  position{line: 2275, col: 1, offset: 83292},
 			expr: &actionExpr{
-				pos: position{line: 2275, col: 13, offset: 83432},
+				pos: position{line: 2275, col: 13, offset: 83304},
 				run: (*parser).callonLocation1,
 				expr: &seqExpr{
-					pos: position{line: 2275, col: 13, offset: 83432},
+					pos: position{line: 2275, col: 13, offset: 83304},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 2275, col: 13, offset: 83432},
+							pos:   position{line: 2275, col: 13, offset: 83304},
 							label: "scheme",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2275, col: 20, offset: 83439},
+								pos: position{line: 2275, col: 20, offset: 83311},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2275, col: 21, offset: 83440},
+									pos:  position{line: 2275, col: 21, offset: 83312},
 									name: "URL_SCHEME",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2275, col: 34, offset: 83453},
+							pos:   position{line: 2275, col: 34, offset: 83325},
 							label: "path",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 2275, col: 39, offset: 83458},
+								pos: position{line: 2275, col: 39, offset: 83330},
 								expr: &choiceExpr{
-									pos: position{line: 2275, col: 40, offset: 83459},
+									pos: position{line: 2275, col: 40, offset: 83331},
 									alternatives: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 2275, col: 40, offset: 83459},
+											pos:  position{line: 2275, col: 40, offset: 83331},
 											name: "FILENAME",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2275, col: 51, offset: 83470},
+											pos:  position{line: 2275, col: 51, offset: 83342},
 											name: "AttributeSubstitution",
 										},
 									},
@@ -16472,35 +16466,35 @@ var g = &grammar{
 		},
 		{
 			name: "LocationWithScheme",
-			pos:  position{line: 2279, col: 1, offset: 83558},
+			pos:  position{line: 2279, col: 1, offset: 83430},
 			expr: &actionExpr{
-				pos: position{line: 2279, col: 23, offset: 83580},
+				pos: position{line: 2279, col: 23, offset: 83452},
 				run: (*parser).callonLocationWithScheme1,
 				expr: &seqExpr{
-					pos: position{line: 2279, col: 23, offset: 83580},
+					pos: position{line: 2279, col: 23, offset: 83452},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 2279, col: 23, offset: 83580},
+							pos:   position{line: 2279, col: 23, offset: 83452},
 							label: "scheme",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2279, col: 31, offset: 83588},
+								pos:  position{line: 2279, col: 31, offset: 83460},
 								name: "URL_SCHEME",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2279, col: 43, offset: 83600},
+							pos:   position{line: 2279, col: 43, offset: 83472},
 							label: "path",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 2279, col: 48, offset: 83605},
+								pos: position{line: 2279, col: 48, offset: 83477},
 								expr: &choiceExpr{
-									pos: position{line: 2279, col: 49, offset: 83606},
+									pos: position{line: 2279, col: 49, offset: 83478},
 									alternatives: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 2279, col: 49, offset: 83606},
+											pos:  position{line: 2279, col: 49, offset: 83478},
 											name: "FILENAME",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2279, col: 60, offset: 83617},
+											pos:  position{line: 2279, col: 60, offset: 83489},
 											name: "AttributeSubstitution",
 										},
 									},
@@ -16513,11 +16507,11 @@ var g = &grammar{
 		},
 		{
 			name: "FILENAME",
-			pos:  position{line: 2283, col: 1, offset: 83705},
+			pos:  position{line: 2283, col: 1, offset: 83577},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 2283, col: 13, offset: 83717},
+				pos: position{line: 2283, col: 13, offset: 83589},
 				expr: &charClassMatcher{
-					pos:        position{line: 2283, col: 14, offset: 83718},
+					pos:        position{line: 2283, col: 14, offset: 83590},
 					val:        "[^\\r\\n{}[\\] ]",
 					chars:      []rune{'\r', '\n', '{', '}', '[', ']', ' '},
 					ignoreCase: false,
@@ -16527,26 +16521,26 @@ var g = &grammar{
 		},
 		{
 			name: "ResolvedLocation",
-			pos:  position{line: 2285, col: 1, offset: 83852},
+			pos:  position{line: 2285, col: 1, offset: 83724},
 			expr: &actionExpr{
-				pos: position{line: 2285, col: 21, offset: 83872},
+				pos: position{line: 2285, col: 21, offset: 83744},
 				run: (*parser).callonResolvedLocation1,
 				expr: &seqExpr{
-					pos: position{line: 2285, col: 21, offset: 83872},
+					pos: position{line: 2285, col: 21, offset: 83744},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 2285, col: 21, offset: 83872},
+							pos:   position{line: 2285, col: 21, offset: 83744},
 							label: "scheme",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2285, col: 29, offset: 83880},
+								pos:  position{line: 2285, col: 29, offset: 83752},
 								name: "URL_SCHEME",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2285, col: 41, offset: 83892},
+							pos:   position{line: 2285, col: 41, offset: 83764},
 							label: "path",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2285, col: 47, offset: 83898},
+								pos:  position{line: 2285, col: 47, offset: 83770},
 								name: "RESOLVED_FILENAME",
 							},
 						},
@@ -16556,11 +16550,11 @@ var g = &grammar{
 		},
 		{
 			name: "RESOLVED_FILENAME",
-			pos:  position{line: 2290, col: 1, offset: 84146},
+			pos:  position{line: 2290, col: 1, offset: 84018},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 2290, col: 22, offset: 84167},
+				pos: position{line: 2290, col: 22, offset: 84039},
 				expr: &charClassMatcher{
-					pos:        position{line: 2290, col: 23, offset: 84168},
+					pos:        position{line: 2290, col: 23, offset: 84040},
 					val:        "[^\\r\\n[\\] ]",
 					chars:      []rune{'\r', '\n', '[', ']', ' '},
 					ignoreCase: false,
@@ -16570,14 +16564,14 @@ var g = &grammar{
 		},
 		{
 			name: "URL",
-			pos:  position{line: 2292, col: 1, offset: 84300},
+			pos:  position{line: 2292, col: 1, offset: 84172},
 			expr: &actionExpr{
-				pos: position{line: 2292, col: 9, offset: 84308},
+				pos: position{line: 2292, col: 9, offset: 84180},
 				run: (*parser).callonURL1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 2292, col: 9, offset: 84308},
+					pos: position{line: 2292, col: 9, offset: 84180},
 					expr: &charClassMatcher{
-						pos:        position{line: 2292, col: 9, offset: 84308},
+						pos:        position{line: 2292, col: 9, offset: 84180},
 						val:        "[^\\r\\n[\\]]",
 						chars:      []rune{'\r', '\n', '[', ']'},
 						ignoreCase: false,
@@ -16588,36 +16582,36 @@ var g = &grammar{
 		},
 		{
 			name: "URL_SCHEME",
-			pos:  position{line: 2296, col: 1, offset: 84356},
+			pos:  position{line: 2296, col: 1, offset: 84228},
 			expr: &choiceExpr{
-				pos: position{line: 2296, col: 15, offset: 84370},
+				pos: position{line: 2296, col: 15, offset: 84242},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 2296, col: 15, offset: 84370},
+						pos:        position{line: 2296, col: 15, offset: 84242},
 						val:        "http://",
 						ignoreCase: false,
 						want:       "\"http://\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2296, col: 27, offset: 84382},
+						pos:        position{line: 2296, col: 27, offset: 84254},
 						val:        "https://",
 						ignoreCase: false,
 						want:       "\"https://\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2296, col: 40, offset: 84395},
+						pos:        position{line: 2296, col: 40, offset: 84267},
 						val:        "ftp://",
 						ignoreCase: false,
 						want:       "\"ftp://\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2296, col: 51, offset: 84406},
+						pos:        position{line: 2296, col: 51, offset: 84278},
 						val:        "irc://",
 						ignoreCase: false,
 						want:       "\"irc://\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2296, col: 62, offset: 84417},
+						pos:        position{line: 2296, col: 62, offset: 84289},
 						val:        "mailto:",
 						ignoreCase: false,
 						want:       "\"mailto:\"",
@@ -16627,14 +16621,14 @@ var g = &grammar{
 		},
 		{
 			name: "ID",
-			pos:  position{line: 2298, col: 1, offset: 84428},
+			pos:  position{line: 2298, col: 1, offset: 84300},
 			expr: &actionExpr{
-				pos: position{line: 2298, col: 7, offset: 84434},
+				pos: position{line: 2298, col: 7, offset: 84306},
 				run: (*parser).callonID1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 2298, col: 7, offset: 84434},
+					pos: position{line: 2298, col: 7, offset: 84306},
 					expr: &charClassMatcher{
-						pos:        position{line: 2298, col: 7, offset: 84434},
+						pos:        position{line: 2298, col: 7, offset: 84306},
 						val:        "[^[\\]<>,]",
 						chars:      []rune{'[', ']', '<', '>', ','},
 						ignoreCase: false,
@@ -16645,12 +16639,12 @@ var g = &grammar{
 		},
 		{
 			name: "DIGIT",
-			pos:  position{line: 2302, col: 1, offset: 84559},
+			pos:  position{line: 2302, col: 1, offset: 84431},
 			expr: &actionExpr{
-				pos: position{line: 2302, col: 10, offset: 84568},
+				pos: position{line: 2302, col: 10, offset: 84440},
 				run: (*parser).callonDIGIT1,
 				expr: &charClassMatcher{
-					pos:        position{line: 2302, col: 10, offset: 84568},
+					pos:        position{line: 2302, col: 10, offset: 84440},
 					val:        "[0-9]",
 					ranges:     []rune{'0', '9'},
 					ignoreCase: false,
@@ -16660,26 +16654,26 @@ var g = &grammar{
 		},
 		{
 			name: "NUMBER",
-			pos:  position{line: 2306, col: 1, offset: 84610},
+			pos:  position{line: 2306, col: 1, offset: 84482},
 			expr: &actionExpr{
-				pos: position{line: 2306, col: 11, offset: 84620},
+				pos: position{line: 2306, col: 11, offset: 84492},
 				run: (*parser).callonNUMBER1,
 				expr: &seqExpr{
-					pos: position{line: 2306, col: 11, offset: 84620},
+					pos: position{line: 2306, col: 11, offset: 84492},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 2306, col: 11, offset: 84620},
+							pos: position{line: 2306, col: 11, offset: 84492},
 							expr: &litMatcher{
-								pos:        position{line: 2306, col: 11, offset: 84620},
+								pos:        position{line: 2306, col: 11, offset: 84492},
 								val:        "-",
 								ignoreCase: false,
 								want:       "\"-\"",
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 2306, col: 16, offset: 84625},
+							pos: position{line: 2306, col: 16, offset: 84497},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2306, col: 16, offset: 84625},
+								pos:  position{line: 2306, col: 16, offset: 84497},
 								name: "DIGIT",
 							},
 						},
@@ -16689,21 +16683,21 @@ var g = &grammar{
 		},
 		{
 			name: "Space",
-			pos:  position{line: 2310, col: 1, offset: 84677},
+			pos:  position{line: 2310, col: 1, offset: 84549},
 			expr: &choiceExpr{
-				pos: position{line: 2310, col: 10, offset: 84686},
+				pos: position{line: 2310, col: 10, offset: 84558},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 2310, col: 10, offset: 84686},
+						pos:        position{line: 2310, col: 10, offset: 84558},
 						val:        " ",
 						ignoreCase: false,
 						want:       "\" \"",
 					},
 					&actionExpr{
-						pos: position{line: 2310, col: 16, offset: 84692},
+						pos: position{line: 2310, col: 16, offset: 84564},
 						run: (*parser).callonSpace3,
 						expr: &litMatcher{
-							pos:        position{line: 2310, col: 16, offset: 84692},
+							pos:        position{line: 2310, col: 16, offset: 84564},
 							val:        "\t",
 							ignoreCase: false,
 							want:       "\"\\t\"",
@@ -16714,24 +16708,24 @@ var g = &grammar{
 		},
 		{
 			name: "Newline",
-			pos:  position{line: 2314, col: 1, offset: 84733},
+			pos:  position{line: 2314, col: 1, offset: 84605},
 			expr: &choiceExpr{
-				pos: position{line: 2314, col: 12, offset: 84744},
+				pos: position{line: 2314, col: 12, offset: 84616},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 2314, col: 12, offset: 84744},
+						pos:        position{line: 2314, col: 12, offset: 84616},
 						val:        "\r\n",
 						ignoreCase: false,
 						want:       "\"\\r\\n\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2314, col: 21, offset: 84753},
+						pos:        position{line: 2314, col: 21, offset: 84625},
 						val:        "\r",
 						ignoreCase: false,
 						want:       "\"\\r\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2314, col: 28, offset: 84760},
+						pos:        position{line: 2314, col: 28, offset: 84632},
 						val:        "\n",
 						ignoreCase: false,
 						want:       "\"\\n\"",
@@ -16741,26 +16735,26 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 2316, col: 1, offset: 84766},
+			pos:  position{line: 2316, col: 1, offset: 84638},
 			expr: &notExpr{
-				pos: position{line: 2316, col: 8, offset: 84773},
+				pos: position{line: 2316, col: 8, offset: 84645},
 				expr: &anyMatcher{
-					line: 2316, col: 9, offset: 84774,
+					line: 2316, col: 9, offset: 84646,
 				},
 			},
 		},
 		{
 			name: "EOL",
-			pos:  position{line: 2318, col: 1, offset: 84777},
+			pos:  position{line: 2318, col: 1, offset: 84649},
 			expr: &choiceExpr{
-				pos: position{line: 2318, col: 8, offset: 84784},
+				pos: position{line: 2318, col: 8, offset: 84656},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 2318, col: 8, offset: 84784},
+						pos:  position{line: 2318, col: 8, offset: 84656},
 						name: "Newline",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2318, col: 18, offset: 84794},
+						pos:  position{line: 2318, col: 18, offset: 84666},
 						name: "EOF",
 					},
 				},
@@ -20663,7 +20657,6 @@ func (p *parser) callonImpliedApostrophe1() (interface{}, error) {
 }
 
 func (c *current) onSpecialCharacter1() (interface{}, error) {
-	// "+" is parsed here for the sake of HTML output compatibility with Asciidoctor which replaces it with the `&#43;` entity
 	return types.NewSpecialCharacter(string(c.text))
 }
 

--- a/pkg/parser/parser.peg
+++ b/pkg/parser/parser.peg
@@ -2229,7 +2229,7 @@ ImpliedApostrophe <- Alphanum "'" &[\pL] {
 // They need to be identified as they may have a special treatment during the rendering
 // ------------------------------------------------------------------------------------
 
-SpecialCharacter <- ("<" / ">" / "&" / "+") { // "+" is parsed here for the sake of HTML output compatibility with Asciidoctor which replaces it with the `&#43;` entity
+SpecialCharacter <- ("<" / ">" / "&" ) {
     return types.NewSpecialCharacter(string(c.text))
 }
 

--- a/pkg/parser/passthrough_test.go
+++ b/pkg/parser/passthrough_test.go
@@ -207,8 +207,9 @@ var _ = Describe("passthroughs", func() {
 						types.Paragraph{
 							Lines: []interface{}{
 								[]interface{}{
-									types.SpecialCharacter{Content: "+"},
-									types.SpecialCharacter{Content: "+"},
+									types.StringElement{
+										Content: "++",
+									},
 								},
 							},
 						},
@@ -247,7 +248,7 @@ var _ = Describe("passthroughs", func() {
 						types.Paragraph{
 							Lines: []interface{}{
 								[]interface{}{
-									types.SpecialCharacter{
+									types.StringElement{
 										Content: "+",
 									},
 									types.QuotedText{
@@ -277,11 +278,8 @@ var _ = Describe("passthroughs", func() {
 						types.Paragraph{
 							Lines: []interface{}{
 								[]interface{}{
-									types.SpecialCharacter{
-										Content: "+",
-									},
 									types.StringElement{
-										Content: " ",
+										Content: "+ ",
 									},
 									types.QuotedText{
 										Kind: types.Bold,
@@ -292,10 +290,7 @@ var _ = Describe("passthroughs", func() {
 										},
 									},
 									types.StringElement{
-										Content: ", world",
-									},
-									types.SpecialCharacter{
-										Content: "+",
+										Content: ", world+",
 									},
 								},
 							},
@@ -312,11 +307,8 @@ var _ = Describe("passthroughs", func() {
 						types.Paragraph{
 							Lines: []interface{}{
 								[]interface{}{
-									types.SpecialCharacter{
-										Content: "+",
-									},
 									types.StringElement{
-										Content: " ",
+										Content: "+ ",
 									},
 									types.QuotedText{
 										Kind: types.Bold,
@@ -345,19 +337,13 @@ var _ = Describe("passthroughs", func() {
 						types.Paragraph{
 							Lines: []interface{}{
 								[]interface{}{
-									types.SpecialCharacter{
-										Content: "+",
-									},
 									types.StringElement{
-										Content: "hello,",
+										Content: "+hello,",
 									},
 								},
 								[]interface{}{
 									types.StringElement{
-										Content: "world",
-									},
-									types.SpecialCharacter{
-										Content: "+",
+										Content: "world+",
 									},
 								},
 							},

--- a/pkg/parser/quoted_text_test.go
+++ b/pkg/parser/quoted_text_test.go
@@ -816,13 +816,13 @@ var _ = Describe("quoted texts", func() {
 						Content: "[.",
 					},
 					types.SpecialCharacter{
-						Content: "<",
+						Name: "<",
 					},
 					types.StringElement{
 						Content: "something \"wicked",
 					},
 					types.SpecialCharacter{
-						Content: ">",
+						Name: ">",
 					},
 					types.StringElement{
 						Content: "]",

--- a/pkg/parser/section_test.go
+++ b/pkg/parser/section_test.go
@@ -822,13 +822,13 @@ Doc Writer <thedoc@asciidoctor.org>`
 										Content: "Doc Writer ",
 									},
 									types.SpecialCharacter{
-										Content: "<",
+										Name: "<",
 									},
 									types.StringElement{
 										Content: "thedoc@asciidoctor.org",
 									},
 									types.SpecialCharacter{
-										Content: ">",
+										Name: ">",
 									},
 								},
 							},
@@ -1976,13 +1976,13 @@ Doc Writer <thedoc@asciidoctor.org>`
 										Content: "Doc Writer ",
 									},
 									types.SpecialCharacter{
-										Content: "<",
+										Name: "<",
 									},
 									types.StringElement{
 										Content: "thedoc@asciidoctor.org",
 									},
 									types.SpecialCharacter{
-										Content: ">",
+										Name: ">",
 									},
 								},
 							},

--- a/pkg/parser/unordered_list_test.go
+++ b/pkg/parser/unordered_list_test.go
@@ -1160,8 +1160,8 @@ The {plus} symbol is on a new line.
 											types.StringElement{
 												Content: "This is a new line inside an unordered list using ",
 											},
-											types.SpecialCharacter{
-												Content: "+",
+											types.PredefinedAttribute{
+												Name: "plus",
 											},
 											types.StringElement{
 												Content: " symbol.",
@@ -1207,8 +1207,8 @@ The {plus} symbol is on a new line.
 										types.StringElement{
 											Content: "The ",
 										},
-										types.SpecialCharacter{
-											Content: "+",
+										types.PredefinedAttribute{
+											Name: "plus",
 										},
 										types.StringElement{
 											Content: " symbol is on a new line.",
@@ -2449,7 +2449,9 @@ on 2 lines, too.`
 										types.Paragraph{
 											Lines: []interface{}{
 												[]interface{}{
-													types.SpecialCharacter{Content: "&"},
+													types.PredefinedAttribute{
+														Name: "amp",
+													},
 												},
 											},
 										},
@@ -2712,8 +2714,8 @@ The {plus} symbol is on a new line.
 																					types.StringElement{
 																						Content: "This is a new line inside an unordered list using ",
 																					},
-																					types.SpecialCharacter{
-																						Content: "+",
+																					types.PredefinedAttribute{
+																						Name: "plus",
 																					},
 																					types.StringElement{
 																						Content: " symbol.",
@@ -2755,8 +2757,8 @@ The {plus} symbol is on a new line.
 																									types.StringElement{
 																										Content: "The ",
 																									},
-																									types.SpecialCharacter{
-																										Content: "+",
+																									types.PredefinedAttribute{
+																										Name: "plus",
 																									},
 																									types.StringElement{
 																										Content: " symbol is on a new line.",

--- a/pkg/renderer/sgml/aliases.go
+++ b/pkg/renderer/sgml/aliases.go
@@ -10,6 +10,7 @@ import (
 // thereby helping minimize collisions based on conflicting package
 // names.  It also reduces the imports we have to use everywhere else.
 
+// Context the rendering context
 type Context = renderer.Context
 
 type textTemplate = text.Template

--- a/pkg/renderer/sgml/delimited_block.go
+++ b/pkg/renderer/sgml/delimited_block.go
@@ -68,7 +68,7 @@ func (r *sgmlRenderer) renderFencedBlock(ctx *renderer.Context, b types.Delimite
 		ID:       r.renderElementID(b.Attributes),
 		Title:    r.renderElementTitle(b.Attributes),
 		Roles:    r.renderElementRoles(b.Attributes),
-		Content:  string(content),
+		Content:  content,
 		Elements: elements,
 	})
 	return result.String(), err
@@ -102,7 +102,7 @@ func (r *sgmlRenderer) renderListingBlock(ctx *renderer.Context, b types.Delimit
 		ID:       r.renderElementID(b.Attributes),
 		Title:    r.renderElementTitle(b.Attributes),
 		Roles:    r.renderElementRoles(b.Attributes),
-		Content:  string(content),
+		Content:  content,
 		Elements: discardTrailingBlankLines(b.Elements),
 	})
 	return result.String(), err
@@ -295,7 +295,7 @@ func (r *sgmlRenderer) renderAdmonitionBlock(ctx *renderer.Context, b types.Deli
 		Roles:    r.renderElementRoles(b.Attributes),
 		Title:    r.renderElementTitle(b.Attributes),
 		Icon:     icon,
-		Content:  string(content),
+		Content:  content,
 		Elements: elements,
 	})
 	return result.String(), err
@@ -318,7 +318,7 @@ func (r *sgmlRenderer) renderExampleBlock(ctx *renderer.Context, b types.Delimit
 
 	c, ok := b.Attributes.GetAsString(types.AttrCaption)
 	if !ok {
-		c, _ = ctx.Attributes.GetAsString(types.AttrExampleCaption)
+		c = ctx.Attributes.GetAsStringWithDefault(types.AttrExampleCaption, "Example")
 		if c != "" {
 			c += " {counter:example-number}. "
 		}
@@ -345,7 +345,7 @@ func (r *sgmlRenderer) renderExampleBlock(ctx *renderer.Context, b types.Delimit
 		Caption:       caption.String(),
 		Roles:         r.renderElementRoles(b.Attributes),
 		ExampleNumber: number,
-		Content:       string(content),
+		Content:       content,
 		Elements:      elements,
 	})
 	return result.String(), err
@@ -373,7 +373,7 @@ func (r *sgmlRenderer) renderQuoteBlock(ctx *renderer.Context, b types.Delimited
 		Title:       r.renderElementTitle(b.Attributes),
 		Roles:       r.renderElementRoles(b.Attributes),
 		Attribution: newDelimitedBlockAttribution(b),
-		Content:     string(content),
+		Content:     content,
 		Elements:    b.Elements,
 	})
 	return result.String(), err
@@ -448,7 +448,7 @@ func (r *sgmlRenderer) renderSidebarBlock(ctx *renderer.Context, b types.Delimit
 		ID:       r.renderElementID(b.Attributes),
 		Title:    r.renderElementTitle(b.Attributes),
 		Roles:    r.renderElementRoles(b.Attributes),
-		Content:  string(content),
+		Content:  content,
 		Elements: discardTrailingBlankLines(b.Elements),
 	})
 	return result.String(), err

--- a/pkg/renderer/sgml/document_details.go
+++ b/pkg/renderer/sgml/document_details.go
@@ -17,7 +17,7 @@ func (r *sgmlRenderer) renderDocumentDetails(ctx *renderer.Context) (*string, er
 			return nil, errors.Wrap(err, "error while rendering the document details")
 		}
 		documentDetailsBuff := &bytes.Buffer{}
-		revLabel, _ := ctx.Attributes.GetAsString("version-label")
+		revLabel := ctx.Attributes.GetAsStringWithDefault("version-label", "version")
 		revNumber, _ := ctx.Attributes.GetAsString("revnumber")
 		revDate, _ := ctx.Attributes.GetAsString("revdate")
 		revRemark, _ := ctx.Attributes.GetAsString("revremark")

--- a/pkg/renderer/sgml/elements.go
+++ b/pkg/renderer/sgml/elements.go
@@ -127,6 +127,8 @@ func (r *sgmlRenderer) renderElement(ctx *renderer.Context, element interface{})
 		return r.renderThematicBreak()
 	case types.SpecialCharacter:
 		return r.renderSpecialCharacter(e)
+	case types.PredefinedAttribute:
+		return r.renderPredefinedAttribute(e)
 	default:
 		return "", errors.Errorf("unsupported type of element: %T", element)
 	}

--- a/pkg/renderer/sgml/html5/html5_test.go
+++ b/pkg/renderer/sgml/html5/html5_test.go
@@ -195,7 +195,6 @@ a note
 	})
 
 	It("render manpage document with header and footer", func() {
-
 		source := `= eve(1)
 Andrew Stanton
 v1.0.0

--- a/pkg/renderer/sgml/html5/passthrough_test.go
+++ b/pkg/renderer/sgml/html5/passthrough_test.go
@@ -54,7 +54,7 @@ var _ = Describe("passthroughs", func() {
 		It("an empty standalone singleplus passthrough", func() {
 			source := `++`
 			expected := `<div class="paragraph">
-<p>&#43;&#43;</p>
+<p>++</p>
 </div>
 `
 			Expect(RenderHTML(source)).To(MatchHTML(expected))
@@ -63,7 +63,7 @@ var _ = Describe("passthroughs", func() {
 		It("an empty singleplus passthrough in a paragraph", func() {
 			source := `++ with more content afterwards...`
 			expected := `<div class="paragraph">
-<p>&#43;&#43; with more content afterwards&#8230;&#8203;</p>
+<p>++ with more content afterwards&#8230;&#8203;</p>
 </div>
 `
 			Expect(RenderHTML(source)).To(MatchHTML(expected))
@@ -90,7 +90,7 @@ var _ = Describe("passthroughs", func() {
 		It("invalid singleplus passthrough in paragraph", func() {
 			source := `The text + *hello*, world + is not passed through.`
 			expected := `<div class="paragraph">
-<p>The text &#43; <strong>hello</strong>, world &#43; is not passed through.</p>
+<p>The text + <strong>hello</strong>, world + is not passed through.</p>
 </div>
 `
 			Expect(RenderHTML(source)).To(MatchHTML(expected))

--- a/pkg/renderer/sgml/html5/predefined_attribute.go
+++ b/pkg/renderer/sgml/html5/predefined_attribute.go
@@ -1,0 +1,5 @@
+package html5
+
+const (
+	predefinedAttributeTmpl = `{{ predefinedAttribute .Name }}`
+)

--- a/pkg/renderer/sgml/html5/special_character.go
+++ b/pkg/renderer/sgml/html5/special_character.go
@@ -1,5 +1,5 @@
 package html5
 
 const (
-	specialCharacterTmpl = `{{ if eq .Content ">" }}&gt;{{ else if eq .Content "<" }}&lt;{{ else if eq .Content "&" }}&amp;{{ else if eq .Content "+" }}&#43;{{ end }}`
+	specialCharacterTmpl = `{{ specialCharacter .Name }}`
 )

--- a/pkg/renderer/sgml/html5/templates.go
+++ b/pkg/renderer/sgml/html5/templates.go
@@ -55,6 +55,7 @@ var templates = sgml.Templates{
 	PassthroughBlock:          pssThroughBlock,
 	Paragraph:                 paragraphTmpl,
 	Preamble:                  preambleTmpl,
+	PredefinedAttribute:       predefinedAttributeTmpl,
 	QAndAList:                 qAndAListTmpl,
 	QAndAListItem:             qAndAListItemTmpl,
 	QuoteBlock:                quoteBlockTmpl,

--- a/pkg/renderer/sgml/icon.go
+++ b/pkg/renderer/sgml/icon.go
@@ -42,6 +42,14 @@ func (r *sgmlRenderer) renderInlineIcon(ctx *renderer.Context, icon types.Icon) 
 	return result.String(), nil
 }
 
+var defaultIconClasses = map[string]string{
+	types.AttrCautionCaption:   "Caution",
+	types.AttrImportantCaption: "Important",
+	types.AttrNoteCaption:      "Note",
+	types.AttrTipCaption:       "Tip",
+	types.AttrWarningCaption:   "Warning",
+}
+
 func (r *sgmlRenderer) renderIcon(ctx *renderer.Context, icon types.Icon, admonition bool) (string, error) {
 	icons := ctx.Attributes.GetAsStringWithDefault("icons", "text")
 	var template *textTemplate
@@ -66,7 +74,7 @@ func (r *sgmlRenderer) renderIcon(ctx *renderer.Context, icon types.Icon, admoni
 		// Admonition uses title on block instead of the icon, and the alt text is
 		// taken from the caption.  However, in admonitions using the font, the alt
 		// is used as the title element instead.  Go figure.
-		alt = ctx.Attributes.GetAsStringWithDefault(icon.Class+"-caption", "")
+		alt = ctx.Attributes.GetAsStringWithDefault(icon.Class+"-caption", defaultIconClasses[icon.Class+"-caption"])
 		alt = icon.Attributes.GetAsStringWithDefault(types.AttrCaption, alt)
 		if font {
 			title = alt

--- a/pkg/renderer/sgml/image.go
+++ b/pkg/renderer/sgml/image.go
@@ -21,7 +21,7 @@ func (r *sgmlRenderer) renderImageBlock(ctx *renderer.Context, img types.ImageBl
 	if _, found := img.Attributes.GetAsString(types.AttrTitle); found {
 		c, ok := img.Attributes.GetAsString(types.AttrCaption)
 		if !ok {
-			c, _ = ctx.Attributes.GetAsString(types.AttrFigureCaption)
+			c = ctx.Attributes.GetAsStringWithDefault(types.AttrFigureCaption, "Figure")
 			if c != "" {
 				// We always append the figure number, unless the caption is disabled.
 				// This is for asciidoctor compatibility.

--- a/pkg/renderer/sgml/paragraph.go
+++ b/pkg/renderer/sgml/paragraph.go
@@ -214,8 +214,11 @@ func renderCheckStyle(style interface{}) string {
 
 func (r *sgmlRenderer) renderElementTitle(attrs types.Attributes) string {
 	if title, found := attrs.GetAsString(types.AttrTitle); found {
-		return string(EscapeString(strings.TrimSpace(title)))
+		result := EscapeString(strings.TrimSpace(title))
+		log.Debugf("rendered title: '%s'", result)
+		return result
 	}
+	log.Debug("no title to render")
 	return ""
 }
 

--- a/pkg/renderer/sgml/predefined_attribute.go
+++ b/pkg/renderer/sgml/predefined_attribute.go
@@ -1,0 +1,22 @@
+package sgml
+
+import (
+	"strings"
+
+	"github.com/bytesparadise/libasciidoc/pkg/types"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+func (r *sgmlRenderer) renderPredefinedAttribute(a types.PredefinedAttribute) (string, error) {
+	result := &strings.Builder{}
+	if err := r.predefinedAttribute.Execute(result, struct {
+		Name string
+	}{
+		Name: a.Name,
+	}); err != nil {
+		return "", errors.Wrap(err, "error while rendering predefined attribute")
+	}
+	log.Debugf("rendered predefined attribute for '%s': '%s'", a.Name, result.String())
+	return result.String(), nil
+}

--- a/pkg/renderer/sgml/predefined_attribute_test.go
+++ b/pkg/renderer/sgml/predefined_attribute_test.go
@@ -1,14 +1,13 @@
-package types_test
+package sgml
 
 import (
-	"github.com/bytesparadise/libasciidoc/pkg/types"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega" //nolint golint
 )
 
 var _ = DescribeTable("predefined attributes",
 	func(code, rendered string) {
-		Expect(types.Predefined[code]).To(Equal(rendered))
+		Expect(predefinedAttribute(code)).To(Equal(rendered))
 	},
 	Entry("sp", "sp", " "),
 	Entry("blank", "blank", ""),

--- a/pkg/renderer/sgml/sgml_renderer.go
+++ b/pkg/renderer/sgml/sgml_renderer.go
@@ -55,6 +55,7 @@ type sgmlRenderer struct {
 	paragraph                 *textTemplate
 	passthroughBlock          *textTemplate
 	preamble                  *textTemplate
+	predefinedAttribute       *textTemplate
 	qAndAList                 *textTemplate
 	qAndAListItem             *textTemplate
 	quoteBlock                *textTemplate
@@ -134,6 +135,7 @@ func (r *sgmlRenderer) prepareTemplates() error {
 		r.paragraph, err = r.newTemplate("paragraph", tmpls.Paragraph, err)
 		r.passthroughBlock, err = r.newTemplate("passthrough", tmpls.PassthroughBlock, err)
 		r.preamble, err = r.newTemplate("preamble", tmpls.Preamble, err)
+		r.predefinedAttribute, err = r.newTemplate("predefined attribute", tmpls.PredefinedAttribute, err)
 		r.qAndAList, err = r.newTemplate("qanda-list", tmpls.QAndAList, err)
 		r.qAndAListItem, err = r.newTemplate("qanda-list-item", tmpls.QAndAListItem, err)
 		r.quoteBlock, err = r.newTemplate("quote-block", tmpls.QuoteBlock, err)

--- a/pkg/renderer/sgml/special_character.go
+++ b/pkg/renderer/sgml/special_character.go
@@ -12,9 +12,9 @@ func (r *sgmlRenderer) renderSpecialCharacter(s types.SpecialCharacter) (string,
 	log.Debugf("rendering special character...")
 	result := &strings.Builder{}
 	if err := r.specialCharacter.Execute(result, struct {
-		Content string
+		Name string
 	}{
-		Content: s.Content,
+		Name: s.Name,
 	}); err != nil {
 		return "", errors.Wrap(err, "error while rendering special character")
 	}

--- a/pkg/renderer/sgml/table.go
+++ b/pkg/renderer/sgml/table.go
@@ -43,7 +43,7 @@ func (r *sgmlRenderer) renderTable(ctx *renderer.Context, t types.Table) (string
 	if t.Attributes.Has(types.AttrTitle) {
 		c, ok := t.Attributes.GetAsString(types.AttrCaption)
 		if !ok {
-			c, _ = ctx.Attributes.GetAsString(types.AttrTableCaption)
+			c = ctx.Attributes.GetAsStringWithDefault(types.AttrTableCaption, "Table")
 			if c != "" {
 				// We always append the figure number, unless the caption is disabled.
 				// This is for asciidoctor compatibility.

--- a/pkg/renderer/sgml/templates.go
+++ b/pkg/renderer/sgml/templates.go
@@ -48,6 +48,7 @@ type Templates struct {
 	Paragraph                 string
 	PassthroughBlock          string
 	Preamble                  string
+	PredefinedAttribute       string
 	QAndAList                 string
 	QAndAListItem             string
 	QuoteBlock                string

--- a/pkg/renderer/sgml/xhtml5/passthrough_test.go
+++ b/pkg/renderer/sgml/xhtml5/passthrough_test.go
@@ -54,7 +54,7 @@ var _ = Describe("passthroughs", func() {
 		It("an empty standalone singleplus passthrough", func() {
 			source := `++`
 			expected := `<div class="paragraph">
-<p>&#43;&#43;</p>
+<p>++</p>
 </div>
 `
 			Expect(RenderXHTML(source)).To(MatchHTML(expected))
@@ -63,7 +63,7 @@ var _ = Describe("passthroughs", func() {
 		It("an empty singleplus passthrough in a paragraph", func() {
 			source := `++ with more content afterwards...`
 			expected := `<div class="paragraph">
-<p>&#43;&#43; with more content afterwards&#8230;&#8203;</p>
+<p>++ with more content afterwards&#8230;&#8203;</p>
 </div>
 `
 			Expect(RenderXHTML(source)).To(MatchHTML(expected))
@@ -90,7 +90,7 @@ var _ = Describe("passthroughs", func() {
 		It("invalid singleplus passthrough in paragraph", func() {
 			source := `The text + *hello*, world + is not passed through.`
 			expected := `<div class="paragraph">
-<p>The text &#43; <strong>hello</strong>, world &#43; is not passed through.</p>
+<p>The text + <strong>hello</strong>, world + is not passed through.</p>
 </div>
 `
 			Expect(RenderXHTML(source)).To(MatchHTML(expected))

--- a/pkg/types/attributes.go
+++ b/pkg/types/attributes.go
@@ -145,6 +145,7 @@ func NewElementOption(opt string) (Attributes, error) {
 	return Attributes{AttrOptions: opt}, nil
 }
 
+// NewElementNamedAttr a named (or positional) element
 func NewElementNamedAttr(key string, value string) (Attributes, error) {
 	if key == AttrOpts { // Handle the alias
 		key = AttrOptions
@@ -361,10 +362,6 @@ func (a Attributes) GetAsString(key string) (string, bool) {
 			return fmt.Sprintf("%v", v), true
 		}
 	}
-	// check in predefined attributes
-	if value, found := Predefined[key]; found {
-		return value, true
-	}
 	return "", false
 }
 
@@ -377,11 +374,9 @@ func (a Attributes) GetAsStringWithDefault(key, defaultValue string) string {
 		}
 		if value, ok := value.(string); ok {
 			return value
+		} else if v, ok := a[key]; ok {
+			return fmt.Sprintf("%v", v)
 		}
-	}
-	// check in predefined attributes
-	if value, found := Predefined[key]; found {
-		return value
 	}
 	return defaultValue
 }
@@ -468,7 +463,6 @@ func NewAttributes(attributes interface{}) (Attributes, error) {
 // AttrID - these are strings, the first occurrence of this wins, and we set AttrCustomID
 // AttrRole - these are strings, we append them into an array
 // AttrOptions - comma separated list, we split and put into a map
-
 func NewElementAttributes(attributes ...interface{}) (Attributes, error) {
 	if len(attributes) == 0 {
 		return nil, nil
@@ -537,43 +531,3 @@ func resolveAlt(path Location) string {
 	}
 	return filename
 }
-
-// // Has returns the true if an entry with the given key exists
-// func (a Attributes) Has(key string) bool {
-// 	_, ok := a[key]
-// 	return ok
-// }
-
-// // Add adds the given attributes
-// func (a Attributes) Add(attrs map[string]interface{}) {
-// 	for k, v := range attrs {
-// 		a.Add(k, v)
-// 	}
-// }
-
-// // Add adds the given attribute if its value is non-nil
-// // TODO: raise a warning if there was already a name/value
-// func (a Attributes) Add(key string, value interface{}) {
-// 	a[key] = value
-// }
-
-// // AddNonEmpty adds the given attribute if its value is non-nil and non-empty
-// // TODO: raise a warning if there was already a name/value
-// func (a Attributes) AddNonEmpty(key string, value interface{}) {
-// 	// do not add nil or empty values
-// 	if value == "" {
-// 		return
-// 	}
-// 	a.Add(key, value)
-// }
-
-// // AddDeclaration adds the given attribute
-// // TODO: raise a warning if there was already a name/value
-// func (a Attributes) AddDeclaration(attr AttributeDeclaration) {
-// 	a.Add(attr.Name, attr.Value)
-// }
-
-// // Delete deletes the given attribute
-// func (a Attributes) Delete(attr AttributeReset) {
-// 	delete(a, attr.Name)
-// }

--- a/pkg/types/document_attributes_overrides.go
+++ b/pkg/types/document_attributes_overrides.go
@@ -41,10 +41,6 @@ func (a AttributesWithOverrides) GetAsString(key string) (string, bool) {
 	if value, found := a.Overrides[key]; found {
 		return value, true
 	}
-	// check in predefined attributes
-	if value, found := Predefined[key]; found {
-		return value, true
-	}
 	// if value is reset
 	if _, found := a.Overrides["!"+key]; found {
 		return "", false
@@ -60,10 +56,6 @@ func (a AttributesWithOverrides) GetAsString(key string) (string, bool) {
 // or returns the given default value
 func (a AttributesWithOverrides) GetAsStringWithDefault(key, defaultValue string) string {
 	if value, found := a.Overrides[key]; found {
-		return value
-	}
-	// check in predefined attributes
-	if value, found := Predefined[key]; found {
 		return value
 	}
 	if value, found := a.Content[key].(string); found {

--- a/pkg/types/predefined_attributes.go
+++ b/pkg/types/predefined_attributes.go
@@ -1,47 +1,44 @@
 package types
 
-// Predefined the predefined document attributes, mainly for special characters
-var Predefined map[string]string
+// PredefinedAttributes the predefined document attributes
+// May be converted into HTML entities
+var predefinedAttributes = []string{
+	"sp",
+	"blank",
+	"empty",
+	"nbsp",
+	"zwsp",
+	"wj",
+	"apos",
+	"quot",
+	"lsquo",
+	"rsquo",
+	"ldquo",
+	"rdquo",
+	"deg",
+	"plus",
+	"brvbar",
+	"vbar",
+	"amp",
+	"lt",
+	"gt",
+	"startsb",
+	"endsb",
+	"caret",
+	"asterisk",
+	"tilde",
+	"backslash",
+	"backtick",
+	"two-colons",
+	"two-semicolons",
+	"cpp",
+}
 
-func init() {
-	Predefined = map[string]string{
-		"sp":                 " ",
-		"blank":              "",
-		"empty":              "",
-		"nbsp":               "\u00a0",
-		"zwsp":               "\u200b",
-		"wj":                 "\u2060",
-		"apos":               "&#39;",
-		"quot":               "&#34;",
-		"lsquo":              "\u2018",
-		"rsquo":              "\u2019",
-		"ldquo":              "\u201c",
-		"rdquo":              "\u201d",
-		"deg":                "\u00b0",
-		"plus":               "+", // leave this to prevent passthrough decode?
-		"brvbar":             "\u00a6",
-		"vbar":               "|", // TODO: maybe convert this because of tables?
-		"amp":                "&",
-		"lt":                 "<",
-		"gt":                 ">",
-		"startsb":            "[",
-		"endsb":              "]",
-		"caret":              "^",
-		"asterisk":           "*",
-		"tilde":              "~",
-		"backslash":          `\`,
-		"backtick":           "`",
-		"two-colons":         "::",
-		"two-semicolons":     ";",
-		"cpp":                "C++",
-		AttrVersionLabel:     "version",
-		AttrExampleCaption:   "Example",
-		AttrTableCaption:     "Table",
-		AttrFigureCaption:    "Figure",
-		AttrCautionCaption:   "Caution",
-		AttrImportantCaption: "Important",
-		AttrNoteCaption:      "Note",
-		AttrTipCaption:       "Tip",
-		AttrWarningCaption:   "Warning",
+func isPrefedinedAttribute(a string) bool {
+	for _, v := range predefinedAttributes {
+		if v == a {
+			return true
+		}
 	}
+	return false
 }

--- a/pkg/types/table.go
+++ b/pkg/types/table.go
@@ -14,6 +14,7 @@ import (
 // Tables
 // ------------------------------------------
 
+// TableColumn a table column
 type TableColumn struct {
 	widthVal float64 // internally used number, will be 0 for automatic, cleared post processing
 	Width    string  // percentage or relative (0 for automatic)

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -296,10 +296,17 @@ type AttributeSubstitution struct {
 	Name string
 }
 
-// NewAttributeSubstitution initializes a new Document Attribute Substitutions
-func NewAttributeSubstitution(attrName string) (AttributeSubstitution, error) {
-	log.Debugf("initialized a new AttributeSubstitution: '%s'", attrName)
-	return AttributeSubstitution{Name: attrName}, nil
+// PredefinedAttribute a special kind of attribute substitution, which
+// uses a predefined attribute
+type PredefinedAttribute AttributeSubstitution
+
+// NewAttributeSubstitution initializes a new Attribute Substitutions
+func NewAttributeSubstitution(name string) (interface{}, error) {
+	if isPrefedinedAttribute(name) {
+		return PredefinedAttribute{Name: name}, nil
+	}
+	log.Debugf("initialized a new AttributeSubstitution: '%s'", name)
+	return AttributeSubstitution{Name: name}, nil
 }
 
 // CounterSubstitution is a counter, that may increment when it is substituted.
@@ -1101,16 +1108,6 @@ func NewParagraph(lines []interface{}, attributes interface{}) (Paragraph, error
 	if err != nil {
 		return Paragraph{}, errors.Wrapf(err, "failed to initialize a Paragraph element")
 	}
-	// // log.Debugf("initializing a new paragraph with %d line(s) and %d attribute(s)", len(lines), len(attrs))
-	// elements := make([]interface{}, 0)
-	// for _, line := range lines {
-	// 	switch l := line.(type) {
-	// 	case RawLine, SingleLineComment, []interface{}:
-	// 		elements = append(elements, l)
-	// 	default:
-	// 		return Paragraph{}, errors.Errorf("unsupported paragraph line of type %[1]T: %[1]v", line)
-	// 	}
-	// }
 	// log.Debugf("generated a paragraph with %d line(s): %v", len(elements), elements)
 	return Paragraph{
 		Attributes: attrs,
@@ -1135,21 +1132,6 @@ func (p Paragraph) ReplaceFootnotes(notes *Footnotes) interface{} {
 	}
 	return p
 }
-
-// // NewRawAdmonitionParagraph returns a new RawParagraph with an extra admonition attribute
-// func NewRawAdmonitionParagraph(lines []interface{}, admonitionKind AdmonitionKind, attributes interface{}) (RawParagraph, error) {
-// 	log.Debugf("new admonition paragraph")
-// 	attrs, err := NewAttributes(attributes)
-// 	if err != nil {
-// 		return RawParagraph{}, errors.Wrapf(err, "failed to initialize an Admonition Paragraph element")
-// 	}
-// 	p, err := NewRawParagraph(lines, attrs)
-// 	if err != nil {
-// 		return RawParagraph{}, err
-// 	}
-// 	p.Attributes = p.Attributes.Set(AttrAdmonitionKind, admonitionKind)
-// 	return p, nil
-// }
 
 // NewAdmonitionParagraph returns a new Paragraph with an extra admonition attribute
 func NewAdmonitionParagraph(lines []interface{}, admonitionKind AdmonitionKind, attributes interface{}) (Paragraph, error) {
@@ -1317,6 +1299,7 @@ func (i InlineImage) ResolveLocation(attrs AttributesWithOverrides) InlineImage 
 // Icons
 // ------------------------------------------
 
+// Icon an icon
 type Icon struct {
 	Class      string
 	Attributes Attributes
@@ -1487,10 +1470,10 @@ func NewDelimitedBlock(kind BlockKind, elements []interface{}, attributes interf
 	}, nil
 }
 
-// ThematicBreak
-
+// ThematicBreak a thematic break
 type ThematicBreak struct{}
 
+// NewThematicBreak returns a new ThematicBreak
 func NewThematicBreak() (ThematicBreak, error) {
 	return ThematicBreak{}, nil
 }
@@ -1800,11 +1783,13 @@ func NewEscapedQuotedText(backslashes string, punctuation string, content interf
 	}, nil
 }
 
+// QuotedString a quoted string
 type QuotedString struct {
 	Kind     QuotedStringKind
 	Elements []interface{}
 }
 
+// NewQuotedString returns a new QuotedString
 func NewQuotedString(kind QuotedStringKind, elements []interface{}) (QuotedString, error) {
 	return QuotedString{Kind: kind, Elements: elements}, nil
 }
@@ -2309,6 +2294,7 @@ func NewString(v interface{}) (string, error) {
 	}
 }
 
+// NewInlineAttribute returns a new InlineAttribute if the value is a string (or an error otherwise)
 func NewInlineAttribute(name string, value interface{}) (interface{}, error) {
 	if value == nil {
 		return nil, nil
@@ -2327,11 +2313,13 @@ func NewInlineAttribute(name string, value interface{}) (interface{}, error) {
 // ------------------------------------------------------------------------------------
 
 // SpecialCharacter a special character, which may get a special treatment later during rendering
-type SpecialCharacter StringElement
+type SpecialCharacter struct {
+	Name string
+}
 
 // NewSpecialCharacter return a new SpecialCharacter
-func NewSpecialCharacter(content string) (SpecialCharacter, error) {
+func NewSpecialCharacter(name string) (SpecialCharacter, error) {
 	return SpecialCharacter{
-		Content: content,
+		Name: name,
 	}, nil
 }


### PR DESCRIPTION
Provide a new `types.PredefinedAttribute` and its
rendering template.
This moves the logic of discovering predefined
attributes during the parsing, but keeoing the
rendering separate (however, the list/map entries
must match).

Further refactoring may be needed when other backends
with different output for these predefined attributes come,
so this commit may needed some rework in the future.

Fixes #742

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>