### PR TITLE
test(parser/renderer): verify special characters

### DIFF
--- a/pkg/parser/special_character_test.go
+++ b/pkg/parser/special_character_test.go
@@ -1,0 +1,117 @@
+package parser_test
+
+import (
+	"github.com/bytesparadise/libasciidoc/pkg/types"
+	. "github.com/bytesparadise/libasciidoc/testsupport"
+
+	. "github.com/onsi/ginkgo" //nolint golint
+	. "github.com/onsi/gomega" //nolint golint
+)
+
+var _ = Describe("special characters", func() {
+
+	It("should parse in paragraph", func() {
+		source := "<b>*</b> &apos; &amp;"
+		expected := types.DraftDocument{
+			Blocks: []interface{}{
+				types.Paragraph{
+					Lines: []interface{}{
+						[]interface{}{
+							types.SpecialCharacter{
+								Name: "<",
+							},
+							types.StringElement{
+								Content: "b",
+							},
+							types.SpecialCharacter{
+								Name: ">",
+							},
+							types.StringElement{
+								Content: "*",
+							},
+							types.SpecialCharacter{
+								Name: "<",
+							},
+							types.StringElement{
+								Content: "/b",
+							},
+							types.SpecialCharacter{
+								Name: ">",
+							},
+							types.StringElement{
+								Content: " ",
+							},
+							types.SpecialCharacter{
+								Name: "&",
+							},
+							types.StringElement{
+								Content: "apos; ",
+							},
+							types.SpecialCharacter{
+								Name: "&",
+							},
+							types.StringElement{
+								Content: "amp;",
+							},
+						},
+					},
+				},
+			},
+		}
+		Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
+	})
+
+	It("should parse in delimited block", func() {
+		source := "```" + "\n" +
+			"<b>*</b> &apos; &amp;" + "\n" +
+			"```"
+		expected := types.DraftDocument{
+			Blocks: []interface{}{
+				types.DelimitedBlock{
+					Kind: types.Fenced,
+					Elements: []interface{}{
+						[]interface{}{
+							types.SpecialCharacter{
+								Name: "<",
+							},
+							types.StringElement{
+								Content: "b",
+							},
+							types.SpecialCharacter{
+								Name: ">",
+							},
+							types.StringElement{
+								Content: "*",
+							},
+							types.SpecialCharacter{
+								Name: "<",
+							},
+							types.StringElement{
+								Content: "/b",
+							},
+							types.SpecialCharacter{
+								Name: ">",
+							},
+							types.StringElement{
+								Content: " ",
+							},
+							types.SpecialCharacter{
+								Name: "&",
+							},
+							types.StringElement{
+								Content: "apos; ",
+							},
+							types.SpecialCharacter{
+								Name: "&",
+							},
+							types.StringElement{
+								Content: "amp;",
+							},
+						},
+					},
+				},
+			},
+		}
+		Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
+	})
+})

--- a/pkg/renderer/sgml/html5/special_character_test.go
+++ b/pkg/renderer/sgml/html5/special_character_test.go
@@ -1,0 +1,50 @@
+package html5_test
+
+import (
+	. "github.com/bytesparadise/libasciidoc/testsupport"
+
+	. "github.com/onsi/ginkgo" //nolint golint
+	. "github.com/onsi/gomega" //nolint golint
+)
+
+var _ = Describe("special characters", func() {
+
+	It("should parse in paragraph", func() {
+		source := "<b>*</b> &apos; &amp;"
+		expected := `<div class="paragraph">
+<p>&lt;b&gt;*&lt;/b&gt; &amp;apos; &amp;amp;</p>
+</div>
+`
+		Expect(RenderHTML(source)).To(MatchHTML(expected))
+	})
+
+	It("should parse in delimited block", func() {
+		source := "```" + "\n" +
+			"<b>*</b> &apos; &amp;" + "\n" +
+			"```"
+		expected := `<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>&lt;b&gt;*&lt;/b&gt; &amp;apos; &amp;amp;</code></pre>
+</div>
+</div>
+`
+		Expect(RenderHTML(source)).To(MatchHTML(expected))
+	})
+
+	It("should parse in paragraph and delimited block", func() {
+		source := "<b>*</b> &apos; &amp;" + "\n\n" +
+			"```" + "\n" +
+			"<b>*</b> &apos; &amp;" + "\n" +
+			"```"
+		expected := `<div class="paragraph">
+<p>&lt;b&gt;*&lt;/b&gt; &amp;apos; &amp;amp;</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>&lt;b&gt;*&lt;/b&gt; &amp;apos; &amp;amp;</code></pre>
+</div>
+</div>
+`
+		Expect(RenderHTML(source)).To(MatchHTML(expected))
+	})
+})


### PR DESCRIPTION
Verifies that special characters are properly
handled in paragraphs and delimited blocks

Fixes #751

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>