### PR TITLE
feat(renderer): default HTML title

### DIFF
--- a/libasciidoc_test.go
+++ b/libasciidoc_test.go
@@ -37,9 +37,10 @@ var _ = Describe("documents", func() {
 			It("empty document", func() {
 				// main title alone is not rendered in the body
 				source := ""
+				expectedTitle := ""
 				expectedContent := ""
 				Expect(RenderHTML(source)).To(Equal(expectedContent))
-				Expect(RenderHTML5Title(source)).To(Equal(""))
+				Expect(MetadataTitle(source)).To(Equal(expectedTitle))
 			})
 
 			It("document with no section", func() {
@@ -48,7 +49,7 @@ var _ = Describe("documents", func() {
 				expectedTitle := "a document title"
 				expectedContent := ""
 				Expect(RenderHTML(source)).To(Equal(expectedContent))
-				Expect(RenderHTML5Title(source)).To(Equal(expectedTitle))
+				Expect(MetadataTitle(source)).To(Equal(expectedTitle))
 			})
 
 			It("section levels 0 and 1", func() {
@@ -68,13 +69,14 @@ a paragraph with *bold content*`
 </div>
 `
 				Expect(RenderHTML(source)).To(Equal(expectedContent))
-				Expect(RenderHTML5Title(source)).To(Equal(expectedTitle))
+				Expect(MetadataTitle(source)).To(Equal(expectedTitle))
 			})
 
 			It("section level 1 with a paragraph", func() {
 				source := `== Section A
 
 a paragraph with *bold content*`
+				expectedTitle := ""
 				expectedContent := `<div class="sect1">
 <h2 id="_section_a">Section A</h2>
 <div class="sectionbody">
@@ -85,7 +87,7 @@ a paragraph with *bold content*`
 </div>
 `
 				Expect(RenderHTML(source)).To(Equal(expectedContent))
-				Expect(RenderHTML5Title(source)).To(Equal(""))
+				Expect(MetadataTitle(source)).To(Equal(expectedTitle))
 			})
 
 			It("section levels 0, 1 and 3", func() {
@@ -115,7 +117,7 @@ a paragraph`
 </div>
 `
 				Expect(RenderHTML(source)).To(Equal(expectedContent))
-				Expect(RenderHTML5Title(source)).To(Equal(expectedTitle))
+				Expect(MetadataTitle(source)).To(Equal(expectedTitle))
 				Expect(DocumentMetadata(source, lastUpdated)).To(Equal(types.Metadata{
 					Title:       "a document title",
 					LastUpdated: lastUpdated.Format(configuration.LastUpdatedFormat),
@@ -178,7 +180,7 @@ a paragraph with _italic content_`
 </div>
 `
 				Expect(RenderHTML(source)).To(Equal(expectedContent))
-				Expect(RenderHTML5Title(source)).To(Equal(expectedTitle))
+				Expect(MetadataTitle(source)).To(Equal(expectedTitle))
 				Expect(DocumentMetadata(source, lastUpdated)).To(Equal(types.Metadata{
 					Title:       "a document title",
 					LastUpdated: lastUpdated.Format(configuration.LastUpdatedFormat),

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -19,23 +19,24 @@ func NewConfiguration(settings ...Setting) Configuration {
 
 // Configuration the configuration used when rendering a document
 type Configuration struct {
-	Filename            string
-	AttributeOverrides  map[string]string
-	LastUpdated         time.Time
-	IncludeHeaderFooter bool
-	CSS                 string
-	BackEnd             string
-	macros              map[string]MacroTemplate
+	Filename           string
+	AttributeOverrides map[string]string
+	LastUpdated        time.Time
+	// WrapInHTMLBodyElement flag to include the content in an html>body element
+	WrapInHTMLBodyElement bool
+	CSS                   string
+	BackEnd               string
+	macros                map[string]MacroTemplate
 }
 
 // Clone return a clone of the current configuration
 func (c Configuration) Clone() Configuration {
 	return Configuration{
-		CSS:                 c.CSS,
-		AttributeOverrides:  c.AttributeOverrides,
-		Filename:            c.Filename,
-		IncludeHeaderFooter: c.IncludeHeaderFooter,
-		LastUpdated:         c.LastUpdated,
+		CSS:                   c.CSS,
+		AttributeOverrides:    c.AttributeOverrides,
+		Filename:              c.Filename,
+		WrapInHTMLBodyElement: c.WrapInHTMLBodyElement,
+		LastUpdated:           c.LastUpdated,
 	}
 }
 
@@ -80,7 +81,7 @@ func WithAttribute(key, value string) Setting {
 // WithHeaderFooter function to set the `include header/footer` setting in the config
 func WithHeaderFooter(value bool) Setting {
 	return func(config *Configuration) {
-		config.IncludeHeaderFooter = value
+		config.WrapInHTMLBodyElement = value
 	}
 }
 

--- a/pkg/renderer/sgml/elements.go
+++ b/pkg/renderer/sgml/elements.go
@@ -13,7 +13,7 @@ import (
 func (r *sgmlRenderer) renderElements(ctx *renderer.Context, elements []interface{}) (string, error) {
 	log.Debugf("rendering %d elements(s)...", len(elements))
 	buff := &strings.Builder{}
-	if !ctx.Config.IncludeHeaderFooter && len(elements) > 0 {
+	if !ctx.Config.WrapInHTMLBodyElement && len(elements) > 0 {
 		if s, ok := elements[0].(types.Section); ok && s.Level == 0 {
 			// don't render the top-level section, but only its elements (plus the rest if there's anything)
 			if len(elements) > 1 {

--- a/pkg/renderer/sgml/html5/document_details_test.go
+++ b/pkg/renderer/sgml/html5/document_details_test.go
@@ -106,7 +106,7 @@ Last updated {{.LastUpdated}}
 
 		now := time.Now()
 
-		It("with header and footer", func() {
+		It("with body header and footer", func() {
 			source := `= Document Title
 
 a paragraph`

--- a/pkg/renderer/sgml/html5/html5.go
+++ b/pkg/renderer/sgml/html5/html5.go
@@ -15,11 +15,11 @@ const (
 		"<body" +
 		"{{ if .ID }} id=\"{{ .ID }}\"{{ end }}" +
 		" class=\"{{ .Doctype }}{{ if .Roles }} {{ .Roles }}{{ end }}\">\n" +
-		"{{ if .IncludeHeader }}{{ .Header }}{{ end }}" +
+		"{{ if .IncludeHTMLBodyHeader }}{{ .Header }}{{ end }}" +
 		"<div id=\"content\">\n" +
 		"{{ .Content }}" +
 		"</div>\n" +
-		"{{ if .IncludeFooter }}<div id=\"footer\">\n" +
+		"{{ if .IncludeHTMLBodyFooter }}<div id=\"footer\">\n" +
 		"<div id=\"footer-text\">\n" +
 		"{{ if .RevNumber }}Version {{ .RevNumber }}<br>\n{{ end }}" +
 		"Last updated {{ .LastUpdated }}\n" +

--- a/pkg/renderer/sgml/html5/html5_test.go
+++ b/pkg/renderer/sgml/html5/html5_test.go
@@ -13,7 +13,7 @@ import (
 
 var _ = Describe("document header", func() {
 
-	It("header with quoted text", func() {
+	It("with quoted text", func() {
 		source := `= The _Document_ *Title*`
 		expected := `<!DOCTYPE html>
 <html lang="en">
@@ -46,7 +46,7 @@ Last updated {{.LastUpdated}}
 			To(MatchHTMLTemplate(expected, now))
 	})
 
-	It("header with role", func() {
+	It("with role", func() {
 		source := `[.my_role]
 = My Title`
 		expected := `<!DOCTYPE html>
@@ -80,7 +80,7 @@ Last updated {{.LastUpdated}}
 			To(MatchHTMLTemplate(expected, now))
 	})
 
-	It("header with multple roles and id", func() {
+	It("with multple roles and id", func() {
 		source := `[.role1#anchor.role2]
 = My Title`
 		expected := `<!DOCTYPE html>
@@ -114,6 +114,55 @@ Last updated {{.LastUpdated}}
 			To(MatchHTMLTemplate(expected, now))
 	})
 
+	Context("without title", func() {
+
+		now := time.Now()
+		source := `a paragraph`
+
+		It("without header and footer", func() {
+			expected := `<div class="paragraph">
+<p>a paragraph</p>
+</div>
+`
+			Expect(RenderHTML(source,
+				configuration.WithLastUpdated(now),
+				configuration.WithAttributes(map[string]string{
+					types.AttrNoHeader: "",
+					types.AttrNoFooter: "",
+				}),
+			)).To(MatchHTMLTemplate(expected, now))
+		})
+
+		It("with body header and footer", func() {
+			expected := `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="generator" content="libasciidoc">
+<title>Untitled</title>
+</head>
+<body class="article">
+<div id="content">
+<div class="paragraph">
+<p>a paragraph</p>
+</div>
+</div>
+<div id="footer">
+<div id="footer-text">
+Last updated {{.LastUpdated}}
+</div>
+</div>
+</body>
+</html>
+`
+			Expect(RenderHTML(source,
+				configuration.WithHeaderFooter(true),
+				configuration.WithLastUpdated(now),
+			)).To(MatchHTMLTemplate(expected, now))
+		})
+	})
 	It("should include adoc file without leveloffset from relative file", func() {
 		source := "include::../../../../../test/includes/grandchild-include.adoc[]" // with filename `tmp/foo.adoc`, we are virtually in a subfolder
 		expectedContent := `<div class="sect1">

--- a/pkg/renderer/sgml/html5/link_test.go
+++ b/pkg/renderer/sgml/html5/link_test.go
@@ -115,7 +115,7 @@ a link to {scheme}://{path}`
 :scheme: https
 :path: foo.bar`
 				expected := `a title to https://foo.bar and https://foo.baz`
-				Expect(RenderHTML5Title(source)).To(Equal(expected))
+				Expect(MetadataTitle(source)).To(Equal(expected))
 			})
 
 			It("with document attribute in section 1 title", func() {

--- a/pkg/renderer/sgml/xhtml5/xhtml5.go
+++ b/pkg/renderer/sgml/xhtml5/xhtml5.go
@@ -15,11 +15,11 @@ const (
 		"<body" +
 		"{{ if .ID }} id=\"{{ .ID }}\"{{ end }}" +
 		" class=\"{{ .Doctype }}{{ if .Roles }} {{ .Roles }}{{ end }}\">\n" +
-		"{{ if .IncludeHeader }}{{ .Header }}{{ end }}" +
+		"{{ if .IncludeHTMLBodyHeader }}{{ .Header }}{{ end }}" +
 		"<div id=\"content\">\n" +
 		"{{ .Content }}" +
 		"</div>\n" +
-		"{{ if .IncludeFooter }}<div id=\"footer\">\n" +
+		"{{ if .IncludeHTMLBodyFooter }}<div id=\"footer\">\n" +
 		"<div id=\"footer-text\">\n" +
 		"{{ if .RevNumber }}Version {{ .RevNumber }}<br/>\n{{ end }}" +
 		"Last updated {{ .LastUpdated }}\n" +

--- a/testsupport/metadata_matcher.go
+++ b/testsupport/metadata_matcher.go
@@ -1,0 +1,28 @@
+package testsupport
+
+import (
+	"bytes"
+	"strings"
+
+	"github.com/bytesparadise/libasciidoc"
+	"github.com/bytesparadise/libasciidoc/pkg/configuration"
+)
+
+// MetadataTitle returns the title entry from the document metadata
+func MetadataTitle(actual string, options ...configuration.Setting) (string, error) {
+	config := configuration.NewConfiguration()
+	configuration.WithBackEnd("html5")(&config)
+	for _, set := range options {
+		set(&config)
+	}
+	contentReader := strings.NewReader(actual)
+	resultWriter := bytes.NewBuffer(nil)
+	metadata, err := libasciidoc.Convert(contentReader, resultWriter, config)
+	if err != nil {
+		return "", err
+	}
+	// if strings.Contains(m.expected, "{{.LastUpdated}}") {
+	// 	m.expected = strings.Replace(m.expected, "{{.LastUpdated}}", metadata.LastUpdated, 1)
+	// }
+	return metadata.Title, nil
+}

--- a/testsupport/metadata_matcher_test.go
+++ b/testsupport/metadata_matcher_test.go
@@ -1,0 +1,32 @@
+package testsupport_test
+
+import (
+	"github.com/bytesparadise/libasciidoc/testsupport"
+
+	. "github.com/onsi/ginkgo" //nolint golint
+	. "github.com/onsi/gomega" //nolint golint
+)
+
+var _ = Describe("html5 body renderer", func() {
+
+	It("should match when title exists", func() {
+		// given
+		actual := `= hello, world!`
+		expected := `hello, world!`
+		// when
+		result, err := testsupport.MetadataTitle(actual)
+		// then
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(Equal(expected))
+	})
+
+	It("should match when title does not exist", func() {
+		// given
+		actual := `foo` // no title in this doc
+		// when
+		result, err := testsupport.MetadataTitle(actual)
+		// then
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(Equal(""))
+	})
+})

--- a/testsupport/render_html5.go
+++ b/testsupport/render_html5.go
@@ -43,25 +43,6 @@ func RenderHTML(actual string, settings ...configuration.Setting) (string, error
 	return resultWriter.String(), nil
 }
 
-// RenderHTML5Title renders the HTML body using the given source
-func RenderHTML5Title(actual string, options ...configuration.Setting) (string, error) {
-	config := configuration.NewConfiguration()
-	configuration.WithBackEnd("html5")(&config)
-	for _, set := range options {
-		set(&config)
-	}
-	contentReader := strings.NewReader(actual)
-	resultWriter := bytes.NewBuffer(nil)
-	metadata, err := libasciidoc.Convert(contentReader, resultWriter, config)
-	if err != nil {
-		return "", err
-	}
-	// if strings.Contains(m.expected, "{{.LastUpdated}}") {
-	// 	m.expected = strings.Replace(m.expected, "{{.LastUpdated}}", metadata.LastUpdated, 1)
-	// }
-	return metadata.Title, nil
-}
-
 // RenderHTML5Document a custom matcher to verify that a block renders as expected
 func RenderHTML5Document(filename string, options ...configuration.Setting) (string, error) {
 	resultWriter := bytes.NewBuffer(nil)

--- a/testsupport/render_html5_test.go
+++ b/testsupport/render_html5_test.go
@@ -22,29 +22,4 @@ var _ = Describe("html5 body renderer", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result).To(Equal(expected))
 	})
-
-})
-
-var _ = Describe("html5 body renderer", func() {
-
-	It("should match when title exists", func() {
-		// given
-		actual := `= hello, world!`
-		expected := `hello, world!`
-		// when
-		result, err := testsupport.RenderHTML5Title(actual)
-		// then
-		Expect(err).ToNot(HaveOccurred())
-		Expect(result).To(Equal(expected))
-	})
-
-	It("should match title does not exist", func() {
-		// given
-		actual := `foo` // no title in this doc
-		// when
-		result, err := testsupport.RenderHTML5Title(actual)
-		// then
-		Expect(err).ToNot(HaveOccurred())
-		Expect(result).To(Equal(""))
-	})
 })


### PR DESCRIPTION
Sets the HTML title to `Untitled` when the document
did not have any section with level 0

Also, refactor a few vars and matchers (checking the
metadata result and not the rendered HTML content)

Fixes #627

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
