### PR TITLE
feature(renderer): inline images deserve links, too

### DIFF
--- a/pkg/renderer/sgml/html5/image.go
+++ b/pkg/renderer/sgml/html5/image.go
@@ -9,5 +9,5 @@ const (
 {{ else }}
 {{ end }}</div>
 `
-	inlineImageTmpl = `<span class="image{{ if .Roles }} {{ .Roles }}{{ end }}"><img src="{{ .Path }}" alt="{{ .Alt }}"{{ if .Width }} width="{{ .Width }}"{{ end }}{{ if .Height }} height="{{ .Height }}"{{ end }}{{ if .Title }} title="{{ .Title }}"{{ end }}></span>`
+	inlineImageTmpl = `<span class="image{{ if .Roles }} {{ .Roles }}{{ end }}">{{ if ne .Href "" }}<a class="image" href="{{ .Href }}">{{ end }}<img src="{{ .Path }}" alt="{{ .Alt }}"{{ if .Width }} width="{{ .Width }}"{{ end }}{{ if .Height }} height="{{ .Height }}"{{ end }}{{ if .Title }} title="{{ .Title }}"{{ end }}>{{ if ne .Href "" }}</a>{{ end }}</span>`
 )

--- a/pkg/renderer/sgml/html5/image_test.go
+++ b/pkg/renderer/sgml/html5/image_test.go
@@ -214,6 +214,15 @@ image::appa.png[]`
 				Expect(RenderHTML(source)).To(MatchHTML(expected))
 			})
 
+			It("inline image with link", func() {
+				source := "image:foo.png[foo image, link=http://foo.bar]"
+				expected := `<div class="paragraph">
+<p><span class="image"><a class="image" href="http://foo.bar"><img src="foo.png" alt="foo image"></a></span></p>
+</div>
+`
+				Expect(RenderHTML(source)).To(MatchHTML(expected))
+			})
+
 			It("paragraph with inline image with alt and dimensions", func() {
 				source := "a foo image:foo.png[foo image, 600, 400] bar"
 				expected := `<div class="paragraph">

--- a/pkg/renderer/sgml/image.go
+++ b/pkg/renderer/sgml/image.go
@@ -87,6 +87,7 @@ func (r *sgmlRenderer) renderInlineImage(img types.InlineImage) (string, error) 
 	}{
 		Title:  r.renderElementTitle(img.Attributes),
 		Roles:  roles,
+		Href:   img.Attributes.GetAsStringWithDefault(types.AttrInlineLink, ""),
 		Alt:    img.Attributes.GetAsStringWithDefault(types.AttrImageAlt, ""),
 		Width:  img.Attributes.GetAsStringWithDefault(types.AttrWidth, ""),
 		Height: img.Attributes.GetAsStringWithDefault(types.AttrImageHeight, ""),

--- a/pkg/renderer/sgml/xhtml5/image.go
+++ b/pkg/renderer/sgml/xhtml5/image.go
@@ -15,9 +15,10 @@ const (
 		"</div>\n"
 
 	inlineImageTmpl = `<span class="image{{ if .Roles }} {{ .Roles }}{{ end }}">` +
+		`{{ if .Href }}<a class="image" href="{{ .Href }}">{{ end }}` +
 		`<img src="{{ .Path }}" alt="{{ .Alt }}"` +
 		`{{ if .Width }} width="{{ .Width }}"{{ end }}` +
 		`{{ if .Height }} height="{{ .Height }}"{{ end }}` +
 		`{{ if .Title }} title="{{ .Title }}"{{ end }}` +
-		`/></span>`
+		`/>{{ if .Href }}</a>{{ end }}</span>`
 )

--- a/pkg/renderer/sgml/xhtml5/image_test.go
+++ b/pkg/renderer/sgml/xhtml5/image_test.go
@@ -201,6 +201,15 @@ image::appa.png[]`
 				Expect(RenderXHTML(source)).To(MatchHTML(expected))
 			})
 
+			It("inline image with link", func() {
+				source := "image:foo.png[foo image, link=http://foo.bar]"
+				expected := `<div class="paragraph">
+<p><span class="image"><a class="image" href="http://foo.bar"><img src="foo.png" alt="foo image"/></a></span></p>
+</div>
+`
+				Expect(RenderXHTML(source)).To(MatchHTML(expected))
+			})
+
 			It("paragraph with inline image with alt and dimensions", func() {
 				source := "a foo image:foo.png[foo image, 600, 400] bar"
 				expected := `<div class="paragraph">


### PR DESCRIPTION
They are used in libasciidoc's own README.adoc for badges and I wanted to use them in mine, without working around it with line noise:

```
perl -pe 's|\b(image:.*?\[.*?),\s*link=([^,]*?)(\])|+++<a href=$2>+++\n$1$3\n+++</a>+++|gx'
```

So that I'm not just bitching in issues. :) This was easy enough to add, even if tiring because of two super similar backends. Also notice that the templates are formatted differently.