### PR TITLE
fix(renderer): do not 'HTML escape' string elements

### DIFF
--- a/pkg/renderer/sgml/html5/delimited_block_test.go
+++ b/pkg/renderer/sgml/html5/delimited_block_test.go
@@ -520,7 +520,7 @@ and "more" content
 <p><strong>bold content</strong></p>
 </div>
 <div class="paragraph">
-<p>and &#34;more&#34; content</p>
+<p>and "more" content</p>
 </div>
 </div>
 </div>

--- a/pkg/renderer/sgml/html5/file_inclusion_test.go
+++ b/pkg/renderer/sgml/html5/file_inclusion_test.go
@@ -243,11 +243,11 @@ include::../../../../test/includes/hello_world.go.txt[]`
 <p>package includes</p>
 </div>
 <div class="paragraph">
-<p>import &#34;fmt&#34;</p>
+<p>import "fmt"</p>
 </div>
 <div class="paragraph">
 <p>func helloworld() {
-	fmt.Println(&#34;hello, world!&#34;)
+	fmt.Println("hello, world!")
 }</p>
 </div>
 `
@@ -296,11 +296,11 @@ include::../../../../test/includes/hello_world.go.txt[]`
 <p>package includes</p>
 </div>
 <div class="paragraph">
-<p>import &#34;fmt&#34;</p>
+<p>import "fmt"</p>
 </div>
 <div class="paragraph">
 <p>func helloworld() {
-	fmt.Println(&#34;hello, world!&#34;)
+	fmt.Println("hello, world!")
 }</p>
 </div>
 </div>
@@ -514,11 +514,11 @@ include::../../../../test/includes/hello_world.go.txt[]
 <p>package includes</p>
 </div>
 <div class="paragraph">
-<p>import &#34;fmt&#34;</p>
+<p>import "fmt"</p>
 </div>
 <div class="paragraph">
 <p>func helloworld() {
-	fmt.Println(&#34;hello, world!&#34;)
+	fmt.Println("hello, world!")
 }</p>
 </div>
 </div>
@@ -537,11 +537,11 @@ ____`
 <p>package includes</p>
 </div>
 <div class="paragraph">
-<p>import &#34;fmt&#34;</p>
+<p>import "fmt"</p>
 </div>
 <div class="paragraph">
 <p>func helloworld() {
-	fmt.Println(&#34;hello, world!&#34;)
+	fmt.Println("hello, world!")
 }</p>
 </div>
 </blockquote>
@@ -558,10 +558,10 @@ ____`
 				expected := `<div class="verseblock">
 <pre class="content">package includes
 
-import &#34;fmt&#34;
+import "fmt"
 
 func helloworld() {
-	fmt.Println(&#34;hello, world!&#34;)
+	fmt.Println("hello, world!")
 }</pre>
 </div>
 `
@@ -578,11 +578,11 @@ include::../../../../test/includes/hello_world.go.txt[]
 <p>package includes</p>
 </div>
 <div class="paragraph">
-<p>import &#34;fmt&#34;</p>
+<p>import "fmt"</p>
 </div>
 <div class="paragraph">
 <p>func helloworld() {
-	fmt.Println(&#34;hello, world!&#34;)
+	fmt.Println("hello, world!")
 }</p>
 </div>
 </div>
@@ -610,7 +610,7 @@ include::../../../../test/includes/hello_world.go.txt[]
 				source := `include::../../../../test/includes/hello_world.go.txt[lines=5..7]`
 				expected := `<div class="paragraph">
 <p>func helloworld() {
-	fmt.Println(&#34;hello, world!&#34;)
+	fmt.Println("hello, world!")
 }</p>
 </div>
 `
@@ -624,7 +624,7 @@ include::../../../../test/includes/hello_world.go.txt[]
 </div>
 <div class="paragraph">
 <p>func helloworld() {
-	fmt.Println(&#34;hello, world!&#34;)
+	fmt.Println("hello, world!")
 }</p>
 </div>
 `

--- a/pkg/renderer/sgml/html5/labeled_list_test.go
+++ b/pkg/renderer/sgml/html5/labeled_list_test.go
@@ -99,7 +99,7 @@ item 2:: description 2.`
 <dl>
 <dt class="hdlist1">item 1</dt>
 <dd>
-<p>&lt;script&gt;alert(&#34;foo!&#34;)&lt;/script&gt;</p>
+<p>&lt;script&gt;alert("foo!")&lt;/script&gt;</p>
 </dd>
 </dl>
 </div>

--- a/pkg/renderer/sgml/html5/paragraph_test.go
+++ b/pkg/renderer/sgml/html5/paragraph_test.go
@@ -65,7 +65,7 @@ and here another paragraph
 		It("paragraph with single quotes", func() {
 			source := `a 'subsection' paragraph.`
 			expected := `<div class="paragraph">
-<p>a &#39;subsection&#39; paragraph.</p>
+<p>a 'subsection' paragraph.</p>
 </div>
 `
 			Expect(RenderHTML(source)).To(MatchHTML(expected))
@@ -99,63 +99,81 @@ some content`
 `
 			Expect(RenderHTML(source)).To(MatchHTML(expected))
 		})
-	})
 
-	Context("paragraphs with line break", func() {
+		Context("with custom substitutions", func() {
 
-		It("with explicit line break", func() {
-			source := `foo +
+			It("with attributes substitution", func() {
+				source := `:github-url: https://github.com
+
+[subs="attributes"]
+a link to https://github.com[] <using the *inline link macro*>
+another one using attribute substitution: {github-url}[]...
+// a single-line comment`
+				expected := `<div class="paragraph">
+<p>a link to https://github.com[] <using the *inline link macro*>
+another one using attribute substitution: https://github.com[]...</p>
+</div>
+`
+				Expect(RenderHTML(source)).To(MatchHTML(expected))
+			})
+		})
+
+		Context("with line break", func() {
+
+			It("with explicit line break", func() {
+				source := `foo +
 bar
 baz`
-			expected := `<div class="paragraph">
+				expected := `<div class="paragraph">
 <p>foo<br>
 bar
 baz</p>
 </div>
 `
-			Expect(RenderHTML(source)).To(MatchHTML(expected))
-		})
+				Expect(RenderHTML(source)).To(MatchHTML(expected))
+			})
 
-		It("with paragraph attribute", func() {
+			It("with paragraph attribute", func() {
 
-			source := `[%hardbreaks]
+				source := `[%hardbreaks]
 foo
 bar
 baz`
-			expected := `<div class="paragraph">
+				expected := `<div class="paragraph">
 <p>foo<br>
 bar<br>
 baz</p>
 </div>
 `
-			Expect(RenderHTML(source)).To(MatchHTML(expected))
-		})
+				Expect(RenderHTML(source)).To(MatchHTML(expected))
+			})
 
-		It("with document attribute", func() {
-			source := `:hardbreaks:
+			It("with document attribute", func() {
+				source := `:hardbreaks:
 foo
 bar
 baz`
-			expected := `<div class="paragraph">
+				expected := `<div class="paragraph">
 <p>foo<br>
 bar<br>
 baz</p>
 </div>
 `
-			Expect(RenderHTML(source)).To(MatchHTML(expected))
-		})
+				Expect(RenderHTML(source)).To(MatchHTML(expected))
+			})
 
-		It("paragraph with document attribute resets", func() {
-			source := `:author: Xavier
+			It("paragraph with document attribute resets", func() {
+				source := `:author: Xavier
 						
 :!author1:
 :author2!:
 a paragraph written by {author}.`
-			expected := `<div class="paragraph">
+				expected := `<div class="paragraph">
 <p>a paragraph written by Xavier.</p>
 </div>
 `
-			Expect(RenderHTML(source)).To(MatchHTML(expected))
+				Expect(RenderHTML(source)).To(MatchHTML(expected))
+			})
 		})
 	})
 

--- a/pkg/renderer/sgml/html5/quoted_string_test.go
+++ b/pkg/renderer/sgml/html5/quoted_string_test.go
@@ -39,7 +39,7 @@ var _ = Describe("quoted strings", func() {
 		It("interior spaces with single quoted string", func() {
 			source := "'` curly was single `' or so they say"
 			expected := "<div class=\"paragraph\">\n" +
-				"<p>&#39;` curly was single &#8217; or so they say</p>\n" +
+				"<p>'` curly was single &#8217; or so they say</p>\n" +
 				"</div>\n"
 			Expect(RenderHTML(source)).To(MatchHTML(expected))
 		})
@@ -209,7 +209,7 @@ var _ = Describe("quoted strings", func() {
 		It("spaces with double quoted string", func() {
 			source := "\"` curly was single `\""
 			expected := "<div class=\"paragraph\">\n" +
-				"<p>&#34;` curly was single `&#34;</p>\n" +
+				"<p>\"` curly was single `\"</p>\n" +
 				"</div>\n"
 			Expect(RenderHTML(source)).To(MatchHTML(expected))
 		})

--- a/pkg/renderer/sgml/html5/quoted_text_test.go
+++ b/pkg/renderer/sgml/html5/quoted_text_test.go
@@ -457,7 +457,7 @@ content</mark>.</p>
 		It("bad syntax", func() {
 			source := "[.<something \"wicked>]**bold**"
 			expected := `<div class="paragraph">
-<p>[.&lt;something &#34;wicked&gt;]<strong>bold</strong></p>
+<p>[.&lt;something "wicked&gt;]<strong>bold</strong></p>
 </div>
 `
 			Expect(RenderHTML(source)).To(MatchHTML(expected))
@@ -737,7 +737,7 @@ b</code></p>
 		It("apostrophes in single bold", func() {
 			source := "this *mother's mothers' mothers`'*\n"
 			expected := "<div class=\"paragraph\">\n" +
-				"<p>this <strong>mother&#8217;s mothers&#39; mothers&#8217;</strong></p>\n" +
+				"<p>this <strong>mother&#8217;s mothers' mothers&#8217;</strong></p>\n" +
 				"</div>\n"
 			Expect(RenderHTML(source)).To(MatchHTML(expected))
 		})
@@ -745,7 +745,7 @@ b</code></p>
 		It("apostrophes in double bold", func() {
 			source := "this **mother's mothers' mothers`'**\n"
 			expected := "<div class=\"paragraph\">\n" +
-				"<p>this <strong>mother&#8217;s mothers&#39; mothers&#8217;</strong></p>\n" +
+				"<p>this <strong>mother&#8217;s mothers' mothers&#8217;</strong></p>\n" +
 				"</div>\n"
 			Expect(RenderHTML(source)).To(MatchHTML(expected))
 		})
@@ -753,7 +753,7 @@ b</code></p>
 		It("apostrophes in single italic", func() {
 			source := "this _mother's mothers' mothers`'_\n"
 			expected := "<div class=\"paragraph\">\n" +
-				"<p>this <em>mother&#8217;s mothers&#39; mothers&#8217;</em></p>\n" +
+				"<p>this <em>mother&#8217;s mothers' mothers&#8217;</em></p>\n" +
 				"</div>\n"
 			Expect(RenderHTML(source)).To(MatchHTML(expected))
 		})
@@ -761,7 +761,7 @@ b</code></p>
 		It("apostrophes in double italic", func() {
 			source := "this __mother's mothers' mothers`'__\n"
 			expected := "<div class=\"paragraph\">\n" +
-				"<p>this <em>mother&#8217;s mothers&#39; mothers&#8217;</em></p>\n" +
+				"<p>this <em>mother&#8217;s mothers' mothers&#8217;</em></p>\n" +
 				"</div>\n"
 			Expect(RenderHTML(source)).To(MatchHTML(expected))
 		})
@@ -769,7 +769,7 @@ b</code></p>
 		It("apostrophes in single mono", func() {
 			source := "this `mother's mothers' day`\n" // no typographic quotes here
 			expected := "<div class=\"paragraph\">\n" +
-				"<p>this <code>mother&#8217;s mothers&#39; day</code></p>\n" +
+				"<p>this <code>mother&#8217;s mothers' day</code></p>\n" +
 				"</div>\n"
 			Expect(RenderHTML(source)).To(MatchHTML(expected))
 		})
@@ -777,7 +777,7 @@ b</code></p>
 		It("apostrophes in double mono", func() {
 			source := "this ``mother's mothers' mothers`' day``\n"
 			expected := "<div class=\"paragraph\">\n" +
-				"<p>this <code>mother&#8217;s mothers&#39; mothers&#8217; day</code></p>\n" +
+				"<p>this <code>mother&#8217;s mothers' mothers&#8217; day</code></p>\n" +
 				"</div>\n"
 			Expect(RenderHTML(source)).To(MatchHTML(expected))
 		})
@@ -785,7 +785,7 @@ b</code></p>
 		It("apostrophes in single marked", func() {
 			source := "this #mother's mothers' mothers`'#\n"
 			expected := "<div class=\"paragraph\">\n" +
-				"<p>this <mark>mother&#8217;s mothers&#39; mothers&#8217;</mark></p>\n" +
+				"<p>this <mark>mother&#8217;s mothers' mothers&#8217;</mark></p>\n" +
 				"</div>\n"
 			Expect(RenderHTML(source)).To(MatchHTML(expected))
 		})
@@ -793,7 +793,7 @@ b</code></p>
 		It("apostrophes in double marked", func() {
 			source := "this ##mother's mothers' mothers`'##\n"
 			expected := "<div class=\"paragraph\">\n" +
-				"<p>this <mark>mother&#8217;s mothers&#39; mothers&#8217;</mark></p>\n" +
+				"<p>this <mark>mother&#8217;s mothers' mothers&#8217;</mark></p>\n" +
 				"</div>\n"
 			Expect(RenderHTML(source)).To(MatchHTML(expected))
 		})

--- a/pkg/renderer/sgml/html5/string.go
+++ b/pkg/renderer/sgml/html5/string.go
@@ -1,5 +1,5 @@
 package html5
 
 const (
-	stringTmpl = "{{ escape . }}"
+	stringTmpl = "{{ . }}"
 )

--- a/pkg/renderer/sgml/html5/string_test.go
+++ b/pkg/renderer/sgml/html5/string_test.go
@@ -57,7 +57,7 @@ var _ = Describe("strings", func() {
 	It("text with implicit apostrophe no match", func() {
 		source := `Mothers' Day`
 		expected := `<div class="paragraph">
-<p>Mothers&#39; Day</p>
+<p>Mothers' Day</p>
 </div>
 `
 		Expect(RenderHTML(source)).To(MatchHTML(expected))

--- a/pkg/renderer/sgml/inline_elements.go
+++ b/pkg/renderer/sgml/inline_elements.go
@@ -43,7 +43,7 @@ func (r *sgmlRenderer) renderInlineElements(ctx *renderer.Context, elements []in
 			if _, ok := element.(types.StringElement); ok { // TODO: only for StringElement? or for any kind of element?
 				// trim trailing spaces before returning the line
 				buf.WriteString(strings.TrimRight(string(renderedElement), " "))
-				log.Debugf("trimmed spaces on '%v'", string(renderedElement))
+				// log.Debugf("trimmed spaces on '%v'", string(renderedElement))
 			} else {
 				buf.WriteString(renderedElement)
 			}

--- a/pkg/renderer/sgml/paragraph.go
+++ b/pkg/renderer/sgml/paragraph.go
@@ -39,15 +39,13 @@ func (r *sgmlRenderer) renderParagraph(ctx *renderer.Context, p types.Paragraph)
 			ID      string
 			Roles   string
 			Title   string
-			Lines   []interface{}
 			Content string
 		}{
 			Context: ctx,
 			ID:      r.renderElementID(p.Attributes),
 			Title:   r.renderElementTitle(p.Attributes),
-			Content: string(content),
 			Roles:   roles,
-			Lines:   p.Lines,
+			Content: string(content),
 		})
 		if err != nil {
 			return "", errors.Wrap(err, "unable to render paragraph")

--- a/pkg/renderer/sgml/xhtml5/delimited_block_test.go
+++ b/pkg/renderer/sgml/xhtml5/delimited_block_test.go
@@ -520,7 +520,7 @@ and "more" content
 <p><strong>bold content</strong></p>
 </div>
 <div class="paragraph">
-<p>and &#34;more&#34; content</p>
+<p>and "more" content</p>
 </div>
 </div>
 </div>

--- a/pkg/renderer/sgml/xhtml5/file_inclusion_test.go
+++ b/pkg/renderer/sgml/xhtml5/file_inclusion_test.go
@@ -243,11 +243,11 @@ include::../../../../test/includes/hello_world.go.txt[]`
 <p>package includes</p>
 </div>
 <div class="paragraph">
-<p>import &#34;fmt&#34;</p>
+<p>import "fmt"</p>
 </div>
 <div class="paragraph">
 <p>func helloworld() {
-	fmt.Println(&#34;hello, world!&#34;)
+	fmt.Println("hello, world!")
 }</p>
 </div>
 `
@@ -296,11 +296,11 @@ include::../../../../test/includes/hello_world.go.txt[]`
 <p>package includes</p>
 </div>
 <div class="paragraph">
-<p>import &#34;fmt&#34;</p>
+<p>import "fmt"</p>
 </div>
 <div class="paragraph">
 <p>func helloworld() {
-	fmt.Println(&#34;hello, world!&#34;)
+	fmt.Println("hello, world!")
 }</p>
 </div>
 </div>
@@ -514,11 +514,11 @@ include::../../../../test/includes/hello_world.go.txt[]
 <p>package includes</p>
 </div>
 <div class="paragraph">
-<p>import &#34;fmt&#34;</p>
+<p>import "fmt"</p>
 </div>
 <div class="paragraph">
 <p>func helloworld() {
-	fmt.Println(&#34;hello, world!&#34;)
+	fmt.Println("hello, world!")
 }</p>
 </div>
 </div>
@@ -537,11 +537,11 @@ ____`
 <p>package includes</p>
 </div>
 <div class="paragraph">
-<p>import &#34;fmt&#34;</p>
+<p>import "fmt"</p>
 </div>
 <div class="paragraph">
 <p>func helloworld() {
-	fmt.Println(&#34;hello, world!&#34;)
+	fmt.Println("hello, world!")
 }</p>
 </div>
 </blockquote>
@@ -558,10 +558,10 @@ ____`
 				expected := `<div class="verseblock">
 <pre class="content">package includes
 
-import &#34;fmt&#34;
+import "fmt"
 
 func helloworld() {
-	fmt.Println(&#34;hello, world!&#34;)
+	fmt.Println("hello, world!")
 }</pre>
 </div>
 `
@@ -578,11 +578,11 @@ include::../../../../test/includes/hello_world.go.txt[]
 <p>package includes</p>
 </div>
 <div class="paragraph">
-<p>import &#34;fmt&#34;</p>
+<p>import "fmt"</p>
 </div>
 <div class="paragraph">
 <p>func helloworld() {
-	fmt.Println(&#34;hello, world!&#34;)
+	fmt.Println("hello, world!")
 }</p>
 </div>
 </div>
@@ -610,7 +610,7 @@ include::../../../../test/includes/hello_world.go.txt[]
 				source := `include::../../../../test/includes/hello_world.go.txt[lines=5..7]`
 				expected := `<div class="paragraph">
 <p>func helloworld() {
-	fmt.Println(&#34;hello, world!&#34;)
+	fmt.Println("hello, world!")
 }</p>
 </div>
 `
@@ -624,7 +624,7 @@ include::../../../../test/includes/hello_world.go.txt[]
 </div>
 <div class="paragraph">
 <p>func helloworld() {
-	fmt.Println(&#34;hello, world!&#34;)
+	fmt.Println("hello, world!")
 }</p>
 </div>
 `

--- a/pkg/renderer/sgml/xhtml5/labeled_list_test.go
+++ b/pkg/renderer/sgml/xhtml5/labeled_list_test.go
@@ -99,7 +99,7 @@ item 2:: description 2.`
 <dl>
 <dt class="hdlist1">item 1</dt>
 <dd>
-<p>&lt;script&gt;alert(&#34;foo!&#34;)&lt;/script&gt;</p>
+<p>&lt;script&gt;alert("foo!")&lt;/script&gt;</p>
 </dd>
 </dl>
 </div>

--- a/pkg/renderer/sgml/xhtml5/paragraph_test.go
+++ b/pkg/renderer/sgml/xhtml5/paragraph_test.go
@@ -65,7 +65,7 @@ and here another paragraph
 		It("paragraph with single quotes", func() {
 			source := `a 'subsection' paragraph.`
 			expected := `<div class="paragraph">
-<p>a &#39;subsection&#39; paragraph.</p>
+<p>a 'subsection' paragraph.</p>
 </div>
 `
 			Expect(RenderXHTML(source)).To(MatchHTML(expected))

--- a/pkg/renderer/sgml/xhtml5/quoted_string_test.go
+++ b/pkg/renderer/sgml/xhtml5/quoted_string_test.go
@@ -31,7 +31,7 @@ var _ = Describe("quoted strings", func() {
 		It("spaces with single quoted string", func() {
 			source := "'` curly was single `' or so they say"
 			expected := "<div class=\"paragraph\">\n" +
-				"<p>&#39;` curly was single &#8217; or so they say</p>\n" +
+				"<p>'` curly was single &#8217; or so they say</p>\n" +
 				"</div>\n"
 			Expect(RenderXHTML(source)).To(MatchHTML(expected))
 		})
@@ -201,7 +201,7 @@ var _ = Describe("quoted strings", func() {
 		It("spaces with double quoted string", func() {
 			source := "\"` curly was single `\""
 			expected := "<div class=\"paragraph\">\n" +
-				"<p>&#34;` curly was single `&#34;</p>\n" +
+				"<p>\"` curly was single `\"</p>\n" +
 				"</div>\n"
 			Expect(RenderXHTML(source)).To(MatchHTML(expected))
 		})

--- a/pkg/renderer/sgml/xhtml5/quoted_text_test.go
+++ b/pkg/renderer/sgml/xhtml5/quoted_text_test.go
@@ -261,7 +261,7 @@ var _ = Describe("quoted texts", func() {
 		It("bad syntax", func() {
 			source := "[.<something \"wicked>]**bold**"
 			expected := `<div class="paragraph">
-<p>[.&lt;something &#34;wicked&gt;]<strong>bold</strong></p>
+<p>[.&lt;something "wicked&gt;]<strong>bold</strong></p>
 </div>
 `
 			Expect(RenderXHTML(source)).To(MatchHTML(expected))

--- a/test/fixtures/supported/basic.html
+++ b/test/fixtures/supported/basic.html
@@ -20,7 +20,7 @@
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight"><code class="language-ruby" data-lang="ruby">puts &#34;Hello, World!&#34;</code></pre>
+<pre class="highlight"><code class="language-ruby" data-lang="ruby">puts "Hello, World!"</code></pre>
 </div>
 </div>
 </div>

--- a/test/fixtures/supported/sample.html
+++ b/test/fixtures/supported/sample.html
@@ -26,7 +26,7 @@ This is test, only a test.
 <div class="sect2">
 <h3 id="id_section_a_subsection">Section A Subsection</h3>
 <div class="paragraph">
-<p><strong>Section A</strong> &#39;subsection&#39; paragraph.</p>
+<p><strong>Section A</strong> 'subsection' paragraph.</p>
 </div>
 </div>
 </div>


### PR DESCRIPTION
With support for special characters in place, there is
no need to using the HTML "escape" func when
rendering StringElements.

Fixes #741

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
