### PR TITLE
chore(test): avoid warning logs when running tests

### DIFF
--- a/cmd/libasciidoc/root_cmd.go
+++ b/cmd/libasciidoc/root_cmd.go
@@ -36,7 +36,7 @@ func NewRootCmd() *cobra.Command {
 				fmt.Fprintf(cmd.OutOrStderr(), "unable to parse log level '%v'", logLevel)
 				return err
 			}
-			logsupport.Setup()
+			logsupport.Setup(log.WarnLevel)
 			log.SetLevel(lvl)
 			log.SetOutput(cmd.OutOrStdout())
 			return nil

--- a/pkg/log/log_init.go
+++ b/pkg/log/log_init.go
@@ -5,7 +5,8 @@ import (
 )
 
 // Setup configures the logger
-func Setup() {
+func Setup(level log.Level) {
+	log.SetLevel(level)
 	log.SetFormatter(&log.TextFormatter{
 		EnvironmentOverrideColors: true,
 		DisableLevelTruncation:    true,

--- a/pkg/parser/document_processing_include_files_test.go
+++ b/pkg/parser/document_processing_include_files_test.go
@@ -80,7 +80,7 @@ var _ = Describe("file inclusions", func() {
 		Context("without file inclusions", func() {
 
 			It("should include adoc file without leveloffset in local dir", func() {
-				console, reset := ConfigureLogger()
+				logs, reset := ConfigureLogger(log.WarnLevel)
 				defer reset()
 				source := "include::../../test/includes/chapter-a.adoc[]"
 				expected := types.RawDocument{
@@ -99,11 +99,11 @@ var _ = Describe("file inclusions", func() {
 				}
 				Expect(ParseRawDocument(source, WithFilename("test.adoc"), WithoutFileInclusions())).To(MatchRawDocument(expected))
 				// verify no error/warning in logs
-				Expect(console).ToNot(ContainAnyMessageWithLevels(log.ErrorLevel, log.WarnLevel))
+				Expect(logs).ToNot(ContainAnyMessageWithLevels(log.ErrorLevel, log.WarnLevel))
 			})
 
 			It("should include adoc file without leveloffset in relative dir", func() {
-				console, reset := ConfigureLogger()
+				logs, reset := ConfigureLogger(log.WarnLevel)
 				defer reset()
 				source := "include::../../../test/includes/chapter-a.adoc[]"
 				expected := types.RawDocument{
@@ -122,7 +122,7 @@ var _ = Describe("file inclusions", func() {
 				}
 				Expect(ParseRawDocument(source, WithFilename("tmp/foo.adoc"), WithoutFileInclusions())).To(MatchRawDocument(expected))
 				// verify no error/warning in logs
-				Expect(console).ToNot(ContainAnyMessageWithLevels(log.ErrorLevel, log.WarnLevel))
+				Expect(logs).ToNot(ContainAnyMessageWithLevels(log.ErrorLevel, log.WarnLevel))
 			})
 
 			It("should include adoc file with leveloffset attribute", func() {
@@ -675,7 +675,7 @@ var _ = Describe("file inclusions", func() {
 		Context("with file inclusions", func() {
 
 			It("should include adoc file without leveloffset from local file", func() {
-				console, reset := ConfigureLogger()
+				logs, reset := ConfigureLogger(log.WarnLevel)
 				defer reset()
 				source := "include::../../test/includes/chapter-a.adoc[]"
 				expected := types.RawDocument{
@@ -701,11 +701,11 @@ var _ = Describe("file inclusions", func() {
 				}
 				Expect(ParseRawDocument(source, WithFilename("foo.adoc"))).To(MatchRawDocument(expected))
 				// verify no error/warning in logs
-				Expect(console).ToNot(ContainAnyMessageWithLevels(log.ErrorLevel, log.WarnLevel))
+				Expect(logs).ToNot(ContainAnyMessageWithLevels(log.ErrorLevel, log.WarnLevel))
 			})
 
 			It("should include adoc file without leveloffset from relative file", func() {
-				console, reset := ConfigureLogger()
+				logs, reset := ConfigureLogger(log.WarnLevel)
 				defer reset()
 				source := "include::../../../test/includes/chapter-a.adoc[]"
 				expected := types.RawDocument{
@@ -731,11 +731,11 @@ var _ = Describe("file inclusions", func() {
 				}
 				Expect(ParseRawDocument(source, WithFilename("tmp/foo.adoc"))).To(MatchRawDocument(expected))
 				// verify no error/warning in logs
-				Expect(console).ToNot(ContainAnyMessageWithLevels(log.ErrorLevel, log.WarnLevel))
+				Expect(logs).ToNot(ContainAnyMessageWithLevels(log.ErrorLevel, log.WarnLevel))
 			})
 
 			It("should include adoc file with leveloffset", func() {
-				console, reset := ConfigureLogger()
+				logs, reset := ConfigureLogger(log.WarnLevel)
 				defer reset()
 				source := "include::../../test/includes/chapter-a.adoc[leveloffset=+1]"
 				expected := types.RawDocument{
@@ -761,7 +761,7 @@ var _ = Describe("file inclusions", func() {
 				}
 				Expect(ParseRawDocument(source)).To(MatchRawDocument(expected))
 				// verify no error/warning in logs
-				Expect(console).ToNot(ContainAnyMessageWithLevels(log.ErrorLevel, log.WarnLevel))
+				Expect(logs).ToNot(ContainAnyMessageWithLevels(log.ErrorLevel, log.WarnLevel))
 			})
 
 			It("should include section 0 by default", func() {
@@ -1497,7 +1497,7 @@ include::../../test/includes/chapter-a.adoc[]
 				Context("with quoted line ranges", func() {
 
 					It("file inclusion with single quoted line", func() {
-						console, reset := ConfigureLogger()
+						logs, reset := ConfigureLogger(log.WarnLevel)
 						defer reset()
 						source := `include::../../test/includes/chapter-a.adoc[lines="1"]`
 						expected := types.RawDocument{
@@ -1515,7 +1515,7 @@ include::../../test/includes/chapter-a.adoc[]
 						}
 						Expect(ParseRawDocument(source)).To(MatchRawDocument(expected))
 						// verify no error/warning in logs
-						Expect(console).ToNot(ContainAnyMessageWithLevels(log.ErrorLevel, log.WarnLevel))
+						Expect(logs).ToNot(ContainAnyMessageWithLevels(log.ErrorLevel, log.WarnLevel))
 					})
 
 					It("file inclusion with multiple quoted lines", func() {
@@ -1639,7 +1639,7 @@ include::../../test/includes/chapter-a.adoc[]
 			Context("with tag ranges", func() {
 
 				It("file inclusion with single tag", func() {
-					console, reset := ConfigureLogger()
+					logs, reset := ConfigureLogger(log.WarnLevel)
 					defer reset()
 					source := `include::../../test/includes/tag-include.adoc[tag=section]`
 					expected := types.RawDocument{
@@ -1657,11 +1657,11 @@ include::../../test/includes/chapter-a.adoc[]
 					}
 					Expect(ParseRawDocument(source)).To(MatchRawDocument(expected))
 					// verify no error/warning in logs
-					Expect(console).ToNot(ContainAnyMessageWithLevels(log.ErrorLevel, log.WarnLevel))
+					Expect(logs).ToNot(ContainAnyMessageWithLevels(log.ErrorLevel, log.WarnLevel))
 				})
 
 				It("file inclusion with surrounding tag", func() {
-					console, reset := ConfigureLogger()
+					logs, reset := ConfigureLogger(log.WarnLevel)
 					defer reset()
 					source := `include::../../test/includes/tag-include.adoc[tag=doc]`
 					expected := types.RawDocument{
@@ -1688,12 +1688,12 @@ include::../../test/includes/chapter-a.adoc[]
 					}
 					Expect(ParseRawDocument(source)).To(MatchRawDocument(expected))
 					// verify no error/warning in logs
-					Expect(console).ToNot(ContainAnyMessageWithLevels(log.ErrorLevel, log.WarnLevel))
+					Expect(logs).ToNot(ContainAnyMessageWithLevels(log.ErrorLevel, log.WarnLevel))
 				})
 
 				It("file inclusion with unclosed tag", func() {
 					// setup logger to write in a buffer so we can check the output
-					console, reset := ConfigureLogger()
+					logs, reset := ConfigureLogger(log.WarnLevel)
 					defer reset()
 					source := `include::../../test/includes/tag-include-unclosed.adoc[tag=unclosed]`
 					expected := types.RawDocument{
@@ -1719,7 +1719,7 @@ include::../../test/includes/chapter-a.adoc[]
 					}
 					Expect(ParseRawDocument(source)).To(MatchRawDocument(expected))
 					// verify error in logs
-					Expect(console).To(ContainMessageWithLevel(log.WarnLevel,
+					Expect(logs).To(ContainMessageWithLevel(log.WarnLevel,
 						"detected unclosed tag 'unclosed' starting at line 6 of include file: ../../test/includes/tag-include-unclosed.adoc",
 					))
 				})

--- a/pkg/renderer/sgml/html5/file_inclusion_test.go
+++ b/pkg/renderer/sgml/html5/file_inclusion_test.go
@@ -15,7 +15,7 @@ import (
 var _ = Describe("file inclusions", func() {
 
 	It("should include adoc file without leveloffset from local file", func() {
-		console, reset := ConfigureLogger()
+		logs, reset := ConfigureLogger(log.WarnLevel)
 		defer reset()
 		lastUpdated := time.Now()
 		source := "include::../../../../test/includes/grandchild-include.adoc[]"
@@ -47,11 +47,11 @@ var _ = Describe("file inclusions", func() {
 			},
 		}))
 		// verify no error/warning in logs
-		Expect(console).ToNot(ContainAnyMessageWithLevels(log.ErrorLevel, log.WarnLevel))
+		Expect(logs).ToNot(ContainAnyMessageWithLevels(log.ErrorLevel, log.WarnLevel))
 	})
 
 	It("should include adoc file without leveloffset from relative file", func() {
-		console, reset := ConfigureLogger()
+		logs, reset := ConfigureLogger(log.WarnLevel)
 		defer reset()
 		source := "include::../../../../../test/includes/grandchild-include.adoc[]"
 		expected := `<div class="sect1">
@@ -68,7 +68,7 @@ var _ = Describe("file inclusions", func() {
 `
 		Expect(RenderHTML(source, configuration.WithFilename("tmp/foo.adoc"))).To(Equal(expected))
 		// verify no error/warning in logs
-		Expect(console).ToNot(ContainAnyMessageWithLevels(log.ErrorLevel, log.WarnLevel))
+		Expect(logs).ToNot(ContainAnyMessageWithLevels(log.ErrorLevel, log.WarnLevel))
 	})
 
 	It("should include grandchild content with relative offset", func() {
@@ -709,7 +709,7 @@ func helloworld() {
 		})
 
 		It("file inclusion with unclosed tag", func() {
-			console, reset := ConfigureLogger()
+			logs, reset := ConfigureLogger(log.WarnLevel)
 			defer reset()
 			source := `include::../../../../test/includes/tag-include-unclosed.adoc[tag=unclosed]`
 			expected := `<div class="paragraph">
@@ -721,7 +721,7 @@ func helloworld() {
 `
 			Expect(RenderHTML(source)).To(MatchHTML(expected))
 			// verify error in logs
-			Expect(console).To(
+			Expect(logs).To(
 				ContainMessageWithLevel(
 					log.WarnLevel,
 					"detected unclosed tag 'unclosed' starting at line 6 of include file: ../../../../test/includes/tag-include-unclosed.adoc",

--- a/pkg/renderer/sgml/xhtml5/file_inclusion_test.go
+++ b/pkg/renderer/sgml/xhtml5/file_inclusion_test.go
@@ -15,7 +15,7 @@ import (
 var _ = Describe("file inclusions", func() {
 
 	It("should include adoc file without leveloffset from local file", func() {
-		console, reset := ConfigureLogger()
+		logs, reset := ConfigureLogger(log.WarnLevel)
 		defer reset()
 		lastUpdated := time.Now()
 		source := "include::../../../../test/includes/grandchild-include.adoc[]"
@@ -47,11 +47,11 @@ var _ = Describe("file inclusions", func() {
 			},
 		}))
 		// verify no error/warning in logs
-		Expect(console).ToNot(ContainAnyMessageWithLevels(log.ErrorLevel, log.WarnLevel))
+		Expect(logs).ToNot(ContainAnyMessageWithLevels(log.ErrorLevel, log.WarnLevel))
 	})
 
 	It("should include adoc file without leveloffset from relative file", func() {
-		console, reset := ConfigureLogger()
+		logs, reset := ConfigureLogger(log.WarnLevel)
 		defer reset()
 		source := "include::../../../../../test/includes/grandchild-include.adoc[]"
 		expected := `<div class="sect1">
@@ -68,7 +68,7 @@ var _ = Describe("file inclusions", func() {
 `
 		Expect(RenderXHTML(source, configuration.WithFilename("tmp/foo.adoc"))).To(Equal(expected))
 		// verify no error/warning in logs
-		Expect(console).ToNot(ContainAnyMessageWithLevels(log.ErrorLevel, log.WarnLevel))
+		Expect(logs).ToNot(ContainAnyMessageWithLevels(log.ErrorLevel, log.WarnLevel))
 	})
 
 	It("should include grandchild content with relative offset", func() {
@@ -709,7 +709,7 @@ func helloworld() {
 		})
 
 		It("file inclusion with unclosed tag", func() {
-			console, reset := ConfigureLogger()
+			logs, reset := ConfigureLogger(log.WarnLevel)
 			defer reset()
 			source := `include::../../../../test/includes/tag-include-unclosed.adoc[tag=unclosed]`
 			expected := `<div class="paragraph">
@@ -721,7 +721,7 @@ func helloworld() {
 `
 			Expect(RenderXHTML(source)).To(MatchHTML(expected))
 			// verify error in logs
-			Expect(console).To(
+			Expect(logs).To(
 				ContainMessageWithLevel(
 					log.WarnLevel,
 					"detected unclosed tag 'unclosed' starting at line 6 of include file: ../../../../test/includes/tag-include-unclosed.adoc",

--- a/testsupport/console_matcher.go
+++ b/testsupport/console_matcher.go
@@ -16,7 +16,7 @@ import (
 // ConfigureLogger configures the logger to write to a `Readable`.
 // Also returns a func that can be used to reset the logger at the
 // end of the test.
-func ConfigureLogger() (io.Reader, func()) {
+func ConfigureLogger(level log.Level) (io.Reader, func()) {
 	fmtr := log.StandardLogger().Formatter
 	t := tee{
 		buf: bytes.NewBuffer(nil),
@@ -26,9 +26,12 @@ func ConfigureLogger() (io.Reader, func()) {
 	log.SetFormatter(&log.JSONFormatter{
 		DisableTimestamp: true,
 	})
+	oldLevel := log.GetLevel()
+	log.SetLevel(level)
 	return t, func() {
 		log.SetOutput(os.Stdout)
 		log.SetFormatter(fmtr)
+		log.SetLevel(oldLevel)
 	}
 }
 

--- a/testsupport/log_init.go
+++ b/testsupport/log_init.go
@@ -5,11 +5,12 @@ import (
 	"os"
 
 	logsupport "github.com/bytesparadise/libasciidoc/pkg/log"
+	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
 )
 
 func init() {
-	logsupport.Setup()
+	logsupport.Setup(logrus.ErrorLevel)
 	if debugMode() {
 		log.SetLevel(log.DebugLevel)
 		log.Info("Running test with logs in DEBUG level")


### PR DESCRIPTION
unless the `-debug` flag was provided

this makes the output of the `ginkgo` command much easier
to read.

also, rename `console` to `logs` in tests.

Fixes #762

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>