### PR TITLE
feat(parser): support for 'idseparator' attribute

### DIFF
--- a/pkg/parser/section_test.go
+++ b/pkg/parser/section_test.go
@@ -142,6 +142,36 @@ and a paragraph`
 				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
+			It("section level 1 with custom idseparator", func() {
+				source := `:idseparator: -
+				
+== section 1`
+				section1Title := []interface{}{
+					types.StringElement{Content: "section 1"},
+				}
+				expected := types.DraftDocument{
+					Attributes: types.Attributes{
+						types.AttrIDSeparator: "-",
+					},
+					Elements: []interface{}{
+						types.AttributeDeclaration{
+							Name:  types.AttrIDSeparator,
+							Value: "-",
+						},
+						types.BlankLine{},
+						types.Section{
+							Attributes: types.Attributes{
+								types.AttrID: "_section-1",
+							},
+							Level:    1,
+							Title:    section1Title,
+							Elements: []interface{}{},
+						},
+					},
+				}
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
+			})
+
 			It("section level 1 with quoted text", func() {
 				source := `==  *2 spaces and bold content*`
 				sectionTitle := []interface{}{

--- a/pkg/renderer/sgml/html5/section_test.go
+++ b/pkg/renderer/sgml/html5/section_test.go
@@ -32,6 +32,19 @@ var _ = Describe("sections", func() {
 			Expect(RenderHTML(source)).To(MatchHTML(expected))
 		})
 
+		It("section level 1 with custom idseparator", func() {
+			source := `:idseparator: -
+			
+== section 1`
+			expected := `<div class="sect1">
+<h2 id="_section-1">section 1</h2>
+<div class="sectionbody">
+</div>
+</div>
+`
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+		})
+
 		It("section level 1 alone with roles and id", func() {
 			source := "[.role1#anchor.role2]\n== a title with *bold* content"
 			// top-level section is not rendered per-say,

--- a/pkg/types/attributes.go
+++ b/pkg/types/attributes.go
@@ -19,10 +19,16 @@ const (
 	AttrDocType = "doctype"
 	// AttrSyntaxHighlighter the attribute to define the syntax highlighter on code source blocks
 	AttrSyntaxHighlighter = "source-highlighter"
+	// AttrID the key to retrieve the ID
+	AttrID = "id"
 	// AttrIDPrefix the key to retrieve the ID Prefix
 	AttrIDPrefix = "idprefix"
 	// DefaultIDPrefix the default ID Prefix
 	DefaultIDPrefix = "_"
+	// AttrIDSeparator the key to retrieve the ID Separator
+	AttrIDSeparator = "idseparator"
+	// DefaultIDSeparator the default ID Separator
+	DefaultIDSeparator = "_"
 	// AttrTableOfContents the `toc` attribute at document level
 	AttrTableOfContents = "toc"
 	// AttrTableOfContentsLevels the document attribute which specifies the number of levels to display in the ToC
@@ -31,8 +37,6 @@ const (
 	AttrNoHeader = "noheader"
 	// AttrNoFooter attribute to disable the rendering of document footer
 	AttrNoFooter = "nofooter"
-	// AttrID the key to retrieve the ID
-	AttrID = "id"
 	// AttrCustomID the key to retrieve the flag that indicates if the element ID is custom or generated
 	AttrCustomID = "@customID"
 	// AttrTitle the key to retrieve the title

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -547,7 +547,8 @@ func NewSection(level int, title []interface{}, ids []interface{}, attributes in
 func (s Section) ResolveID(docAttributes AttributesWithOverrides) (Section, error) {
 	if !s.Attributes.GetAsBool(AttrCustomID) {
 		log.Debugf("resolving section id")
-		replacement, err := ReplaceNonAlphanumerics(s.Title, "_")
+		separator := docAttributes.GetAsStringWithDefault(AttrIDSeparator, DefaultIDSeparator)
+		replacement, err := ReplaceNonAlphanumerics(s.Title, separator)
 		if err != nil {
 			return s, errors.Wrapf(err, "failed to generate default ID on Section element")
 		}


### PR DESCRIPTION
Fixes #783

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
