### PR TITLE
refactor(parser): simplified grammar rules for attributes

### DIFF
--- a/LIMITATIONS.adoc
+++ b/LIMITATIONS.adoc
@@ -124,9 +124,21 @@ See https://github.com/bytesparadise/libasciidoc/issues/677[Issue #677].
 
 == File Inclusions
 
-File inclusions are performed before the full parsing takes place. During this phase, the main file is parsed to look for `include::` directives and then replace them with the content of the file to include. 
+File inclusions are performed before the full parsing takes place. During this phase, the parser looks for `include::` directives and replace them with the content of the file(s) to include. 
 If the file to include has an empty last line, it will be ignored, so it's always a good practice to include a blank line after the `include::` directive in the main document, to avoid side-effects during
 the "full" parsing.
+Also, the `lines` and `tags` attribute values must use semicolon (`;`) to join multiple ranges when they are not wrapped in quotes, and they can use both colon (`,`) and semicolon within quotes.
+
+For example:
+
+[source]
+====
+pass:[include::chapter-a.adoc[lines=1;3..4;6..10]]
+
+pass:[include::chapter-a.adoc[lines="1,3..4,6..10"]]
+
+pass:[include::chapter-a.adoc[lines="1;3..4;6..10"]]
+====
 
 == Substitutions
 

--- a/pkg/parser/attributes_test.go
+++ b/pkg/parser/attributes_test.go
@@ -1,11 +1,16 @@
 package parser_test
 
 import (
+	"strings"
+
+	"github.com/bytesparadise/libasciidoc/pkg/parser"
 	"github.com/bytesparadise/libasciidoc/pkg/types"
 	. "github.com/bytesparadise/libasciidoc/testsupport"
+	log "github.com/sirupsen/logrus"
 
-	. "github.com/onsi/ginkgo" //nolint golint
-	. "github.com/onsi/gomega" //nolint golint
+	. "github.com/onsi/ginkgo"                  //nolint golint
+	. "github.com/onsi/ginkgo/extensions/table" //nolint golint
+	. "github.com/onsi/gomega"                  //nolint golint
 )
 
 var _ = Describe("attributes", func() {
@@ -80,7 +85,7 @@ var _ = Describe("attributes", func() {
 			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
-		It("block image with simple double quoted alt", func() {
+		It("block image with double quoted alt", func() {
 			source := "image::foo.png[\"Quoted, Here\"]"
 			expected := types.DraftDocument{
 				Elements: []interface{}{
@@ -100,12 +105,12 @@ var _ = Describe("attributes", func() {
 		})
 
 		It("block image with double quoted alt and embedded quotes", func() {
-			source := `image::foo.png[  "The Ascii\"Doctor\" Is In" ]`
+			source := `image::foo.png["The Foo\"Bar\" here"]`
 			expected := types.DraftDocument{
 				Elements: []interface{}{
 					types.ImageBlock{
 						Attributes: types.Attributes{
-							types.AttrImageAlt: `The Ascii"Doctor" Is In`,
+							types.AttrImageAlt: `The Foo"Bar" here`,
 						},
 						Location: types.Location{
 							Path: []interface{}{
@@ -116,65 +121,6 @@ var _ = Describe("attributes", func() {
 				},
 			}
 			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
-		})
-
-		It("block image with double quoted alt extra whitespace", func() {
-			source := `image::foo.png[ "This \Backslash  2Spaced End Space " ]`
-			expected := types.DraftDocument{
-				Elements: []interface{}{
-					types.ImageBlock{
-						Attributes: types.Attributes{
-							types.AttrImageAlt: `This \Backslash  2Spaced End Space `, // trailing space is retained
-						},
-						Location: types.Location{
-							Path: []interface{}{
-								types.StringElement{Content: "foo.png"},
-							},
-						},
-					},
-				},
-			}
-			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
-		})
-
-		It("block image with single quoted alt and embedded quotes", func() {
-			source := "image::foo.png[  'It\\'s It!' ]"
-			expected := types.DraftDocument{
-				Elements: []interface{}{
-					types.ImageBlock{
-						Attributes: types.Attributes{
-							types.AttrImageAlt: `It's It!`,
-						},
-						Location: types.Location{
-							Path: []interface{}{
-								types.StringElement{Content: "foo.png"},
-							},
-						},
-					},
-				},
-			}
-			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
-		})
-
-		It("block image with single quoted alt extra whitespace", func() {
-			source := "image::foo.png[ 'This \\Backslash  2Spaced End Space ' ]"
-			expected := types.DraftDocument{
-				Elements: []interface{}{
-					types.ImageBlock{
-						Attributes: types.Attributes{
-							types.AttrImageAlt: `This \Backslash  2Spaced End Space `, // trailing space within quotes is retained
-						},
-						Location: types.Location{
-							Path: []interface{}{
-								types.StringElement{Content: "foo.png"},
-							},
-						},
-					},
-				},
-			}
-			result, err := ParseDraftDocument(source)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(MatchDraftDocument(expected))
 		})
 
 		It("block image alt and named pair", func() {
@@ -183,8 +129,8 @@ var _ = Describe("attributes", func() {
 				Elements: []interface{}{
 					types.ImageBlock{
 						Attributes: types.Attributes{
-							types.AttrImageAlt:    `Quoted, Here`,
-							types.AttrImageHeight: "100",
+							types.AttrImageAlt: `Quoted, Here`,
+							types.AttrHeight:   "100",
 						},
 						Location: types.Location{
 							Path: []interface{}{
@@ -205,9 +151,9 @@ var _ = Describe("attributes", func() {
 				Elements: []interface{}{
 					types.ImageBlock{
 						Attributes: types.Attributes{
-							types.AttrImageAlt:    `Quoted, Here`,
-							types.AttrImageHeight: "100", // last one wins
-							types.AttrWidth:       "1",
+							types.AttrImageAlt: `Quoted, Here`,
+							types.AttrHeight:   "100", // last one wins
+							types.AttrWidth:    "1",
 						},
 						Location: types.Location{
 							Path: []interface{}{
@@ -226,11 +172,11 @@ var _ = Describe("attributes", func() {
 				Elements: []interface{}{
 					types.ImageBlock{
 						Attributes: types.Attributes{
-							types.AttrImageAlt:    `Quoted, Here`,
-							types.AttrImageHeight: "100", // last one wins
-							types.AttrWidth:       "1",
-							"test1":               "123",
-							"test2":               "second test", // shows trailing pad removed
+							types.AttrImageAlt: `Quoted, Here`,
+							types.AttrHeight:   "100", // last one wins
+							types.AttrWidth:    "1",
+							"test1":            "123",
+							"test2":            "second test", // shows trailing pad removed
 						},
 						Location: types.Location{
 							Path: []interface{}{
@@ -249,11 +195,11 @@ var _ = Describe("attributes", func() {
 				Elements: []interface{}{
 					types.ImageBlock{
 						Attributes: types.Attributes{
-							types.AttrImageAlt:    `Quoted, Here`,
-							types.AttrImageHeight: "100", // last one wins
-							types.AttrWidth:       "1",
-							"test1":               "123",
-							"test2":               `second "test"`, // shows trailing pad removed
+							types.AttrImageAlt: `Quoted, Here`,
+							types.AttrHeight:   "100", // last one wins
+							types.AttrWidth:    "1",
+							"test1":            "123",
+							"test2":            `second "test"`, // shows trailing pad removed
 						},
 						Location: types.Location{
 							Path: []interface{}{
@@ -267,7 +213,7 @@ var _ = Describe("attributes", func() {
 		})
 	})
 
-	Context("recursive attributes", func() {
+	Context("attributes with substitutions", func() {
 
 		It("should substitute an attribute in another attribute", func() {
 			source := `:def: foo
@@ -330,5 +276,310 @@ var _ = Describe("attributes", func() {
 			}
 			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
+
+		Context("invalid syntax", func() {
+
+			// no space should be allowed at the beginning of inline attributes,
+			// (to be consistent with block attributes)
+
+			It("block image with double quoted alt extra whitespace", func() {
+				source := `image::foo.png[ "This \Backslash  2Spaced End Space " ]`
+				expected := types.DraftDocument{
+					Elements: []interface{}{
+						types.Paragraph{
+							Lines: [][]interface{}{
+								{
+									types.StringElement{
+										Content: `image::foo.png[ "This \Backslash  2Spaced End Space " ]`,
+									},
+								},
+							},
+						},
+					},
+				}
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
+			})
+		})
 	})
 })
+
+var _ = DescribeTable("valid block attributes",
+
+	func(source string, expected types.Attributes) {
+		// given
+		log.Debugf("processing '%s'", source)
+		content := strings.NewReader(source + "\n")
+		// when parsing only (ie, no substitution applied)
+		result, err := parser.ParseReader("", content, parser.Entrypoint("BlockAttributes"))
+		// then
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(expected))
+	},
+
+	// named attributes
+	Entry(`[foo1=bar1]`, `[foo1=bar1]`,
+		types.Attributes{
+			`foo1`: `bar1`,
+		},
+	),
+	Entry(`[foo1=bar1,foo2='bar2']`, `[foo1=bar1,foo2='bar2']`,
+		types.Attributes{
+			`foo1`: `bar1`,
+			`foo2`: `bar2`,
+		},
+	),
+	Entry(`[foo1=bar1,foo2=bar2]`, `[foo1=bar1,foo2="bar2"]`,
+		types.Attributes{
+			`foo1`: `bar1`,
+			`foo2`: `bar2`,
+		},
+	),
+
+	// positional attributes
+	Entry(`[literal]`, `[literal]`,
+		types.Attributes{
+			types.AttrPositional1: `literal`,
+		},
+	),
+	Entry(`[pass]`, `[pass]`,
+		types.Attributes{
+			types.AttrPositional1: `pass`,
+		},
+	),
+	Entry(`[example]`, `[example]`,
+		types.Attributes{
+			types.AttrPositional1: `example`,
+		},
+	),
+	Entry(`[listing]`, `[listing]`,
+		types.Attributes{
+			types.AttrPositional1: `listing`,
+		},
+	),
+	Entry(`[NOTE]`, `[NOTE]`, // admonitions
+		types.Attributes{
+			types.AttrPositional1: `NOTE`,
+		},
+	),
+	Entry(`[source,go]`, `[source,go]`,
+		types.Attributes{
+			types.AttrPositional1: `source`,
+			types.AttrPositional2: `go`,
+		},
+	),
+	Entry(`[source,go,foo=bar]`, `[source,go,foo=bar]`,
+		types.Attributes{
+			types.AttrPositional1: `source`,
+			types.AttrPositional2: `go`,
+			`foo`:                 `bar`,
+		},
+	),
+	Entry(`[quote,an author,a title]`, `[quote,an author,a title]`,
+		types.Attributes{
+			types.AttrPositional1: `quote`,
+			types.AttrPositional2: `an author`,
+			types.AttrPositional3: `a title`,
+		},
+	),
+	Entry(`[verse,an author,a title]`, `[verse,an author,a title]`,
+		types.Attributes{
+			types.AttrPositional1: `verse`,
+			types.AttrPositional2: `an author`,
+			types.AttrPositional3: `a title`,
+		},
+	),
+	Entry(`[verse , an author , a title ]`, `[verse, an author , a title ]`, // with spaces around
+		types.Attributes{
+			types.AttrPositional1: `verse`,
+			types.AttrPositional2: `an author`,
+			types.AttrPositional3: `a title`,
+		},
+	),
+	Entry(`[verse, ,a title]`, `[verse, ,a title]`, // with empty positional-2
+		types.Attributes{
+			types.AttrPositional1: `verse`,
+			types.AttrPositional2: nil,
+			types.AttrPositional3: `a title`,
+		},
+	),
+	Entry(`[verse,,a title]`, `[verse,,a title]`, // with empty positional-2
+		types.Attributes{
+			types.AttrPositional1: `verse`,
+			types.AttrPositional2: nil,
+			types.AttrPositional3: `a title`,
+		},
+	),
+	Entry(`[verse,an author,]`, `[verse,an author,]`, // with empty positional-3
+		types.Attributes{
+			types.AttrPositional1: `verse`,
+			types.AttrPositional2: `an author`,
+		},
+	),
+	Entry(`[verse,an author, ]`, `[verse,an author, ]`, // with empty positional-3
+		types.Attributes{
+			types.AttrPositional1: `verse`,
+			types.AttrPositional2: `an author`,
+		},
+	),
+	Entry(`[]`, `[]`, // with empty positional-1
+		types.Attributes{},
+	),
+	Entry(`[ ]`, `[ ]`, // with empty positional-1
+		types.Attributes{
+			types.AttrPositional1: nil,
+		},
+	),
+	Entry(`[,foo]`, `[,foo]`, // with empty positional-1
+		types.Attributes{
+			types.AttrPositional1: nil,
+			types.AttrPositional2: "foo",
+		},
+	),
+	Entry(`[ ,foo]`, `[ ,foo]`, // with empty positional-1
+		types.Attributes{
+			types.AttrPositional1: nil,
+			types.AttrPositional2: "foo",
+		},
+	),
+	Entry(`[,,]`, `[,,]`, // with empty positional-1
+		types.Attributes{
+			types.AttrPositional1: nil,
+			types.AttrPositional2: nil,
+			// types.AttrPositional3: nil,
+		},
+	),
+	// quoted values
+	Entry(`.a "title"`, ".a \"title\"",
+		types.Attributes{
+			types.AttrTitle: `a "title"`,
+		},
+	),
+
+	// -------------------------
+	// shorthand syntaxes
+	// -------------------------
+
+	// title shorthand
+	Entry(`.a title`, `.a title`,
+		types.Attributes{
+			types.AttrTitle: `a title`,
+		},
+	),
+	Entry(`.'a title'`, `.'a title'`,
+		types.Attributes{
+			types.AttrTitle: `'a title'`,
+		},
+	),
+	Entry(`."a title"`, `."a title"`,
+		types.Attributes{
+			types.AttrTitle: `"a title"`,
+		},
+	),
+	Entry(`.a title.not_a_role`, `.a title.not_a_role`,
+		types.Attributes{
+			types.AttrTitle: `a title.not_a_role`,
+		},
+	),
+
+	// role shorthand
+	Entry(`[.a_role]`, `[.a_role]`,
+		types.Attributes{
+			types.AttrRoles: []interface{}{`a_role`},
+		},
+	),
+	Entry(`[.a_role.another_role]`, `[.a_role.another_role]`,
+		types.Attributes{
+			types.AttrRoles: []interface{}{`a_role`, `another_role`},
+		},
+	),
+	Entry(`[source.a_role,go]`, `[source.a_role,go]`,
+		types.Attributes{
+			types.AttrPositional1: `source`,
+			types.AttrPositional2: `go`,
+			types.AttrRoles:       []interface{}{`a_role`},
+		},
+	),
+	Entry(`[source,go.not_a_role]`, `[source,go.not_a_role]`,
+		types.Attributes{
+			types.AttrPositional1: `source`,
+			types.AttrPositional2: `go.not_a_role`,
+		},
+	),
+
+	// option shorthand
+	Entry(`[%hardbreaks]`, `[%hardbreaks]`,
+		types.Attributes{
+			types.AttrOptions: []interface{}{"hardbreaks"},
+		},
+	),
+
+	// id (alone)
+	Entry(`[#an_id]`, `[#an_id]`,
+		types.Attributes{
+			types.AttrID: `an_id`,
+		},
+	),
+	// id (with roles and options)
+	Entry(`[#an_id.a_role]`, `[#an_id.a_role]`,
+		types.Attributes{
+			types.AttrID:    `an_id`,
+			types.AttrRoles: []interface{}{`a_role`},
+		},
+	),
+	Entry(`[#an_id.role_1%option_1.role_2]`, `[#an_id.role_1%option_1.role_2]`,
+		types.Attributes{
+			types.AttrID:      `an_id`,
+			types.AttrRoles:   []interface{}{`role_1`, `role_2`},
+			types.AttrOptions: []interface{}{`option_1`},
+		},
+	),
+	Entry(`[#an_id.role_1%option_1.role_2%option_2]`, `[#an_id.role_1%option_1.role_2%option_2]`,
+		types.Attributes{
+			types.AttrID:      `an_id`,
+			types.AttrRoles:   []interface{}{`role_1`, `role_2`},
+			types.AttrOptions: []interface{}{`option_1`, `option_2`},
+		},
+	),
+	Entry(`[#an_id,role="a role"]`, `[#an_id,role="a role"]`,
+		types.Attributes{
+			types.AttrID:    `an_id`,
+			types.AttrRoles: []interface{}{`a role`},
+		},
+	),
+	Entry(`[qanda#quiz]`, `[qanda#quiz]`,
+		types.Attributes{
+			types.AttrPositional1: "qanda",
+			types.AttrID:          `quiz`,
+		},
+	),
+
+	Entry(`[[here, an id]]`, `[[here, an id]]`,
+		types.Attributes{
+			types.AttrID: `here, an id`,
+		},
+	),
+	Entry(`[[another id.not_a_role]]`, `[[another id.not_a_role]]`,
+		types.Attributes{
+			types.AttrID: `another id.not_a_role`,
+		},
+	),
+
+	// TODO: attributes with substitutions
+)
+
+var _ = DescribeTable("invalid block attributes",
+
+	func(source string) {
+		// given
+		content := strings.NewReader(source + "\n")
+		// when parsing only (ie, no substitution applied)
+		_, err := parser.ParseReader("", content, parser.Entrypoint("BlockAttributes"))
+		// then
+		Expect(err).To(HaveOccurred())
+	},
+
+	// space after `[` is not allowed if more content exists
+	Entry(`[ foo1=bar1]`, `[ foo1=bar1]`),
+
+	Entry(`[ foo1=bar1 ]`, `[ foo1=bar1 ]`),
+)

--- a/pkg/parser/comment_test.go
+++ b/pkg/parser/comment_test.go
@@ -84,7 +84,7 @@ another line // not a comment`
 						Elements: []interface{}{
 							types.LiteralBlock{
 								Attributes: types.Attributes{
-									types.AttrBlockKind:        types.Literal,
+									types.AttrStyle:            types.Literal,
 									types.AttrLiteralBlockType: types.LiteralBlockWithSpacesOnFirstLine,
 								},
 								Lines: [][]interface{}{
@@ -108,7 +108,7 @@ another line // not a comment`
 						Elements: []interface{}{
 							types.LiteralBlock{
 								Attributes: types.Attributes{
-									types.AttrBlockKind:        types.Literal,
+									types.AttrStyle:            types.Literal,
 									types.AttrLiteralBlockType: types.LiteralBlockWithSpacesOnFirstLine,
 								},
 								Lines: [][]interface{}{
@@ -254,7 +254,7 @@ a second paragraph`
 					Elements: []interface{}{
 						types.LiteralBlock{
 							Attributes: types.Attributes{
-								types.AttrBlockKind:        types.Literal,
+								types.AttrStyle:            types.Literal,
 								types.AttrLiteralBlockType: types.LiteralBlockWithSpacesOnFirstLine,
 							},
 							Lines: [][]interface{}{
@@ -276,7 +276,7 @@ a second paragraph`
 					Elements: []interface{}{
 						types.LiteralBlock{
 							Attributes: types.Attributes{
-								types.AttrBlockKind:        types.Literal,
+								types.AttrStyle:            types.Literal,
 								types.AttrLiteralBlockType: types.LiteralBlockWithSpacesOnFirstLine,
 							},
 							Lines: [][]interface{}{

--- a/pkg/parser/cross_reference_test.go
+++ b/pkg/parser/cross_reference_test.go
@@ -120,9 +120,10 @@ with some content linked to <<thetitle,a label to the title>>!`
 					Elements: []interface{}{
 						types.Paragraph{
 							Lines: [][]interface{}{
-								{types.StringElement{
-									Content: "some content linked to ",
-								},
+								{
+									types.StringElement{
+										Content: "some content linked to ",
+									},
 									types.ExternalCrossReference{
 										Location: types.Location{
 											Path: []interface{}{
@@ -159,9 +160,10 @@ with some content linked to <<thetitle,a label to the title>>!`
 					Elements: []interface{}{
 						types.Paragraph{
 							Lines: [][]interface{}{
-								{types.StringElement{
-									Content: "some content linked to ",
-								},
+								{
+									types.StringElement{
+										Content: "some content linked to ",
+									},
 									types.ExternalCrossReference{
 										Location: types.Location{
 											Path: []interface{}{
@@ -170,11 +172,7 @@ with some content linked to <<thetitle,a label to the title>>!`
 												},
 											},
 										},
-										Label: []interface{}{
-											types.StringElement{
-												Content: "another doc",
-											},
-										},
+										Label: "another doc",
 									},
 									types.StringElement{
 										Content: "!",
@@ -210,11 +208,7 @@ some content linked to xref:{foo}[another_doc()]!`
 												},
 											},
 										},
-										Label: []interface{}{
-											types.StringElement{
-												Content: "another_doc()",
-											},
-										},
+										Label: "another_doc()",
 									},
 									types.StringElement{
 										Content: "!",

--- a/pkg/parser/delimited_block_admonition_test.go
+++ b/pkg/parser/delimited_block_admonition_test.go
@@ -23,7 +23,7 @@ foo
 					Elements: []interface{}{
 						types.ExampleBlock{
 							Attributes: types.Attributes{
-								types.AttrAdmonitionKind: types.Note,
+								types.AttrStyle: types.Note,
 							},
 							Elements: []interface{}{
 								types.Paragraph{
@@ -54,7 +54,7 @@ paragraphs
 					Elements: []interface{}{
 						types.ListingBlock{
 							Attributes: types.Attributes{
-								types.AttrAdmonitionKind: types.Note,
+								types.AttrStyle: types.Note,
 							},
 							Lines: [][]interface{}{
 								{
@@ -90,7 +90,7 @@ foo
 					Elements: []interface{}{
 						types.ExampleBlock{
 							Attributes: types.Attributes{
-								types.AttrAdmonitionKind: types.Note,
+								types.AttrStyle: types.Note,
 							},
 							Elements: []interface{}{
 								types.Paragraph{
@@ -122,7 +122,7 @@ paragraphs
 					Elements: []interface{}{
 						types.ExampleBlock{
 							Attributes: types.Attributes{
-								types.AttrAdmonitionKind: types.Note,
+								types.AttrStyle: types.Note,
 							},
 							Elements: []interface{}{
 								types.Paragraph{

--- a/pkg/parser/delimited_block_example_test.go
+++ b/pkg/parser/delimited_block_example_test.go
@@ -236,7 +236,7 @@ some *example* content`
 					Elements: []interface{}{
 						types.Paragraph{
 							Attributes: types.Attributes{
-								types.AttrBlockKind: types.Example,
+								types.AttrStyle: types.Example,
 							},
 							Lines: [][]interface{}{
 								{
@@ -455,7 +455,7 @@ some *example* content`
 					Elements: []interface{}{
 						types.Paragraph{
 							Attributes: types.Attributes{
-								types.AttrBlockKind: types.Example,
+								types.AttrStyle: types.Example,
 							},
 							Lines: [][]interface{}{
 								{

--- a/pkg/parser/delimited_block_listing_test.go
+++ b/pkg/parser/delimited_block_listing_test.go
@@ -480,7 +480,7 @@ some *listing* content`
 					Elements: []interface{}{
 						types.Paragraph{
 							Attributes: types.Attributes{
-								types.AttrBlockKind: types.Listing,
+								types.AttrStyle: types.Listing,
 							},
 							Lines: [][]interface{}{
 								{
@@ -968,7 +968,7 @@ some *listing* content`
 					Elements: []interface{}{
 						types.Paragraph{
 							Attributes: types.Attributes{
-								types.AttrBlockKind: types.Listing,
+								types.AttrStyle: types.Listing,
 							},
 							Lines: [][]interface{}{
 								{

--- a/pkg/parser/delimited_block_literal_test.go
+++ b/pkg/parser/delimited_block_literal_test.go
@@ -20,7 +20,7 @@ var _ = Describe("literal blocks", func() {
 					Elements: []interface{}{
 						types.LiteralBlock{
 							Attributes: types.Attributes{
-								types.AttrBlockKind:        types.Literal,
+								types.AttrStyle:            types.Literal,
 								types.AttrLiteralBlockType: types.LiteralBlockWithSpacesOnFirstLine,
 							},
 							Lines: [][]interface{}{
@@ -44,7 +44,7 @@ lines.`
 					Elements: []interface{}{
 						types.LiteralBlock{
 							Attributes: types.Attributes{
-								types.AttrBlockKind:        types.Literal,
+								types.AttrStyle:            types.Literal,
 								types.AttrLiteralBlockType: types.LiteralBlockWithSpacesOnFirstLine,
 							},
 							Lines: [][]interface{}{
@@ -82,11 +82,11 @@ a normal paragraph.`
 					Elements: []interface{}{
 						types.LiteralBlock{
 							Attributes: types.Attributes{
-								types.AttrBlockKind:        types.Literal,
+								types.AttrStyle:            types.Literal,
 								types.AttrLiteralBlockType: types.LiteralBlockWithSpacesOnFirstLine,
 								types.AttrID:               "ID",
-								types.AttrCustomID:         true,
-								types.AttrTitle:            "title",
+								// types.AttrCustomID:         true,
+								types.AttrTitle: "title",
 							},
 							Lines: [][]interface{}{
 								{
@@ -113,7 +113,6 @@ a normal paragraph.`
 		Context("literal blocks with block delimiter", func() {
 
 			It("literal block with empty blank line", func() {
-
 				source := `....
 
 some content
@@ -122,7 +121,7 @@ some content
 					Elements: []interface{}{
 						types.LiteralBlock{
 							Attributes: types.Attributes{
-								types.AttrBlockKind:        types.Literal,
+								types.AttrStyle:            types.Literal,
 								types.AttrLiteralBlockType: types.LiteralBlockWithDelimiter,
 							},
 							Lines: [][]interface{}{
@@ -152,11 +151,11 @@ a normal paragraph.`
 					Elements: []interface{}{
 						types.LiteralBlock{
 							Attributes: types.Attributes{
-								types.AttrBlockKind:        types.Literal,
+								types.AttrStyle:            types.Literal,
 								types.AttrLiteralBlockType: types.LiteralBlockWithDelimiter,
 								types.AttrID:               "ID",
-								types.AttrCustomID:         true,
-								types.AttrTitle:            "title",
+								// types.AttrCustomID:         true,
+								types.AttrTitle: "title",
 							},
 							Lines: [][]interface{}{
 								{
@@ -190,7 +189,7 @@ a normal paragraph.`
 					Elements: []interface{}{
 						types.LiteralBlock{
 							Attributes: types.Attributes{
-								types.AttrBlockKind:        types.Literal,
+								types.AttrStyle:            types.Literal,
 								types.AttrLiteralBlockType: types.LiteralBlockWithAttribute,
 							},
 							Lines: [][]interface{}{
@@ -226,9 +225,9 @@ a normal paragraph.`
 					Elements: []interface{}{
 						types.LiteralBlock{
 							Attributes: types.Attributes{
-								types.AttrBlockKind:        types.Literal,
-								types.AttrID:               "ID",
-								types.AttrCustomID:         true,
+								types.AttrStyle: types.Literal,
+								types.AttrID:    "ID",
+								// types.AttrCustomID:         true,
 								types.AttrTitle:            "title",
 								types.AttrLiteralBlockType: types.LiteralBlockWithAttribute,
 							},
@@ -290,7 +289,7 @@ and <more text> on the +
 						types.BlankLine{},
 						types.LiteralBlock{
 							Attributes: types.Attributes{
-								types.AttrBlockKind:        types.Literal,
+								types.AttrStyle:            types.Literal,
 								types.AttrLiteralBlockType: types.LiteralBlockWithDelimiter,
 							},
 							Lines: [][]interface{}{
@@ -377,7 +376,7 @@ and <more text> on the +
 						types.BlankLine{},
 						types.LiteralBlock{
 							Attributes: types.Attributes{
-								types.AttrBlockKind:        types.Literal,
+								types.AttrStyle:            types.Literal,
 								types.AttrLiteralBlockType: types.LiteralBlockWithDelimiter,
 								types.AttrSubstitutions:    "normal",
 							},
@@ -504,7 +503,7 @@ and <more text> on the +
 						types.BlankLine{},
 						types.LiteralBlock{
 							Attributes: types.Attributes{
-								types.AttrBlockKind:        types.Literal,
+								types.AttrStyle:            types.Literal,
 								types.AttrLiteralBlockType: types.LiteralBlockWithDelimiter,
 								types.AttrSubstitutions:    "quotes,macros",
 							},
@@ -595,7 +594,7 @@ and <more text> on the +
 						types.BlankLine{},
 						types.LiteralBlock{
 							Attributes: types.Attributes{
-								types.AttrBlockKind:        types.Literal,
+								types.AttrStyle:            types.Literal,
 								types.AttrLiteralBlockType: types.LiteralBlockWithSpacesOnFirstLine,
 								types.AttrSubstitutions:    "quotes,macros",
 							},
@@ -684,7 +683,7 @@ and <more text> on the +
 						types.BlankLine{},
 						types.LiteralBlock{
 							Attributes: types.Attributes{
-								types.AttrBlockKind:        types.Literal,
+								types.AttrStyle:            types.Literal,
 								types.AttrLiteralBlockType: types.LiteralBlockWithAttribute,
 								types.AttrSubstitutions:    "quotes,macros",
 							},

--- a/pkg/parser/delimited_block_passthrough_test.go
+++ b/pkg/parser/delimited_block_passthrough_test.go
@@ -147,7 +147,7 @@ another paragraph`
 					Elements: []interface{}{
 						types.PassthroughBlock{
 							Attributes: types.Attributes{
-								types.AttrBlockKind: types.Passthrough,
+								types.AttrStyle: types.Passthrough,
 							},
 							Lines: [][]interface{}{
 								{
@@ -231,7 +231,7 @@ another paragraph`
 					Elements: []interface{}{
 						types.PassthroughBlock{
 							Attributes: types.Attributes{
-								types.AttrBlockKind: types.Passthrough,
+								types.AttrStyle: types.Passthrough,
 							},
 							Lines: [][]interface{}{
 								{

--- a/pkg/parser/delimited_block_quote_test.go
+++ b/pkg/parser/delimited_block_quote_test.go
@@ -23,7 +23,7 @@ ____`
 					Elements: []interface{}{
 						types.QuoteBlock{
 							Attributes: types.Attributes{
-								types.AttrBlockKind:   types.Quote,
+								types.AttrStyle:       types.Quote,
 								types.AttrQuoteAuthor: "john doe",
 								types.AttrQuoteTitle:  "quote title",
 							},
@@ -69,7 +69,7 @@ ____
 					Elements: []interface{}{
 						types.QuoteBlock{
 							Attributes: types.Attributes{
-								types.AttrBlockKind:   types.Quote,
+								types.AttrStyle:       types.Quote,
 								types.AttrQuoteAuthor: "john doe",
 							},
 							Elements: []interface{}{
@@ -138,7 +138,7 @@ ____
 					Elements: []interface{}{
 						types.QuoteBlock{
 							Attributes: types.Attributes{
-								types.AttrBlockKind:  types.Quote,
+								types.AttrStyle:      types.Quote,
 								types.AttrQuoteTitle: "quote title",
 							},
 							Elements: []interface{}{
@@ -173,7 +173,7 @@ ____`
 					Elements: []interface{}{
 						types.QuoteBlock{
 							Attributes: types.Attributes{
-								types.AttrBlockKind: types.Quote,
+								types.AttrStyle: types.Quote,
 							},
 							Elements: []interface{}{
 								types.UnorderedListItem{
@@ -243,7 +243,7 @@ ____`
 					Elements: []interface{}{
 						types.QuoteBlock{
 							Attributes: types.Attributes{
-								types.AttrBlockKind: types.Quote,
+								types.AttrStyle: types.Quote,
 							},
 						},
 					},
@@ -260,7 +260,7 @@ foo
 					Elements: []interface{}{
 						types.QuoteBlock{
 							Attributes: types.Attributes{
-								types.AttrBlockKind: types.Quote,
+								types.AttrStyle: types.Quote,
 							},
 							Elements: []interface{}{
 								types.Paragraph{
@@ -294,7 +294,7 @@ ____`
 					Elements: []interface{}{
 						types.QuoteBlock{
 							Attributes: types.Attributes{
-								types.AttrBlockKind:   types.Quote,
+								types.AttrStyle:       types.Quote,
 								types.AttrQuoteAuthor: "john doe",
 								types.AttrQuoteTitle:  "quote title",
 							},
@@ -338,7 +338,7 @@ ____
 					Elements: []interface{}{
 						types.QuoteBlock{
 							Attributes: types.Attributes{
-								types.AttrBlockKind:   types.Quote,
+								types.AttrStyle:       types.Quote,
 								types.AttrQuoteAuthor: "john doe",
 							},
 							Elements: []interface{}{
@@ -411,7 +411,7 @@ ____
 					Elements: []interface{}{
 						types.QuoteBlock{
 							Attributes: types.Attributes{
-								types.AttrBlockKind:  types.Quote,
+								types.AttrStyle:      types.Quote,
 								types.AttrQuoteTitle: "quote title",
 							},
 							Elements: []interface{}{
@@ -440,7 +440,7 @@ ____`
 					Elements: []interface{}{
 						types.QuoteBlock{
 							Attributes: types.Attributes{
-								types.AttrBlockKind: types.Quote,
+								types.AttrStyle: types.Quote,
 							},
 							Elements: []interface{}{},
 						},
@@ -462,7 +462,7 @@ ____`
 					Elements: []interface{}{
 						types.QuoteBlock{
 							Attributes: types.Attributes{
-								types.AttrBlockKind: types.Quote,
+								types.AttrStyle: types.Quote,
 							},
 							Elements: []interface{}{
 								types.UnorderedList{
@@ -536,7 +536,7 @@ ____`
 					Elements: []interface{}{
 						types.QuoteBlock{
 							Attributes: types.Attributes{
-								types.AttrBlockKind: types.Quote,
+								types.AttrStyle: types.Quote,
 							},
 							Elements: []interface{}{
 								types.UnorderedList{
@@ -606,7 +606,7 @@ ____`
 					Elements: []interface{}{
 						types.QuoteBlock{
 							Attributes: types.Attributes{
-								types.AttrBlockKind: types.Quote,
+								types.AttrStyle: types.Quote,
 							},
 							Elements: []interface{}{},
 						},
@@ -624,7 +624,7 @@ foo
 					Elements: []interface{}{
 						types.QuoteBlock{
 							Attributes: types.Attributes{
-								types.AttrBlockKind: types.Quote,
+								types.AttrStyle: types.Quote,
 							},
 							Elements: []interface{}{
 								types.Paragraph{

--- a/pkg/parser/delimited_block_source_test.go
+++ b/pkg/parser/delimited_block_source_test.go
@@ -56,7 +56,7 @@ type Foo struct{
 					Elements: []interface{}{
 						types.ListingBlock{
 							Attributes: types.Attributes{
-								types.AttrBlockKind: types.Source,
+								types.AttrStyle: types.Source,
 							},
 							Lines: sourceCode,
 						},
@@ -79,7 +79,7 @@ type Foo struct{
 					Elements: []interface{}{
 						types.ListingBlock{
 							Attributes: types.Attributes{
-								types.AttrBlockKind: types.Source,
+								types.AttrStyle: types.Source,
 							},
 							Lines: sourceCode,
 						},
@@ -103,9 +103,9 @@ type Foo struct{
 					Elements: []interface{}{
 						types.ListingBlock{
 							Attributes: types.Attributes{
-								types.AttrBlockKind: types.Source,
-								types.AttrLanguage:  "go",
-								types.AttrTitle:     "foo.go",
+								types.AttrStyle:    types.Source,
+								types.AttrLanguage: "go",
+								types.AttrTitle:    "foo.go",
 							},
 							Lines: sourceCode,
 						},
@@ -130,12 +130,11 @@ type Foo struct{
 					Elements: []interface{}{
 						types.ListingBlock{
 							Attributes: types.Attributes{
-								types.AttrBlockKind: types.Source,
-								types.AttrLanguage:  "go",
-								types.AttrID:        "id-for-source-block",
-								types.AttrCustomID:  true,
-								types.AttrTitle:     "foo.go",
-								types.AttrLineNums:  nil,
+								types.AttrStyle:    types.Source,
+								types.AttrLanguage: "go",
+								types.AttrID:       "id-for-source-block",
+								types.AttrTitle:    "foo.go",
+								types.AttrLineNums: true,
 							},
 							Lines: sourceCode,
 						},
@@ -160,7 +159,7 @@ a note
 					Elements: []interface{}{
 						types.ListingBlock{
 							Attributes: types.Attributes{
-								types.AttrBlockKind: types.Source,
+								types.AttrStyle: types.Source,
 							},
 							Lines: [][]interface{}{
 								{
@@ -190,7 +189,7 @@ a note
 						types.BlankLine{},
 						types.ExampleBlock{
 							Attributes: types.Attributes{
-								types.AttrAdmonitionKind: types.Note,
+								types.AttrStyle: types.Note,
 							},
 							Elements: []interface{}{
 								types.Paragraph{
@@ -218,9 +217,9 @@ const Cookie = "cookie"
 					Elements: []interface{}{
 						types.ListingBlock{
 							Attributes: types.Attributes{
-								types.AttrBlockKind:         types.Source,
-								types.AttrSourceBlockOption: "nowrap",
-								types.AttrLanguage:          "go",
+								types.AttrStyle:    types.Source,
+								types.AttrOptions:  []interface{}{"nowrap"},
+								types.AttrLanguage: "go",
 							},
 							Lines: [][]interface{}{
 								{
@@ -254,7 +253,7 @@ end
 					Elements: []interface{}{
 						types.ListingBlock{
 							Attributes: types.Attributes{
-								types.AttrBlockKind: types.Source,
+								types.AttrStyle: types.Source,
 							},
 							Lines: [][]interface{}{
 								{
@@ -299,9 +298,9 @@ end
 					Elements: []interface{}{
 						types.ListingBlock{
 							Attributes: types.Attributes{
-								types.AttrBlockKind: types.Source,
-								types.AttrLanguage:  "ruby",
-								types.AttrTitle:     "Source block title",
+								types.AttrStyle:    types.Source,
+								types.AttrLanguage: "ruby",
+								types.AttrTitle:    "Source block title",
 							},
 							Lines: [][]interface{}{
 								{
@@ -347,11 +346,10 @@ end
 					Elements: []interface{}{
 						types.ListingBlock{
 							Attributes: types.Attributes{
-								types.AttrBlockKind: types.Source,
-								types.AttrLanguage:  "ruby",
-								types.AttrID:        "id-for-source-block",
-								types.AttrCustomID:  true,
-								types.AttrTitle:     "app.rb",
+								types.AttrStyle:    types.Source,
+								types.AttrLanguage: "ruby",
+								types.AttrID:       "id-for-source-block",
+								types.AttrTitle:    "app.rb",
 							},
 							Lines: [][]interface{}{
 								{
@@ -398,7 +396,7 @@ a note
 					Elements: []interface{}{
 						types.ListingBlock{
 							Attributes: types.Attributes{
-								types.AttrBlockKind: types.Source,
+								types.AttrStyle: types.Source,
 							},
 							Lines: [][]interface{}{
 								{
@@ -431,7 +429,7 @@ a note
 						},
 						types.ExampleBlock{
 							Attributes: types.Attributes{
-								types.AttrAdmonitionKind: types.Note,
+								types.AttrStyle: types.Note,
 							},
 							Elements: []interface{}{
 								types.Paragraph{

--- a/pkg/parser/delimited_block_verse_test.go
+++ b/pkg/parser/delimited_block_verse_test.go
@@ -25,7 +25,7 @@ ____`
 					Elements: []interface{}{
 						types.VerseBlock{
 							Attributes: types.Attributes{
-								types.AttrBlockKind:   types.Verse,
+								types.AttrStyle:       types.Verse,
 								types.AttrQuoteAuthor: "john doe",
 								types.AttrQuoteTitle:  "verse title",
 							},
@@ -67,7 +67,7 @@ ____
 					Elements: []interface{}{
 						types.VerseBlock{
 							Attributes: types.Attributes{
-								types.AttrBlockKind:   types.Verse,
+								types.AttrStyle:       types.Verse,
 								types.AttrQuoteAuthor: "john doe",
 							},
 							Lines: [][]interface{}{
@@ -103,7 +103,7 @@ ____
 					Elements: []interface{}{
 						types.VerseBlock{
 							Attributes: types.Attributes{
-								types.AttrBlockKind:  types.Verse,
+								types.AttrStyle:      types.Verse,
 								types.AttrQuoteTitle: "verse title",
 							},
 							Lines: [][]interface{}{
@@ -132,7 +132,7 @@ ____`
 					Elements: []interface{}{
 						types.VerseBlock{
 							Attributes: types.Attributes{
-								types.AttrBlockKind: types.Verse,
+								types.AttrStyle: types.Verse,
 							},
 							Lines: [][]interface{}{
 								{
@@ -179,7 +179,7 @@ ____`
 					Elements: []interface{}{
 						types.VerseBlock{
 							Attributes: types.Attributes{
-								types.AttrBlockKind: types.Verse,
+								types.AttrStyle: types.Verse,
 							},
 							Lines: [][]interface{}{
 								{
@@ -209,7 +209,7 @@ ____`
 					Elements: []interface{}{
 						types.VerseBlock{
 							Attributes: types.Attributes{
-								types.AttrBlockKind: types.Verse,
+								types.AttrStyle: types.Verse,
 							},
 							Lines: [][]interface{}{
 								{},
@@ -229,7 +229,7 @@ foo
 					Elements: []interface{}{
 						types.VerseBlock{
 							Attributes: types.Attributes{
-								types.AttrBlockKind: types.Verse,
+								types.AttrStyle: types.Verse,
 							},
 							Lines: [][]interface{}{
 								{
@@ -275,7 +275,7 @@ ____
 							types.BlankLine{},
 							types.VerseBlock{
 								Attributes: types.Attributes{
-									types.AttrBlockKind:   types.Verse,
+									types.AttrStyle:       types.Verse,
 									types.AttrQuoteAuthor: "john doe",
 									types.AttrQuoteTitle:  "verse title",
 								},
@@ -390,7 +390,7 @@ ____
 							types.BlankLine{},
 							types.VerseBlock{
 								Attributes: types.Attributes{
-									types.AttrBlockKind:     types.Verse,
+									types.AttrStyle:         types.Verse,
 									types.AttrQuoteAuthor:   "john doe",
 									types.AttrQuoteTitle:    "verse title",
 									types.AttrSubstitutions: "normal",
@@ -506,7 +506,7 @@ ____
 							types.BlankLine{},
 							types.VerseBlock{
 								Attributes: types.Attributes{
-									types.AttrBlockKind:     types.Verse,
+									types.AttrStyle:         types.Verse,
 									types.AttrQuoteAuthor:   "john doe",
 									types.AttrQuoteTitle:    "verse title",
 									types.AttrSubstitutions: "quotes",
@@ -577,7 +577,7 @@ ____
 							types.BlankLine{},
 							types.VerseBlock{
 								Attributes: types.Attributes{
-									types.AttrBlockKind:     types.Verse,
+									types.AttrStyle:         types.Verse,
 									types.AttrQuoteAuthor:   "john doe",
 									types.AttrQuoteTitle:    "verse title",
 									types.AttrSubstitutions: "macros",
@@ -653,7 +653,7 @@ ____
 							types.BlankLine{},
 							types.VerseBlock{
 								Attributes: types.Attributes{
-									types.AttrBlockKind:     types.Verse,
+									types.AttrStyle:         types.Verse,
 									types.AttrQuoteAuthor:   "john doe",
 									types.AttrQuoteTitle:    "verse title",
 									types.AttrSubstitutions: "attributes",
@@ -716,7 +716,7 @@ ____
 							types.BlankLine{},
 							types.VerseBlock{
 								Attributes: types.Attributes{
-									types.AttrBlockKind:     types.Verse,
+									types.AttrStyle:         types.Verse,
 									types.AttrQuoteAuthor:   "john doe",
 									types.AttrQuoteTitle:    "verse title",
 									types.AttrSubstitutions: "attributes,macros",
@@ -802,7 +802,7 @@ ____
 							types.BlankLine{},
 							types.VerseBlock{
 								Attributes: types.Attributes{
-									types.AttrBlockKind:     types.Verse,
+									types.AttrStyle:         types.Verse,
 									types.AttrQuoteAuthor:   "john doe",
 									types.AttrQuoteTitle:    "verse title",
 									types.AttrSubstitutions: "specialchars",
@@ -886,7 +886,7 @@ ____
 							types.BlankLine{},
 							types.VerseBlock{
 								Attributes: types.Attributes{
-									types.AttrBlockKind:     types.Verse,
+									types.AttrStyle:         types.Verse,
 									types.AttrQuoteAuthor:   "john doe",
 									types.AttrQuoteTitle:    "verse title",
 									types.AttrSubstitutions: "replacements",
@@ -949,7 +949,7 @@ ____
 							types.BlankLine{},
 							types.VerseBlock{
 								Attributes: types.Attributes{
-									types.AttrBlockKind:     types.Verse,
+									types.AttrStyle:         types.Verse,
 									types.AttrQuoteAuthor:   "john doe",
 									types.AttrQuoteTitle:    "verse title",
 									types.AttrSubstitutions: "post_replacements",
@@ -1013,7 +1013,7 @@ ____
 							types.BlankLine{},
 							types.VerseBlock{
 								Attributes: types.Attributes{
-									types.AttrBlockKind:     types.Verse,
+									types.AttrStyle:         types.Verse,
 									types.AttrQuoteAuthor:   "john doe",
 									types.AttrQuoteTitle:    "verse title",
 									types.AttrSubstitutions: "quotes,macros",
@@ -1097,7 +1097,7 @@ ____
 							types.BlankLine{},
 							types.VerseBlock{
 								Attributes: types.Attributes{
-									types.AttrBlockKind:     types.Verse,
+									types.AttrStyle:         types.Verse,
 									types.AttrQuoteAuthor:   "john doe",
 									types.AttrQuoteTitle:    "verse title",
 									types.AttrSubstitutions: "macros,quotes",
@@ -1181,7 +1181,7 @@ ____
 							types.BlankLine{},
 							types.VerseBlock{
 								Attributes: types.Attributes{
-									types.AttrBlockKind:     types.Verse,
+									types.AttrStyle:         types.Verse,
 									types.AttrQuoteAuthor:   "john doe",
 									types.AttrQuoteTitle:    "verse title",
 									types.AttrSubstitutions: "none",
@@ -1246,7 +1246,7 @@ ____`
 					Elements: []interface{}{
 						types.VerseBlock{
 							Attributes: types.Attributes{
-								types.AttrBlockKind:   types.Verse,
+								types.AttrStyle:       types.Verse,
 								types.AttrQuoteAuthor: "john doe",
 								types.AttrQuoteTitle:  "verse title",
 							},
@@ -1286,7 +1286,7 @@ ____
 					Elements: []interface{}{
 						types.VerseBlock{
 							Attributes: types.Attributes{
-								types.AttrBlockKind:   types.Verse,
+								types.AttrStyle:       types.Verse,
 								types.AttrQuoteAuthor: "john doe",
 							},
 							Lines: [][]interface{}{
@@ -1322,7 +1322,7 @@ ____
 					Elements: []interface{}{
 						types.VerseBlock{
 							Attributes: types.Attributes{
-								types.AttrBlockKind:  types.Verse,
+								types.AttrStyle:      types.Verse,
 								types.AttrQuoteTitle: "verse title",
 							},
 							Lines: [][]interface{}{
@@ -1351,7 +1351,7 @@ ____`
 					Elements: []interface{}{
 						types.VerseBlock{
 							Attributes: types.Attributes{
-								types.AttrBlockKind: types.Verse,
+								types.AttrStyle: types.Verse,
 							},
 							Lines: [][]interface{}{
 								{
@@ -1398,7 +1398,7 @@ ____`
 					Elements: []interface{}{
 						types.VerseBlock{
 							Attributes: types.Attributes{
-								types.AttrBlockKind: types.Verse,
+								types.AttrStyle: types.Verse,
 							},
 							Lines: [][]interface{}{
 								{
@@ -1428,7 +1428,7 @@ ____`
 					Elements: []interface{}{
 						types.VerseBlock{
 							Attributes: types.Attributes{
-								types.AttrBlockKind: types.Verse,
+								types.AttrStyle: types.Verse,
 							},
 							Lines: [][]interface{}{
 								{},
@@ -1448,7 +1448,7 @@ foo
 					Elements: []interface{}{
 						types.VerseBlock{
 							Attributes: types.Attributes{
-								types.AttrBlockKind: types.Verse,
+								types.AttrStyle: types.Verse,
 							},
 							Lines: [][]interface{}{
 								{

--- a/pkg/parser/document_processing.go
+++ b/pkg/parser/document_processing.go
@@ -41,7 +41,7 @@ func ParseDocument(r io.Reader, config configuration.Configuration, options ...O
 	doc.Footnotes = footnotes
 	// insert the preamble at the right location
 	doc = includePreamble(doc)
-	doc.Attributes = doc.Attributes.Add(draftDoc.Attributes)
+	doc.Attributes = doc.Attributes.SetAll(draftDoc.Attributes)
 	// also insert the table of contents
 	doc = includeTableOfContentsPlaceHolder(doc)
 	// finally

--- a/pkg/parser/document_processing_apply_custom_substitutions_test.go
+++ b/pkg/parser/document_processing_apply_custom_substitutions_test.go
@@ -2550,7 +2550,7 @@ and <more text> on the +
 						types.BlankLine{},
 						types.Paragraph{
 							Attributes: types.Attributes{
-								types.AttrBlockKind: types.Listing,
+								types.AttrStyle: types.Listing,
 							},
 							Lines: [][]interface{}{
 								{
@@ -2619,7 +2619,7 @@ and <more text> on the +
 						types.BlankLine{},
 						types.Paragraph{
 							Attributes: types.Attributes{
-								types.AttrBlockKind:     types.Listing,
+								types.AttrStyle:         types.Listing,
 								types.AttrSubstitutions: "quotes",
 							},
 							Lines: [][]interface{}{
@@ -2682,7 +2682,7 @@ and <more text> on the +
 						types.BlankLine{},
 						types.Paragraph{
 							Attributes: types.Attributes{
-								types.AttrBlockKind:     types.Listing,
+								types.AttrStyle:         types.Listing,
 								types.AttrSubstitutions: "+quotes",
 							},
 							Lines: [][]interface{}{
@@ -2760,7 +2760,7 @@ and <more text> on the +
 						types.BlankLine{},
 						types.Paragraph{
 							Attributes: types.Attributes{
-								types.AttrBlockKind:     types.Listing,
+								types.AttrStyle:         types.Listing,
 								types.AttrSubstitutions: "macros,+quotes,-quotes", // ie, "macros" only
 							},
 							Lines: [][]interface{}{

--- a/pkg/parser/document_processing_apply_substitutions.go
+++ b/pkg/parser/document_processing_apply_substitutions.go
@@ -206,7 +206,6 @@ func (f funcs) remove(other string) funcs {
 }
 
 func applySubstitutionsOnElements(elements []interface{}, subs []elementsSubstitution, attrs types.AttributesWithOverrides) ([]interface{}, error) {
-	// var err error
 	// apply all the substitutions on elements that need to be processed
 	for i, element := range elements {
 		log.Debugf("applying substitution on element of type '%T'", element)
@@ -442,7 +441,6 @@ func parserPlaceHolderElements(elements []interface{}, options ...Option) ([]int
 }
 
 func parseContent(filename string, content string, options ...Option) ([]interface{}, error) {
-	// log.Debugf("parsing content '%s'", content)
 	result, err := ParseReader(filename, strings.NewReader(content), options...)
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to parse '%s'", content)
@@ -460,7 +458,6 @@ func restorePlaceholderElements(elements []interface{}, placeholders *placeholde
 		return elements
 	}
 	for i, e := range elements {
-		// log.Debugf("restoring (placeholder) on element of type '%T'", e)
 		//
 		if e, ok := e.(types.ElementPlaceHolder); ok {
 			elements[i] = placeholders.elements[e.Ref]
@@ -570,7 +567,6 @@ func applyAttributeSubstitutionsOnElements(elements []interface{}, attrs types.A
 		}
 		result = append(result, e)
 	}
-	// result = types.Merge(result)
 	return result, nil
 }
 

--- a/pkg/parser/document_processing_apply_substitutions_test.go
+++ b/pkg/parser/document_processing_apply_substitutions_test.go
@@ -737,10 +737,16 @@ var _ = Describe("document substitutions", func() {
 				Counters:  map[string]interface{}{},
 			})
 			Expect(err).To(Not(HaveOccurred()))
-			Expect(result).To(Equal([]interface{}{ // at this stage, AttributeDeclaration and AttributeReset are still present
-				types.StringElement{
-					Content: "112b35", // elements get concatenated
-				},
+			Expect(result).To(Equal([]interface{}{
+				// elements are not concatenated after calling `applyAttributeSubstitutionsOnElements`
+				types.StringElement{Content: "1"},
+				types.StringElement{Content: "1"},
+				types.StringElement{Content: "2"},
+				types.StringElement{Content: ""},
+				types.StringElement{Content: "b"},
+				types.StringElement{Content: ""},
+				types.StringElement{Content: ""},
+				types.StringElement{Content: "35"},
 			}))
 		})
 	})

--- a/pkg/parser/document_processing_apply_substitutions_test.go
+++ b/pkg/parser/document_processing_apply_substitutions_test.go
@@ -288,6 +288,108 @@ var _ = Describe("document substitutions", func() {
 		})
 	})
 
+	Context("paragraph with attributes", func() {
+
+		It("should replace title attribute", func() {
+			// given
+			elements := []interface{}{
+				types.Paragraph{
+					Attributes: types.Attributes{
+						"title": []interface{}{
+							types.AttributeSubstitution{
+								Name: "title",
+							},
+						},
+					},
+					Lines: [][]interface{}{
+						{
+							types.StringElement{
+								Content: "some content.",
+							},
+						},
+					},
+				},
+			}
+			// when
+			result, err := applySubstitutions(elements, types.AttributesWithOverrides{
+				Content: map[string]interface{}{
+					"title": "TITLE",
+				},
+				Overrides: map[string]string{},
+			})
+			// then
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(result).To(Equal([]interface{}{
+				types.Paragraph{
+					Attributes: types.Attributes{
+						"title": "TITLE",
+					},
+					Lines: [][]interface{}{
+						{
+							types.StringElement{
+								Content: "some content.",
+							},
+						},
+					},
+				},
+			}))
+		})
+
+		It("should replace roles attribute", func() {
+			// given
+			elements := []interface{}{
+				types.Paragraph{
+					Attributes: types.Attributes{
+						types.AttrRoles: []interface{}{
+							[]interface{}{
+								types.AttributeSubstitution{
+									Name: "role1",
+								},
+							},
+							[]interface{}{
+								types.AttributeSubstitution{
+									Name: "role2",
+								},
+							},
+						},
+					},
+					Lines: [][]interface{}{
+						{
+							types.StringElement{
+								Content: "some content.",
+							},
+						},
+					},
+				},
+			}
+			// when
+			result, err := applySubstitutions(elements, types.AttributesWithOverrides{
+				Content: map[string]interface{}{
+					"role1": "ROLE1",
+					"role2": "ROLE2",
+				},
+				Overrides: map[string]string{},
+			})
+			// then
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(result).To(Equal([]interface{}{
+				types.Paragraph{
+					Attributes: types.Attributes{
+						types.AttrRoles: []interface{}{"ROLE1", "ROLE2"},
+					},
+					Lines: [][]interface{}{
+						{
+							types.StringElement{
+								Content: "some content.",
+							},
+						},
+					},
+				},
+			}))
+		})
+
+	})
+
 	Context("image blocks", func() {
 
 		It("should substitute inline attribute", func() {

--- a/pkg/parser/document_processing_filter_blocks.go
+++ b/pkg/parser/document_processing_filter_blocks.go
@@ -12,6 +12,7 @@ import (
 // - single line comments and comment blocks
 // - standalone attributes
 func filter(elements []interface{}, matchers ...filterMatcher) []interface{} {
+	log.Debug("filtering elements out")
 	result := make([]interface{}, 0, len(elements))
 elements:
 	for _, element := range elements {
@@ -26,9 +27,6 @@ elements:
 
 		// also, process the content if the element to retain
 		switch e := element.(type) {
-		case types.Preamble:
-			e.Elements = filter(e.Elements, matchers...)
-			result = append(result, e)
 		case types.Paragraph:
 			log.Debug("filtering on paragraph")
 			lines := make([][]interface{}, 0, len(e.Lines))
@@ -82,20 +80,10 @@ elements:
 }
 
 // AllMatchers all the matchers needed to remove the unneeded blocks/elements from the final document
-var allMatchers = []filterMatcher{emptyPreambleMatcher, attributeMatcher, singleLineCommentMatcher, commentBlockMatcher}
+var allMatchers = []filterMatcher{attributeMatcher, singleLineCommentMatcher, commentBlockMatcher}
 
 // filterMatcher returns true if the given element is to be filtered out
 type filterMatcher func(element interface{}) bool
-
-// emptyPreambleMatcher filters the element if it is an empty preamble
-var emptyPreambleMatcher filterMatcher = func(element interface{}) bool {
-	result := false
-	if p, match := element.(types.Preamble); match {
-		result = p.Elements == nil || len(p.Elements) == 0
-	}
-	// log.Debugf(" element of type '%T' is an empty preamble: %t", element, result)
-	return result
-}
 
 // attributeMatcher filters the element if it is a AttributeDeclaration,
 // a AttributeSubstitution, a AttributeReset or a standalone Attribute

--- a/pkg/parser/document_processing_include_files.go
+++ b/pkg/parser/document_processing_include_files.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/bytesparadise/libasciidoc/pkg/configuration"
 	"github.com/bytesparadise/libasciidoc/pkg/types"
+	"github.com/davecgh/go-spew/spew"
 	"github.com/pkg/errors"
 
 	log "github.com/sirupsen/logrus"
@@ -143,13 +144,17 @@ func parseFileToInclude(incl types.FileInclusion, attrs types.AttributesWithOver
 	}
 	content := bytes.NewBuffer(nil)
 	scanner := bufio.NewScanner(bufio.NewReader(f))
-	if lineRanges, ok := incl.LineRanges(); ok {
-		if err := readWithinLines(scanner, content, lineRanges); err != nil {
+	if log.IsLevelEnabled(log.DebugLevel) {
+		log.Debug("parsing file to include")
+		spew.Fdump(log.StandardLogger().Out, incl)
+	}
+	if lr, ok := lineRanges(incl, config); ok {
+		if err := readWithinLines(scanner, content, lr); err != nil {
 			return nil, fmt.Errorf("Unresolved directive in %s - %s", config.Filename, incl.RawText)
 		}
-	} else if tagRanges, ok := incl.TagRanges(); ok {
-		if err := readWithinTags(path, scanner, content, tagRanges); err != nil {
-			return nil, err
+	} else if tr, ok := tagRanges(incl, config); ok {
+		if err := readWithinTags(path, scanner, content, tr); err != nil {
+			return nil, err // keep the underlying error here
 		}
 	} else {
 		if err := readAll(scanner, content); err != nil {
@@ -181,6 +186,36 @@ func parseFileToInclude(incl types.FileInclusion, attrs types.AttributesWithOver
 	inclConfig.Filename = absPath
 	// now, let's parse this content and process nested file inclusions
 	return parseRawSource(content, attrs, levelOffsets, inclConfig, options...)
+}
+
+// lineRanges parses the `lines` attribute if it exists in the given FileInclusion, and returns
+// a corresponding `LineRanges` (or `false` if parsing failed to invalid input)
+func lineRanges(incl types.FileInclusion, config configuration.Configuration) (types.LineRanges, bool) {
+	if lineRanges, exists := incl.Attributes.GetAsString(types.AttrLineRanges); exists {
+		log.Debugf("parsing line ranges: '%s'", lineRanges)
+		lr, err := Parse("", []byte(lineRanges), Entrypoint("LineRanges"))
+		if err != nil {
+			log.Errorf("Unresolved directive in %s - %s", config.Filename, incl.RawText)
+			return types.LineRanges{}, false
+		}
+		return types.NewLineRanges(lr), true
+	}
+	return types.LineRanges{}, false
+}
+
+// tagRanges parses the `tags` attribute if it exists in the given FileInclusion, and returns
+// a corresponding `TagRanges` (or `false` if parsing failed to invalid input)
+func tagRanges(incl types.FileInclusion, config configuration.Configuration) (types.TagRanges, bool) {
+	if tagRanges, exists := incl.Attributes.GetAsString(types.AttrTagRanges); exists {
+		// log.Debugf("parsing tag ranges: '%s'", tagRanges)
+		tr, err := Parse("", []byte(tagRanges), Entrypoint("TagRanges"))
+		if err != nil {
+			log.Errorf("Unresolved directive in %s - %s", config.Filename, incl.RawText)
+			return types.TagRanges{}, false
+		}
+		return types.NewTagRanges(tr), true
+	}
+	return types.TagRanges{}, false
 }
 
 func readWithinLines(scanner *bufio.Scanner, content *bytes.Buffer, lineRanges types.LineRanges) error {

--- a/pkg/parser/document_processing_include_files.go
+++ b/pkg/parser/document_processing_include_files.go
@@ -29,7 +29,6 @@ func ParseRawSource(r io.Reader, config configuration.Configuration, options ...
 }
 
 func parseRawSource(r io.Reader, attrs types.AttributesWithOverrides, levelOffsets []levelOffset, config configuration.Configuration, options ...Option) ([]byte, error) {
-	// log.Debugf("parsing raw document '%s'", config.Filename)
 	lines, err := ParseReader(config.Filename, r, options...)
 	if err != nil {
 		log.Errorf("failed to parse raw document: %s", err)
@@ -136,7 +135,6 @@ func parseFileToInclude(incl types.FileInclusion, attrs types.AttributesWithOver
 	}
 	path := incl.Location.Stringify()
 	currentDir := filepath.Dir(config.Filename)
-	// log.Debugf("parsing '%s' from current dir '%s' (%s)", path, currentDir, config.Filename)
 	f, absPath, done, err := open(filepath.Join(currentDir, path))
 	defer done()
 	if err != nil {
@@ -192,7 +190,6 @@ func parseFileToInclude(incl types.FileInclusion, attrs types.AttributesWithOver
 // a corresponding `LineRanges` (or `false` if parsing failed to invalid input)
 func lineRanges(incl types.FileInclusion, config configuration.Configuration) (types.LineRanges, bool) {
 	if lineRanges, exists := incl.Attributes.GetAsString(types.AttrLineRanges); exists {
-		log.Debugf("parsing line ranges: '%s'", lineRanges)
 		lr, err := Parse("", []byte(lineRanges), Entrypoint("LineRanges"))
 		if err != nil {
 			log.Errorf("Unresolved directive in %s - %s", config.Filename, incl.RawText)
@@ -207,7 +204,6 @@ func lineRanges(incl types.FileInclusion, config configuration.Configuration) (t
 // a corresponding `TagRanges` (or `false` if parsing failed to invalid input)
 func tagRanges(incl types.FileInclusion, config configuration.Configuration) (types.TagRanges, bool) {
 	if tagRanges, exists := incl.Attributes.GetAsString(types.AttrTagRanges); exists {
-		// log.Debugf("parsing tag ranges: '%s'", tagRanges)
 		tr, err := Parse("", []byte(tagRanges), Entrypoint("TagRanges"))
 		if err != nil {
 			log.Errorf("Unresolved directive in %s - %s", config.Filename, incl.RawText)
@@ -219,11 +215,9 @@ func tagRanges(incl types.FileInclusion, config configuration.Configuration) (ty
 }
 
 func readWithinLines(scanner *bufio.Scanner, content *bytes.Buffer, lineRanges types.LineRanges) error {
-	log.Debugf("limiting to line ranges: %v", lineRanges)
 	line := 0
 	for scanner.Scan() {
 		line++
-		log.Debugf("line %d: '%s' (matching range: %t)", line, scanner.Text(), lineRanges.Match(line))
 		// parse the line in search for the `tag::<tag>[]` or `end:<tag>[]` macros
 		l, err := Parse("", scanner.Bytes(), Entrypoint("IncludedFileLine"))
 		if err != nil {

--- a/pkg/parser/document_processing_include_files_test.go
+++ b/pkg/parser/document_processing_include_files_test.go
@@ -902,6 +902,8 @@ include::{includedir}/include.foo[]`
 					})
 
 					It("file inclusion with invalid unquoted range - case 1", func() {
+						_, reset := ConfigureLogger(log.WarnLevel)
+						defer reset()
 						source := `include::../../test/includes/chapter-a.adoc[lines=1;3..4;6..foo]` // not a number
 						expected := types.RawDocument{
 							Elements: []interface{}{
@@ -991,7 +993,7 @@ include::{includedir}/include.foo[]`
 						Expect(ParseRawDocument(source)).To(MatchRawDocument(expected))
 					})
 
-					It("file inclusion with multiple quoted ranges", func() {
+					It("file inclusion with multiple quoted ranges with colons", func() {
 						// here, the `content` paragraph gets attached to the header and becomes the author
 						source := `include::../../test/includes/chapter-a.adoc[lines="1,3..4,6..-1"]`
 						expected := types.RawDocument{
@@ -1017,12 +1019,20 @@ include::{includedir}/include.foo[]`
 						Expect(ParseRawDocument(source)).To(MatchRawDocument(expected))
 					})
 
-					It("file inclusion with invalid quoted range - case 1", func() {
-						source := `include::../../test/includes/chapter-a.adoc[lines="1,3..4,6..foo"]` // not a number
+					It("file inclusion with multiple quoted ranges with semicolons", func() {
+						// here, the `content` paragraph gets attached to the header and becomes the author
+						source := `include::../../test/includes/chapter-a.adoc[lines="1;3..4;6..-1"]`
 						expected := types.RawDocument{
 							Elements: []interface{}{
 								types.Section{
 									Level: 0,
+									Attributes: types.Attributes{
+										types.AttrAuthors: []types.DocumentAuthor{
+											{
+												FullName: "content",
+											},
+										},
+									},
 									Title: []interface{}{
 										types.StringElement{
 											Content: "Chapter A",
@@ -1030,23 +1040,15 @@ include::{includedir}/include.foo[]`
 									},
 									Elements: []interface{}{},
 								},
-								types.BlankLine{},
-								types.Paragraph{
-									Lines: [][]interface{}{
-										{
-											types.StringElement{
-												Content: "content",
-											},
-										},
-									},
-								},
 							},
 						}
 						Expect(ParseRawDocument(source)).To(MatchRawDocument(expected))
 					})
 
-					It("file inclusion with invalid quoted range - case 2", func() {
-						source := `include::../../test/includes/chapter-a.adoc[lines="1;3..4;6..10"]` // using semi-colons instead of commas
+					It("file inclusion with invalid quoted range - case 1", func() {
+						_, reset := ConfigureLogger(log.WarnLevel)
+						defer reset()
+						source := `include::../../test/includes/chapter-a.adoc[lines="1,3..4,6..foo"]` // not a number
 						expected := types.RawDocument{
 							Elements: []interface{}{
 								types.Section{

--- a/pkg/parser/document_processing_test.go
+++ b/pkg/parser/document_processing_test.go
@@ -25,7 +25,7 @@ foo
 				Elements: []interface{}{
 					types.ListingBlock{
 						Attributes: types.Attributes{
-							types.AttrBlockKind: types.Source,
+							types.AttrStyle: types.Source,
 						},
 						Lines: [][]interface{}{
 							{

--- a/pkg/parser/element_attributes_test.go
+++ b/pkg/parser/element_attributes_test.go
@@ -123,8 +123,7 @@ a paragraph`
 						Elements: []interface{}{
 							types.Paragraph{
 								Attributes: types.Attributes{
-									types.AttrID:       "img-foobar",
-									types.AttrCustomID: true,
+									types.AttrID: "img-foobar",
 								},
 								Lines: [][]interface{}{
 									{
@@ -146,8 +145,7 @@ a paragraph`
 						Elements: []interface{}{
 							types.Paragraph{
 								Attributes: types.Attributes{
-									types.AttrID:       "img-foobar",
-									types.AttrCustomID: true,
+									types.AttrID: "img-foobar",
 								},
 								Lines: [][]interface{}{
 									{
@@ -310,13 +308,13 @@ a paragraph`
 			Context("with valid syntax", func() {
 
 				It("shortcut role element", func() {
-					source := `[.a role]
+					source := `[.a_role]
 a paragraph`
 					expected := types.Document{
 						Elements: []interface{}{
 							types.Paragraph{
 								Attributes: types.Attributes{
-									types.AttrRole: types.ElementRole{"a role"},
+									types.AttrRoles: []interface{}{"a_role"},
 								},
 								Lines: [][]interface{}{
 									{
@@ -332,13 +330,13 @@ a paragraph`
 				})
 
 				It("full role syntax", func() {
-					source := `[role=a role]
+					source := `[role=a_role]
 a paragraph`
 					expected := types.Document{
 						Elements: []interface{}{
 							types.Paragraph{
 								Attributes: types.Attributes{
-									types.AttrRole: types.ElementRole{"a role"},
+									types.AttrRoles: []interface{}{"a_role"},
 								},
 								Lines: [][]interface{}{
 									{
@@ -355,14 +353,14 @@ a paragraph`
 			})
 
 			It("blank line after role attribute", func() {
-				source := `[.a role]
+				source := `[.a_role]
 
 a paragraph`
 				expected := types.Document{
 					Elements: []interface{}{
 						types.Paragraph{
 							Attributes: types.Attributes{
-								types.AttrRole: types.ElementRole{"a role"},
+								types.AttrRoles: []interface{}{"a_role"},
 							},
 							Lines: [][]interface{}{
 								{types.StringElement{
@@ -379,7 +377,7 @@ a paragraph`
 			})
 
 			It("blank lines after id, role and title attributes", func() {
-				source := `[.a role]
+				source := `[.a_role]
 [[ID]]
 .title
 
@@ -389,10 +387,9 @@ a paragraph`
 					Elements: []interface{}{
 						types.Paragraph{
 							Attributes: types.Attributes{
-								types.AttrRole:     types.ElementRole{"a role"},
-								types.AttrTitle:    "title",
-								types.AttrID:       "ID",
-								types.AttrCustomID: true,
+								types.AttrRoles: []interface{}{"a_role"},
+								types.AttrTitle: "title",
+								types.AttrID:    "ID",
 							},
 							Lines: [][]interface{}{
 								{types.StringElement{
@@ -410,7 +407,7 @@ a paragraph`
 		Context("standalone attributes", func() {
 
 			It("single standalone attribute", func() {
-				source := `[.a role]
+				source := `[.a_role]
 `
 				expected := types.Document{
 					Elements: []interface{}{},
@@ -419,7 +416,7 @@ a paragraph`
 			})
 
 			It("multiple standalone attributes", func() {
-				source := `[.a role]
+				source := `[.a_role]
 [[ID]]
 .title`
 				expected := types.Document{
@@ -431,7 +428,7 @@ a paragraph`
 			It("multiple standalone attributes after a paragraph", func() {
 				source := `a paragraph
 			
-[.a role]
+[.a_role]
 [[ID]]
 .title`
 				expected := types.Document{

--- a/pkg/parser/footnote_test.go
+++ b/pkg/parser/footnote_test.go
@@ -66,11 +66,7 @@ var _ = Describe("footnotes - document", func() {
 					},
 					types.InlineLink{
 						Attributes: types.Attributes{
-							"positional-1": []interface{}{
-								types.StringElement{
-									Content: "content",
-								},
-							},
+							types.AttrInlineLinkText: "content",
 						},
 						Location: types.Location{
 							Scheme: "https://",

--- a/pkg/parser/generate.go
+++ b/pkg/parser/generate.go
@@ -1,3 +1,3 @@
 package parser
 
-//go:generate pigeon -optimize-parser -alternate-entrypoints RawSource,RawDocument,DocumentRawBlock,IncludedFileLine,LabeledListItemTerm,MarkdownQuoteAttribution,QuotedTextSubs,NoneSubs,AttributeSubs,ReplacementSubs,PostReplacementSubs,InlinePassthroughSubs,CalloutSubs,InlineMacroSubs,MarkdownQuoteMacroSubs -o parser.go parser.peg
+//go:generate pigeon -optimize-parser -alternate-entrypoints RawSource,RawDocument,DocumentRawBlock,IncludedFileLine,LabeledListItemTerm,MarkdownQuoteAttribution,QuotedTextSubs,NoneSubs,AttributeSubs,ReplacementSubs,PostReplacementSubs,InlinePassthroughSubs,CalloutSubs,InlineMacroSubs,MarkdownQuoteMacroSubs,BlockAttributes,LineRanges,TagRanges -o parser.go parser.peg

--- a/pkg/parser/icon_test.go
+++ b/pkg/parser/icon_test.go
@@ -124,8 +124,7 @@ var _ = Describe("icons", func() {
 									types.Icon{
 										Class: "caution",
 										Attributes: types.Attributes{
-											types.AttrID:       "anchor",
-											types.AttrCustomID: true,
+											types.AttrID: "anchor",
 										},
 									},
 								},
@@ -146,9 +145,8 @@ var _ = Describe("icons", func() {
 									types.Icon{
 										Class: "caution",
 										Attributes: types.Attributes{
-											types.AttrID:       "anchor",
-											types.AttrCustomID: true,
-											types.AttrTitle:    "White Fang",
+											types.AttrID:    "anchor",
+											types.AttrTitle: "White Fang",
 										},
 									},
 								},
@@ -170,7 +168,6 @@ var _ = Describe("icons", func() {
 										Class: "caution",
 										Attributes: types.Attributes{
 											types.AttrID:       "anchor",
-											types.AttrCustomID: true,
 											types.AttrTitle:    "White Fang",
 											types.AttrIconSize: "fw",
 										},

--- a/pkg/parser/image_test.go
+++ b/pkg/parser/image_test.go
@@ -101,13 +101,13 @@ image::images/foo.png[the foo.png image, 600, 400]`
 				Elements: []interface{}{
 					types.ImageBlock{
 						Attributes: types.Attributes{
-							types.AttrID:          "img-foobar",
-							types.AttrCustomID:    true,
-							types.AttrTitle:       "A title to foobar",
-							types.AttrInlineLink:  "http://foo.bar",
-							types.AttrImageAlt:    "the foo.png image",
-							types.AttrWidth:       "600",
-							types.AttrImageHeight: "400",
+							types.AttrID: "img-foobar",
+							// types.AttrCustomID: true,    true,
+							types.AttrTitle:      "A title to foobar",
+							types.AttrInlineLink: "http://foo.bar",
+							types.AttrImageAlt:   "the foo.png image",
+							types.AttrWidth:      "600",
+							types.AttrHeight:     "400",
 						},
 						Location: types.Location{
 							Path: []interface{}{
@@ -126,13 +126,10 @@ image::images/foo.png[the foo.png image, 600, 400]`
 				Elements: []interface{}{
 					types.ImageBlock{
 						Attributes: types.Attributes{
-							types.AttrImageAlt:    "the foo.png image",
-							types.AttrWidth:       "600",
-							types.AttrImageHeight: "400",
-							types.AttrRole: []interface{}{
-								types.ElementRole{"role1"},
-								types.ElementRole{"role2"},
-							},
+							types.AttrImageAlt: "the foo.png image",
+							types.AttrWidth:    "600",
+							types.AttrHeight:   "400",
+							types.AttrRoles:    []interface{}{"role1", "role2"},
 						},
 						Location: types.Location{
 							Path: []interface{}{
@@ -507,9 +504,9 @@ var _ = Describe("inline images", func() {
 							{
 								types.InlineImage{
 									Attributes: types.Attributes{
-										types.AttrImageAlt:    "the foo.png image",
-										types.AttrWidth:       "600",
-										types.AttrImageHeight: "400",
+										types.AttrImageAlt: "the foo.png image",
+										types.AttrWidth:    "600",
+										types.AttrHeight:   "400",
 									},
 									Location: types.Location{
 										Path: []interface{}{
@@ -559,8 +556,7 @@ var _ = Describe("inline images", func() {
 							{
 								types.InlineImage{
 									Attributes: types.Attributes{
-										types.AttrID:       "myid",
-										types.AttrCustomID: true,
+										types.AttrID: "myid",
 									},
 									Location: types.Location{
 										Path: []interface{}{
@@ -585,10 +581,9 @@ var _ = Describe("inline images", func() {
 							{
 								types.InlineImage{
 									Attributes: types.Attributes{
-										types.AttrID:       "myid",
-										types.AttrCustomID: true,
-										types.AttrTitle:    "mytitle",
-										types.AttrRole:     types.ElementRole{"myrole"},
+										types.AttrID:    "myid",
+										types.AttrTitle: "mytitle",
+										types.AttrRoles: []interface{}{"myrole"},
 									},
 									Location: types.Location{
 										Path: []interface{}{
@@ -605,7 +600,7 @@ var _ = Describe("inline images", func() {
 		})
 
 		It("with alt, width, height and other attributes", func() {
-			source := "image:images/foo.png[ foo, 600, 400, id=myid, title=mytitle, role=myrole ]"
+			source := "image:images/foo.png[foo, 600, 400, id=myid, title=mytitle, role=myrole ]"
 			expected := types.DraftDocument{
 				Elements: []interface{}{
 					types.Paragraph{
@@ -613,13 +608,13 @@ var _ = Describe("inline images", func() {
 							{
 								types.InlineImage{
 									Attributes: types.Attributes{
-										types.AttrImageAlt:    "foo",
-										types.AttrWidth:       "600",
-										types.AttrImageHeight: "400",
-										types.AttrID:          "myid",
-										types.AttrCustomID:    true,
-										types.AttrTitle:       "mytitle",
-										types.AttrRole:        types.ElementRole{"myrole"},
+										types.AttrImageAlt: "foo",
+										types.AttrWidth:    "600",
+										types.AttrHeight:   "400",
+										types.AttrID:       "myid",
+										// types.AttrCustomID: true,    true,
+										types.AttrTitle: "mytitle",
+										types.AttrRoles: []interface{}{"myrole"},
 									},
 									Location: types.Location{
 										Path: []interface{}{

--- a/pkg/parser/labeled_list_test.go
+++ b/pkg/parser/labeled_list_test.go
@@ -1905,7 +1905,7 @@ TIP: tip`
 									},
 									types.Paragraph{
 										Attributes: types.Attributes{
-											types.AttrAdmonitionKind: types.Note,
+											types.AttrStyle: types.Note,
 										},
 										Lines: [][]interface{}{
 											{
@@ -1939,7 +1939,7 @@ TIP: tip`
 									},
 									types.Paragraph{
 										Attributes: types.Attributes{
-											types.AttrAdmonitionKind: types.Important,
+											types.AttrStyle: types.Important,
 										},
 										Lines: [][]interface{}{
 											{
@@ -1949,7 +1949,7 @@ TIP: tip`
 									},
 									types.Paragraph{
 										Attributes: types.Attributes{
-											types.AttrAdmonitionKind: types.Tip,
+											types.AttrStyle: types.Tip,
 										},
 										Lines: [][]interface{}{
 											{
@@ -2029,7 +2029,7 @@ TIP: We can embed admonitions too!
 									},
 									types.Paragraph{
 										Attributes: types.Attributes{
-											types.AttrAdmonitionKind: types.Tip,
+											types.AttrStyle: types.Tip,
 										},
 										Lines: [][]interface{}{
 											{

--- a/pkg/parser/link_test.go
+++ b/pkg/parser/link_test.go
@@ -10,7 +10,7 @@ import (
 
 var _ = Describe("links", func() {
 
-	Context("draft document", func() {
+	Context("draft documents", func() {
 
 		It("link with special characters", func() {
 			source := `a link to https://example.com?a=1&b=2`
@@ -104,7 +104,8 @@ var _ = Describe("links", func() {
 					Elements: []interface{}{
 						types.Paragraph{
 							Lines: [][]interface{}{
-								{types.StringElement{Content: "a link to "},
+								{
+									types.StringElement{Content: "a link to "},
 									types.InlineLink{
 										Location: types.Location{
 											Scheme: "mailto:",
@@ -115,14 +116,12 @@ var _ = Describe("links", func() {
 											},
 										},
 										Attributes: types.Attributes{
-											"positional-1": []interface{}{
-												types.StringElement{
-													Content: "the foo@bar email",
-												},
-											},
+											types.AttrInlineLinkText: "the foo@bar email",
 										},
 									},
-									types.StringElement{Content: "."},
+									types.StringElement{
+										Content: ".",
+									},
 								},
 							},
 						},
@@ -148,12 +147,8 @@ var _ = Describe("links", func() {
 											},
 										},
 										Attributes: types.Attributes{
-											"positional-1": []interface{}{
-												types.StringElement{
-													Content: "the foo@bar email",
-												},
-											},
-											"foo": "bar",
+											types.AttrInlineLinkText: "the foo@bar email",
+											"foo":                    "bar",
 										},
 									},
 								},
@@ -290,21 +285,9 @@ next lines`
 												},
 											},
 											Attributes: types.Attributes{
-												"positional-1": []interface{}{
-													types.StringElement{
-														Content: "A",
-													},
-												},
-												"positional-2": []interface{}{
-													types.StringElement{
-														Content: " B",
-													},
-												},
-												"positional-3": []interface{}{
-													types.StringElement{
-														Content: " and C",
-													},
-												},
+												types.AttrInlineLinkText: "A",
+												types.AttrPositional2:    "B",
+												types.AttrPositional3:    "and C",
 											},
 										},
 									},
@@ -333,11 +316,7 @@ next lines`
 												},
 											},
 											Attributes: types.Attributes{
-												"positional-1": []interface{}{
-													types.StringElement{
-														Content: "A, B, and C",
-													},
-												},
+												types.AttrInlineLinkText: "A, B, and C",
 											},
 										},
 									},
@@ -366,12 +345,8 @@ next lines`
 												},
 											},
 											Attributes: types.Attributes{
-												"positional-1": []interface{}{
-													types.StringElement{
-														Content: "A, B, and C",
-													},
-												},
-												types.AttrRole: types.ElementRole{"foo"},
+												types.AttrInlineLinkText: "A, B, and C",
+												types.AttrRoles:          []interface{}{"foo"},
 											},
 										},
 									},
@@ -400,22 +375,10 @@ next lines`
 												},
 											},
 											Attributes: types.Attributes{
-												"positional-1": []interface{}{
-													types.StringElement{
-														Content: "A",
-													},
-												},
-												"positional-2": []interface{}{
-													types.StringElement{
-														Content: " B",
-													},
-												},
-												"positional-3": []interface{}{
-													types.StringElement{
-														Content: " and C",
-													},
-												},
-												types.AttrRole: types.ElementRole{"foo"},
+												types.AttrInlineLinkText: "A",
+												types.AttrPositional2:    "B",
+												types.AttrPositional3:    "and C",
+												types.AttrRoles:          []interface{}{"foo"},
 											},
 										},
 									},
@@ -461,7 +424,7 @@ next lines`
 								{types.StringElement{Content: "a link to "},
 									types.InlineLink{
 										Attributes: types.Attributes{
-											"positional-1": []interface{}{
+											types.AttrInlineLinkText: []interface{}{
 												types.QuotedText{
 													Kind: types.Italic,
 													Elements: []interface{}{
@@ -963,11 +926,7 @@ a link to {scheme}://{path} and https://foo.com`
 											},
 										},
 										Attributes: types.Attributes{
-											"positional-1": []interface{}{
-												types.StringElement{
-													Content: "foo doc",
-												},
-											},
+											types.AttrInlineLinkText: "foo doc",
 										},
 									},
 								},
@@ -995,11 +954,7 @@ a link to {scheme}://{path} and https://foo.com`
 											},
 										},
 										Attributes: types.Attributes{
-											"positional-1": []interface{}{
-												types.StringElement{
-													Content: "foo doc",
-												},
-											},
+											types.AttrInlineLinkText: "foo doc",
 										},
 									},
 								},
@@ -1027,12 +982,8 @@ a link to {scheme}://{path} and https://foo.com`
 											},
 										},
 										Attributes: types.Attributes{
-											"positional-1": []interface{}{
-												types.StringElement{
-													Content: "foo doc",
-												},
-											},
-											"foo": "bar",
+											types.AttrInlineLinkText: "foo doc",
+											"foo":                    "bar",
 										},
 									},
 								},
@@ -1104,7 +1055,7 @@ a link to {scheme}://{path} and https://foo.com`
 										},
 									},
 									Attributes: types.Attributes{
-										"positional-1": []interface{}{
+										types.AttrInlineLinkText: []interface{}{
 											types.StringElement{
 												Content: "a ",
 											},
@@ -1172,11 +1123,7 @@ a link to {scheme}://{path} and https://foo.com`
 											},
 										},
 										Attributes: types.Attributes{
-											"positional-1": []interface{}{
-												types.StringElement{
-													Content: "as expected",
-												},
-											},
+											types.AttrInlineLinkText: "as expected",
 										},
 									},
 								},
@@ -1211,11 +1158,7 @@ Test 2: link:/test/a%20b[with encoded space]`
 											},
 										},
 										Attributes: types.Attributes{
-											"positional-1": []interface{}{
-												types.StringElement{
-													Content: "with encoded space",
-												},
-											},
+											types.AttrInlineLinkText: "with encoded space",
 										},
 									},
 								},
@@ -1325,21 +1268,9 @@ a link to {scheme}:{path}[] and https://foo.com`
 												},
 											},
 											Attributes: types.Attributes{
-												"positional-1": []interface{}{
-													types.StringElement{
-														Content: "A",
-													},
-												},
-												"positional-2": []interface{}{
-													types.StringElement{
-														Content: " B",
-													},
-												},
-												"positional-3": []interface{}{
-													types.StringElement{
-														Content: " and C",
-													},
-												},
+												types.AttrInlineLinkText: "A",
+												types.AttrPositional2:    "B",
+												types.AttrPositional3:    "and C",
 											},
 										},
 									},
@@ -1368,11 +1299,7 @@ a link to {scheme}:{path}[] and https://foo.com`
 												},
 											},
 											Attributes: types.Attributes{
-												"positional-1": []interface{}{
-													types.StringElement{
-														Content: "A, B, and C",
-													},
-												},
+												types.AttrInlineLinkText: "A, B, and C",
 											},
 										},
 									},
@@ -1401,12 +1328,8 @@ a link to {scheme}:{path}[] and https://foo.com`
 												},
 											},
 											Attributes: types.Attributes{
-												"positional-1": []interface{}{
-													types.StringElement{
-														Content: "A, B, and C",
-													},
-												},
-												types.AttrRole: types.ElementRole{"foo"},
+												types.AttrInlineLinkText: "A, B, and C",
+												types.AttrRoles:          []interface{}{"foo"},
 											},
 										},
 									},
@@ -1435,22 +1358,10 @@ a link to {scheme}:{path}[] and https://foo.com`
 												},
 											},
 											Attributes: types.Attributes{
-												"positional-1": []interface{}{
-													types.StringElement{
-														Content: "A",
-													},
-												},
-												"positional-2": []interface{}{
-													types.StringElement{
-														Content: " B",
-													},
-												},
-												"positional-3": []interface{}{
-													types.StringElement{
-														Content: " and C",
-													},
-												},
-												types.AttrRole: types.ElementRole{"foo"},
+												types.AttrInlineLinkText: "A",
+												types.AttrPositional2:    "B",
+												types.AttrPositional3:    "and C",
+												types.AttrRoles:          []interface{}{"foo"},
 											},
 										},
 									},

--- a/pkg/parser/paragraph_test.go
+++ b/pkg/parser/paragraph_test.go
@@ -346,20 +346,55 @@ foo`
 				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
-			It("with counters", func() {
-				source := `foo{counter:foo} bar{counter2:foo} baz{counter:foo} bob{counter:bob}`
-				expected := types.DraftDocument{
-					Elements: []interface{}{
-						types.Paragraph{
-							Lines: [][]interface{}{
-								{
-									types.StringElement{Content: "foo1 bar baz3 bob1"},
+			Context("with counters", func() {
+
+				It("default", func() {
+					source := `foo{counter:foo} bar{counter2:foo} baz{counter:foo} bob{counter:bob}`
+					expected := types.DraftDocument{
+						Elements: []interface{}{
+							types.Paragraph{
+								Lines: [][]interface{}{
+									{
+										types.StringElement{Content: "foo1 bar baz3 bob1"},
+									},
 								},
 							},
 						},
-					},
-				}
-				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
+					}
+					Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
+				})
+
+				It("with numeric start", func() {
+					source := `foo{counter:foo:2} bar{counter2:foo} baz{counter:foo} bob{counter:bob:10}`
+					expected := types.DraftDocument{
+						Elements: []interface{}{
+							types.Paragraph{
+								Lines: [][]interface{}{
+									{
+										types.StringElement{Content: "foo2 bar baz4 bob10"},
+									},
+								},
+							},
+						},
+					}
+					Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
+				})
+
+				It("with alphanumeric start", func() {
+					source := `foo{counter:foo:b} bar{counter2:foo} baz{counter:foo} bob{counter:bob:z}`
+					expected := types.DraftDocument{
+						Elements: []interface{}{
+							types.Paragraph{
+								Lines: [][]interface{}{
+									{
+										types.StringElement{Content: "foob bar bazd bobz"},
+									},
+								},
+							},
+						},
+					}
+					Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
+				})
 			})
 
 			Context("with custom substitutions", func() {

--- a/pkg/parser/paragraph_test.go
+++ b/pkg/parser/paragraph_test.go
@@ -52,7 +52,7 @@ baz`
 					Elements: []interface{}{
 						types.Paragraph{
 							Attributes: types.Attributes{
-								types.AttrOptions: map[string]bool{"hardbreaks": true},
+								types.AttrOptions: []interface{}{"hardbreaks"},
 							},
 							Lines: [][]interface{}{
 								{
@@ -241,7 +241,7 @@ baz`
 				Expect(result).To(MatchDraftDocument(expected))
 			})
 
-			It("with paragraph multiple attributes", func() {
+			It("with multiple attributes without blanklines in-between", func() {
 				source := `[%hardbreaks.role1.role2]
 [#anchor]
 foo
@@ -250,10 +250,9 @@ baz`
 					Elements: []interface{}{
 						types.Paragraph{
 							Attributes: types.Attributes{
-								types.AttrCustomID: true,
-								types.AttrID:       "anchor",
-								types.AttrRole:     []interface{}{types.ElementRole{"role1"}, types.ElementRole{"role2"}},
-								types.AttrOptions:  map[string]bool{"hardbreaks": true},
+								types.AttrID:      "anchor",
+								types.AttrRoles:   []interface{}{"role1", "role2"},
+								types.AttrOptions: []interface{}{"hardbreaks"},
 							},
 							Lines: [][]interface{}{
 								{
@@ -269,7 +268,7 @@ baz`
 				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
-			It("with paragraph multiple attributes and blanklines in-between", func() {
+			It("with multiple attributes and blanklines in-between", func() {
 				source := `[%hardbreaks.role1.role2]
 
 [#anchor]
@@ -280,10 +279,9 @@ baz`
 					Elements: []interface{}{
 						types.Paragraph{
 							Attributes: types.Attributes{
-								types.AttrCustomID: true,
-								types.AttrID:       "anchor",
-								types.AttrRole:     []interface{}{types.ElementRole{"role1"}, types.ElementRole{"role2"}},
-								types.AttrOptions:  map[string]bool{"hardbreaks": true},
+								types.AttrID:      "anchor",
+								types.AttrRoles:   []interface{}{"role1", "role2"},
+								types.AttrOptions: []interface{}{"hardbreaks"},
 							},
 							Lines: [][]interface{}{
 								{
@@ -308,8 +306,8 @@ baz`
 					Elements: []interface{}{
 						types.Paragraph{
 							Attributes: types.Attributes{
-								types.AttrOptions: map[string]bool{"hardbreaks": true},
-								types.AttrRole:    []interface{}{types.ElementRole{"role1"}, types.ElementRole{"role2"}},
+								types.AttrOptions: []interface{}{"hardbreaks"},
+								types.AttrRoles:   []interface{}{"role1", "role2"},
 							},
 							Lines: [][]interface{}{
 								{
@@ -980,7 +978,7 @@ another one using attribute substitution: {github-url}[]...
 					Elements: []interface{}{
 						types.Paragraph{
 							Attributes: types.Attributes{
-								types.AttrAdmonitionKind: types.Note,
+								types.AttrStyle: types.Note,
 							},
 							Lines: [][]interface{}{
 								{
@@ -1000,7 +998,7 @@ warning!`
 					Elements: []interface{}{
 						types.Paragraph{
 							Attributes: types.Attributes{
-								types.AttrAdmonitionKind: types.Warning,
+								types.AttrStyle: types.Warning,
 							},
 							Lines: [][]interface{}{
 								{
@@ -1024,10 +1022,9 @@ NOTE: this is a note.`
 					Elements: []interface{}{
 						types.Paragraph{
 							Attributes: types.Attributes{
-								types.AttrAdmonitionKind: types.Note,
-								types.AttrID:             "foo",
-								types.AttrCustomID:       true,
-								types.AttrTitle:          "bar",
+								types.AttrStyle: types.Note,
+								types.AttrID:    "foo",
+								types.AttrTitle: "bar",
 							},
 							Lines: [][]interface{}{
 								{
@@ -1047,7 +1044,7 @@ this is a caution!`
 					Elements: []interface{}{
 						types.Paragraph{
 							Attributes: types.Attributes{
-								types.AttrAdmonitionKind: types.Caution,
+								types.AttrStyle: types.Caution,
 							},
 							Lines: [][]interface{}{
 								{
@@ -1070,10 +1067,9 @@ this is a
 					Elements: []interface{}{
 						types.Paragraph{
 							Attributes: types.Attributes{
-								types.AttrAdmonitionKind: types.Caution,
-								types.AttrID:             "foo",
-								types.AttrCustomID:       true,
-								types.AttrTitle:          "bar",
+								types.AttrStyle: types.Caution,
+								types.AttrID:    "foo",
+								types.AttrTitle: "bar",
 							},
 							Lines: [][]interface{}{
 								{
@@ -1109,7 +1105,7 @@ And no space after [CAUTION] either.`
 					Elements: []interface{}{
 						types.Paragraph{
 							Attributes: types.Attributes{
-								types.AttrAdmonitionKind: types.Note,
+								types.AttrStyle: types.Note,
 							},
 							Lines: [][]interface{}{
 								{
@@ -1120,7 +1116,7 @@ And no space after [CAUTION] either.`
 						types.BlankLine{},
 						types.Paragraph{
 							Attributes: types.Attributes{
-								types.AttrAdmonitionKind: types.Caution,
+								types.AttrStyle: types.Caution,
 							},
 							Lines: [][]interface{}{
 								{
@@ -1145,7 +1141,7 @@ I am a verse paragraph.`
 					Elements: []interface{}{
 						types.Paragraph{
 							Attributes: types.Attributes{
-								types.AttrBlockKind:   types.Verse,
+								types.AttrStyle:       types.Verse,
 								types.AttrQuoteAuthor: "john doe",
 								types.AttrQuoteTitle:  "verse title",
 							},
@@ -1169,12 +1165,12 @@ I am a verse paragraph.`
 					Elements: []interface{}{
 						types.Paragraph{
 							Attributes: types.Attributes{
-								types.AttrBlockKind:   types.Verse,
+								types.AttrStyle:       types.Verse,
 								types.AttrQuoteAuthor: "john doe",
 								types.AttrQuoteTitle:  "verse title",
 								types.AttrID:          "universal",
-								types.AttrCustomID:    true,
-								types.AttrTitle:       "universe",
+								// types.AttrCustomID:    true,
+								types.AttrTitle: "universe",
 							},
 							Lines: [][]interface{}{
 								{
@@ -1194,7 +1190,7 @@ I am a verse paragraph.`
 					Elements: []interface{}{
 						types.Paragraph{
 							Attributes: types.Attributes{
-								types.AttrBlockKind:   types.Verse,
+								types.AttrStyle:       types.Verse,
 								types.AttrQuoteAuthor: "john doe",
 							},
 							Lines: [][]interface{}{
@@ -1215,7 +1211,7 @@ I am a verse paragraph.`
 					Elements: []interface{}{
 						types.Paragraph{
 							Attributes: types.Attributes{
-								types.AttrBlockKind:   types.Verse,
+								types.AttrStyle:       types.Verse,
 								types.AttrQuoteAuthor: "john doe",
 							},
 							Lines: [][]interface{}{
@@ -1236,7 +1232,7 @@ I am a verse paragraph.`
 					Elements: []interface{}{
 						types.Paragraph{
 							Attributes: types.Attributes{
-								types.AttrBlockKind: types.Verse,
+								types.AttrStyle: types.Verse,
 							},
 							Lines: [][]interface{}{
 								{
@@ -1256,7 +1252,7 @@ I am a verse paragraph.`
 					Elements: []interface{}{
 						types.Paragraph{
 							Attributes: types.Attributes{
-								types.AttrBlockKind: types.Verse,
+								types.AttrStyle: types.Verse,
 							},
 							Lines: [][]interface{}{
 								{
@@ -1277,7 +1273,7 @@ image::foo.png[]`
 					Elements: []interface{}{
 						types.Paragraph{
 							Attributes: types.Attributes{
-								types.AttrBlockKind:   types.Verse,
+								types.AttrStyle:       types.Verse,
 								types.AttrQuoteAuthor: "john doe",
 								types.AttrQuoteTitle:  "verse title",
 							},
@@ -1304,7 +1300,7 @@ I am a quote paragraph.`
 					Elements: []interface{}{
 						types.Paragraph{
 							Attributes: types.Attributes{
-								types.AttrBlockKind:   types.Quote,
+								types.AttrStyle:       types.Quote,
 								types.AttrQuoteAuthor: "john doe",
 								types.AttrQuoteTitle:  "quote title",
 							},
@@ -1328,12 +1324,12 @@ I am a quote paragraph.`
 					Elements: []interface{}{
 						types.Paragraph{
 							Attributes: types.Attributes{
-								types.AttrBlockKind:   types.Quote,
+								types.AttrStyle:       types.Quote,
 								types.AttrQuoteAuthor: "john doe",
 								types.AttrQuoteTitle:  "quote title",
 								types.AttrID:          "universal",
-								types.AttrCustomID:    true,
-								types.AttrTitle:       "universe",
+								// types.AttrCustomID:    true,
+								types.AttrTitle: "universe",
 							},
 							Lines: [][]interface{}{
 								{
@@ -1353,7 +1349,7 @@ I am a quote paragraph.`
 					Elements: []interface{}{
 						types.Paragraph{
 							Attributes: types.Attributes{
-								types.AttrBlockKind:   types.Quote,
+								types.AttrStyle:       types.Quote,
 								types.AttrQuoteAuthor: "john doe",
 							},
 							Lines: [][]interface{}{
@@ -1374,7 +1370,7 @@ I am a quote paragraph.`
 					Elements: []interface{}{
 						types.Paragraph{
 							Attributes: types.Attributes{
-								types.AttrBlockKind:   types.Quote,
+								types.AttrStyle:       types.Quote,
 								types.AttrQuoteAuthor: "john doe",
 							},
 							Lines: [][]interface{}{
@@ -1395,7 +1391,7 @@ I am a quote paragraph.`
 					Elements: []interface{}{
 						types.Paragraph{
 							Attributes: types.Attributes{
-								types.AttrBlockKind: types.Quote,
+								types.AttrStyle: types.Quote,
 							},
 							Lines: [][]interface{}{
 								{
@@ -1415,7 +1411,7 @@ I am a quote paragraph.`
 					Elements: []interface{}{
 						types.Paragraph{
 							Attributes: types.Attributes{
-								types.AttrBlockKind: types.Quote,
+								types.AttrStyle: types.Quote,
 							},
 							Lines: [][]interface{}{
 								{
@@ -1440,9 +1436,9 @@ image::foo.png[]`
 								Path:   []interface{}{types.StringElement{Content: "foo.png"}},
 							},
 							Attributes: types.Attributes{
-								types.AttrImageAlt:    "quote",
-								types.AttrWidth:       "john doe",
-								types.AttrImageHeight: "quote title",
+								types.AttrImageAlt: "quote",
+								types.AttrWidth:    "john doe",
+								types.AttrHeight:   "quote title",
 							},
 						},
 					},
@@ -1592,7 +1588,9 @@ a paragraph`
 						},
 					},
 				}
-				Expect(ParseDocument(source)).To(MatchDocument(expected))
+				result, err := ParseDocument(source)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(MatchDocument(expected))
 			})
 
 			It("paragraph with predefined attribute", func() {
@@ -1977,7 +1975,7 @@ a foo image:foo.png[]`
 					Elements: []interface{}{
 						types.Paragraph{
 							Attributes: types.Attributes{
-								types.AttrBlockKind:   types.Quote,
+								types.AttrStyle:       types.Quote,
 								types.AttrQuoteAuthor: "john doe",
 								types.AttrQuoteTitle:  "quote title",
 							},

--- a/pkg/parser/paragraph_test.go
+++ b/pkg/parser/paragraph_test.go
@@ -1611,7 +1611,7 @@ a paragraph`
 				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
-			Context("with substitutions", func() {
+			Context("with custom substitutions", func() {
 
 				// using the same input for all substitution tests
 				source := `:github-url: https://github.com

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"unicode"
 	"unicode/utf8"
 
@@ -267,23 +268,23 @@ var g = &grammar{
 							},
 							&ruleRefExpr{
 								pos:  position{line: 66, col: 11, offset: 2007},
-								name: "ImageBlock",
-							},
-							&ruleRefExpr{
-								pos:  position{line: 67, col: 11, offset: 2028},
 								name: "SimpleRawParagraph",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 68, col: 11, offset: 2057},
+								pos:  position{line: 67, col: 11, offset: 2036},
 								name: "BlankLine",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 69, col: 11, offset: 2109},
+								pos:  position{line: 68, col: 11, offset: 2088},
 								name: "Section",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 70, col: 11, offset: 2127},
+								pos:  position{line: 69, col: 11, offset: 2106},
 								name: "DelimitedBlock",
+							},
+							&ruleRefExpr{
+								pos:  position{line: 70, col: 11, offset: 2131},
+								name: "ImageBlock",
 							},
 							&ruleRefExpr{
 								pos:  position{line: 71, col: 11, offset: 2152},
@@ -1643,179 +1644,38 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "ElementAttribute",
+			name: "InlineElementID",
 			pos:  position{line: 231, col: 1, offset: 7526},
 			expr: &actionExpr{
-				pos: position{line: 231, col: 21, offset: 7546},
-				run: (*parser).callonElementAttribute1,
-				expr: &seqExpr{
-					pos: position{line: 231, col: 21, offset: 7546},
-					exprs: []interface{}{
-						&andExpr{
-							pos: position{line: 231, col: 21, offset: 7546},
-							expr: &choiceExpr{
-								pos: position{line: 231, col: 23, offset: 7548},
-								alternatives: []interface{}{
-									&litMatcher{
-										pos:        position{line: 231, col: 23, offset: 7548},
-										val:        "[",
-										ignoreCase: false,
-										want:       "\"[\"",
-									},
-									&litMatcher{
-										pos:        position{line: 231, col: 29, offset: 7554},
-										val:        ".",
-										ignoreCase: false,
-										want:       "\".\"",
-									},
-								},
-							},
-						},
-						&labeledExpr{
-							pos:   position{line: 232, col: 5, offset: 7678},
-							label: "attr",
-							expr: &choiceExpr{
-								pos: position{line: 232, col: 11, offset: 7684},
-								alternatives: []interface{}{
-									&ruleRefExpr{
-										pos:  position{line: 232, col: 11, offset: 7684},
-										name: "ElementID",
-									},
-									&ruleRefExpr{
-										pos:  position{line: 233, col: 9, offset: 7705},
-										name: "ElementTitle",
-									},
-									&ruleRefExpr{
-										pos:  position{line: 234, col: 9, offset: 7729},
-										name: "ElementShortHandAttributes",
-									},
-									&ruleRefExpr{
-										pos:  position{line: 235, col: 9, offset: 7766},
-										name: "LiteralBlockAttribute",
-									},
-									&ruleRefExpr{
-										pos:  position{line: 236, col: 9, offset: 7799},
-										name: "SourceAttributes",
-									},
-									&ruleRefExpr{
-										pos:  position{line: 237, col: 9, offset: 7827},
-										name: "ExampleBlockAttribute",
-									},
-									&ruleRefExpr{
-										pos:  position{line: 238, col: 9, offset: 7859},
-										name: "ListingBlockAttribute",
-									},
-									&ruleRefExpr{
-										pos:  position{line: 239, col: 9, offset: 7891},
-										name: "QuoteAttributes",
-									},
-									&ruleRefExpr{
-										pos:  position{line: 240, col: 9, offset: 7918},
-										name: "VerseAttributes",
-									},
-									&ruleRefExpr{
-										pos:  position{line: 241, col: 9, offset: 7945},
-										name: "AdmonitionMarkerAttribute",
-									},
-									&ruleRefExpr{
-										pos:  position{line: 242, col: 9, offset: 7982},
-										name: "PassthroughBlockAttribute",
-									},
-									&ruleRefExpr{
-										pos:  position{line: 243, col: 9, offset: 8018},
-										name: "AttributeGroup",
-									},
-								},
-							},
-						},
-						&zeroOrMoreExpr{
-							pos: position{line: 243, col: 25, offset: 8034},
-							expr: &ruleRefExpr{
-								pos:  position{line: 243, col: 25, offset: 8034},
-								name: "BlankLine",
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "ElementID",
-			pos:  position{line: 247, col: 1, offset: 8132},
-			expr: &actionExpr{
-				pos: position{line: 247, col: 14, offset: 8145},
-				run: (*parser).callonElementID1,
-				expr: &seqExpr{
-					pos: position{line: 247, col: 14, offset: 8145},
-					exprs: []interface{}{
-						&litMatcher{
-							pos:        position{line: 247, col: 14, offset: 8145},
-							val:        "[[",
-							ignoreCase: false,
-							want:       "\"[[\"",
-						},
-						&labeledExpr{
-							pos:   position{line: 247, col: 19, offset: 8150},
-							label: "id",
-							expr: &ruleRefExpr{
-								pos:  position{line: 247, col: 23, offset: 8154},
-								name: "Id",
-							},
-						},
-						&litMatcher{
-							pos:        position{line: 247, col: 27, offset: 8158},
-							val:        "]]",
-							ignoreCase: false,
-							want:       "\"]]\"",
-						},
-						&zeroOrMoreExpr{
-							pos: position{line: 247, col: 32, offset: 8163},
-							expr: &ruleRefExpr{
-								pos:  position{line: 247, col: 32, offset: 8163},
-								name: "Space",
-							},
-						},
-						&ruleRefExpr{
-							pos:  position{line: 247, col: 39, offset: 8170},
-							name: "EOL",
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "InlineElementID",
-			pos:  position{line: 251, col: 1, offset: 8213},
-			expr: &actionExpr{
-				pos: position{line: 251, col: 20, offset: 8232},
+				pos: position{line: 231, col: 20, offset: 7545},
 				run: (*parser).callonInlineElementID1,
 				expr: &seqExpr{
-					pos: position{line: 251, col: 20, offset: 8232},
+					pos: position{line: 231, col: 20, offset: 7545},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 251, col: 20, offset: 8232},
+							pos:        position{line: 231, col: 20, offset: 7545},
 							val:        "[[",
 							ignoreCase: false,
 							want:       "\"[[\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 251, col: 25, offset: 8237},
+							pos:   position{line: 231, col: 25, offset: 7550},
 							label: "id",
 							expr: &ruleRefExpr{
-								pos:  position{line: 251, col: 29, offset: 8241},
+								pos:  position{line: 231, col: 29, offset: 7554},
 								name: "Id",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 251, col: 33, offset: 8245},
+							pos:        position{line: 231, col: 33, offset: 7558},
 							val:        "]]",
 							ignoreCase: false,
 							want:       "\"]]\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 251, col: 38, offset: 8250},
+							pos: position{line: 231, col: 38, offset: 7563},
 							expr: &ruleRefExpr{
-								pos:  position{line: 251, col: 38, offset: 8250},
+								pos:  position{line: 231, col: 38, offset: 7563},
 								name: "Space",
 							},
 						},
@@ -1824,574 +1684,190 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "ElementTitle",
-			pos:  position{line: 257, col: 1, offset: 8527},
+			name: "StandaloneAttributeKey",
+			pos:  position{line: 235, col: 1, offset: 7702},
 			expr: &actionExpr{
-				pos: position{line: 257, col: 17, offset: 8543},
-				run: (*parser).callonElementTitle1,
+				pos: position{line: 235, col: 27, offset: 7728},
+				run: (*parser).callonStandaloneAttributeKey1,
 				expr: &seqExpr{
-					pos: position{line: 257, col: 17, offset: 8543},
+					pos: position{line: 235, col: 27, offset: 7728},
 					exprs: []interface{}{
-						&litMatcher{
-							pos:        position{line: 257, col: 17, offset: 8543},
-							val:        ".",
-							ignoreCase: false,
-							want:       "\".\"",
-						},
-						&labeledExpr{
-							pos:   position{line: 257, col: 21, offset: 8547},
-							label: "title",
-							expr: &ruleRefExpr{
-								pos:  position{line: 257, col: 28, offset: 8554},
-								name: "ElementTitleContent",
-							},
-						},
-						&zeroOrMoreExpr{
-							pos: position{line: 257, col: 49, offset: 8575},
-							expr: &ruleRefExpr{
-								pos:  position{line: 257, col: 49, offset: 8575},
-								name: "Space",
-							},
-						},
-						&ruleRefExpr{
-							pos:  position{line: 257, col: 56, offset: 8582},
-							name: "EOL",
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "ElementTitleContent",
-			pos:  position{line: 261, col: 1, offset: 8647},
-			expr: &oneOrMoreExpr{
-				pos: position{line: 261, col: 24, offset: 8670},
-				expr: &choiceExpr{
-					pos: position{line: 262, col: 5, offset: 8676},
-					alternatives: []interface{}{
-						&actionExpr{
-							pos: position{line: 262, col: 6, offset: 8677},
-							run: (*parser).callonElementTitleContent3,
-							expr: &seqExpr{
-								pos: position{line: 262, col: 6, offset: 8677},
-								exprs: []interface{}{
-									&charClassMatcher{
-										pos:        position{line: 262, col: 6, offset: 8677},
-										val:        "[\\pL0-9]",
-										ranges:     []rune{'0', '9'},
-										classes:    []*unicode.RangeTable{rangeTable("L")},
-										ignoreCase: false,
-										inverted:   false,
-									},
-									&oneOrMoreExpr{
-										pos: position{line: 262, col: 14, offset: 8685},
-										expr: &charClassMatcher{
-											pos:        position{line: 262, col: 14, offset: 8685},
-											val:        "[^\\r\\n{<>]",
-											chars:      []rune{'\r', '\n', '{', '<', '>'},
-											ignoreCase: false,
-											inverted:   true,
-										},
-									},
-								},
-							},
-						},
-						&ruleRefExpr{
-							pos:  position{line: 265, col: 5, offset: 8880},
-							name: "AttrSub",
-						},
-						&actionExpr{
-							pos: position{line: 266, col: 6, offset: 8895},
-							run: (*parser).callonElementTitleContent9,
+						&notExpr{
+							pos: position{line: 235, col: 27, offset: 7728},
 							expr: &litMatcher{
-								pos:        position{line: 266, col: 6, offset: 8895},
-								val:        "{",
+								pos:        position{line: 235, col: 28, offset: 7729},
+								val:        "quote",
 								ignoreCase: false,
-								want:       "\"{\"",
+								want:       "\"quote\"",
 							},
 						},
-					},
-				},
-			},
-		},
-		{
-			name: "ElementShortHandAttributes",
-			pos:  position{line: 273, col: 1, offset: 9092},
-			expr: &actionExpr{
-				pos: position{line: 273, col: 31, offset: 9122},
-				run: (*parser).callonElementShortHandAttributes1,
-				expr: &seqExpr{
-					pos: position{line: 273, col: 31, offset: 9122},
-					exprs: []interface{}{
-						&litMatcher{
-							pos:        position{line: 273, col: 31, offset: 9122},
-							val:        "[",
-							ignoreCase: false,
-							want:       "\"[\"",
+						&notExpr{
+							pos: position{line: 235, col: 36, offset: 7737},
+							expr: &litMatcher{
+								pos:        position{line: 235, col: 37, offset: 7738},
+								val:        "verse",
+								ignoreCase: false,
+								want:       "\"verse\"",
+							},
+						},
+						&notExpr{
+							pos: position{line: 235, col: 45, offset: 7746},
+							expr: &litMatcher{
+								pos:        position{line: 235, col: 46, offset: 7747},
+								val:        "literal",
+								ignoreCase: false,
+								want:       "\"literal\"",
+							},
 						},
 						&labeledExpr{
-							pos:   position{line: 273, col: 35, offset: 9126},
-							label: "attributes",
+							pos:   position{line: 235, col: 56, offset: 7757},
+							label: "key",
+							expr: &ruleRefExpr{
+								pos:  position{line: 235, col: 61, offset: 7762},
+								name: "NamedAttributeKey",
+							},
+						},
+						&zeroOrOneExpr{
+							pos: position{line: 235, col: 80, offset: 7781},
 							expr: &seqExpr{
-								pos: position{line: 273, col: 47, offset: 9138},
+								pos: position{line: 235, col: 81, offset: 7782},
 								exprs: []interface{}{
-									&zeroOrMoreExpr{
-										pos: position{line: 273, col: 47, offset: 9138},
-										expr: &ruleRefExpr{
-											pos:  position{line: 273, col: 47, offset: 9138},
-											name: "ShortHandAttr",
-										},
-									},
-									&zeroOrMoreExpr{
-										pos: position{line: 273, col: 62, offset: 9153},
-										expr: &ruleRefExpr{
-											pos:  position{line: 273, col: 62, offset: 9153},
-											name: "NamedAttribute",
-										},
-									},
-								},
-							},
-						},
-						&litMatcher{
-							pos:        position{line: 273, col: 79, offset: 9170},
-							val:        "]",
-							ignoreCase: false,
-							want:       "\"]\"",
-						},
-						&zeroOrMoreExpr{
-							pos: position{line: 273, col: 83, offset: 9174},
-							expr: &ruleRefExpr{
-								pos:  position{line: 273, col: 83, offset: 9174},
-								name: "Space",
-							},
-						},
-						&ruleRefExpr{
-							pos:  position{line: 273, col: 90, offset: 9181},
-							name: "EOL",
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "BlockAttribute",
-			pos:  position{line: 277, col: 1, offset: 9256},
-			expr: &choiceExpr{
-				pos: position{line: 277, col: 19, offset: 9274},
-				alternatives: []interface{}{
-					&ruleRefExpr{
-						pos:  position{line: 277, col: 19, offset: 9274},
-						name: "BlockAttributeList",
-					},
-					&ruleRefExpr{
-						pos:  position{line: 277, col: 40, offset: 9295},
-						name: "ElementTitle",
-					},
-					&ruleRefExpr{
-						pos:  position{line: 277, col: 55, offset: 9310},
-						name: "ElementID",
-					},
-				},
-			},
-		},
-		{
-			name: "BlockAttributeList",
-			pos:  position{line: 281, col: 1, offset: 9538},
-			expr: &actionExpr{
-				pos: position{line: 281, col: 23, offset: 9560},
-				run: (*parser).callonBlockAttributeList1,
-				expr: &seqExpr{
-					pos: position{line: 281, col: 23, offset: 9560},
-					exprs: []interface{}{
-						&litMatcher{
-							pos:        position{line: 281, col: 23, offset: 9560},
-							val:        "[",
-							ignoreCase: false,
-							want:       "\"[\"",
-						},
-						&labeledExpr{
-							pos:   position{line: 281, col: 27, offset: 9564},
-							label: "attributes",
-							expr: &seqExpr{
-								pos: position{line: 281, col: 39, offset: 9576},
-								exprs: []interface{}{
-									&zeroOrOneExpr{
-										pos: position{line: 281, col: 39, offset: 9576},
-										expr: &ruleRefExpr{
-											pos:  position{line: 281, col: 39, offset: 9576},
-											name: "BlockAttrStyle",
-										},
-									},
-									&zeroOrMoreExpr{
-										pos: position{line: 281, col: 55, offset: 9592},
-										expr: &ruleRefExpr{
-											pos:  position{line: 281, col: 55, offset: 9592},
-											name: "ShortHandAttr",
-										},
-									},
-									&zeroOrOneExpr{
-										pos: position{line: 281, col: 70, offset: 9607},
-										expr: &ruleRefExpr{
-											pos:  position{line: 281, col: 70, offset: 9607},
-											name: "BlockAttrPositional2",
-										},
-									},
-									&zeroOrOneExpr{
-										pos: position{line: 281, col: 92, offset: 9629},
-										expr: &ruleRefExpr{
-											pos:  position{line: 281, col: 92, offset: 9629},
-											name: "BlockAttrPositional3",
-										},
-									},
-									&zeroOrMoreExpr{
-										pos: position{line: 281, col: 114, offset: 9651},
-										expr: &ruleRefExpr{
-											pos:  position{line: 281, col: 114, offset: 9651},
-											name: "NamedAttribute",
-										},
-									},
-								},
-							},
-						},
-						&litMatcher{
-							pos:        position{line: 281, col: 131, offset: 9668},
-							val:        "]",
-							ignoreCase: false,
-							want:       "\"]\"",
-						},
-						&ruleRefExpr{
-							pos:  position{line: 281, col: 135, offset: 9672},
-							name: "EOL",
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "BlockAttrStyle",
-			pos:  position{line: 285, col: 1, offset: 9747},
-			expr: &actionExpr{
-				pos: position{line: 285, col: 19, offset: 9765},
-				run: (*parser).callonBlockAttrStyle1,
-				expr: &labeledExpr{
-					pos:   position{line: 285, col: 19, offset: 9765},
-					label: "style",
-					expr: &ruleRefExpr{
-						pos:  position{line: 285, col: 25, offset: 9771},
-						name: "PositionalValue",
-					},
-				},
-			},
-		},
-		{
-			name: "BlockAttrPositional2",
-			pos:  position{line: 289, col: 1, offset: 9832},
-			expr: &actionExpr{
-				pos: position{line: 289, col: 25, offset: 9856},
-				run: (*parser).callonBlockAttrPositional21,
-				expr: &seqExpr{
-					pos: position{line: 289, col: 25, offset: 9856},
-					exprs: []interface{}{
-						&zeroOrMoreExpr{
-							pos: position{line: 289, col: 25, offset: 9856},
-							expr: &ruleRefExpr{
-								pos:  position{line: 289, col: 25, offset: 9856},
-								name: "Space",
-							},
-						},
-						&litMatcher{
-							pos:        position{line: 289, col: 32, offset: 9863},
-							val:        ",",
-							ignoreCase: false,
-							want:       "\",\"",
-						},
-						&zeroOrMoreExpr{
-							pos: position{line: 289, col: 36, offset: 9867},
-							expr: &ruleRefExpr{
-								pos:  position{line: 289, col: 36, offset: 9867},
-								name: "Space",
-							},
-						},
-						&labeledExpr{
-							pos:   position{line: 289, col: 43, offset: 9874},
-							label: "value",
-							expr: &zeroOrOneExpr{
-								pos: position{line: 289, col: 49, offset: 9880},
-								expr: &ruleRefExpr{
-									pos:  position{line: 289, col: 49, offset: 9880},
-									name: "PositionalValue",
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "BlockAttrPositional3",
-			pos:  position{line: 296, col: 1, offset: 10019},
-			expr: &actionExpr{
-				pos: position{line: 296, col: 25, offset: 10043},
-				run: (*parser).callonBlockAttrPositional31,
-				expr: &seqExpr{
-					pos: position{line: 296, col: 25, offset: 10043},
-					exprs: []interface{}{
-						&zeroOrMoreExpr{
-							pos: position{line: 296, col: 25, offset: 10043},
-							expr: &ruleRefExpr{
-								pos:  position{line: 296, col: 25, offset: 10043},
-								name: "Space",
-							},
-						},
-						&litMatcher{
-							pos:        position{line: 296, col: 32, offset: 10050},
-							val:        ",",
-							ignoreCase: false,
-							want:       "\",\"",
-						},
-						&zeroOrMoreExpr{
-							pos: position{line: 296, col: 36, offset: 10054},
-							expr: &ruleRefExpr{
-								pos:  position{line: 296, col: 36, offset: 10054},
-								name: "Space",
-							},
-						},
-						&labeledExpr{
-							pos:   position{line: 296, col: 43, offset: 10061},
-							label: "value",
-							expr: &zeroOrOneExpr{
-								pos: position{line: 296, col: 49, offset: 10067},
-								expr: &ruleRefExpr{
-									pos:  position{line: 296, col: 49, offset: 10067},
-									name: "PositionalValue",
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "LiteralBlockAttribute",
-			pos:  position{line: 303, col: 1, offset: 10206},
-			expr: &actionExpr{
-				pos: position{line: 303, col: 26, offset: 10231},
-				run: (*parser).callonLiteralBlockAttribute1,
-				expr: &seqExpr{
-					pos: position{line: 303, col: 26, offset: 10231},
-					exprs: []interface{}{
-						&litMatcher{
-							pos:        position{line: 303, col: 26, offset: 10231},
-							val:        "[literal]",
-							ignoreCase: false,
-							want:       "\"[literal]\"",
-						},
-						&zeroOrMoreExpr{
-							pos: position{line: 303, col: 38, offset: 10243},
-							expr: &ruleRefExpr{
-								pos:  position{line: 303, col: 38, offset: 10243},
-								name: "Space",
-							},
-						},
-						&ruleRefExpr{
-							pos:  position{line: 303, col: 45, offset: 10250},
-							name: "Newline",
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "PassthroughBlockAttribute",
-			pos:  position{line: 307, col: 1, offset: 10307},
-			expr: &actionExpr{
-				pos: position{line: 307, col: 30, offset: 10336},
-				run: (*parser).callonPassthroughBlockAttribute1,
-				expr: &seqExpr{
-					pos: position{line: 307, col: 30, offset: 10336},
-					exprs: []interface{}{
-						&litMatcher{
-							pos:        position{line: 307, col: 30, offset: 10336},
-							val:        "[pass]",
-							ignoreCase: false,
-							want:       "\"[pass]\"",
-						},
-						&zeroOrMoreExpr{
-							pos: position{line: 307, col: 39, offset: 10345},
-							expr: &ruleRefExpr{
-								pos:  position{line: 307, col: 39, offset: 10345},
-								name: "Space",
-							},
-						},
-						&ruleRefExpr{
-							pos:  position{line: 307, col: 46, offset: 10352},
-							name: "Newline",
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "ExampleBlockAttribute",
-			pos:  position{line: 311, col: 1, offset: 10413},
-			expr: &actionExpr{
-				pos: position{line: 311, col: 26, offset: 10438},
-				run: (*parser).callonExampleBlockAttribute1,
-				expr: &seqExpr{
-					pos: position{line: 311, col: 26, offset: 10438},
-					exprs: []interface{}{
-						&litMatcher{
-							pos:        position{line: 311, col: 26, offset: 10438},
-							val:        "[example]",
-							ignoreCase: false,
-							want:       "\"[example]\"",
-						},
-						&zeroOrMoreExpr{
-							pos: position{line: 311, col: 38, offset: 10450},
-							expr: &ruleRefExpr{
-								pos:  position{line: 311, col: 38, offset: 10450},
-								name: "Space",
-							},
-						},
-						&ruleRefExpr{
-							pos:  position{line: 311, col: 45, offset: 10457},
-							name: "EOL",
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "ListingBlockAttribute",
-			pos:  position{line: 315, col: 1, offset: 10510},
-			expr: &actionExpr{
-				pos: position{line: 315, col: 26, offset: 10535},
-				run: (*parser).callonListingBlockAttribute1,
-				expr: &seqExpr{
-					pos: position{line: 315, col: 26, offset: 10535},
-					exprs: []interface{}{
-						&litMatcher{
-							pos:        position{line: 315, col: 26, offset: 10535},
-							val:        "[listing]",
-							ignoreCase: false,
-							want:       "\"[listing]\"",
-						},
-						&zeroOrMoreExpr{
-							pos: position{line: 315, col: 38, offset: 10547},
-							expr: &ruleRefExpr{
-								pos:  position{line: 315, col: 38, offset: 10547},
-								name: "Space",
-							},
-						},
-						&ruleRefExpr{
-							pos:  position{line: 315, col: 45, offset: 10554},
-							name: "EOL",
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "AdmonitionMarkerAttribute",
-			pos:  position{line: 320, col: 1, offset: 10687},
-			expr: &actionExpr{
-				pos: position{line: 320, col: 30, offset: 10716},
-				run: (*parser).callonAdmonitionMarkerAttribute1,
-				expr: &seqExpr{
-					pos: position{line: 320, col: 30, offset: 10716},
-					exprs: []interface{}{
-						&litMatcher{
-							pos:        position{line: 320, col: 30, offset: 10716},
-							val:        "[",
-							ignoreCase: false,
-							want:       "\"[\"",
-						},
-						&labeledExpr{
-							pos:   position{line: 320, col: 34, offset: 10720},
-							label: "k",
-							expr: &ruleRefExpr{
-								pos:  position{line: 320, col: 37, offset: 10723},
-								name: "AdmonitionKind",
-							},
-						},
-						&litMatcher{
-							pos:        position{line: 320, col: 53, offset: 10739},
-							val:        "]",
-							ignoreCase: false,
-							want:       "\"]\"",
-						},
-						&zeroOrMoreExpr{
-							pos: position{line: 320, col: 57, offset: 10743},
-							expr: &ruleRefExpr{
-								pos:  position{line: 320, col: 57, offset: 10743},
-								name: "Space",
-							},
-						},
-						&ruleRefExpr{
-							pos:  position{line: 320, col: 64, offset: 10750},
-							name: "EOL",
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "SourceAttributes",
-			pos:  position{line: 325, col: 1, offset: 10905},
-			expr: &actionExpr{
-				pos: position{line: 325, col: 21, offset: 10925},
-				run: (*parser).callonSourceAttributes1,
-				expr: &seqExpr{
-					pos: position{line: 325, col: 21, offset: 10925},
-					exprs: []interface{}{
-						&litMatcher{
-							pos:        position{line: 325, col: 21, offset: 10925},
-							val:        "[source",
-							ignoreCase: false,
-							want:       "\"[source\"",
-						},
-						&labeledExpr{
-							pos:   position{line: 326, col: 5, offset: 10940},
-							label: "option",
-							expr: &zeroOrOneExpr{
-								pos: position{line: 326, col: 12, offset: 10947},
-								expr: &actionExpr{
-									pos: position{line: 326, col: 13, offset: 10948},
-									run: (*parser).callonSourceAttributes6,
-									expr: &litMatcher{
-										pos:        position{line: 326, col: 13, offset: 10948},
-										val:        "%nowrap",
+									&litMatcher{
+										pos:        position{line: 235, col: 81, offset: 7782},
+										val:        ",",
 										ignoreCase: false,
-										want:       "\"%nowrap\"",
+										want:       "\",\"",
+									},
+									&zeroOrMoreExpr{
+										pos: position{line: 235, col: 85, offset: 7786},
+										expr: &ruleRefExpr{
+											pos:  position{line: 235, col: 85, offset: 7786},
+											name: "Space",
+										},
 									},
 								},
 							},
 						},
-						&labeledExpr{
-							pos:   position{line: 329, col: 5, offset: 11001},
-							label: "language",
-							expr: &zeroOrOneExpr{
-								pos: position{line: 329, col: 14, offset: 11010},
-								expr: &actionExpr{
-									pos: position{line: 329, col: 15, offset: 11011},
-									run: (*parser).callonSourceAttributes10,
+					},
+				},
+			},
+		},
+		{
+			name: "BlockAttributes",
+			pos:  position{line: 242, col: 1, offset: 7996},
+			expr: &actionExpr{
+				pos: position{line: 243, col: 5, offset: 8020},
+				run: (*parser).callonBlockAttributes1,
+				expr: &labeledExpr{
+					pos:   position{line: 243, col: 5, offset: 8020},
+					label: "attributes",
+					expr: &oneOrMoreExpr{
+						pos: position{line: 243, col: 16, offset: 8031},
+						expr: &choiceExpr{
+							pos: position{line: 245, col: 9, offset: 8098},
+							alternatives: []interface{}{
+								&actionExpr{
+									pos: position{line: 245, col: 10, offset: 8099},
+									run: (*parser).callonBlockAttributes5,
 									expr: &seqExpr{
-										pos: position{line: 329, col: 15, offset: 11011},
+										pos: position{line: 245, col: 10, offset: 8099},
 										exprs: []interface{}{
-											&litMatcher{
-												pos:        position{line: 329, col: 15, offset: 11011},
-												val:        ",",
-												ignoreCase: false,
-												want:       "\",\"",
-											},
 											&labeledExpr{
-												pos:   position{line: 329, col: 19, offset: 11015},
-												label: "attr",
-												expr: &zeroOrOneExpr{
-													pos: position{line: 329, col: 24, offset: 11020},
-													expr: &ruleRefExpr{
-														pos:  position{line: 329, col: 25, offset: 11021},
-														name: "AttributeValue",
+												pos:   position{line: 245, col: 10, offset: 8099},
+												label: "anchor",
+												expr: &ruleRefExpr{
+													pos:  position{line: 245, col: 18, offset: 8107},
+													name: "ShortHandAnchor",
+												},
+											},
+											&oneOrMoreExpr{
+												pos: position{line: 245, col: 35, offset: 8124},
+												expr: &seqExpr{
+													pos: position{line: 245, col: 36, offset: 8125},
+													exprs: []interface{}{
+														&zeroOrMoreExpr{
+															pos: position{line: 245, col: 36, offset: 8125},
+															expr: &ruleRefExpr{
+																pos:  position{line: 245, col: 36, offset: 8125},
+																name: "Space",
+															},
+														},
+														&ruleRefExpr{
+															pos:  position{line: 245, col: 43, offset: 8132},
+															name: "Newline",
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+								&actionExpr{
+									pos: position{line: 249, col: 12, offset: 8252},
+									run: (*parser).callonBlockAttributes14,
+									expr: &seqExpr{
+										pos: position{line: 249, col: 12, offset: 8252},
+										exprs: []interface{}{
+											&labeledExpr{
+												pos:   position{line: 249, col: 12, offset: 8252},
+												label: "title",
+												expr: &ruleRefExpr{
+													pos:  position{line: 249, col: 19, offset: 8259},
+													name: "ShortHandTitle",
+												},
+											},
+											&oneOrMoreExpr{
+												pos: position{line: 249, col: 35, offset: 8275},
+												expr: &seqExpr{
+													pos: position{line: 249, col: 36, offset: 8276},
+													exprs: []interface{}{
+														&zeroOrMoreExpr{
+															pos: position{line: 249, col: 36, offset: 8276},
+															expr: &ruleRefExpr{
+																pos:  position{line: 249, col: 36, offset: 8276},
+																name: "Space",
+															},
+														},
+														&ruleRefExpr{
+															pos:  position{line: 249, col: 43, offset: 8283},
+															name: "Newline",
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+								&actionExpr{
+									pos: position{line: 253, col: 12, offset: 8373},
+									run: (*parser).callonBlockAttributes23,
+									expr: &seqExpr{
+										pos: position{line: 253, col: 12, offset: 8373},
+										exprs: []interface{}{
+											&labeledExpr{
+												pos:   position{line: 253, col: 12, offset: 8373},
+												label: "attributes",
+												expr: &ruleRefExpr{
+													pos:  position{line: 253, col: 24, offset: 8385},
+													name: "LongHandAttributes",
+												},
+											},
+											&oneOrMoreExpr{
+												pos: position{line: 253, col: 44, offset: 8405},
+												expr: &seqExpr{
+													pos: position{line: 253, col: 45, offset: 8406},
+													exprs: []interface{}{
+														&zeroOrMoreExpr{
+															pos: position{line: 253, col: 45, offset: 8406},
+															expr: &ruleRefExpr{
+																pos:  position{line: 253, col: 45, offset: 8406},
+																name: "Space",
+															},
+														},
+														&ruleRefExpr{
+															pos:  position{line: 253, col: 52, offset: 8413},
+															name: "Newline",
+														},
 													},
 												},
 											},
@@ -2400,38 +1876,236 @@ var g = &grammar{
 								},
 							},
 						},
+					},
+				},
+			},
+		},
+		{
+			name: "InlineAttributes",
+			pos:  position{line: 260, col: 1, offset: 8553},
+			expr: &actionExpr{
+				pos: position{line: 261, col: 5, offset: 8577},
+				run: (*parser).callonInlineAttributes1,
+				expr: &seqExpr{
+					pos: position{line: 261, col: 5, offset: 8577},
+					exprs: []interface{}{
+						&stateCodeExpr{
+							pos: position{line: 261, col: 5, offset: 8577},
+							run: (*parser).callonInlineAttributes3,
+						},
+						&litMatcher{
+							pos:        position{line: 264, col: 5, offset: 8628},
+							val:        "[",
+							ignoreCase: false,
+							want:       "\"[\"",
+						},
 						&labeledExpr{
-							pos:   position{line: 330, col: 5, offset: 11066},
-							label: "others",
+							pos:   position{line: 265, col: 5, offset: 8636},
+							label: "attributes",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 330, col: 12, offset: 11073},
-								expr: &actionExpr{
-									pos: position{line: 330, col: 13, offset: 11074},
-									run: (*parser).callonSourceAttributes18,
-									expr: &seqExpr{
-										pos: position{line: 330, col: 13, offset: 11074},
-										exprs: []interface{}{
-											&litMatcher{
-												pos:        position{line: 330, col: 13, offset: 11074},
-												val:        ",",
-												ignoreCase: false,
-												want:       "\",\"",
+								pos: position{line: 265, col: 16, offset: 8647},
+								expr: &choiceExpr{
+									pos: position{line: 265, col: 17, offset: 8648},
+									alternatives: []interface{}{
+										&ruleRefExpr{
+											pos:  position{line: 265, col: 17, offset: 8648},
+											name: "PositionalAttribute",
+										},
+										&ruleRefExpr{
+											pos:  position{line: 265, col: 37, offset: 8668},
+											name: "NamedAttribute",
+										},
+									},
+								},
+							},
+						},
+						&litMatcher{
+							pos:        position{line: 266, col: 5, offset: 8689},
+							val:        "]",
+							ignoreCase: false,
+							want:       "\"]\"",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "StandaloneAttributes",
+			pos:  position{line: 271, col: 1, offset: 8823},
+			expr: &actionExpr{
+				pos: position{line: 271, col: 25, offset: 8847},
+				run: (*parser).callonStandaloneAttributes1,
+				expr: &seqExpr{
+					pos: position{line: 271, col: 25, offset: 8847},
+					exprs: []interface{}{
+						&labeledExpr{
+							pos:   position{line: 271, col: 25, offset: 8847},
+							label: "attributes",
+							expr: &ruleRefExpr{
+								pos:  position{line: 271, col: 37, offset: 8859},
+								name: "BlockAttributes",
+							},
+						},
+						&zeroOrMoreExpr{
+							pos: position{line: 271, col: 54, offset: 8876},
+							expr: &ruleRefExpr{
+								pos:  position{line: 271, col: 54, offset: 8876},
+								name: "BlankLine",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "ShortHandAnchor",
+			pos:  position{line: 276, col: 1, offset: 8969},
+			expr: &actionExpr{
+				pos: position{line: 277, col: 4, offset: 8991},
+				run: (*parser).callonShortHandAnchor1,
+				expr: &seqExpr{
+					pos: position{line: 277, col: 4, offset: 8991},
+					exprs: []interface{}{
+						&litMatcher{
+							pos:        position{line: 277, col: 4, offset: 8991},
+							val:        "[[",
+							ignoreCase: false,
+							want:       "\"[[\"",
+						},
+						&labeledExpr{
+							pos:   position{line: 278, col: 5, offset: 9001},
+							label: "id",
+							expr: &actionExpr{
+								pos: position{line: 279, col: 9, offset: 9014},
+								run: (*parser).callonShortHandAnchor5,
+								expr: &labeledExpr{
+									pos:   position{line: 279, col: 9, offset: 9014},
+									label: "elements",
+									expr: &oneOrMoreExpr{
+										pos: position{line: 279, col: 18, offset: 9023},
+										expr: &choiceExpr{
+											pos: position{line: 280, col: 13, offset: 9037},
+											alternatives: []interface{}{
+												&actionExpr{
+													pos: position{line: 280, col: 14, offset: 9038},
+													run: (*parser).callonShortHandAnchor9,
+													expr: &oneOrMoreExpr{
+														pos: position{line: 280, col: 14, offset: 9038},
+														expr: &charClassMatcher{
+															pos:        position{line: 280, col: 14, offset: 9038},
+															val:        "[^=\\r\\n\\uFFFD{\\]]",
+															chars:      []rune{'=', '\r', '\n', '�', '{', ']'},
+															ignoreCase: false,
+															inverted:   true,
+														},
+													},
+												},
+												&ruleRefExpr{
+													pos:  position{line: 283, col: 13, offset: 9205},
+													name: "ElementPlaceHolder",
+												},
+												&ruleRefExpr{
+													pos:  position{line: 284, col: 13, offset: 9238},
+													name: "AttrSub",
+												},
+												&actionExpr{
+													pos: position{line: 285, col: 14, offset: 9261},
+													run: (*parser).callonShortHandAnchor14,
+													expr: &litMatcher{
+														pos:        position{line: 285, col: 14, offset: 9261},
+														val:        "{",
+														ignoreCase: false,
+														want:       "\"{\"",
+													},
+												},
 											},
-											&labeledExpr{
-												pos:   position{line: 330, col: 17, offset: 11078},
-												label: "attr",
-												expr: &zeroOrOneExpr{
-													pos: position{line: 330, col: 22, offset: 11083},
-													expr: &choiceExpr{
-														pos: position{line: 330, col: 23, offset: 11084},
-														alternatives: []interface{}{
-															&ruleRefExpr{
-																pos:  position{line: 330, col: 23, offset: 11084},
-																name: "NamedAttribute",
+										},
+									},
+								},
+							},
+						},
+						&litMatcher{
+							pos:        position{line: 291, col: 5, offset: 9447},
+							val:        "]]",
+							ignoreCase: false,
+							want:       "\"]]\"",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "ShortHandTitle",
+			pos:  position{line: 296, col: 1, offset: 9548},
+			expr: &actionExpr{
+				pos: position{line: 296, col: 19, offset: 9566},
+				run: (*parser).callonShortHandTitle1,
+				expr: &seqExpr{
+					pos: position{line: 296, col: 19, offset: 9566},
+					exprs: []interface{}{
+						&litMatcher{
+							pos:        position{line: 296, col: 19, offset: 9566},
+							val:        ".",
+							ignoreCase: false,
+							want:       "\".\"",
+						},
+						&labeledExpr{
+							pos:   position{line: 296, col: 23, offset: 9570},
+							label: "title",
+							expr: &actionExpr{
+								pos: position{line: 297, col: 5, offset: 9582},
+								run: (*parser).callonShortHandTitle5,
+								expr: &seqExpr{
+									pos: position{line: 297, col: 5, offset: 9582},
+									exprs: []interface{}{
+										&notExpr{
+											pos: position{line: 297, col: 5, offset: 9582},
+											expr: &charClassMatcher{
+												pos:        position{line: 297, col: 6, offset: 9583},
+												val:        "[. ]",
+												chars:      []rune{'.', ' '},
+												ignoreCase: false,
+												inverted:   false,
+											},
+										},
+										&labeledExpr{
+											pos:   position{line: 298, col: 5, offset: 9695},
+											label: "elements",
+											expr: &oneOrMoreExpr{
+												pos: position{line: 298, col: 14, offset: 9704},
+												expr: &choiceExpr{
+													pos: position{line: 299, col: 9, offset: 9714},
+													alternatives: []interface{}{
+														&actionExpr{
+															pos: position{line: 299, col: 10, offset: 9715},
+															run: (*parser).callonShortHandTitle12,
+															expr: &oneOrMoreExpr{
+																pos: position{line: 299, col: 10, offset: 9715},
+																expr: &charClassMatcher{
+																	pos:        position{line: 299, col: 10, offset: 9715},
+																	val:        "[^\\r\\n\\uFFFD{]",
+																	chars:      []rune{'\r', '\n', '�', '{'},
+																	ignoreCase: false,
+																	inverted:   true,
+																},
 															},
-															&ruleRefExpr{
-																pos:  position{line: 330, col: 40, offset: 11101},
-																name: "StandaloneAttributeKey",
+														},
+														&ruleRefExpr{
+															pos:  position{line: 302, col: 9, offset: 9813},
+															name: "ElementPlaceHolder",
+														},
+														&ruleRefExpr{
+															pos:  position{line: 303, col: 9, offset: 9842},
+															name: "AttrSub",
+														},
+														&actionExpr{
+															pos: position{line: 304, col: 10, offset: 9861},
+															run: (*parser).callonShortHandTitle17,
+															expr: &litMatcher{
+																pos:        position{line: 304, col: 10, offset: 9861},
+																val:        "{",
+																ignoreCase: false,
+																want:       "\"{\"",
 															},
 														},
 													},
@@ -2442,105 +2116,437 @@ var g = &grammar{
 								},
 							},
 						},
-						&litMatcher{
-							pos:        position{line: 331, col: 5, offset: 11154},
-							val:        "]",
-							ignoreCase: false,
-							want:       "\"]\"",
-						},
-						&zeroOrMoreExpr{
-							pos: position{line: 331, col: 9, offset: 11158},
-							expr: &ruleRefExpr{
-								pos:  position{line: 331, col: 9, offset: 11158},
-								name: "Space",
-							},
-						},
-						&ruleRefExpr{
-							pos:  position{line: 331, col: 16, offset: 11165},
-							name: "EOL",
-						},
 					},
 				},
 			},
 		},
 		{
-			name: "AttributeGroup",
-			pos:  position{line: 336, col: 1, offset: 11324},
+			name: "LongHandAttributes",
+			pos:  position{line: 315, col: 1, offset: 10261},
 			expr: &actionExpr{
-				pos: position{line: 336, col: 19, offset: 11342},
-				run: (*parser).callonAttributeGroup1,
+				pos: position{line: 316, col: 5, offset: 10287},
+				run: (*parser).callonLongHandAttributes1,
 				expr: &seqExpr{
-					pos: position{line: 336, col: 19, offset: 11342},
+					pos: position{line: 316, col: 5, offset: 10287},
 					exprs: []interface{}{
+						&stateCodeExpr{
+							pos: position{line: 316, col: 5, offset: 10287},
+							run: (*parser).callonLongHandAttributes3,
+						},
 						&litMatcher{
-							pos:        position{line: 336, col: 19, offset: 11342},
+							pos:        position{line: 319, col: 5, offset: 10338},
 							val:        "[",
 							ignoreCase: false,
 							want:       "\"[\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 336, col: 23, offset: 11346},
-							label: "attributes",
-							expr: &ruleRefExpr{
-								pos:  position{line: 336, col: 35, offset: 11358},
-								name: "Attributes",
+							pos:   position{line: 321, col: 5, offset: 10404},
+							label: "firstPositionalAttribute",
+							expr: &zeroOrOneExpr{
+								pos: position{line: 321, col: 30, offset: 10429},
+								expr: &ruleRefExpr{
+									pos:  position{line: 321, col: 31, offset: 10430},
+									name: "FirstPositionalAttribute",
+								},
+							},
+						},
+						&labeledExpr{
+							pos:   position{line: 322, col: 5, offset: 10461},
+							label: "otherAttributes",
+							expr: &zeroOrMoreExpr{
+								pos: position{line: 322, col: 21, offset: 10477},
+								expr: &choiceExpr{
+									pos: position{line: 322, col: 22, offset: 10478},
+									alternatives: []interface{}{
+										&ruleRefExpr{
+											pos:  position{line: 322, col: 22, offset: 10478},
+											name: "PositionalAttribute",
+										},
+										&ruleRefExpr{
+											pos:  position{line: 322, col: 44, offset: 10500},
+											name: "NamedAttribute",
+										},
+									},
+								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 336, col: 47, offset: 11370},
+							pos:        position{line: 323, col: 5, offset: 10521},
 							val:        "]",
 							ignoreCase: false,
 							want:       "\"]\"",
 						},
-						&zeroOrMoreExpr{
-							pos: position{line: 336, col: 51, offset: 11374},
-							expr: &ruleRefExpr{
-								pos:  position{line: 336, col: 51, offset: 11374},
-								name: "Space",
+					},
+				},
+			},
+		},
+		{
+			name: "FirstPositionalAttribute",
+			pos:  position{line: 334, col: 1, offset: 10978},
+			expr: &actionExpr{
+				pos: position{line: 335, col: 5, offset: 11011},
+				run: (*parser).callonFirstPositionalAttribute1,
+				expr: &seqExpr{
+					pos: position{line: 335, col: 5, offset: 11011},
+					exprs: []interface{}{
+						&labeledExpr{
+							pos:   position{line: 335, col: 5, offset: 11011},
+							label: "main",
+							expr: &zeroOrOneExpr{
+								pos: position{line: 335, col: 10, offset: 11016},
+								expr: &ruleRefExpr{
+									pos:  position{line: 336, col: 9, offset: 11026},
+									name: "ShortHandAttribute",
+								},
 							},
 						},
-						&ruleRefExpr{
-							pos:  position{line: 336, col: 58, offset: 11381},
-							name: "EOL",
+						&labeledExpr{
+							pos:   position{line: 338, col: 5, offset: 11056},
+							label: "extras",
+							expr: &zeroOrMoreExpr{
+								pos: position{line: 338, col: 12, offset: 11063},
+								expr: &choiceExpr{
+									pos: position{line: 339, col: 9, offset: 11074},
+									alternatives: []interface{}{
+										&ruleRefExpr{
+											pos:  position{line: 339, col: 9, offset: 11074},
+											name: "ShortHandIDAttribute",
+										},
+										&ruleRefExpr{
+											pos:  position{line: 340, col: 11, offset: 11106},
+											name: "ShortHandOptionAttribute",
+										},
+										&ruleRefExpr{
+											pos:  position{line: 341, col: 11, offset: 11141},
+											name: "ShortHandDotRoleAttribute",
+										},
+									},
+								},
+							},
+						},
+						&zeroOrOneExpr{
+							pos: position{line: 342, col: 8, offset: 11174},
+							expr: &seqExpr{
+								pos: position{line: 342, col: 9, offset: 11175},
+								exprs: []interface{}{
+									&litMatcher{
+										pos:        position{line: 342, col: 9, offset: 11175},
+										val:        ",",
+										ignoreCase: false,
+										want:       "\",\"",
+									},
+									&zeroOrMoreExpr{
+										pos: position{line: 342, col: 13, offset: 11179},
+										expr: &ruleRefExpr{
+											pos:  position{line: 342, col: 13, offset: 11179},
+											name: "Space",
+										},
+									},
+								},
+							},
+						},
+						&andCodeExpr{
+							pos: position{line: 343, col: 5, offset: 11193},
+							run: (*parser).callonFirstPositionalAttribute17,
 						},
 					},
 				},
 			},
 		},
 		{
-			name: "Attributes",
-			pos:  position{line: 340, col: 1, offset: 11456},
-			expr: &zeroOrMoreExpr{
-				pos: position{line: 340, col: 15, offset: 11470},
-				expr: &choiceExpr{
-					pos: position{line: 340, col: 16, offset: 11471},
-					alternatives: []interface{}{
-						&ruleRefExpr{
-							pos:  position{line: 340, col: 16, offset: 11471},
-							name: "NamedAttribute",
-						},
-						&ruleRefExpr{
-							pos:  position{line: 340, col: 33, offset: 11488},
-							name: "StandaloneAttributeKey",
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "NamedAttributes",
-			pos:  position{line: 342, col: 1, offset: 11514},
+			name: "ShortHandIDAttribute",
+			pos:  position{line: 357, col: 1, offset: 11550},
 			expr: &actionExpr{
-				pos: position{line: 342, col: 20, offset: 11533},
-				run: (*parser).callonNamedAttributes1,
+				pos: position{line: 357, col: 25, offset: 11574},
+				run: (*parser).callonShortHandIDAttribute1,
+				expr: &seqExpr{
+					pos: position{line: 357, col: 25, offset: 11574},
+					exprs: []interface{}{
+						&litMatcher{
+							pos:        position{line: 357, col: 25, offset: 11574},
+							val:        "#",
+							ignoreCase: false,
+							want:       "\"#\"",
+						},
+						&labeledExpr{
+							pos:   position{line: 357, col: 29, offset: 11578},
+							label: "id",
+							expr: &ruleRefExpr{
+								pos:  position{line: 357, col: 33, offset: 11582},
+								name: "ShortHandAttributeValue",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "ShortHandAttribute",
+			pos:  position{line: 365, col: 1, offset: 11745},
+			expr: &actionExpr{
+				pos: position{line: 365, col: 23, offset: 11767},
+				run: (*parser).callonShortHandAttribute1,
 				expr: &labeledExpr{
-					pos:   position{line: 342, col: 20, offset: 11533},
-					label: "attributes",
-					expr: &zeroOrMoreExpr{
-						pos: position{line: 342, col: 31, offset: 11544},
-						expr: &ruleRefExpr{
-							pos:  position{line: 342, col: 32, offset: 11545},
-							name: "NamedAttribute",
+					pos:   position{line: 365, col: 23, offset: 11767},
+					label: "value",
+					expr: &ruleRefExpr{
+						pos:  position{line: 365, col: 30, offset: 11774},
+						name: "ShortHandAttributeValue",
+					},
+				},
+			},
+		},
+		{
+			name: "ShortHandDotRoleAttribute",
+			pos:  position{line: 374, col: 1, offset: 11992},
+			expr: &actionExpr{
+				pos: position{line: 374, col: 30, offset: 12021},
+				run: (*parser).callonShortHandDotRoleAttribute1,
+				expr: &seqExpr{
+					pos: position{line: 374, col: 30, offset: 12021},
+					exprs: []interface{}{
+						&litMatcher{
+							pos:        position{line: 374, col: 30, offset: 12021},
+							val:        ".",
+							ignoreCase: false,
+							want:       "\".\"",
+						},
+						&labeledExpr{
+							pos:   position{line: 374, col: 34, offset: 12025},
+							label: "role",
+							expr: &ruleRefExpr{
+								pos:  position{line: 374, col: 40, offset: 12031},
+								name: "ShortHandAttributeValue",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "ShortHandOptionAttribute",
+			pos:  position{line: 379, col: 1, offset: 12145},
+			expr: &actionExpr{
+				pos: position{line: 379, col: 29, offset: 12173},
+				run: (*parser).callonShortHandOptionAttribute1,
+				expr: &seqExpr{
+					pos: position{line: 379, col: 29, offset: 12173},
+					exprs: []interface{}{
+						&litMatcher{
+							pos:        position{line: 379, col: 29, offset: 12173},
+							val:        "%",
+							ignoreCase: false,
+							want:       "\"%\"",
+						},
+						&labeledExpr{
+							pos:   position{line: 379, col: 33, offset: 12177},
+							label: "option",
+							expr: &ruleRefExpr{
+								pos:  position{line: 379, col: 41, offset: 12185},
+								name: "ShortHandAttributeValue",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "ShortHandAttributeValue",
+			pos:  position{line: 384, col: 1, offset: 12290},
+			expr: &choiceExpr{
+				pos: position{line: 385, col: 5, offset: 12322},
+				alternatives: []interface{}{
+					&ruleRefExpr{
+						pos:  position{line: 385, col: 5, offset: 12322},
+						name: "SingleQuotedAttributeValue",
+					},
+					&ruleRefExpr{
+						pos:  position{line: 386, col: 7, offset: 12356},
+						name: "DoubleQuotedAttributeValue",
+					},
+					&actionExpr{
+						pos: position{line: 387, col: 7, offset: 12390},
+						run: (*parser).callonShortHandAttributeValue4,
+						expr: &seqExpr{
+							pos: position{line: 387, col: 7, offset: 12390},
+							exprs: []interface{}{
+								&labeledExpr{
+									pos:   position{line: 387, col: 7, offset: 12390},
+									label: "elements",
+									expr: &oneOrMoreExpr{
+										pos: position{line: 387, col: 16, offset: 12399},
+										expr: &choiceExpr{
+											pos: position{line: 390, col: 5, offset: 12569},
+											alternatives: []interface{}{
+												&actionExpr{
+													pos: position{line: 390, col: 6, offset: 12570},
+													run: (*parser).callonShortHandAttributeValue9,
+													expr: &oneOrMoreExpr{
+														pos: position{line: 390, col: 6, offset: 12570},
+														expr: &charClassMatcher{
+															pos:        position{line: 390, col: 6, offset: 12570},
+															val:        "[^,=.%# \\r\\n\\uFFFD{\\]]",
+															chars:      []rune{',', '=', '.', '%', '#', ' ', '\r', '\n', '�', '{', ']'},
+															ignoreCase: false,
+															inverted:   true,
+														},
+													},
+												},
+												&ruleRefExpr{
+													pos:  position{line: 393, col: 5, offset: 12664},
+													name: "ElementPlaceHolder",
+												},
+												&ruleRefExpr{
+													pos:  position{line: 394, col: 5, offset: 12689},
+													name: "AttrSub",
+												},
+												&actionExpr{
+													pos: position{line: 395, col: 6, offset: 12704},
+													run: (*parser).callonShortHandAttributeValue14,
+													expr: &litMatcher{
+														pos:        position{line: 395, col: 6, offset: 12704},
+														val:        "{",
+														ignoreCase: false,
+														want:       "\"{\"",
+													},
+												},
+											},
+										},
+									},
+								},
+								&andExpr{
+									pos: position{line: 397, col: 10, offset: 12774},
+									expr: &charClassMatcher{
+										pos:        position{line: 397, col: 11, offset: 12775},
+										val:        "[^=]",
+										chars:      []rune{'='},
+										ignoreCase: false,
+										inverted:   true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "PositionalAttribute",
+			pos:  position{line: 401, col: 1, offset: 12851},
+			expr: &choiceExpr{
+				pos: position{line: 401, col: 24, offset: 12874},
+				alternatives: []interface{}{
+					&actionExpr{
+						pos: position{line: 402, col: 5, offset: 12880},
+						run: (*parser).callonPositionalAttribute2,
+						expr: &seqExpr{
+							pos: position{line: 402, col: 5, offset: 12880},
+							exprs: []interface{}{
+								&labeledExpr{
+									pos:   position{line: 402, col: 5, offset: 12880},
+									label: "value",
+									expr: &ruleRefExpr{
+										pos:  position{line: 402, col: 12, offset: 12887},
+										name: "AttributeValue",
+									},
+								},
+								&choiceExpr{
+									pos: position{line: 402, col: 29, offset: 12904},
+									alternatives: []interface{}{
+										&zeroOrOneExpr{
+											pos: position{line: 402, col: 29, offset: 12904},
+											expr: &seqExpr{
+												pos: position{line: 402, col: 30, offset: 12905},
+												exprs: []interface{}{
+													&litMatcher{
+														pos:        position{line: 402, col: 30, offset: 12905},
+														val:        ",",
+														ignoreCase: false,
+														want:       "\",\"",
+													},
+													&zeroOrMoreExpr{
+														pos: position{line: 402, col: 34, offset: 12909},
+														expr: &ruleRefExpr{
+															pos:  position{line: 402, col: 34, offset: 12909},
+															name: "Space",
+														},
+													},
+												},
+											},
+										},
+										&andExpr{
+											pos: position{line: 402, col: 45, offset: 12920},
+											expr: &litMatcher{
+												pos:        position{line: 402, col: 46, offset: 12921},
+												val:        "]",
+												ignoreCase: false,
+												want:       "\"]\"",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					&actionExpr{
+						pos: position{line: 411, col: 6, offset: 13172},
+						run: (*parser).callonPositionalAttribute14,
+						expr: &seqExpr{
+							pos: position{line: 411, col: 6, offset: 13172},
+							exprs: []interface{}{
+								&labeledExpr{
+									pos:   position{line: 411, col: 6, offset: 13172},
+									label: "value",
+									expr: &seqExpr{
+										pos: position{line: 411, col: 13, offset: 13179},
+										exprs: []interface{}{
+											&zeroOrMoreExpr{
+												pos: position{line: 411, col: 13, offset: 13179},
+												expr: &ruleRefExpr{
+													pos:  position{line: 411, col: 13, offset: 13179},
+													name: "Space",
+												},
+											},
+											&choiceExpr{
+												pos: position{line: 411, col: 21, offset: 13187},
+												alternatives: []interface{}{
+													&seqExpr{
+														pos: position{line: 411, col: 22, offset: 13188},
+														exprs: []interface{}{
+															&litMatcher{
+																pos:        position{line: 411, col: 22, offset: 13188},
+																val:        ",",
+																ignoreCase: false,
+																want:       "\",\"",
+															},
+															&zeroOrMoreExpr{
+																pos: position{line: 411, col: 26, offset: 13192},
+																expr: &ruleRefExpr{
+																	pos:  position{line: 411, col: 26, offset: 13192},
+																	name: "Space",
+																},
+															},
+														},
+													},
+													&andExpr{
+														pos: position{line: 411, col: 36, offset: 13202},
+														expr: &litMatcher{
+															pos:        position{line: 411, col: 37, offset: 13203},
+															val:        "]",
+															ignoreCase: false,
+															want:       "\"]\"",
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+								&andCodeExpr{
+									pos: position{line: 412, col: 5, offset: 13213},
+									run: (*parser).callonPositionalAttribute27,
+								},
+							},
 						},
 					},
 				},
@@ -2548,50 +2554,57 @@ var g = &grammar{
 		},
 		{
 			name: "NamedAttribute",
-			pos:  position{line: 346, col: 1, offset: 11633},
+			pos:  position{line: 427, col: 1, offset: 13648},
 			expr: &actionExpr{
-				pos: position{line: 346, col: 19, offset: 11651},
+				pos: position{line: 427, col: 19, offset: 13666},
 				run: (*parser).callonNamedAttribute1,
 				expr: &seqExpr{
-					pos: position{line: 346, col: 19, offset: 11651},
+					pos: position{line: 427, col: 19, offset: 13666},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 346, col: 19, offset: 11651},
+							pos:   position{line: 427, col: 19, offset: 13666},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 346, col: 24, offset: 11656},
+								pos:  position{line: 427, col: 24, offset: 13671},
 								name: "NamedAttributeKey",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 346, col: 44, offset: 11676},
+							pos:        position{line: 427, col: 43, offset: 13690},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
+						&zeroOrMoreExpr{
+							pos: position{line: 427, col: 47, offset: 13694},
+							expr: &ruleRefExpr{
+								pos:  position{line: 427, col: 47, offset: 13694},
+								name: "Space",
+							},
+						},
 						&labeledExpr{
-							pos:   position{line: 346, col: 48, offset: 11680},
+							pos:   position{line: 427, col: 54, offset: 13701},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 346, col: 55, offset: 11687},
+								pos:  position{line: 427, col: 61, offset: 13708},
 								name: "AttributeValue",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 346, col: 71, offset: 11703},
+							pos: position{line: 427, col: 77, offset: 13724},
 							expr: &seqExpr{
-								pos: position{line: 346, col: 72, offset: 11704},
+								pos: position{line: 427, col: 78, offset: 13725},
 								exprs: []interface{}{
 									&litMatcher{
-										pos:        position{line: 346, col: 72, offset: 11704},
+										pos:        position{line: 427, col: 78, offset: 13725},
 										val:        ",",
 										ignoreCase: false,
 										want:       "\",\"",
 									},
 									&zeroOrMoreExpr{
-										pos: position{line: 346, col: 76, offset: 11708},
+										pos: position{line: 427, col: 82, offset: 13729},
 										expr: &ruleRefExpr{
-											pos:  position{line: 346, col: 76, offset: 11708},
+											pos:  position{line: 427, col: 82, offset: 13729},
 											name: "Space",
 										},
 									},
@@ -2604,24 +2617,24 @@ var g = &grammar{
 		},
 		{
 			name: "NamedAttributeKey",
-			pos:  position{line: 351, col: 1, offset: 11889},
+			pos:  position{line: 436, col: 1, offset: 14042},
 			expr: &actionExpr{
-				pos: position{line: 351, col: 22, offset: 11910},
+				pos: position{line: 436, col: 22, offset: 14063},
 				run: (*parser).callonNamedAttributeKey1,
 				expr: &seqExpr{
-					pos: position{line: 351, col: 22, offset: 11910},
+					pos: position{line: 436, col: 22, offset: 14063},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 351, col: 22, offset: 11910},
+							pos: position{line: 436, col: 22, offset: 14063},
 							expr: &ruleRefExpr{
-								pos:  position{line: 351, col: 23, offset: 11911},
+								pos:  position{line: 436, col: 23, offset: 14064},
 								name: "Space",
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 351, col: 29, offset: 11917},
+							pos: position{line: 436, col: 29, offset: 14070},
 							expr: &charClassMatcher{
-								pos:        position{line: 351, col: 29, offset: 11917},
+								pos:        position{line: 436, col: 29, offset: 14070},
 								val:        "[^\\r\\n=,\\]]",
 								chars:      []rune{'\r', '\n', '=', ',', ']'},
 								ignoreCase: false,
@@ -2629,9 +2642,9 @@ var g = &grammar{
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 351, col: 42, offset: 11930},
+							pos: position{line: 436, col: 42, offset: 14083},
 							expr: &ruleRefExpr{
-								pos:  position{line: 351, col: 42, offset: 11930},
+								pos:  position{line: 436, col: 42, offset: 14083},
 								name: "Space",
 							},
 						},
@@ -2641,56 +2654,56 @@ var g = &grammar{
 		},
 		{
 			name: "AttributeValue",
-			pos:  position{line: 355, col: 1, offset: 11992},
+			pos:  position{line: 440, col: 1, offset: 14145},
 			expr: &actionExpr{
-				pos: position{line: 355, col: 19, offset: 12010},
+				pos: position{line: 441, col: 5, offset: 14168},
 				run: (*parser).callonAttributeValue1,
 				expr: &seqExpr{
-					pos: position{line: 355, col: 19, offset: 12010},
+					pos: position{line: 441, col: 5, offset: 14168},
 					exprs: []interface{}{
-						&zeroOrMoreExpr{
-							pos: position{line: 355, col: 19, offset: 12010},
-							expr: &ruleRefExpr{
-								pos:  position{line: 355, col: 19, offset: 12010},
-								name: "Space",
-							},
-						},
 						&labeledExpr{
-							pos:   position{line: 355, col: 26, offset: 12017},
+							pos:   position{line: 441, col: 5, offset: 14168},
 							label: "value",
 							expr: &choiceExpr{
-								pos: position{line: 355, col: 33, offset: 12024},
+								pos: position{line: 442, col: 9, offset: 14184},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 355, col: 33, offset: 12024},
+										pos:  position{line: 442, col: 9, offset: 14184},
 										name: "SingleQuotedAttributeValue",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 355, col: 62, offset: 12053},
+										pos:  position{line: 443, col: 11, offset: 14222},
 										name: "DoubleQuotedAttributeValue",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 355, col: 91, offset: 12082},
+										pos:  position{line: 444, col: 11, offset: 14260},
 										name: "UnquotedAttributeValue",
 									},
 								},
 							},
 						},
-						&zeroOrMoreExpr{
-							pos: position{line: 355, col: 115, offset: 12106},
-							expr: &ruleRefExpr{
-								pos:  position{line: 355, col: 115, offset: 12106},
-								name: "Space",
-							},
-						},
 						&andExpr{
-							pos: position{line: 355, col: 122, offset: 12113},
-							expr: &charClassMatcher{
-								pos:        position{line: 355, col: 123, offset: 12114},
-								val:        "[,\\]]",
-								chars:      []rune{',', ']'},
-								ignoreCase: false,
-								inverted:   false,
+							pos: position{line: 446, col: 5, offset: 14294},
+							expr: &notExpr{
+								pos: position{line: 446, col: 7, offset: 14296},
+								expr: &seqExpr{
+									pos: position{line: 446, col: 9, offset: 14298},
+									exprs: []interface{}{
+										&zeroOrMoreExpr{
+											pos: position{line: 446, col: 9, offset: 14298},
+											expr: &ruleRefExpr{
+												pos:  position{line: 446, col: 9, offset: 14298},
+												name: "Space",
+											},
+										},
+										&litMatcher{
+											pos:        position{line: 446, col: 16, offset: 14305},
+											val:        "=",
+											ignoreCase: false,
+											want:       "\"=\"",
+										},
+									},
+								},
 							},
 						},
 					},
@@ -2699,34 +2712,34 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedAttributeValue",
-			pos:  position{line: 359, col: 1, offset: 12147},
+			pos:  position{line: 450, col: 1, offset: 14346},
 			expr: &actionExpr{
-				pos: position{line: 359, col: 31, offset: 12177},
+				pos: position{line: 451, col: 5, offset: 14381},
 				run: (*parser).callonSingleQuotedAttributeValue1,
 				expr: &seqExpr{
-					pos: position{line: 359, col: 31, offset: 12177},
+					pos: position{line: 451, col: 5, offset: 14381},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 359, col: 31, offset: 12177},
+							pos:        position{line: 451, col: 5, offset: 14381},
 							val:        "'",
 							ignoreCase: false,
 							want:       "\"'\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 359, col: 35, offset: 12181},
+							pos:   position{line: 452, col: 5, offset: 14390},
 							label: "elements",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 359, col: 44, offset: 12190},
+								pos: position{line: 452, col: 14, offset: 14399},
 								expr: &choiceExpr{
-									pos: position{line: 360, col: 5, offset: 12196},
+									pos: position{line: 453, col: 9, offset: 14409},
 									alternatives: []interface{}{
 										&actionExpr{
-											pos: position{line: 360, col: 6, offset: 12197},
+											pos: position{line: 453, col: 10, offset: 14410},
 											run: (*parser).callonSingleQuotedAttributeValue7,
 											expr: &oneOrMoreExpr{
-												pos: position{line: 360, col: 6, offset: 12197},
+												pos: position{line: 453, col: 10, offset: 14410},
 												expr: &charClassMatcher{
-													pos:        position{line: 360, col: 6, offset: 12197},
+													pos:        position{line: 453, col: 10, offset: 14410},
 													val:        "[^'\\r\\n\\uFFFD\\\\{]",
 													chars:      []rune{'\'', '\r', '\n', '�', '\\', '{'},
 													ignoreCase: false,
@@ -2735,32 +2748,42 @@ var g = &grammar{
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 363, col: 5, offset: 12333},
+											pos:  position{line: 456, col: 11, offset: 14556},
 											name: "ElementPlaceHolder",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 364, col: 5, offset: 12358},
+											pos:  position{line: 457, col: 11, offset: 14585},
 											name: "AttrSub",
 										},
-										&actionExpr{
-											pos: position{line: 365, col: 6, offset: 12373},
-											run: (*parser).callonSingleQuotedAttributeValue12,
-											expr: &litMatcher{
-												pos:        position{line: 365, col: 6, offset: 12373},
-												val:        "\\'",
-												ignoreCase: false,
-												want:       "\"\\\\'\"",
-											},
-										},
-										&actionExpr{
-											pos: position{line: 366, col: 6, offset: 12407},
-											run: (*parser).callonSingleQuotedAttributeValue14,
-											expr: &charClassMatcher{
-												pos:        position{line: 366, col: 6, offset: 12407},
-												val:        "[{\\\\]",
-												chars:      []rune{'{', '\\'},
-												ignoreCase: false,
-												inverted:   false,
+										&choiceExpr{
+											pos: position{line: 458, col: 12, offset: 14604},
+											alternatives: []interface{}{
+												&actionExpr{
+													pos: position{line: 458, col: 12, offset: 14604},
+													run: (*parser).callonSingleQuotedAttributeValue13,
+													expr: &litMatcher{
+														pos:        position{line: 458, col: 12, offset: 14604},
+														val:        "\\'",
+														ignoreCase: false,
+														want:       "\"\\\\'\"",
+													},
+												},
+												&litMatcher{
+													pos:        position{line: 461, col: 11, offset: 14696},
+													val:        "{",
+													ignoreCase: false,
+													want:       "\"{\"",
+												},
+												&actionExpr{
+													pos: position{line: 461, col: 17, offset: 14702},
+													run: (*parser).callonSingleQuotedAttributeValue16,
+													expr: &litMatcher{
+														pos:        position{line: 461, col: 17, offset: 14702},
+														val:        "\\",
+														ignoreCase: false,
+														want:       "\"\\\\\"",
+													},
+												},
 											},
 										},
 									},
@@ -2768,7 +2791,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 369, col: 4, offset: 12493},
+							pos:        position{line: 465, col: 5, offset: 14791},
 							val:        "'",
 							ignoreCase: false,
 							want:       "\"'\"",
@@ -2779,34 +2802,34 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedAttributeValue",
-			pos:  position{line: 373, col: 1, offset: 12541},
+			pos:  position{line: 469, col: 1, offset: 14847},
 			expr: &actionExpr{
-				pos: position{line: 373, col: 31, offset: 12571},
+				pos: position{line: 470, col: 5, offset: 14882},
 				run: (*parser).callonDoubleQuotedAttributeValue1,
 				expr: &seqExpr{
-					pos: position{line: 373, col: 31, offset: 12571},
+					pos: position{line: 470, col: 5, offset: 14882},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 373, col: 31, offset: 12571},
+							pos:        position{line: 470, col: 5, offset: 14882},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 373, col: 36, offset: 12576},
+							pos:   position{line: 471, col: 5, offset: 14892},
 							label: "elements",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 373, col: 45, offset: 12585},
+								pos: position{line: 471, col: 14, offset: 14901},
 								expr: &choiceExpr{
-									pos: position{line: 374, col: 5, offset: 12591},
+									pos: position{line: 472, col: 9, offset: 14911},
 									alternatives: []interface{}{
 										&actionExpr{
-											pos: position{line: 374, col: 6, offset: 12592},
+											pos: position{line: 472, col: 10, offset: 14912},
 											run: (*parser).callonDoubleQuotedAttributeValue7,
 											expr: &oneOrMoreExpr{
-												pos: position{line: 374, col: 6, offset: 12592},
+												pos: position{line: 472, col: 10, offset: 14912},
 												expr: &charClassMatcher{
-													pos:        position{line: 374, col: 6, offset: 12592},
+													pos:        position{line: 472, col: 10, offset: 14912},
 													val:        "[^\\r\\n\\uFFFD\"\\\\{]",
 													chars:      []rune{'\r', '\n', '�', '"', '\\', '{'},
 													ignoreCase: false,
@@ -2815,32 +2838,42 @@ var g = &grammar{
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 377, col: 5, offset: 12728},
+											pos:  position{line: 475, col: 11, offset: 15058},
 											name: "ElementPlaceHolder",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 378, col: 5, offset: 12753},
+											pos:  position{line: 476, col: 11, offset: 15087},
 											name: "AttrSub",
 										},
-										&actionExpr{
-											pos: position{line: 379, col: 6, offset: 12768},
-											run: (*parser).callonDoubleQuotedAttributeValue12,
-											expr: &litMatcher{
-												pos:        position{line: 379, col: 6, offset: 12768},
-												val:        "\\\"",
-												ignoreCase: false,
-												want:       "\"\\\\\\\"\"",
-											},
-										},
-										&actionExpr{
-											pos: position{line: 382, col: 7, offset: 12859},
-											run: (*parser).callonDoubleQuotedAttributeValue14,
-											expr: &charClassMatcher{
-												pos:        position{line: 382, col: 7, offset: 12859},
-												val:        "[{\\\\]",
-												chars:      []rune{'{', '\\'},
-												ignoreCase: false,
-												inverted:   false,
+										&choiceExpr{
+											pos: position{line: 477, col: 12, offset: 15106},
+											alternatives: []interface{}{
+												&actionExpr{
+													pos: position{line: 477, col: 12, offset: 15106},
+													run: (*parser).callonDoubleQuotedAttributeValue13,
+													expr: &litMatcher{
+														pos:        position{line: 477, col: 12, offset: 15106},
+														val:        "\\\"",
+														ignoreCase: false,
+														want:       "\"\\\\\\\"\"",
+													},
+												},
+												&litMatcher{
+													pos:        position{line: 480, col: 11, offset: 15198},
+													val:        "{",
+													ignoreCase: false,
+													want:       "\"{\"",
+												},
+												&actionExpr{
+													pos: position{line: 480, col: 17, offset: 15204},
+													run: (*parser).callonDoubleQuotedAttributeValue16,
+													expr: &litMatcher{
+														pos:        position{line: 480, col: 17, offset: 15204},
+														val:        "\\",
+														ignoreCase: false,
+														want:       "\"\\\\\"",
+													},
+												},
 											},
 										},
 									},
@@ -2848,7 +2881,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 385, col: 4, offset: 12945},
+							pos:        position{line: 484, col: 5, offset: 15293},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -2859,758 +2892,67 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedAttributeValue",
-			pos:  position{line: 390, col: 1, offset: 13048},
+			pos:  position{line: 489, col: 1, offset: 15428},
 			expr: &actionExpr{
-				pos: position{line: 390, col: 27, offset: 13074},
+				pos: position{line: 490, col: 5, offset: 15459},
 				run: (*parser).callonUnquotedAttributeValue1,
-				expr: &labeledExpr{
-					pos:   position{line: 390, col: 27, offset: 13074},
-					label: "elements",
-					expr: &oneOrMoreExpr{
-						pos: position{line: 390, col: 36, offset: 13083},
-						expr: &choiceExpr{
-							pos: position{line: 391, col: 5, offset: 13089},
-							alternatives: []interface{}{
-								&actionExpr{
-									pos: position{line: 391, col: 6, offset: 13090},
-									run: (*parser).callonUnquotedAttributeValue5,
-									expr: &oneOrMoreExpr{
-										pos: position{line: 391, col: 6, offset: 13090},
-										expr: &charClassMatcher{
-											pos:        position{line: 391, col: 6, offset: 13090},
-											val:        "[^,=\\r\\n\\uFFFD{\\]]",
-											chars:      []rune{',', '=', '\r', '\n', '�', '{', ']'},
-											ignoreCase: false,
-											inverted:   true,
-										},
-									},
-								},
-								&ruleRefExpr{
-									pos:  position{line: 394, col: 5, offset: 13180},
-									name: "ElementPlaceHolder",
-								},
-								&ruleRefExpr{
-									pos:  position{line: 395, col: 5, offset: 13205},
-									name: "AttrSub",
-								},
-								&actionExpr{
-									pos: position{line: 396, col: 6, offset: 13220},
-									run: (*parser).callonUnquotedAttributeValue10,
-									expr: &litMatcher{
-										pos:        position{line: 396, col: 6, offset: 13220},
-										val:        "{",
-										ignoreCase: false,
-										want:       "\"{\"",
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "StandaloneAttributeKey",
-			pos:  position{line: 402, col: 1, offset: 13361},
-			expr: &actionExpr{
-				pos: position{line: 402, col: 27, offset: 13387},
-				run: (*parser).callonStandaloneAttributeKey1,
 				expr: &seqExpr{
-					pos: position{line: 402, col: 27, offset: 13387},
+					pos: position{line: 490, col: 5, offset: 15459},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 402, col: 27, offset: 13387},
-							expr: &litMatcher{
-								pos:        position{line: 402, col: 28, offset: 13388},
-								val:        "quote",
-								ignoreCase: false,
-								want:       "\"quote\"",
-							},
-						},
-						&notExpr{
-							pos: position{line: 402, col: 36, offset: 13396},
-							expr: &litMatcher{
-								pos:        position{line: 402, col: 37, offset: 13397},
-								val:        "verse",
-								ignoreCase: false,
-								want:       "\"verse\"",
-							},
-						},
-						&notExpr{
-							pos: position{line: 402, col: 45, offset: 13405},
-							expr: &litMatcher{
-								pos:        position{line: 402, col: 46, offset: 13406},
-								val:        "literal",
-								ignoreCase: false,
-								want:       "\"literal\"",
-							},
-						},
-						&labeledExpr{
-							pos:   position{line: 402, col: 56, offset: 13416},
-							label: "key",
+							pos: position{line: 490, col: 5, offset: 15459},
 							expr: &ruleRefExpr{
-								pos:  position{line: 402, col: 61, offset: 13421},
-								name: "NamedAttributeKey",
-							},
-						},
-						&zeroOrOneExpr{
-							pos: position{line: 402, col: 80, offset: 13440},
-							expr: &seqExpr{
-								pos: position{line: 402, col: 81, offset: 13441},
-								exprs: []interface{}{
-									&litMatcher{
-										pos:        position{line: 402, col: 81, offset: 13441},
-										val:        ",",
-										ignoreCase: false,
-										want:       "\",\"",
-									},
-									&zeroOrMoreExpr{
-										pos: position{line: 402, col: 85, offset: 13445},
-										expr: &ruleRefExpr{
-											pos:  position{line: 402, col: 85, offset: 13445},
-											name: "Space",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "QuoteAttributes",
-			pos:  position{line: 406, col: 1, offset: 13537},
-			expr: &actionExpr{
-				pos: position{line: 406, col: 20, offset: 13556},
-				run: (*parser).callonQuoteAttributes1,
-				expr: &seqExpr{
-					pos: position{line: 406, col: 20, offset: 13556},
-					exprs: []interface{}{
-						&litMatcher{
-							pos:        position{line: 406, col: 20, offset: 13556},
-							val:        "[quote",
-							ignoreCase: false,
-							want:       "\"[quote\"",
-						},
-						&zeroOrMoreExpr{
-							pos: position{line: 406, col: 29, offset: 13565},
-							expr: &ruleRefExpr{
-								pos:  position{line: 406, col: 29, offset: 13565},
+								pos:  position{line: 490, col: 6, offset: 15460},
 								name: "Space",
 							},
 						},
-						&zeroOrOneExpr{
-							pos: position{line: 406, col: 36, offset: 13572},
-							expr: &litMatcher{
-								pos:        position{line: 406, col: 36, offset: 13572},
-								val:        ",",
-								ignoreCase: false,
-								want:       "\",\"",
-							},
-						},
 						&labeledExpr{
-							pos:   position{line: 406, col: 41, offset: 13577},
-							label: "author",
-							expr: &zeroOrOneExpr{
-								pos: position{line: 406, col: 48, offset: 13584},
-								expr: &ruleRefExpr{
-									pos:  position{line: 406, col: 49, offset: 13585},
-									name: "QuoteAttribute",
-								},
-							},
-						},
-						&zeroOrOneExpr{
-							pos: position{line: 406, col: 66, offset: 13602},
-							expr: &litMatcher{
-								pos:        position{line: 406, col: 66, offset: 13602},
-								val:        ",",
-								ignoreCase: false,
-								want:       "\",\"",
-							},
-						},
-						&labeledExpr{
-							pos:   position{line: 406, col: 71, offset: 13607},
-							label: "title",
-							expr: &zeroOrOneExpr{
-								pos: position{line: 406, col: 77, offset: 13613},
-								expr: &ruleRefExpr{
-									pos:  position{line: 406, col: 78, offset: 13614},
-									name: "QuoteAttribute",
-								},
-							},
-						},
-						&litMatcher{
-							pos:        position{line: 406, col: 95, offset: 13631},
-							val:        "]",
-							ignoreCase: false,
-							want:       "\"]\"",
-						},
-						&zeroOrMoreExpr{
-							pos: position{line: 406, col: 99, offset: 13635},
-							expr: &ruleRefExpr{
-								pos:  position{line: 406, col: 99, offset: 13635},
-								name: "Space",
-							},
-						},
-						&ruleRefExpr{
-							pos:  position{line: 406, col: 106, offset: 13642},
-							name: "EOL",
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "VerseAttributes",
-			pos:  position{line: 410, col: 1, offset: 13711},
-			expr: &actionExpr{
-				pos: position{line: 410, col: 20, offset: 13730},
-				run: (*parser).callonVerseAttributes1,
-				expr: &seqExpr{
-					pos: position{line: 410, col: 20, offset: 13730},
-					exprs: []interface{}{
-						&litMatcher{
-							pos:        position{line: 410, col: 20, offset: 13730},
-							val:        "[verse",
-							ignoreCase: false,
-							want:       "\"[verse\"",
-						},
-						&zeroOrMoreExpr{
-							pos: position{line: 410, col: 29, offset: 13739},
-							expr: &ruleRefExpr{
-								pos:  position{line: 410, col: 29, offset: 13739},
-								name: "Space",
-							},
-						},
-						&zeroOrOneExpr{
-							pos: position{line: 410, col: 36, offset: 13746},
-							expr: &litMatcher{
-								pos:        position{line: 410, col: 36, offset: 13746},
-								val:        ",",
-								ignoreCase: false,
-								want:       "\",\"",
-							},
-						},
-						&labeledExpr{
-							pos:   position{line: 410, col: 41, offset: 13751},
-							label: "author",
-							expr: &zeroOrOneExpr{
-								pos: position{line: 410, col: 48, offset: 13758},
-								expr: &ruleRefExpr{
-									pos:  position{line: 410, col: 49, offset: 13759},
-									name: "QuoteAttribute",
-								},
-							},
-						},
-						&zeroOrOneExpr{
-							pos: position{line: 410, col: 66, offset: 13776},
-							expr: &litMatcher{
-								pos:        position{line: 410, col: 66, offset: 13776},
-								val:        ",",
-								ignoreCase: false,
-								want:       "\",\"",
-							},
-						},
-						&labeledExpr{
-							pos:   position{line: 410, col: 71, offset: 13781},
-							label: "title",
-							expr: &zeroOrOneExpr{
-								pos: position{line: 410, col: 77, offset: 13787},
-								expr: &ruleRefExpr{
-									pos:  position{line: 410, col: 78, offset: 13788},
-									name: "QuoteAttribute",
-								},
-							},
-						},
-						&litMatcher{
-							pos:        position{line: 410, col: 95, offset: 13805},
-							val:        "]",
-							ignoreCase: false,
-							want:       "\"]\"",
-						},
-						&zeroOrMoreExpr{
-							pos: position{line: 410, col: 99, offset: 13809},
-							expr: &ruleRefExpr{
-								pos:  position{line: 410, col: 99, offset: 13809},
-								name: "Space",
-							},
-						},
-						&ruleRefExpr{
-							pos:  position{line: 410, col: 106, offset: 13816},
-							name: "EOL",
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "QuoteAttribute",
-			pos:  position{line: 414, col: 1, offset: 13903},
-			expr: &actionExpr{
-				pos: position{line: 414, col: 19, offset: 13921},
-				run: (*parser).callonQuoteAttribute1,
-				expr: &zeroOrMoreExpr{
-					pos: position{line: 414, col: 20, offset: 13922},
-					expr: &charClassMatcher{
-						pos:        position{line: 414, col: 20, offset: 13922},
-						val:        "[^\\r\\n,\\]]",
-						chars:      []rune{'\r', '\n', ',', ']'},
-						ignoreCase: false,
-						inverted:   true,
-					},
-				},
-			},
-		},
-		{
-			name: "QuotedTextAttributes",
-			pos:  position{line: 418, col: 1, offset: 13971},
-			expr: &actionExpr{
-				pos: position{line: 418, col: 25, offset: 13995},
-				run: (*parser).callonQuotedTextAttributes1,
-				expr: &seqExpr{
-					pos: position{line: 418, col: 25, offset: 13995},
-					exprs: []interface{}{
-						&litMatcher{
-							pos:        position{line: 418, col: 25, offset: 13995},
-							val:        "[",
-							ignoreCase: false,
-							want:       "\"[\"",
-						},
-						&labeledExpr{
-							pos:   position{line: 418, col: 29, offset: 13999},
-							label: "attributes",
-							expr: &seqExpr{
-								pos: position{line: 418, col: 41, offset: 14011},
-								exprs: []interface{}{
-									&zeroOrOneExpr{
-										pos: position{line: 418, col: 41, offset: 14011},
-										expr: &ruleRefExpr{
-											pos:  position{line: 418, col: 41, offset: 14011},
-											name: "QuotedTextAttrRole",
-										},
-									},
-									&zeroOrMoreExpr{
-										pos: position{line: 418, col: 61, offset: 14031},
-										expr: &ruleRefExpr{
-											pos:  position{line: 418, col: 61, offset: 14031},
-											name: "ShortHandAttr",
-										},
-									},
-									&zeroOrMoreExpr{
-										pos: position{line: 418, col: 76, offset: 14046},
-										expr: &ruleRefExpr{
-											pos:  position{line: 418, col: 76, offset: 14046},
-											name: "NamedAttribute",
-										},
-									},
-								},
-							},
-						},
-						&litMatcher{
-							pos:        position{line: 418, col: 93, offset: 14063},
-							val:        "]",
-							ignoreCase: false,
-							want:       "\"]\"",
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "QuotedTextAttrRole",
-			pos:  position{line: 422, col: 1, offset: 14138},
-			expr: &actionExpr{
-				pos: position{line: 422, col: 23, offset: 14160},
-				run: (*parser).callonQuotedTextAttrRole1,
-				expr: &seqExpr{
-					pos: position{line: 422, col: 23, offset: 14160},
-					exprs: []interface{}{
-						&labeledExpr{
-							pos:   position{line: 422, col: 23, offset: 14160},
-							label: "role",
-							expr: &ruleRefExpr{
-								pos:  position{line: 422, col: 28, offset: 14165},
-								name: "PositionalValue",
-							},
-						},
-						&zeroOrOneExpr{
-							pos: position{line: 422, col: 44, offset: 14181},
-							expr: &seqExpr{
-								pos: position{line: 422, col: 45, offset: 14182},
-								exprs: []interface{}{
-									&litMatcher{
-										pos:        position{line: 422, col: 45, offset: 14182},
-										val:        ",",
-										ignoreCase: false,
-										want:       "\",\"",
-									},
-									&zeroOrMoreExpr{
-										pos: position{line: 422, col: 49, offset: 14186},
-										expr: &ruleRefExpr{
-											pos:  position{line: 422, col: 49, offset: 14186},
-											name: "Space",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "StandaloneAttributes",
-			pos:  position{line: 426, col: 1, offset: 14238},
-			expr: &actionExpr{
-				pos: position{line: 426, col: 25, offset: 14262},
-				run: (*parser).callonStandaloneAttributes1,
-				expr: &seqExpr{
-					pos: position{line: 426, col: 25, offset: 14262},
-					exprs: []interface{}{
-						&labeledExpr{
-							pos:   position{line: 426, col: 25, offset: 14262},
-							label: "attributes",
+							pos:   position{line: 491, col: 5, offset: 15470},
+							label: "elements",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 426, col: 36, offset: 14273},
-								expr: &ruleRefExpr{
-									pos:  position{line: 426, col: 37, offset: 14274},
-									name: "ElementAttribute",
-								},
-							},
-						},
-						&zeroOrMoreExpr{
-							pos: position{line: 426, col: 56, offset: 14293},
-							expr: &ruleRefExpr{
-								pos:  position{line: 426, col: 56, offset: 14293},
-								name: "BlankLine",
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "ShortHandAttr",
-			pos:  position{line: 430, col: 1, offset: 14431},
-			expr: &choiceExpr{
-				pos: position{line: 430, col: 18, offset: 14448},
-				alternatives: []interface{}{
-					&ruleRefExpr{
-						pos:  position{line: 430, col: 18, offset: 14448},
-						name: "ShortHandAttrID",
-					},
-					&ruleRefExpr{
-						pos:  position{line: 430, col: 36, offset: 14466},
-						name: "ShortHandAttrOption",
-					},
-					&ruleRefExpr{
-						pos:  position{line: 430, col: 58, offset: 14488},
-						name: "ShortHandAttrRole",
-					},
-				},
-			},
-		},
-		{
-			name: "ShortHandAttrOption",
-			pos:  position{line: 432, col: 1, offset: 14507},
-			expr: &actionExpr{
-				pos: position{line: 432, col: 24, offset: 14530},
-				run: (*parser).callonShortHandAttrOption1,
-				expr: &seqExpr{
-					pos: position{line: 432, col: 24, offset: 14530},
-					exprs: []interface{}{
-						&litMatcher{
-							pos:        position{line: 432, col: 24, offset: 14530},
-							val:        "%",
-							ignoreCase: false,
-							want:       "\"%\"",
-						},
-						&labeledExpr{
-							pos:   position{line: 432, col: 28, offset: 14534},
-							label: "option",
-							expr: &ruleRefExpr{
-								pos:  position{line: 432, col: 36, offset: 14542},
-								name: "ShortHandValue",
-							},
-						},
-						&andExpr{
-							pos: position{line: 432, col: 52, offset: 14558},
-							expr: &charClassMatcher{
-								pos:        position{line: 432, col: 53, offset: 14559},
-								val:        "[,#%.\\r\\n\\]]",
-								chars:      []rune{',', '#', '%', '.', '\r', '\n', ']'},
-								ignoreCase: false,
-								inverted:   false,
-							},
-						},
-						&zeroOrOneExpr{
-							pos: position{line: 432, col: 66, offset: 14572},
-							expr: &seqExpr{
-								pos: position{line: 432, col: 67, offset: 14573},
-								exprs: []interface{}{
-									&litMatcher{
-										pos:        position{line: 432, col: 67, offset: 14573},
-										val:        ",",
-										ignoreCase: false,
-										want:       "\",\"",
-									},
-									&zeroOrMoreExpr{
-										pos: position{line: 432, col: 71, offset: 14577},
-										expr: &ruleRefExpr{
-											pos:  position{line: 432, col: 71, offset: 14577},
-											name: "Space",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "ShortHandAttrID",
-			pos:  position{line: 436, col: 1, offset: 14633},
-			expr: &actionExpr{
-				pos: position{line: 436, col: 20, offset: 14652},
-				run: (*parser).callonShortHandAttrID1,
-				expr: &seqExpr{
-					pos: position{line: 436, col: 20, offset: 14652},
-					exprs: []interface{}{
-						&litMatcher{
-							pos:        position{line: 436, col: 20, offset: 14652},
-							val:        "#",
-							ignoreCase: false,
-							want:       "\"#\"",
-						},
-						&labeledExpr{
-							pos:   position{line: 436, col: 24, offset: 14656},
-							label: "id",
-							expr: &ruleRefExpr{
-								pos:  position{line: 436, col: 28, offset: 14660},
-								name: "ShortHandValue",
-							},
-						},
-						&andExpr{
-							pos: position{line: 436, col: 44, offset: 14676},
-							expr: &charClassMatcher{
-								pos:        position{line: 436, col: 45, offset: 14677},
-								val:        "[,#%.\\r\\n\\]]",
-								chars:      []rune{',', '#', '%', '.', '\r', '\n', ']'},
-								ignoreCase: false,
-								inverted:   false,
-							},
-						},
-						&zeroOrOneExpr{
-							pos: position{line: 436, col: 58, offset: 14690},
-							expr: &seqExpr{
-								pos: position{line: 436, col: 59, offset: 14691},
-								exprs: []interface{}{
-									&litMatcher{
-										pos:        position{line: 436, col: 59, offset: 14691},
-										val:        ",",
-										ignoreCase: false,
-										want:       "\",\"",
-									},
-									&zeroOrMoreExpr{
-										pos: position{line: 436, col: 63, offset: 14695},
-										expr: &ruleRefExpr{
-											pos:  position{line: 436, col: 63, offset: 14695},
-											name: "Space",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "ShortHandAttrRole",
-			pos:  position{line: 440, col: 1, offset: 14743},
-			expr: &actionExpr{
-				pos: position{line: 440, col: 22, offset: 14764},
-				run: (*parser).callonShortHandAttrRole1,
-				expr: &seqExpr{
-					pos: position{line: 440, col: 22, offset: 14764},
-					exprs: []interface{}{
-						&litMatcher{
-							pos:        position{line: 440, col: 22, offset: 14764},
-							val:        ".",
-							ignoreCase: false,
-							want:       "\".\"",
-						},
-						&labeledExpr{
-							pos:   position{line: 440, col: 26, offset: 14768},
-							label: "role",
-							expr: &ruleRefExpr{
-								pos:  position{line: 440, col: 32, offset: 14774},
-								name: "ShortHandValue",
-							},
-						},
-						&andExpr{
-							pos: position{line: 440, col: 48, offset: 14790},
-							expr: &charClassMatcher{
-								pos:        position{line: 440, col: 49, offset: 14791},
-								val:        "[,#%.\\r\\n\\]]",
-								chars:      []rune{',', '#', '%', '.', '\r', '\n', ']'},
-								ignoreCase: false,
-								inverted:   false,
-							},
-						},
-						&zeroOrOneExpr{
-							pos: position{line: 440, col: 62, offset: 14804},
-							expr: &seqExpr{
-								pos: position{line: 440, col: 63, offset: 14805},
-								exprs: []interface{}{
-									&litMatcher{
-										pos:        position{line: 440, col: 63, offset: 14805},
-										val:        ",",
-										ignoreCase: false,
-										want:       "\",\"",
-									},
-									&zeroOrMoreExpr{
-										pos: position{line: 440, col: 67, offset: 14809},
-										expr: &ruleRefExpr{
-											pos:  position{line: 440, col: 67, offset: 14809},
-											name: "Space",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "PositionalValue",
-			pos:  position{line: 445, col: 1, offset: 14905},
-			expr: &actionExpr{
-				pos: position{line: 445, col: 20, offset: 14924},
-				run: (*parser).callonPositionalValue1,
-				expr: &seqExpr{
-					pos: position{line: 445, col: 20, offset: 14924},
-					exprs: []interface{}{
-						&labeledExpr{
-							pos:   position{line: 445, col: 20, offset: 14924},
-							label: "value",
-							expr: &ruleRefExpr{
-								pos:  position{line: 445, col: 27, offset: 14931},
-								name: "ShortHandValue",
-							},
-						},
-						&andExpr{
-							pos: position{line: 445, col: 43, offset: 14947},
-							expr: &charClassMatcher{
-								pos:        position{line: 445, col: 44, offset: 14948},
-								val:        "[,#%.\\]]",
-								chars:      []rune{',', '#', '%', '.', ']'},
-								ignoreCase: false,
-								inverted:   false,
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "ShortHandValue",
-			pos:  position{line: 449, col: 1, offset: 15017},
-			expr: &choiceExpr{
-				pos: position{line: 449, col: 19, offset: 15035},
-				alternatives: []interface{}{
-					&ruleRefExpr{
-						pos:  position{line: 449, col: 19, offset: 15035},
-						name: "ShortHandValuePlain",
-					},
-					&ruleRefExpr{
-						pos:  position{line: 449, col: 41, offset: 15057},
-						name: "SingleQuotedAttributeValue",
-					},
-					&ruleRefExpr{
-						pos:  position{line: 449, col: 70, offset: 15086},
-						name: "DoubleQuotedAttributeValue",
-					},
-				},
-			},
-		},
-		{
-			name: "ShortHandValuePlain",
-			pos:  position{line: 453, col: 1, offset: 15289},
-			expr: &actionExpr{
-				pos: position{line: 453, col: 24, offset: 15312},
-				run: (*parser).callonShortHandValuePlain1,
-				expr: &seqExpr{
-					pos: position{line: 453, col: 24, offset: 15312},
-					exprs: []interface{}{
-						&labeledExpr{
-							pos:   position{line: 453, col: 24, offset: 15312},
-							label: "first",
-							expr: &actionExpr{
-								pos: position{line: 453, col: 31, offset: 15319},
-								run: (*parser).callonShortHandValuePlain4,
-								expr: &charClassMatcher{
-									pos:        position{line: 453, col: 31, offset: 15319},
-									val:        "[^,\\r\\n\"' \\t.#%=\\]]",
-									chars:      []rune{',', '\r', '\n', '"', '\'', ' ', '\t', '.', '#', '%', '=', ']'},
-									ignoreCase: false,
-									inverted:   true,
-								},
-							},
-						},
-						&labeledExpr{
-							pos:   position{line: 456, col: 5, offset: 15405},
-							label: "others",
-							expr: &zeroOrMoreExpr{
-								pos: position{line: 456, col: 13, offset: 15413},
+								pos: position{line: 491, col: 14, offset: 15479},
 								expr: &choiceExpr{
-									pos: position{line: 456, col: 14, offset: 15414},
+									pos: position{line: 492, col: 9, offset: 15489},
 									alternatives: []interface{}{
-										&ruleRefExpr{
-											pos:  position{line: 456, col: 14, offset: 15414},
-											name: "ElementPlaceHolder",
-										},
-										&choiceExpr{
-											pos: position{line: 457, col: 12, offset: 15445},
-											alternatives: []interface{}{
-												&charClassMatcher{
-													pos:        position{line: 457, col: 12, offset: 15445},
-													val:        "[^ \\t,\\r\\n\"'.#%=\\]]",
-													chars:      []rune{' ', '\t', ',', '\r', '\n', '"', '\'', '.', '#', '%', '=', ']'},
+										&actionExpr{
+											pos: position{line: 492, col: 10, offset: 15490},
+											run: (*parser).callonUnquotedAttributeValue8,
+											expr: &oneOrMoreExpr{
+												pos: position{line: 492, col: 10, offset: 15490},
+												expr: &charClassMatcher{
+													pos:        position{line: 492, col: 10, offset: 15490},
+													val:        "[^,=\\r\\n\\uFFFD{\\]]",
+													chars:      []rune{',', '=', '\r', '\n', '�', '{', ']'},
 													ignoreCase: false,
 													inverted:   true,
 												},
-												&actionExpr{
-													pos: position{line: 457, col: 34, offset: 15467},
-													run: (*parser).callonShortHandValuePlain12,
-													expr: &seqExpr{
-														pos: position{line: 457, col: 34, offset: 15467},
-														exprs: []interface{}{
-															&charClassMatcher{
-																pos:        position{line: 457, col: 34, offset: 15467},
-																val:        "[ \\t]",
-																chars:      []rune{' ', '\t'},
-																ignoreCase: false,
-																inverted:   false,
-															},
-															&charClassMatcher{
-																pos:        position{line: 457, col: 39, offset: 15472},
-																val:        "[^ \\t,\\r\\n\"'.#%=\\]]",
-																chars:      []rune{' ', '\t', ',', '\r', '\n', '"', '\'', '.', '#', '%', '=', ']'},
-																ignoreCase: false,
-																inverted:   true,
-															},
-														},
-													},
-												},
+											},
+										},
+										&ruleRefExpr{
+											pos:  position{line: 495, col: 11, offset: 15592},
+											name: "ElementPlaceHolder",
+										},
+										&ruleRefExpr{
+											pos:  position{line: 496, col: 11, offset: 15621},
+											name: "AttrSub",
+										},
+										&actionExpr{
+											pos: position{line: 497, col: 12, offset: 15640},
+											run: (*parser).callonUnquotedAttributeValue13,
+											expr: &litMatcher{
+												pos:        position{line: 497, col: 12, offset: 15640},
+												val:        "{",
+												ignoreCase: false,
+												want:       "\"{\"",
 											},
 										},
 									},
 								},
 							},
+						},
+						&andCodeExpr{
+							pos: position{line: 501, col: 5, offset: 15728},
+							run: (*parser).callonUnquotedAttributeValue15,
 						},
 					},
 				},
@@ -3618,34 +2960,34 @@ var g = &grammar{
 		},
 		{
 			name: "Section",
-			pos:  position{line: 467, col: 1, offset: 15759},
+			pos:  position{line: 512, col: 1, offset: 16029},
 			expr: &actionExpr{
-				pos: position{line: 467, col: 12, offset: 15770},
+				pos: position{line: 512, col: 12, offset: 16040},
 				run: (*parser).callonSection1,
 				expr: &seqExpr{
-					pos: position{line: 467, col: 12, offset: 15770},
+					pos: position{line: 512, col: 12, offset: 16040},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 467, col: 12, offset: 15770},
+							pos:   position{line: 512, col: 12, offset: 16040},
 							label: "attributes",
-							expr: &zeroOrMoreExpr{
-								pos: position{line: 467, col: 23, offset: 15781},
+							expr: &zeroOrOneExpr{
+								pos: position{line: 512, col: 23, offset: 16051},
 								expr: &ruleRefExpr{
-									pos:  position{line: 467, col: 24, offset: 15782},
-									name: "BlockAttribute",
+									pos:  position{line: 512, col: 24, offset: 16052},
+									name: "BlockAttributes",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 468, col: 5, offset: 15803},
+							pos:   position{line: 513, col: 5, offset: 16074},
 							label: "level",
 							expr: &actionExpr{
-								pos: position{line: 468, col: 12, offset: 15810},
+								pos: position{line: 513, col: 12, offset: 16081},
 								run: (*parser).callonSection7,
 								expr: &oneOrMoreExpr{
-									pos: position{line: 468, col: 12, offset: 15810},
+									pos: position{line: 513, col: 12, offset: 16081},
 									expr: &litMatcher{
-										pos:        position{line: 468, col: 13, offset: 15811},
+										pos:        position{line: 513, col: 13, offset: 16082},
 										val:        "=",
 										ignoreCase: false,
 										want:       "\"=\"",
@@ -3654,37 +2996,37 @@ var g = &grammar{
 							},
 						},
 						&andCodeExpr{
-							pos: position{line: 472, col: 5, offset: 15902},
+							pos: position{line: 517, col: 5, offset: 16173},
 							run: (*parser).callonSection10,
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 476, col: 5, offset: 16054},
+							pos: position{line: 521, col: 5, offset: 16325},
 							expr: &ruleRefExpr{
-								pos:  position{line: 476, col: 5, offset: 16054},
+								pos:  position{line: 521, col: 5, offset: 16325},
 								name: "Space",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 476, col: 12, offset: 16061},
+							pos:   position{line: 521, col: 12, offset: 16332},
 							label: "title",
 							expr: &ruleRefExpr{
-								pos:  position{line: 476, col: 19, offset: 16068},
+								pos:  position{line: 521, col: 19, offset: 16339},
 								name: "TitleElements",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 476, col: 34, offset: 16083},
+							pos:   position{line: 521, col: 34, offset: 16354},
 							label: "id",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 476, col: 38, offset: 16087},
+								pos: position{line: 521, col: 38, offset: 16358},
 								expr: &ruleRefExpr{
-									pos:  position{line: 476, col: 38, offset: 16087},
+									pos:  position{line: 521, col: 38, offset: 16358},
 									name: "InlineElementID",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 476, col: 56, offset: 16105},
+							pos:  position{line: 521, col: 56, offset: 16376},
 							name: "EOL",
 						},
 					},
@@ -3693,34 +3035,34 @@ var g = &grammar{
 		},
 		{
 			name: "TitleElements",
-			pos:  position{line: 480, col: 1, offset: 16227},
+			pos:  position{line: 525, col: 1, offset: 16482},
 			expr: &actionExpr{
-				pos: position{line: 480, col: 18, offset: 16244},
+				pos: position{line: 525, col: 18, offset: 16499},
 				run: (*parser).callonTitleElements1,
 				expr: &labeledExpr{
-					pos:   position{line: 480, col: 18, offset: 16244},
+					pos:   position{line: 525, col: 18, offset: 16499},
 					label: "elements",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 480, col: 27, offset: 16253},
+						pos: position{line: 525, col: 27, offset: 16508},
 						expr: &seqExpr{
-							pos: position{line: 480, col: 28, offset: 16254},
+							pos: position{line: 525, col: 28, offset: 16509},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 480, col: 28, offset: 16254},
+									pos: position{line: 525, col: 28, offset: 16509},
 									expr: &ruleRefExpr{
-										pos:  position{line: 480, col: 29, offset: 16255},
+										pos:  position{line: 525, col: 29, offset: 16510},
 										name: "Newline",
 									},
 								},
 								&notExpr{
-									pos: position{line: 480, col: 37, offset: 16263},
+									pos: position{line: 525, col: 37, offset: 16518},
 									expr: &ruleRefExpr{
-										pos:  position{line: 480, col: 38, offset: 16264},
+										pos:  position{line: 525, col: 38, offset: 16519},
 										name: "InlineElementID",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 480, col: 54, offset: 16280},
+									pos:  position{line: 525, col: 54, offset: 16535},
 									name: "TitleElement",
 								},
 							},
@@ -3731,37 +3073,37 @@ var g = &grammar{
 		},
 		{
 			name: "TitleElement",
-			pos:  position{line: 484, col: 1, offset: 16401},
+			pos:  position{line: 529, col: 1, offset: 16656},
 			expr: &actionExpr{
-				pos: position{line: 484, col: 17, offset: 16417},
+				pos: position{line: 529, col: 17, offset: 16672},
 				run: (*parser).callonTitleElement1,
 				expr: &labeledExpr{
-					pos:   position{line: 484, col: 17, offset: 16417},
+					pos:   position{line: 529, col: 17, offset: 16672},
 					label: "element",
 					expr: &choiceExpr{
-						pos: position{line: 484, col: 26, offset: 16426},
+						pos: position{line: 529, col: 26, offset: 16681},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 484, col: 26, offset: 16426},
+								pos:  position{line: 529, col: 26, offset: 16681},
 								name: "Word",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 485, col: 11, offset: 16441},
+								pos:  position{line: 530, col: 11, offset: 16696},
 								name: "LineBreak",
 							},
 							&oneOrMoreExpr{
-								pos: position{line: 486, col: 11, offset: 16486},
+								pos: position{line: 531, col: 11, offset: 16741},
 								expr: &ruleRefExpr{
-									pos:  position{line: 486, col: 11, offset: 16486},
+									pos:  position{line: 531, col: 11, offset: 16741},
 									name: "Space",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 487, col: 11, offset: 16504},
+								pos:  position{line: 532, col: 11, offset: 16759},
 								name: "ElementPlaceHolder",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 488, col: 11, offset: 16533},
+								pos:  position{line: 533, col: 11, offset: 16788},
 								name: "AnyChar",
 							},
 						},
@@ -3771,18 +3113,18 @@ var g = &grammar{
 		},
 		{
 			name: "TableOfContentsPlaceHolder",
-			pos:  position{line: 495, col: 1, offset: 16684},
+			pos:  position{line: 540, col: 1, offset: 16939},
 			expr: &seqExpr{
-				pos: position{line: 495, col: 31, offset: 16714},
+				pos: position{line: 540, col: 31, offset: 16969},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 495, col: 31, offset: 16714},
+						pos:        position{line: 540, col: 31, offset: 16969},
 						val:        "toc::[]",
 						ignoreCase: false,
 						want:       "\"toc::[]\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 495, col: 41, offset: 16724},
+						pos:  position{line: 540, col: 41, offset: 16979},
 						name: "EOL",
 					},
 				},
@@ -3790,41 +3132,41 @@ var g = &grammar{
 		},
 		{
 			name: "UserMacroBlock",
-			pos:  position{line: 500, col: 1, offset: 16835},
+			pos:  position{line: 545, col: 1, offset: 17090},
 			expr: &actionExpr{
-				pos: position{line: 500, col: 19, offset: 16853},
+				pos: position{line: 545, col: 19, offset: 17108},
 				run: (*parser).callonUserMacroBlock1,
 				expr: &seqExpr{
-					pos: position{line: 500, col: 19, offset: 16853},
+					pos: position{line: 545, col: 19, offset: 17108},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 500, col: 19, offset: 16853},
+							pos:   position{line: 545, col: 19, offset: 17108},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 500, col: 25, offset: 16859},
+								pos:  position{line: 545, col: 25, offset: 17114},
 								name: "UserMacroName",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 500, col: 40, offset: 16874},
+							pos:        position{line: 545, col: 40, offset: 17129},
 							val:        "::",
 							ignoreCase: false,
 							want:       "\"::\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 500, col: 45, offset: 16879},
+							pos:   position{line: 545, col: 45, offset: 17134},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 500, col: 52, offset: 16886},
+								pos:  position{line: 545, col: 52, offset: 17141},
 								name: "UserMacroValue",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 500, col: 68, offset: 16902},
-							label: "attributes",
+							pos:   position{line: 545, col: 68, offset: 17157},
+							label: "inlineAttributes",
 							expr: &ruleRefExpr{
-								pos:  position{line: 500, col: 80, offset: 16914},
-								name: "UserMacroAttributes",
+								pos:  position{line: 545, col: 86, offset: 17175},
+								name: "InlineAttributes",
 							},
 						},
 					},
@@ -3833,41 +3175,41 @@ var g = &grammar{
 		},
 		{
 			name: "InlineUserMacro",
-			pos:  position{line: 504, col: 1, offset: 17053},
+			pos:  position{line: 549, col: 1, offset: 17298},
 			expr: &actionExpr{
-				pos: position{line: 504, col: 20, offset: 17072},
+				pos: position{line: 549, col: 20, offset: 17317},
 				run: (*parser).callonInlineUserMacro1,
 				expr: &seqExpr{
-					pos: position{line: 504, col: 20, offset: 17072},
+					pos: position{line: 549, col: 20, offset: 17317},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 504, col: 20, offset: 17072},
+							pos:   position{line: 549, col: 20, offset: 17317},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 504, col: 26, offset: 17078},
+								pos:  position{line: 549, col: 26, offset: 17323},
 								name: "UserMacroName",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 504, col: 41, offset: 17093},
+							pos:        position{line: 549, col: 41, offset: 17338},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 504, col: 45, offset: 17097},
+							pos:   position{line: 549, col: 45, offset: 17342},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 504, col: 52, offset: 17104},
+								pos:  position{line: 549, col: 52, offset: 17349},
 								name: "UserMacroValue",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 504, col: 68, offset: 17120},
-							label: "attributes",
+							pos:   position{line: 549, col: 68, offset: 17365},
+							label: "inlineAttributes",
 							expr: &ruleRefExpr{
-								pos:  position{line: 504, col: 80, offset: 17132},
-								name: "UserMacroAttributes",
+								pos:  position{line: 549, col: 86, offset: 17383},
+								name: "InlineAttributes",
 							},
 						},
 					},
@@ -3876,26 +3218,26 @@ var g = &grammar{
 		},
 		{
 			name: "UserMacroName",
-			pos:  position{line: 508, col: 1, offset: 17272},
+			pos:  position{line: 553, col: 1, offset: 17507},
 			expr: &actionExpr{
-				pos: position{line: 508, col: 18, offset: 17289},
+				pos: position{line: 553, col: 18, offset: 17524},
 				run: (*parser).callonUserMacroName1,
 				expr: &seqExpr{
-					pos: position{line: 508, col: 18, offset: 17289},
+					pos: position{line: 553, col: 18, offset: 17524},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 508, col: 18, offset: 17289},
+							pos: position{line: 553, col: 18, offset: 17524},
 							expr: &litMatcher{
-								pos:        position{line: 508, col: 19, offset: 17290},
+								pos:        position{line: 553, col: 19, offset: 17525},
 								val:        "include",
 								ignoreCase: false,
 								want:       "\"include\"",
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 508, col: 30, offset: 17301},
+							pos: position{line: 553, col: 30, offset: 17536},
 							expr: &charClassMatcher{
-								pos:        position{line: 508, col: 30, offset: 17301},
+								pos:        position{line: 553, col: 30, offset: 17536},
 								val:        "[\\pL0-9_-]",
 								chars:      []rune{'_', '-'},
 								ranges:     []rune{'0', '9'},
@@ -3910,14 +3252,14 @@ var g = &grammar{
 		},
 		{
 			name: "UserMacroValue",
-			pos:  position{line: 512, col: 1, offset: 17350},
+			pos:  position{line: 557, col: 1, offset: 17585},
 			expr: &actionExpr{
-				pos: position{line: 512, col: 19, offset: 17368},
+				pos: position{line: 557, col: 19, offset: 17603},
 				run: (*parser).callonUserMacroValue1,
 				expr: &zeroOrMoreExpr{
-					pos: position{line: 512, col: 19, offset: 17368},
+					pos: position{line: 557, col: 19, offset: 17603},
 					expr: &charClassMatcher{
-						pos:        position{line: 512, col: 19, offset: 17368},
+						pos:        position{line: 557, col: 19, offset: 17603},
 						val:        "[^:[ \\r\\n]",
 						chars:      []rune{':', '[', ' ', '\r', '\n'},
 						ignoreCase: false,
@@ -3927,79 +3269,43 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "UserMacroAttributes",
-			pos:  position{line: 516, col: 1, offset: 17416},
-			expr: &actionExpr{
-				pos: position{line: 516, col: 24, offset: 17439},
-				run: (*parser).callonUserMacroAttributes1,
-				expr: &seqExpr{
-					pos: position{line: 516, col: 24, offset: 17439},
-					exprs: []interface{}{
-						&litMatcher{
-							pos:        position{line: 516, col: 24, offset: 17439},
-							val:        "[",
-							ignoreCase: false,
-							want:       "\"[\"",
-						},
-						&labeledExpr{
-							pos:   position{line: 516, col: 28, offset: 17443},
-							label: "attributes",
-							expr: &zeroOrMoreExpr{
-								pos: position{line: 516, col: 39, offset: 17454},
-								expr: &ruleRefExpr{
-									pos:  position{line: 516, col: 40, offset: 17455},
-									name: "NamedAttribute",
-								},
-							},
-						},
-						&litMatcher{
-							pos:        position{line: 516, col: 57, offset: 17472},
-							val:        "]",
-							ignoreCase: false,
-							want:       "\"]\"",
-						},
-					},
-				},
-			},
-		},
-		{
 			name: "FileInclusion",
-			pos:  position{line: 523, col: 1, offset: 17658},
+			pos:  position{line: 564, col: 1, offset: 17762},
 			expr: &actionExpr{
-				pos: position{line: 523, col: 18, offset: 17675},
+				pos: position{line: 565, col: 5, offset: 17784},
 				run: (*parser).callonFileInclusion1,
 				expr: &seqExpr{
-					pos: position{line: 523, col: 18, offset: 17675},
+					pos: position{line: 565, col: 5, offset: 17784},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 523, col: 18, offset: 17675},
+							pos:   position{line: 565, col: 5, offset: 17784},
 							label: "incl",
 							expr: &actionExpr{
-								pos: position{line: 523, col: 24, offset: 17681},
+								pos: position{line: 566, col: 9, offset: 17799},
 								run: (*parser).callonFileInclusion4,
 								expr: &seqExpr{
-									pos: position{line: 523, col: 24, offset: 17681},
+									pos: position{line: 566, col: 9, offset: 17799},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 523, col: 24, offset: 17681},
+											pos:        position{line: 566, col: 9, offset: 17799},
 											val:        "include::",
 											ignoreCase: false,
 											want:       "\"include::\"",
 										},
 										&labeledExpr{
-											pos:   position{line: 523, col: 36, offset: 17693},
+											pos:   position{line: 567, col: 9, offset: 17820},
 											label: "path",
 											expr: &ruleRefExpr{
-												pos:  position{line: 523, col: 42, offset: 17699},
+												pos:  position{line: 567, col: 15, offset: 17826},
 												name: "FileLocation",
 											},
 										},
 										&labeledExpr{
-											pos:   position{line: 523, col: 56, offset: 17713},
+											pos:   position{line: 568, col: 9, offset: 17849},
 											label: "inlineAttributes",
 											expr: &ruleRefExpr{
-												pos:  position{line: 523, col: 74, offset: 17731},
-												name: "FileIncludeAttributes",
+												pos:  position{line: 568, col: 27, offset: 17867},
+												name: "InlineAttributes",
 											},
 										},
 									},
@@ -4007,14 +3313,14 @@ var g = &grammar{
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 525, col: 8, offset: 17878},
+							pos: position{line: 572, col: 5, offset: 18027},
 							expr: &ruleRefExpr{
-								pos:  position{line: 525, col: 8, offset: 17878},
+								pos:  position{line: 572, col: 5, offset: 18027},
 								name: "Space",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 525, col: 15, offset: 17885},
+							pos:  position{line: 572, col: 12, offset: 18034},
 							name: "EOL",
 						},
 					},
@@ -4023,168 +3329,45 @@ var g = &grammar{
 		},
 		{
 			name: "FileIncludeAttributes",
-			pos:  position{line: 529, col: 1, offset: 17937},
-			expr: &actionExpr{
-				pos: position{line: 529, col: 26, offset: 17962},
-				run: (*parser).callonFileIncludeAttributes1,
-				expr: &seqExpr{
-					pos: position{line: 529, col: 26, offset: 17962},
-					exprs: []interface{}{
-						&litMatcher{
-							pos:        position{line: 529, col: 26, offset: 17962},
-							val:        "[",
-							ignoreCase: false,
-							want:       "\"[\"",
-						},
-						&labeledExpr{
-							pos:   position{line: 529, col: 30, offset: 17966},
-							label: "attributes",
-							expr: &zeroOrMoreExpr{
-								pos: position{line: 529, col: 41, offset: 17977},
-								expr: &choiceExpr{
-									pos: position{line: 529, col: 42, offset: 17978},
-									alternatives: []interface{}{
-										&ruleRefExpr{
-											pos:  position{line: 529, col: 42, offset: 17978},
-											name: "LineRangesAttribute",
-										},
-										&ruleRefExpr{
-											pos:  position{line: 529, col: 64, offset: 18000},
-											name: "TagRangesAttribute",
-										},
-										&ruleRefExpr{
-											pos:  position{line: 529, col: 85, offset: 18021},
-											name: "NamedAttribute",
-										},
-										&ruleRefExpr{
-											pos:  position{line: 529, col: 102, offset: 18038},
-											name: "StandaloneAttributeKey",
-										},
-									},
-								},
-							},
-						},
-						&litMatcher{
-							pos:        position{line: 529, col: 127, offset: 18063},
-							val:        "]",
-							ignoreCase: false,
-							want:       "\"]\"",
-						},
-					},
-				},
+			pos:  position{line: 576, col: 1, offset: 18094},
+			expr: &ruleRefExpr{
+				pos:  position{line: 576, col: 26, offset: 18119},
+				name: "LongHandAttributes",
 			},
 		},
 		{
-			name: "LineRangesAttribute",
-			pos:  position{line: 533, col: 1, offset: 18139},
+			name: "LineRanges",
+			pos:  position{line: 579, col: 1, offset: 18159},
 			expr: &actionExpr{
-				pos: position{line: 533, col: 24, offset: 18162},
-				run: (*parser).callonLineRangesAttribute1,
+				pos: position{line: 579, col: 15, offset: 18173},
+				run: (*parser).callonLineRanges1,
 				expr: &seqExpr{
-					pos: position{line: 533, col: 24, offset: 18162},
-					exprs: []interface{}{
-						&litMatcher{
-							pos:        position{line: 533, col: 24, offset: 18162},
-							val:        "lines=",
-							ignoreCase: false,
-							want:       "\"lines=\"",
-						},
-						&labeledExpr{
-							pos:   position{line: 533, col: 33, offset: 18171},
-							label: "lines",
-							expr: &ruleRefExpr{
-								pos:  position{line: 533, col: 40, offset: 18178},
-								name: "LineRangesAttributeValue",
-							},
-						},
-						&zeroOrOneExpr{
-							pos: position{line: 533, col: 66, offset: 18204},
-							expr: &litMatcher{
-								pos:        position{line: 533, col: 66, offset: 18204},
-								val:        ",",
-								ignoreCase: false,
-								want:       "\",\"",
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "LineRangesAttributeValue",
-			pos:  position{line: 537, col: 1, offset: 18263},
-			expr: &actionExpr{
-				pos: position{line: 537, col: 29, offset: 18291},
-				run: (*parser).callonLineRangesAttributeValue1,
-				expr: &seqExpr{
-					pos: position{line: 537, col: 29, offset: 18291},
+					pos: position{line: 579, col: 15, offset: 18173},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 537, col: 29, offset: 18291},
+							pos:   position{line: 579, col: 15, offset: 18173},
 							label: "value",
 							expr: &choiceExpr{
-								pos: position{line: 537, col: 36, offset: 18298},
+								pos: position{line: 579, col: 22, offset: 18180},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 537, col: 36, offset: 18298},
+										pos:  position{line: 579, col: 22, offset: 18180},
 										name: "MultipleLineRanges",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 538, col: 11, offset: 18415},
-										name: "MultipleQuotedLineRanges",
-									},
-									&ruleRefExpr{
-										pos:  position{line: 539, col: 11, offset: 18451},
+										pos:  position{line: 580, col: 11, offset: 18210},
 										name: "MultiLineRange",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 540, col: 11, offset: 18477},
-										name: "MultiLineQuotedRange",
-									},
-									&ruleRefExpr{
-										pos:  position{line: 541, col: 11, offset: 18509},
-										name: "SingleLineQuotedRange",
-									},
-									&ruleRefExpr{
-										pos:  position{line: 542, col: 11, offset: 18541},
+										pos:  position{line: 581, col: 11, offset: 18236},
 										name: "SingleLineRange",
 									},
-									&ruleRefExpr{
-										pos:  position{line: 543, col: 11, offset: 18568},
-										name: "UndefinedLineRange",
-									},
 								},
 							},
 						},
-						&zeroOrMoreExpr{
-							pos: position{line: 543, col: 31, offset: 18588},
-							expr: &ruleRefExpr{
-								pos:  position{line: 543, col: 31, offset: 18588},
-								name: "Space",
-							},
-						},
-						&choiceExpr{
-							pos: position{line: 543, col: 39, offset: 18596},
-							alternatives: []interface{}{
-								&andExpr{
-									pos: position{line: 543, col: 39, offset: 18596},
-									expr: &litMatcher{
-										pos:        position{line: 543, col: 40, offset: 18597},
-										val:        ",",
-										ignoreCase: false,
-										want:       "\",\"",
-									},
-								},
-								&andExpr{
-									pos: position{line: 543, col: 46, offset: 18603},
-									expr: &litMatcher{
-										pos:        position{line: 543, col: 47, offset: 18604},
-										val:        "]",
-										ignoreCase: false,
-										want:       "\"]\"",
-									},
-								},
-							},
+						&ruleRefExpr{
+							pos:  position{line: 582, col: 11, offset: 18263},
+							name: "EOF",
 						},
 					},
 				},
@@ -4192,59 +3375,70 @@ var g = &grammar{
 		},
 		{
 			name: "MultipleLineRanges",
-			pos:  position{line: 547, col: 1, offset: 18636},
+			pos:  position{line: 586, col: 1, offset: 18345},
 			expr: &actionExpr{
-				pos: position{line: 547, col: 23, offset: 18658},
+				pos: position{line: 586, col: 23, offset: 18367},
 				run: (*parser).callonMultipleLineRanges1,
 				expr: &seqExpr{
-					pos: position{line: 547, col: 23, offset: 18658},
+					pos: position{line: 586, col: 23, offset: 18367},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 547, col: 23, offset: 18658},
+							pos:   position{line: 586, col: 23, offset: 18367},
 							label: "first",
 							expr: &choiceExpr{
-								pos: position{line: 547, col: 30, offset: 18665},
+								pos: position{line: 586, col: 30, offset: 18374},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 547, col: 30, offset: 18665},
+										pos:  position{line: 586, col: 30, offset: 18374},
 										name: "MultiLineRange",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 547, col: 47, offset: 18682},
+										pos:  position{line: 586, col: 47, offset: 18391},
 										name: "SingleLineRange",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 548, col: 5, offset: 18704},
+							pos:   position{line: 587, col: 5, offset: 18413},
 							label: "others",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 548, col: 12, offset: 18711},
+								pos: position{line: 587, col: 12, offset: 18420},
 								expr: &actionExpr{
-									pos: position{line: 548, col: 13, offset: 18712},
+									pos: position{line: 588, col: 9, offset: 18430},
 									run: (*parser).callonMultipleLineRanges9,
 									expr: &seqExpr{
-										pos: position{line: 548, col: 13, offset: 18712},
+										pos: position{line: 588, col: 9, offset: 18430},
 										exprs: []interface{}{
-											&litMatcher{
-												pos:        position{line: 548, col: 13, offset: 18712},
-												val:        ";",
-												ignoreCase: false,
-												want:       "\";\"",
+											&choiceExpr{
+												pos: position{line: 588, col: 10, offset: 18431},
+												alternatives: []interface{}{
+													&litMatcher{
+														pos:        position{line: 588, col: 10, offset: 18431},
+														val:        ",",
+														ignoreCase: false,
+														want:       "\",\"",
+													},
+													&litMatcher{
+														pos:        position{line: 588, col: 16, offset: 18437},
+														val:        ";",
+														ignoreCase: false,
+														want:       "\";\"",
+													},
+												},
 											},
 											&labeledExpr{
-												pos:   position{line: 548, col: 17, offset: 18716},
+												pos:   position{line: 589, col: 9, offset: 18548},
 												label: "other",
 												expr: &choiceExpr{
-													pos: position{line: 548, col: 24, offset: 18723},
+													pos: position{line: 589, col: 16, offset: 18555},
 													alternatives: []interface{}{
 														&ruleRefExpr{
-															pos:  position{line: 548, col: 24, offset: 18723},
+															pos:  position{line: 589, col: 16, offset: 18555},
 															name: "MultiLineRange",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 548, col: 41, offset: 18740},
+															pos:  position{line: 589, col: 33, offset: 18572},
 															name: "SingleLineRange",
 														},
 													},
@@ -4254,87 +3448,6 @@ var g = &grammar{
 									},
 								},
 							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "MultipleQuotedLineRanges",
-			pos:  position{line: 554, col: 1, offset: 18878},
-			expr: &actionExpr{
-				pos: position{line: 554, col: 29, offset: 18906},
-				run: (*parser).callonMultipleQuotedLineRanges1,
-				expr: &seqExpr{
-					pos: position{line: 554, col: 29, offset: 18906},
-					exprs: []interface{}{
-						&litMatcher{
-							pos:        position{line: 554, col: 29, offset: 18906},
-							val:        "\"",
-							ignoreCase: false,
-							want:       "\"\\\"\"",
-						},
-						&labeledExpr{
-							pos:   position{line: 554, col: 34, offset: 18911},
-							label: "first",
-							expr: &choiceExpr{
-								pos: position{line: 554, col: 41, offset: 18918},
-								alternatives: []interface{}{
-									&ruleRefExpr{
-										pos:  position{line: 554, col: 41, offset: 18918},
-										name: "MultiLineRange",
-									},
-									&ruleRefExpr{
-										pos:  position{line: 554, col: 58, offset: 18935},
-										name: "SingleLineRange",
-									},
-								},
-							},
-						},
-						&labeledExpr{
-							pos:   position{line: 555, col: 5, offset: 18957},
-							label: "others",
-							expr: &oneOrMoreExpr{
-								pos: position{line: 555, col: 12, offset: 18964},
-								expr: &actionExpr{
-									pos: position{line: 555, col: 13, offset: 18965},
-									run: (*parser).callonMultipleQuotedLineRanges10,
-									expr: &seqExpr{
-										pos: position{line: 555, col: 13, offset: 18965},
-										exprs: []interface{}{
-											&litMatcher{
-												pos:        position{line: 555, col: 13, offset: 18965},
-												val:        ",",
-												ignoreCase: false,
-												want:       "\",\"",
-											},
-											&labeledExpr{
-												pos:   position{line: 555, col: 17, offset: 18969},
-												label: "other",
-												expr: &choiceExpr{
-													pos: position{line: 555, col: 24, offset: 18976},
-													alternatives: []interface{}{
-														&ruleRefExpr{
-															pos:  position{line: 555, col: 24, offset: 18976},
-															name: "MultiLineRange",
-														},
-														&ruleRefExpr{
-															pos:  position{line: 555, col: 41, offset: 18993},
-															name: "SingleLineRange",
-														},
-													},
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-						&litMatcher{
-							pos:        position{line: 557, col: 9, offset: 19046},
-							val:        "\"",
-							ignoreCase: false,
-							want:       "\"\\\"\"",
 						},
 					},
 				},
@@ -4342,81 +3455,34 @@ var g = &grammar{
 		},
 		{
 			name: "MultiLineRange",
-			pos:  position{line: 561, col: 1, offset: 19136},
+			pos:  position{line: 595, col: 1, offset: 18714},
 			expr: &actionExpr{
-				pos: position{line: 561, col: 19, offset: 19154},
+				pos: position{line: 595, col: 19, offset: 18732},
 				run: (*parser).callonMultiLineRange1,
 				expr: &seqExpr{
-					pos: position{line: 561, col: 19, offset: 19154},
+					pos: position{line: 595, col: 19, offset: 18732},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 561, col: 19, offset: 19154},
+							pos:   position{line: 595, col: 19, offset: 18732},
 							label: "start",
 							expr: &ruleRefExpr{
-								pos:  position{line: 561, col: 26, offset: 19161},
+								pos:  position{line: 595, col: 26, offset: 18739},
 								name: "Number",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 561, col: 34, offset: 19169},
+							pos:        position{line: 595, col: 34, offset: 18747},
 							val:        "..",
 							ignoreCase: false,
 							want:       "\"..\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 561, col: 39, offset: 19174},
+							pos:   position{line: 595, col: 39, offset: 18752},
 							label: "end",
 							expr: &ruleRefExpr{
-								pos:  position{line: 561, col: 44, offset: 19179},
+								pos:  position{line: 595, col: 44, offset: 18757},
 								name: "Number",
 							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "MultiLineQuotedRange",
-			pos:  position{line: 565, col: 1, offset: 19267},
-			expr: &actionExpr{
-				pos: position{line: 565, col: 25, offset: 19291},
-				run: (*parser).callonMultiLineQuotedRange1,
-				expr: &seqExpr{
-					pos: position{line: 565, col: 25, offset: 19291},
-					exprs: []interface{}{
-						&litMatcher{
-							pos:        position{line: 565, col: 25, offset: 19291},
-							val:        "\"",
-							ignoreCase: false,
-							want:       "\"\\\"\"",
-						},
-						&labeledExpr{
-							pos:   position{line: 565, col: 30, offset: 19296},
-							label: "start",
-							expr: &ruleRefExpr{
-								pos:  position{line: 565, col: 37, offset: 19303},
-								name: "Number",
-							},
-						},
-						&litMatcher{
-							pos:        position{line: 565, col: 45, offset: 19311},
-							val:        "..",
-							ignoreCase: false,
-							want:       "\"..\"",
-						},
-						&labeledExpr{
-							pos:   position{line: 565, col: 50, offset: 19316},
-							label: "end",
-							expr: &ruleRefExpr{
-								pos:  position{line: 565, col: 55, offset: 19321},
-								name: "Number",
-							},
-						},
-						&litMatcher{
-							pos:        position{line: 565, col: 63, offset: 19329},
-							val:        "\"",
-							ignoreCase: false,
-							want:       "\"\\\"\"",
 						},
 					},
 				},
@@ -4424,164 +3490,40 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineRange",
-			pos:  position{line: 569, col: 1, offset: 19414},
+			pos:  position{line: 599, col: 1, offset: 18845},
 			expr: &actionExpr{
-				pos: position{line: 569, col: 20, offset: 19433},
+				pos: position{line: 599, col: 20, offset: 18864},
 				run: (*parser).callonSingleLineRange1,
 				expr: &labeledExpr{
-					pos:   position{line: 569, col: 20, offset: 19433},
+					pos:   position{line: 599, col: 20, offset: 18864},
 					label: "singleline",
 					expr: &ruleRefExpr{
-						pos:  position{line: 569, col: 32, offset: 19445},
+						pos:  position{line: 599, col: 32, offset: 18876},
 						name: "Number",
 					},
 				},
 			},
 		},
 		{
-			name: "SingleLineQuotedRange",
-			pos:  position{line: 573, col: 1, offset: 19540},
+			name: "TagRanges",
+			pos:  position{line: 604, col: 1, offset: 18991},
 			expr: &actionExpr{
-				pos: position{line: 573, col: 26, offset: 19565},
-				run: (*parser).callonSingleLineQuotedRange1,
+				pos: position{line: 604, col: 14, offset: 19004},
+				run: (*parser).callonTagRanges1,
 				expr: &seqExpr{
-					pos: position{line: 573, col: 26, offset: 19565},
-					exprs: []interface{}{
-						&litMatcher{
-							pos:        position{line: 573, col: 26, offset: 19565},
-							val:        "\"",
-							ignoreCase: false,
-							want:       "\"\\\"\"",
-						},
-						&labeledExpr{
-							pos:   position{line: 573, col: 31, offset: 19570},
-							label: "singleline",
-							expr: &ruleRefExpr{
-								pos:  position{line: 573, col: 43, offset: 19582},
-								name: "Number",
-							},
-						},
-						&litMatcher{
-							pos:        position{line: 573, col: 51, offset: 19590},
-							val:        "\"",
-							ignoreCase: false,
-							want:       "\"\\\"\"",
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "UndefinedLineRange",
-			pos:  position{line: 577, col: 1, offset: 19682},
-			expr: &actionExpr{
-				pos: position{line: 577, col: 23, offset: 19704},
-				run: (*parser).callonUndefinedLineRange1,
-				expr: &zeroOrMoreExpr{
-					pos: position{line: 577, col: 23, offset: 19704},
-					expr: &charClassMatcher{
-						pos:        position{line: 577, col: 23, offset: 19704},
-						val:        "[^\\], ]",
-						chars:      []rune{']', ',', ' '},
-						ignoreCase: false,
-						inverted:   true,
-					},
-				},
-			},
-		},
-		{
-			name: "TagRangesAttribute",
-			pos:  position{line: 581, col: 1, offset: 19749},
-			expr: &actionExpr{
-				pos: position{line: 581, col: 23, offset: 19771},
-				run: (*parser).callonTagRangesAttribute1,
-				expr: &seqExpr{
-					pos: position{line: 581, col: 23, offset: 19771},
-					exprs: []interface{}{
-						&choiceExpr{
-							pos: position{line: 581, col: 24, offset: 19772},
-							alternatives: []interface{}{
-								&litMatcher{
-									pos:        position{line: 581, col: 24, offset: 19772},
-									val:        "tags=",
-									ignoreCase: false,
-									want:       "\"tags=\"",
-								},
-								&litMatcher{
-									pos:        position{line: 581, col: 34, offset: 19782},
-									val:        "tag=",
-									ignoreCase: false,
-									want:       "\"tag=\"",
-								},
-							},
-						},
-						&labeledExpr{
-							pos:   position{line: 581, col: 42, offset: 19790},
-							label: "tags",
-							expr: &ruleRefExpr{
-								pos:  position{line: 581, col: 48, offset: 19796},
-								name: "TagRangesAttributeValue",
-							},
-						},
-						&zeroOrOneExpr{
-							pos: position{line: 581, col: 73, offset: 19821},
-							expr: &litMatcher{
-								pos:        position{line: 581, col: 73, offset: 19821},
-								val:        ",",
-								ignoreCase: false,
-								want:       "\",\"",
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "TagRangesAttributeValue",
-			pos:  position{line: 585, col: 1, offset: 19970},
-			expr: &actionExpr{
-				pos: position{line: 585, col: 28, offset: 19997},
-				run: (*parser).callonTagRangesAttributeValue1,
-				expr: &seqExpr{
-					pos: position{line: 585, col: 28, offset: 19997},
+					pos: position{line: 604, col: 14, offset: 19004},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 585, col: 28, offset: 19997},
+							pos:   position{line: 604, col: 14, offset: 19004},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 585, col: 35, offset: 20004},
+								pos:  position{line: 604, col: 21, offset: 19011},
 								name: "MultipleTagRanges",
 							},
 						},
-						&zeroOrMoreExpr{
-							pos: position{line: 585, col: 54, offset: 20023},
-							expr: &ruleRefExpr{
-								pos:  position{line: 585, col: 54, offset: 20023},
-								name: "Space",
-							},
-						},
-						&choiceExpr{
-							pos: position{line: 585, col: 62, offset: 20031},
-							alternatives: []interface{}{
-								&andExpr{
-									pos: position{line: 585, col: 62, offset: 20031},
-									expr: &litMatcher{
-										pos:        position{line: 585, col: 63, offset: 20032},
-										val:        ",",
-										ignoreCase: false,
-										want:       "\",\"",
-									},
-								},
-								&andExpr{
-									pos: position{line: 585, col: 69, offset: 20038},
-									expr: &litMatcher{
-										pos:        position{line: 585, col: 70, offset: 20039},
-										val:        "]",
-										ignoreCase: false,
-										want:       "\"]\"",
-									},
-								},
-							},
+						&ruleRefExpr{
+							pos:  position{line: 604, col: 40, offset: 19030},
+							name: "EOF",
 						},
 					},
 				},
@@ -4589,43 +3531,54 @@ var g = &grammar{
 		},
 		{
 			name: "MultipleTagRanges",
-			pos:  position{line: 589, col: 1, offset: 20071},
+			pos:  position{line: 608, col: 1, offset: 19112},
 			expr: &actionExpr{
-				pos: position{line: 589, col: 22, offset: 20092},
+				pos: position{line: 608, col: 22, offset: 19133},
 				run: (*parser).callonMultipleTagRanges1,
 				expr: &seqExpr{
-					pos: position{line: 589, col: 22, offset: 20092},
+					pos: position{line: 608, col: 22, offset: 19133},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 589, col: 22, offset: 20092},
+							pos:   position{line: 608, col: 22, offset: 19133},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 589, col: 29, offset: 20099},
+								pos:  position{line: 608, col: 29, offset: 19140},
 								name: "TagRange",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 590, col: 5, offset: 20113},
+							pos:   position{line: 609, col: 5, offset: 19154},
 							label: "others",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 590, col: 12, offset: 20120},
+								pos: position{line: 609, col: 12, offset: 19161},
 								expr: &actionExpr{
-									pos: position{line: 590, col: 13, offset: 20121},
+									pos: position{line: 610, col: 9, offset: 19171},
 									run: (*parser).callonMultipleTagRanges7,
 									expr: &seqExpr{
-										pos: position{line: 590, col: 13, offset: 20121},
+										pos: position{line: 610, col: 9, offset: 19171},
 										exprs: []interface{}{
-											&litMatcher{
-												pos:        position{line: 590, col: 13, offset: 20121},
-												val:        ";",
-												ignoreCase: false,
-												want:       "\";\"",
+											&choiceExpr{
+												pos: position{line: 610, col: 10, offset: 19172},
+												alternatives: []interface{}{
+													&litMatcher{
+														pos:        position{line: 610, col: 10, offset: 19172},
+														val:        ",",
+														ignoreCase: false,
+														want:       "\",\"",
+													},
+													&litMatcher{
+														pos:        position{line: 610, col: 16, offset: 19178},
+														val:        ";",
+														ignoreCase: false,
+														want:       "\";\"",
+													},
+												},
 											},
 											&labeledExpr{
-												pos:   position{line: 590, col: 17, offset: 20125},
+												pos:   position{line: 611, col: 9, offset: 19289},
 												label: "other",
 												expr: &ruleRefExpr{
-													pos:  position{line: 590, col: 24, offset: 20132},
+													pos:  position{line: 611, col: 16, offset: 19296},
 													name: "TagRange",
 												},
 											},
@@ -4640,25 +3593,25 @@ var g = &grammar{
 		},
 		{
 			name: "TagRange",
-			pos:  position{line: 596, col: 1, offset: 20263},
+			pos:  position{line: 617, col: 1, offset: 19431},
 			expr: &choiceExpr{
-				pos: position{line: 596, col: 13, offset: 20275},
+				pos: position{line: 617, col: 13, offset: 19443},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 596, col: 13, offset: 20275},
+						pos: position{line: 617, col: 13, offset: 19443},
 						run: (*parser).callonTagRange2,
 						expr: &labeledExpr{
-							pos:   position{line: 596, col: 13, offset: 20275},
+							pos:   position{line: 617, col: 13, offset: 19443},
 							label: "tag",
 							expr: &choiceExpr{
-								pos: position{line: 596, col: 18, offset: 20280},
+								pos: position{line: 617, col: 18, offset: 19448},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 596, col: 18, offset: 20280},
+										pos:  position{line: 617, col: 18, offset: 19448},
 										name: "Alphanums",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 596, col: 30, offset: 20292},
+										pos:  position{line: 617, col: 30, offset: 19460},
 										name: "TagWildcard",
 									},
 								},
@@ -4666,29 +3619,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 598, col: 5, offset: 20360},
+						pos: position{line: 619, col: 5, offset: 19528},
 						run: (*parser).callonTagRange7,
 						expr: &seqExpr{
-							pos: position{line: 598, col: 5, offset: 20360},
+							pos: position{line: 619, col: 5, offset: 19528},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 598, col: 5, offset: 20360},
+									pos:        position{line: 619, col: 5, offset: 19528},
 									val:        "!",
 									ignoreCase: false,
 									want:       "\"!\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 598, col: 9, offset: 20364},
+									pos:   position{line: 619, col: 9, offset: 19532},
 									label: "tag",
 									expr: &choiceExpr{
-										pos: position{line: 598, col: 14, offset: 20369},
+										pos: position{line: 619, col: 14, offset: 19537},
 										alternatives: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 598, col: 14, offset: 20369},
+												pos:  position{line: 619, col: 14, offset: 19537},
 												name: "Alphanums",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 598, col: 26, offset: 20381},
+												pos:  position{line: 619, col: 26, offset: 19549},
 												name: "TagWildcard",
 											},
 										},
@@ -4702,23 +3655,23 @@ var g = &grammar{
 		},
 		{
 			name: "TagWildcard",
-			pos:  position{line: 602, col: 1, offset: 20449},
+			pos:  position{line: 623, col: 1, offset: 19617},
 			expr: &actionExpr{
-				pos: position{line: 602, col: 16, offset: 20464},
+				pos: position{line: 623, col: 16, offset: 19632},
 				run: (*parser).callonTagWildcard1,
 				expr: &seqExpr{
-					pos: position{line: 602, col: 16, offset: 20464},
+					pos: position{line: 623, col: 16, offset: 19632},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 602, col: 16, offset: 20464},
+							pos:   position{line: 623, col: 16, offset: 19632},
 							label: "stars",
 							expr: &actionExpr{
-								pos: position{line: 602, col: 23, offset: 20471},
+								pos: position{line: 623, col: 23, offset: 19639},
 								run: (*parser).callonTagWildcard4,
 								expr: &oneOrMoreExpr{
-									pos: position{line: 602, col: 23, offset: 20471},
+									pos: position{line: 623, col: 23, offset: 19639},
 									expr: &litMatcher{
-										pos:        position{line: 602, col: 24, offset: 20472},
+										pos:        position{line: 623, col: 24, offset: 19640},
 										val:        "*",
 										ignoreCase: false,
 										want:       "\"*\"",
@@ -4727,7 +3680,7 @@ var g = &grammar{
 							},
 						},
 						&andCodeExpr{
-							pos: position{line: 605, col: 5, offset: 20526},
+							pos: position{line: 626, col: 5, offset: 19694},
 							run: (*parser).callonTagWildcard7,
 						},
 					},
@@ -4736,34 +3689,34 @@ var g = &grammar{
 		},
 		{
 			name: "IncludedFileLine",
-			pos:  position{line: 615, col: 1, offset: 20820},
+			pos:  position{line: 636, col: 1, offset: 19988},
 			expr: &actionExpr{
-				pos: position{line: 615, col: 21, offset: 20840},
+				pos: position{line: 636, col: 21, offset: 20008},
 				run: (*parser).callonIncludedFileLine1,
 				expr: &seqExpr{
-					pos: position{line: 615, col: 21, offset: 20840},
+					pos: position{line: 636, col: 21, offset: 20008},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 615, col: 21, offset: 20840},
+							pos:   position{line: 636, col: 21, offset: 20008},
 							label: "content",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 615, col: 29, offset: 20848},
+								pos: position{line: 636, col: 29, offset: 20016},
 								expr: &choiceExpr{
-									pos: position{line: 615, col: 30, offset: 20849},
+									pos: position{line: 636, col: 30, offset: 20017},
 									alternatives: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 615, col: 30, offset: 20849},
+											pos:  position{line: 636, col: 30, offset: 20017},
 											name: "IncludedFileStartTag",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 615, col: 53, offset: 20872},
+											pos:  position{line: 636, col: 53, offset: 20040},
 											name: "IncludedFileEndTag",
 										},
 										&actionExpr{
-											pos: position{line: 615, col: 74, offset: 20893},
+											pos: position{line: 636, col: 74, offset: 20061},
 											run: (*parser).callonIncludedFileLine8,
 											expr: &anyMatcher{
-												line: 615, col: 74, offset: 20893,
+												line: 636, col: 74, offset: 20061,
 											},
 										},
 									},
@@ -4771,7 +3724,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 615, col: 107, offset: 20926},
+							pos:  position{line: 636, col: 107, offset: 20094},
 							name: "EOL",
 						},
 					},
@@ -4780,33 +3733,33 @@ var g = &grammar{
 		},
 		{
 			name: "IncludedFileStartTag",
-			pos:  position{line: 619, col: 1, offset: 20997},
+			pos:  position{line: 640, col: 1, offset: 20165},
 			expr: &actionExpr{
-				pos: position{line: 619, col: 25, offset: 21021},
+				pos: position{line: 640, col: 25, offset: 20189},
 				run: (*parser).callonIncludedFileStartTag1,
 				expr: &seqExpr{
-					pos: position{line: 619, col: 25, offset: 21021},
+					pos: position{line: 640, col: 25, offset: 20189},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 619, col: 25, offset: 21021},
+							pos:        position{line: 640, col: 25, offset: 20189},
 							val:        "tag::",
 							ignoreCase: false,
 							want:       "\"tag::\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 619, col: 33, offset: 21029},
+							pos:   position{line: 640, col: 33, offset: 20197},
 							label: "tag",
 							expr: &actionExpr{
-								pos: position{line: 619, col: 38, offset: 21034},
+								pos: position{line: 640, col: 38, offset: 20202},
 								run: (*parser).callonIncludedFileStartTag5,
 								expr: &ruleRefExpr{
-									pos:  position{line: 619, col: 38, offset: 21034},
+									pos:  position{line: 640, col: 38, offset: 20202},
 									name: "Alphanums",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 619, col: 78, offset: 21074},
+							pos:        position{line: 640, col: 78, offset: 20242},
 							val:        "[]",
 							ignoreCase: false,
 							want:       "\"[]\"",
@@ -4817,33 +3770,33 @@ var g = &grammar{
 		},
 		{
 			name: "IncludedFileEndTag",
-			pos:  position{line: 623, col: 1, offset: 21139},
+			pos:  position{line: 644, col: 1, offset: 20307},
 			expr: &actionExpr{
-				pos: position{line: 623, col: 23, offset: 21161},
+				pos: position{line: 644, col: 23, offset: 20329},
 				run: (*parser).callonIncludedFileEndTag1,
 				expr: &seqExpr{
-					pos: position{line: 623, col: 23, offset: 21161},
+					pos: position{line: 644, col: 23, offset: 20329},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 623, col: 23, offset: 21161},
+							pos:        position{line: 644, col: 23, offset: 20329},
 							val:        "end::",
 							ignoreCase: false,
 							want:       "\"end::\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 623, col: 31, offset: 21169},
+							pos:   position{line: 644, col: 31, offset: 20337},
 							label: "tag",
 							expr: &actionExpr{
-								pos: position{line: 623, col: 36, offset: 21174},
+								pos: position{line: 644, col: 36, offset: 20342},
 								run: (*parser).callonIncludedFileEndTag5,
 								expr: &ruleRefExpr{
-									pos:  position{line: 623, col: 36, offset: 21174},
+									pos:  position{line: 644, col: 36, offset: 20342},
 									name: "Alphanums",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 623, col: 76, offset: 21214},
+							pos:        position{line: 644, col: 76, offset: 20382},
 							val:        "[]",
 							ignoreCase: false,
 							want:       "\"[]\"",
@@ -4854,32 +3807,32 @@ var g = &grammar{
 		},
 		{
 			name: "ListParagraph",
-			pos:  position{line: 630, col: 1, offset: 21378},
+			pos:  position{line: 651, col: 1, offset: 20546},
 			expr: &choiceExpr{
-				pos: position{line: 630, col: 18, offset: 21395},
+				pos: position{line: 651, col: 18, offset: 20563},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 630, col: 18, offset: 21395},
+						pos: position{line: 651, col: 18, offset: 20563},
 						run: (*parser).callonListParagraph2,
 						expr: &labeledExpr{
-							pos:   position{line: 630, col: 18, offset: 21395},
+							pos:   position{line: 651, col: 18, offset: 20563},
 							label: "comment",
 							expr: &ruleRefExpr{
-								pos:  position{line: 630, col: 27, offset: 21404},
+								pos:  position{line: 651, col: 27, offset: 20572},
 								name: "SingleLineComment",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 632, col: 9, offset: 21461},
+						pos: position{line: 653, col: 9, offset: 20629},
 						run: (*parser).callonListParagraph5,
 						expr: &labeledExpr{
-							pos:   position{line: 632, col: 9, offset: 21461},
+							pos:   position{line: 653, col: 9, offset: 20629},
 							label: "lines",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 632, col: 15, offset: 21467},
+								pos: position{line: 653, col: 15, offset: 20635},
 								expr: &ruleRefExpr{
-									pos:  position{line: 632, col: 16, offset: 21468},
+									pos:  position{line: 653, col: 16, offset: 20636},
 									name: "ListParagraphLine",
 								},
 							},
@@ -4890,106 +3843,106 @@ var g = &grammar{
 		},
 		{
 			name: "ListParagraphLine",
-			pos:  position{line: 636, col: 1, offset: 21560},
+			pos:  position{line: 657, col: 1, offset: 20728},
 			expr: &actionExpr{
-				pos: position{line: 636, col: 22, offset: 21581},
+				pos: position{line: 657, col: 22, offset: 20749},
 				run: (*parser).callonListParagraphLine1,
 				expr: &seqExpr{
-					pos: position{line: 636, col: 22, offset: 21581},
+					pos: position{line: 657, col: 22, offset: 20749},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 636, col: 22, offset: 21581},
+							pos: position{line: 657, col: 22, offset: 20749},
 							expr: &ruleRefExpr{
-								pos:  position{line: 636, col: 23, offset: 21582},
+								pos:  position{line: 657, col: 23, offset: 20750},
 								name: "EOF",
 							},
 						},
 						&notExpr{
-							pos: position{line: 637, col: 5, offset: 21590},
+							pos: position{line: 658, col: 5, offset: 20758},
 							expr: &ruleRefExpr{
-								pos:  position{line: 637, col: 6, offset: 21591},
+								pos:  position{line: 658, col: 6, offset: 20759},
 								name: "BlankLine",
 							},
 						},
 						&notExpr{
-							pos: position{line: 638, col: 5, offset: 21605},
+							pos: position{line: 659, col: 5, offset: 20773},
 							expr: &ruleRefExpr{
-								pos:  position{line: 638, col: 6, offset: 21606},
+								pos:  position{line: 659, col: 6, offset: 20774},
 								name: "SingleLineComment",
 							},
 						},
 						&notExpr{
-							pos: position{line: 639, col: 5, offset: 21628},
+							pos: position{line: 660, col: 5, offset: 20796},
 							expr: &ruleRefExpr{
-								pos:  position{line: 639, col: 6, offset: 21629},
+								pos:  position{line: 660, col: 6, offset: 20797},
 								name: "OrderedListItemPrefix",
 							},
 						},
 						&notExpr{
-							pos: position{line: 640, col: 5, offset: 21655},
+							pos: position{line: 661, col: 5, offset: 20823},
 							expr: &ruleRefExpr{
-								pos:  position{line: 640, col: 6, offset: 21656},
+								pos:  position{line: 661, col: 6, offset: 20824},
 								name: "UnorderedListItemPrefix",
 							},
 						},
 						&notExpr{
-							pos: position{line: 641, col: 5, offset: 21684},
+							pos: position{line: 662, col: 5, offset: 20852},
 							expr: &ruleRefExpr{
-								pos:  position{line: 641, col: 6, offset: 21685},
+								pos:  position{line: 662, col: 6, offset: 20853},
 								name: "CalloutListItemPrefix",
 							},
 						},
 						&notExpr{
-							pos: position{line: 642, col: 5, offset: 21711},
+							pos: position{line: 663, col: 5, offset: 20879},
 							expr: &ruleRefExpr{
-								pos:  position{line: 642, col: 6, offset: 21712},
+								pos:  position{line: 663, col: 6, offset: 20880},
 								name: "ListItemContinuation",
 							},
 						},
 						&notExpr{
-							pos: position{line: 643, col: 5, offset: 21737},
+							pos: position{line: 664, col: 5, offset: 20905},
 							expr: &ruleRefExpr{
-								pos:  position{line: 643, col: 6, offset: 21738},
-								name: "ElementAttribute",
+								pos:  position{line: 664, col: 6, offset: 20906},
+								name: "BlockAttributes",
 							},
 						},
 						&notExpr{
-							pos: position{line: 644, col: 5, offset: 21759},
+							pos: position{line: 665, col: 5, offset: 20926},
 							expr: &ruleRefExpr{
-								pos:  position{line: 644, col: 6, offset: 21760},
+								pos:  position{line: 665, col: 6, offset: 20927},
 								name: "BlockDelimiter",
 							},
 						},
 						&notExpr{
-							pos: position{line: 645, col: 5, offset: 21779},
+							pos: position{line: 666, col: 5, offset: 20946},
 							expr: &ruleRefExpr{
-								pos:  position{line: 645, col: 6, offset: 21780},
+								pos:  position{line: 666, col: 6, offset: 20947},
 								name: "LabeledListItemPrefix",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 646, col: 5, offset: 21807},
+							pos:   position{line: 667, col: 5, offset: 20974},
 							label: "line",
 							expr: &actionExpr{
-								pos: position{line: 646, col: 11, offset: 21813},
+								pos: position{line: 667, col: 11, offset: 20980},
 								run: (*parser).callonListParagraphLine24,
 								expr: &seqExpr{
-									pos: position{line: 646, col: 11, offset: 21813},
+									pos: position{line: 667, col: 11, offset: 20980},
 									exprs: []interface{}{
 										&zeroOrMoreExpr{
-											pos: position{line: 646, col: 11, offset: 21813},
+											pos: position{line: 667, col: 11, offset: 20980},
 											expr: &ruleRefExpr{
-												pos:  position{line: 646, col: 11, offset: 21813},
+												pos:  position{line: 667, col: 11, offset: 20980},
 												name: "Space",
 											},
 										},
 										&labeledExpr{
-											pos:   position{line: 646, col: 18, offset: 21820},
+											pos:   position{line: 667, col: 18, offset: 20987},
 											label: "elements",
 											expr: &oneOrMoreExpr{
-												pos: position{line: 646, col: 27, offset: 21829},
+												pos: position{line: 667, col: 27, offset: 20996},
 												expr: &ruleRefExpr{
-													pos:  position{line: 646, col: 28, offset: 21830},
+													pos:  position{line: 667, col: 28, offset: 20997},
 													name: "InlineElement",
 												},
 											},
@@ -4999,7 +3952,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 648, col: 12, offset: 21929},
+							pos:  position{line: 669, col: 12, offset: 21096},
 							name: "EOL",
 						},
 					},
@@ -5008,25 +3961,25 @@ var g = &grammar{
 		},
 		{
 			name: "ListItemContinuation",
-			pos:  position{line: 652, col: 1, offset: 21968},
+			pos:  position{line: 673, col: 1, offset: 21135},
 			expr: &seqExpr{
-				pos: position{line: 652, col: 25, offset: 21992},
+				pos: position{line: 673, col: 25, offset: 21159},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 652, col: 25, offset: 21992},
+						pos:        position{line: 673, col: 25, offset: 21159},
 						val:        "+",
 						ignoreCase: false,
 						want:       "\"+\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 652, col: 29, offset: 21996},
+						pos: position{line: 673, col: 29, offset: 21163},
 						expr: &ruleRefExpr{
-							pos:  position{line: 652, col: 29, offset: 21996},
+							pos:  position{line: 673, col: 29, offset: 21163},
 							name: "Space",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 652, col: 36, offset: 22003},
+						pos:  position{line: 673, col: 36, offset: 21170},
 						name: "Newline",
 					},
 				},
@@ -5034,22 +3987,22 @@ var g = &grammar{
 		},
 		{
 			name: "ContinuedListItemElement",
-			pos:  position{line: 654, col: 1, offset: 22075},
+			pos:  position{line: 675, col: 1, offset: 21242},
 			expr: &actionExpr{
-				pos: position{line: 654, col: 29, offset: 22103},
+				pos: position{line: 675, col: 29, offset: 21270},
 				run: (*parser).callonContinuedListItemElement1,
 				expr: &seqExpr{
-					pos: position{line: 654, col: 29, offset: 22103},
+					pos: position{line: 675, col: 29, offset: 21270},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 654, col: 29, offset: 22103},
+							pos:  position{line: 675, col: 29, offset: 21270},
 							name: "ListItemContinuation",
 						},
 						&labeledExpr{
-							pos:   position{line: 654, col: 50, offset: 22124},
+							pos:   position{line: 675, col: 50, offset: 21291},
 							label: "element",
 							expr: &ruleRefExpr{
-								pos:  position{line: 654, col: 58, offset: 22132},
+								pos:  position{line: 675, col: 58, offset: 21299},
 								name: "ContinuedListItemContent",
 							},
 						},
@@ -5059,84 +4012,84 @@ var g = &grammar{
 		},
 		{
 			name: "ContinuedListItemContent",
-			pos:  position{line: 658, col: 1, offset: 22238},
+			pos:  position{line: 679, col: 1, offset: 21405},
 			expr: &actionExpr{
-				pos: position{line: 658, col: 29, offset: 22266},
+				pos: position{line: 679, col: 29, offset: 21433},
 				run: (*parser).callonContinuedListItemContent1,
 				expr: &seqExpr{
-					pos: position{line: 658, col: 29, offset: 22266},
+					pos: position{line: 679, col: 29, offset: 21433},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 658, col: 29, offset: 22266},
+							pos: position{line: 679, col: 29, offset: 21433},
 							expr: &ruleRefExpr{
-								pos:  position{line: 658, col: 30, offset: 22267},
+								pos:  position{line: 679, col: 30, offset: 21434},
 								name: "EOF",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 659, col: 5, offset: 22276},
+							pos:   position{line: 680, col: 5, offset: 21443},
 							label: "content",
 							expr: &choiceExpr{
-								pos: position{line: 659, col: 14, offset: 22285},
+								pos: position{line: 680, col: 14, offset: 21452},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 659, col: 14, offset: 22285},
+										pos:  position{line: 680, col: 14, offset: 21452},
 										name: "DelimitedBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 660, col: 11, offset: 22310},
+										pos:  position{line: 681, col: 11, offset: 21477},
 										name: "SingleLineComment",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 661, col: 11, offset: 22338},
+										pos:  position{line: 682, col: 11, offset: 21505},
 										name: "Table",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 662, col: 11, offset: 22354},
+										pos:  position{line: 683, col: 11, offset: 21521},
 										name: "ImageBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 663, col: 11, offset: 22375},
+										pos:  position{line: 684, col: 11, offset: 21542},
 										name: "ThematicBreak",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 664, col: 11, offset: 22399},
+										pos:  position{line: 685, col: 11, offset: 21566},
 										name: "OrderedListItem",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 665, col: 11, offset: 22426},
+										pos:  position{line: 686, col: 11, offset: 21593},
 										name: "UnorderedListItem",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 666, col: 11, offset: 22455},
+										pos:  position{line: 687, col: 11, offset: 21622},
 										name: "LabeledListItem",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 667, col: 11, offset: 22482},
+										pos:  position{line: 688, col: 11, offset: 21649},
 										name: "BlankLine",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 668, col: 11, offset: 22533},
+										pos:  position{line: 689, col: 11, offset: 21700},
 										name: "LiteralBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 669, col: 11, offset: 22557},
+										pos:  position{line: 690, col: 11, offset: 21724},
 										name: "AttributeDeclaration",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 670, col: 11, offset: 22589},
+										pos:  position{line: 691, col: 11, offset: 21756},
 										name: "AttributeReset",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 671, col: 11, offset: 22615},
+										pos:  position{line: 692, col: 11, offset: 21782},
 										name: "TableOfContentsPlaceHolder",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 672, col: 11, offset: 22652},
+										pos:  position{line: 693, col: 11, offset: 21819},
 										name: "UserMacroBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 673, col: 11, offset: 22677},
+										pos:  position{line: 694, col: 11, offset: 21844},
 										name: "ContinuedRawParagraph",
 									},
 								},
@@ -5148,37 +4101,37 @@ var g = &grammar{
 		},
 		{
 			name: "OrderedListItem",
-			pos:  position{line: 680, col: 1, offset: 22843},
+			pos:  position{line: 701, col: 1, offset: 22010},
 			expr: &actionExpr{
-				pos: position{line: 680, col: 20, offset: 22862},
+				pos: position{line: 701, col: 20, offset: 22029},
 				run: (*parser).callonOrderedListItem1,
 				expr: &seqExpr{
-					pos: position{line: 680, col: 20, offset: 22862},
+					pos: position{line: 701, col: 20, offset: 22029},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 680, col: 20, offset: 22862},
+							pos:   position{line: 701, col: 20, offset: 22029},
 							label: "attributes",
-							expr: &zeroOrMoreExpr{
-								pos: position{line: 680, col: 31, offset: 22873},
+							expr: &zeroOrOneExpr{
+								pos: position{line: 701, col: 31, offset: 22040},
 								expr: &ruleRefExpr{
-									pos:  position{line: 680, col: 32, offset: 22874},
-									name: "BlockAttribute",
+									pos:  position{line: 701, col: 32, offset: 22041},
+									name: "BlockAttributes",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 680, col: 49, offset: 22891},
+							pos:   position{line: 701, col: 50, offset: 22059},
 							label: "prefix",
 							expr: &ruleRefExpr{
-								pos:  position{line: 680, col: 57, offset: 22899},
+								pos:  position{line: 701, col: 58, offset: 22067},
 								name: "OrderedListItemPrefix",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 680, col: 80, offset: 22922},
+							pos:   position{line: 701, col: 81, offset: 22090},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 680, col: 89, offset: 22931},
+								pos:  position{line: 701, col: 90, offset: 22099},
 								name: "OrderedListItemContent",
 							},
 						},
@@ -5188,42 +4141,42 @@ var g = &grammar{
 		},
 		{
 			name: "OrderedListItemPrefix",
-			pos:  position{line: 684, col: 1, offset: 23087},
+			pos:  position{line: 705, col: 1, offset: 22239},
 			expr: &actionExpr{
-				pos: position{line: 685, col: 5, offset: 23117},
+				pos: position{line: 706, col: 5, offset: 22269},
 				run: (*parser).callonOrderedListItemPrefix1,
 				expr: &seqExpr{
-					pos: position{line: 685, col: 5, offset: 23117},
+					pos: position{line: 706, col: 5, offset: 22269},
 					exprs: []interface{}{
 						&zeroOrMoreExpr{
-							pos: position{line: 685, col: 5, offset: 23117},
+							pos: position{line: 706, col: 5, offset: 22269},
 							expr: &ruleRefExpr{
-								pos:  position{line: 685, col: 5, offset: 23117},
+								pos:  position{line: 706, col: 5, offset: 22269},
 								name: "Space",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 685, col: 12, offset: 23124},
+							pos:   position{line: 706, col: 12, offset: 22276},
 							label: "prefix",
 							expr: &choiceExpr{
-								pos: position{line: 687, col: 9, offset: 23187},
+								pos: position{line: 708, col: 9, offset: 22339},
 								alternatives: []interface{}{
 									&actionExpr{
-										pos: position{line: 687, col: 9, offset: 23187},
+										pos: position{line: 708, col: 9, offset: 22339},
 										run: (*parser).callonOrderedListItemPrefix7,
 										expr: &seqExpr{
-											pos: position{line: 687, col: 9, offset: 23187},
+											pos: position{line: 708, col: 9, offset: 22339},
 											exprs: []interface{}{
 												&labeledExpr{
-													pos:   position{line: 687, col: 9, offset: 23187},
+													pos:   position{line: 708, col: 9, offset: 22339},
 													label: "depth",
 													expr: &actionExpr{
-														pos: position{line: 687, col: 16, offset: 23194},
+														pos: position{line: 708, col: 16, offset: 22346},
 														run: (*parser).callonOrderedListItemPrefix10,
 														expr: &oneOrMoreExpr{
-															pos: position{line: 687, col: 16, offset: 23194},
+															pos: position{line: 708, col: 16, offset: 22346},
 															expr: &litMatcher{
-																pos:        position{line: 687, col: 17, offset: 23195},
+																pos:        position{line: 708, col: 17, offset: 22347},
 																val:        ".",
 																ignoreCase: false,
 																want:       "\".\"",
@@ -5232,22 +4185,22 @@ var g = &grammar{
 													},
 												},
 												&andCodeExpr{
-													pos: position{line: 691, col: 9, offset: 23295},
+													pos: position{line: 712, col: 9, offset: 22447},
 													run: (*parser).callonOrderedListItemPrefix13,
 												},
 											},
 										},
 									},
 									&actionExpr{
-										pos: position{line: 710, col: 11, offset: 24012},
+										pos: position{line: 731, col: 11, offset: 23164},
 										run: (*parser).callonOrderedListItemPrefix14,
 										expr: &seqExpr{
-											pos: position{line: 710, col: 11, offset: 24012},
+											pos: position{line: 731, col: 11, offset: 23164},
 											exprs: []interface{}{
 												&oneOrMoreExpr{
-													pos: position{line: 710, col: 11, offset: 24012},
+													pos: position{line: 731, col: 11, offset: 23164},
 													expr: &charClassMatcher{
-														pos:        position{line: 710, col: 12, offset: 24013},
+														pos:        position{line: 731, col: 12, offset: 23165},
 														val:        "[0-9]",
 														ranges:     []rune{'0', '9'},
 														ignoreCase: false,
@@ -5255,7 +4208,7 @@ var g = &grammar{
 													},
 												},
 												&litMatcher{
-													pos:        position{line: 710, col: 20, offset: 24021},
+													pos:        position{line: 731, col: 20, offset: 23173},
 													val:        ".",
 													ignoreCase: false,
 													want:       "\".\"",
@@ -5264,20 +4217,20 @@ var g = &grammar{
 										},
 									},
 									&actionExpr{
-										pos: position{line: 712, col: 13, offset: 24132},
+										pos: position{line: 733, col: 13, offset: 23284},
 										run: (*parser).callonOrderedListItemPrefix19,
 										expr: &seqExpr{
-											pos: position{line: 712, col: 13, offset: 24132},
+											pos: position{line: 733, col: 13, offset: 23284},
 											exprs: []interface{}{
 												&charClassMatcher{
-													pos:        position{line: 712, col: 14, offset: 24133},
+													pos:        position{line: 733, col: 14, offset: 23285},
 													val:        "[a-z]",
 													ranges:     []rune{'a', 'z'},
 													ignoreCase: false,
 													inverted:   false,
 												},
 												&litMatcher{
-													pos:        position{line: 712, col: 21, offset: 24140},
+													pos:        position{line: 733, col: 21, offset: 23292},
 													val:        ".",
 													ignoreCase: false,
 													want:       "\".\"",
@@ -5286,20 +4239,20 @@ var g = &grammar{
 										},
 									},
 									&actionExpr{
-										pos: position{line: 714, col: 13, offset: 24254},
+										pos: position{line: 735, col: 13, offset: 23406},
 										run: (*parser).callonOrderedListItemPrefix23,
 										expr: &seqExpr{
-											pos: position{line: 714, col: 13, offset: 24254},
+											pos: position{line: 735, col: 13, offset: 23406},
 											exprs: []interface{}{
 												&charClassMatcher{
-													pos:        position{line: 714, col: 14, offset: 24255},
+													pos:        position{line: 735, col: 14, offset: 23407},
 													val:        "[A-Z]",
 													ranges:     []rune{'A', 'Z'},
 													ignoreCase: false,
 													inverted:   false,
 												},
 												&litMatcher{
-													pos:        position{line: 714, col: 21, offset: 24262},
+													pos:        position{line: 735, col: 21, offset: 23414},
 													val:        ".",
 													ignoreCase: false,
 													want:       "\".\"",
@@ -5308,15 +4261,15 @@ var g = &grammar{
 										},
 									},
 									&actionExpr{
-										pos: position{line: 716, col: 13, offset: 24376},
+										pos: position{line: 737, col: 13, offset: 23528},
 										run: (*parser).callonOrderedListItemPrefix27,
 										expr: &seqExpr{
-											pos: position{line: 716, col: 13, offset: 24376},
+											pos: position{line: 737, col: 13, offset: 23528},
 											exprs: []interface{}{
 												&oneOrMoreExpr{
-													pos: position{line: 716, col: 13, offset: 24376},
+													pos: position{line: 737, col: 13, offset: 23528},
 													expr: &charClassMatcher{
-														pos:        position{line: 716, col: 14, offset: 24377},
+														pos:        position{line: 737, col: 14, offset: 23529},
 														val:        "[ivxdlcm]",
 														chars:      []rune{'i', 'v', 'x', 'd', 'l', 'c', 'm'},
 														ignoreCase: false,
@@ -5324,7 +4277,7 @@ var g = &grammar{
 													},
 												},
 												&litMatcher{
-													pos:        position{line: 716, col: 26, offset: 24389},
+													pos:        position{line: 737, col: 26, offset: 23541},
 													val:        ")",
 													ignoreCase: false,
 													want:       "\")\"",
@@ -5333,15 +4286,15 @@ var g = &grammar{
 										},
 									},
 									&actionExpr{
-										pos: position{line: 718, col: 13, offset: 24503},
+										pos: position{line: 739, col: 13, offset: 23655},
 										run: (*parser).callonOrderedListItemPrefix32,
 										expr: &seqExpr{
-											pos: position{line: 718, col: 13, offset: 24503},
+											pos: position{line: 739, col: 13, offset: 23655},
 											exprs: []interface{}{
 												&oneOrMoreExpr{
-													pos: position{line: 718, col: 13, offset: 24503},
+													pos: position{line: 739, col: 13, offset: 23655},
 													expr: &charClassMatcher{
-														pos:        position{line: 718, col: 14, offset: 24504},
+														pos:        position{line: 739, col: 14, offset: 23656},
 														val:        "[IVXDLCM]",
 														chars:      []rune{'I', 'V', 'X', 'D', 'L', 'C', 'M'},
 														ignoreCase: false,
@@ -5349,7 +4302,7 @@ var g = &grammar{
 													},
 												},
 												&litMatcher{
-													pos:        position{line: 718, col: 26, offset: 24516},
+													pos:        position{line: 739, col: 26, offset: 23668},
 													val:        ")",
 													ignoreCase: false,
 													want:       "\")\"",
@@ -5361,9 +4314,9 @@ var g = &grammar{
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 720, col: 12, offset: 24629},
+							pos: position{line: 741, col: 12, offset: 23781},
 							expr: &ruleRefExpr{
-								pos:  position{line: 720, col: 12, offset: 24629},
+								pos:  position{line: 741, col: 12, offset: 23781},
 								name: "Space",
 							},
 						},
@@ -5373,17 +4326,17 @@ var g = &grammar{
 		},
 		{
 			name: "OrderedListItemContent",
-			pos:  position{line: 724, col: 1, offset: 24664},
+			pos:  position{line: 745, col: 1, offset: 23816},
 			expr: &actionExpr{
-				pos: position{line: 724, col: 27, offset: 24690},
+				pos: position{line: 745, col: 27, offset: 23842},
 				run: (*parser).callonOrderedListItemContent1,
 				expr: &labeledExpr{
-					pos:   position{line: 724, col: 27, offset: 24690},
+					pos:   position{line: 745, col: 27, offset: 23842},
 					label: "elements",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 724, col: 37, offset: 24700},
+						pos: position{line: 745, col: 37, offset: 23852},
 						expr: &ruleRefExpr{
-							pos:  position{line: 724, col: 37, offset: 24700},
+							pos:  position{line: 745, col: 37, offset: 23852},
 							name: "ListParagraph",
 						},
 					},
@@ -5392,48 +4345,48 @@ var g = &grammar{
 		},
 		{
 			name: "UnorderedListItem",
-			pos:  position{line: 731, col: 1, offset: 24900},
+			pos:  position{line: 752, col: 1, offset: 24052},
 			expr: &actionExpr{
-				pos: position{line: 731, col: 22, offset: 24921},
+				pos: position{line: 752, col: 22, offset: 24073},
 				run: (*parser).callonUnorderedListItem1,
 				expr: &seqExpr{
-					pos: position{line: 731, col: 22, offset: 24921},
+					pos: position{line: 752, col: 22, offset: 24073},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 731, col: 22, offset: 24921},
+							pos:   position{line: 752, col: 22, offset: 24073},
 							label: "attributes",
-							expr: &zeroOrMoreExpr{
-								pos: position{line: 731, col: 33, offset: 24932},
+							expr: &zeroOrOneExpr{
+								pos: position{line: 752, col: 33, offset: 24084},
 								expr: &ruleRefExpr{
-									pos:  position{line: 731, col: 34, offset: 24933},
-									name: "BlockAttribute",
+									pos:  position{line: 752, col: 34, offset: 24085},
+									name: "BlockAttributes",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 731, col: 51, offset: 24950},
+							pos:   position{line: 752, col: 52, offset: 24103},
 							label: "prefix",
 							expr: &ruleRefExpr{
-								pos:  position{line: 731, col: 59, offset: 24958},
+								pos:  position{line: 752, col: 60, offset: 24111},
 								name: "UnorderedListItemPrefix",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 731, col: 84, offset: 24983},
+							pos:   position{line: 752, col: 85, offset: 24136},
 							label: "checkstyle",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 731, col: 95, offset: 24994},
+								pos: position{line: 752, col: 96, offset: 24147},
 								expr: &ruleRefExpr{
-									pos:  position{line: 731, col: 96, offset: 24995},
+									pos:  position{line: 752, col: 97, offset: 24148},
 									name: "UnorderedListItemCheckStyle",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 731, col: 126, offset: 25025},
+							pos:   position{line: 752, col: 127, offset: 24178},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 731, col: 135, offset: 25034},
+								pos:  position{line: 752, col: 136, offset: 24187},
 								name: "UnorderedListItemContent",
 							},
 						},
@@ -5443,42 +4396,42 @@ var g = &grammar{
 		},
 		{
 			name: "UnorderedListItemPrefix",
-			pos:  position{line: 735, col: 1, offset: 25208},
+			pos:  position{line: 756, col: 1, offset: 24345},
 			expr: &actionExpr{
-				pos: position{line: 736, col: 5, offset: 25240},
+				pos: position{line: 757, col: 5, offset: 24377},
 				run: (*parser).callonUnorderedListItemPrefix1,
 				expr: &seqExpr{
-					pos: position{line: 736, col: 5, offset: 25240},
+					pos: position{line: 757, col: 5, offset: 24377},
 					exprs: []interface{}{
 						&zeroOrMoreExpr{
-							pos: position{line: 736, col: 5, offset: 25240},
+							pos: position{line: 757, col: 5, offset: 24377},
 							expr: &ruleRefExpr{
-								pos:  position{line: 736, col: 5, offset: 25240},
+								pos:  position{line: 757, col: 5, offset: 24377},
 								name: "Space",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 736, col: 12, offset: 25247},
+							pos:   position{line: 757, col: 12, offset: 24384},
 							label: "prefix",
 							expr: &choiceExpr{
-								pos: position{line: 736, col: 20, offset: 25255},
+								pos: position{line: 757, col: 20, offset: 24392},
 								alternatives: []interface{}{
 									&actionExpr{
-										pos: position{line: 738, col: 9, offset: 25312},
+										pos: position{line: 759, col: 9, offset: 24449},
 										run: (*parser).callonUnorderedListItemPrefix7,
 										expr: &seqExpr{
-											pos: position{line: 738, col: 9, offset: 25312},
+											pos: position{line: 759, col: 9, offset: 24449},
 											exprs: []interface{}{
 												&labeledExpr{
-													pos:   position{line: 738, col: 9, offset: 25312},
+													pos:   position{line: 759, col: 9, offset: 24449},
 													label: "depth",
 													expr: &actionExpr{
-														pos: position{line: 738, col: 16, offset: 25319},
+														pos: position{line: 759, col: 16, offset: 24456},
 														run: (*parser).callonUnorderedListItemPrefix10,
 														expr: &oneOrMoreExpr{
-															pos: position{line: 738, col: 16, offset: 25319},
+															pos: position{line: 759, col: 16, offset: 24456},
 															expr: &litMatcher{
-																pos:        position{line: 738, col: 17, offset: 25320},
+																pos:        position{line: 759, col: 17, offset: 24457},
 																val:        "*",
 																ignoreCase: false,
 																want:       "\"*\"",
@@ -5487,20 +4440,20 @@ var g = &grammar{
 													},
 												},
 												&andCodeExpr{
-													pos: position{line: 742, col: 9, offset: 25420},
+													pos: position{line: 763, col: 9, offset: 24557},
 													run: (*parser).callonUnorderedListItemPrefix13,
 												},
 											},
 										},
 									},
 									&labeledExpr{
-										pos:   position{line: 759, col: 14, offset: 26127},
+										pos:   position{line: 780, col: 14, offset: 25264},
 										label: "depth",
 										expr: &actionExpr{
-											pos: position{line: 759, col: 21, offset: 26134},
+											pos: position{line: 780, col: 21, offset: 25271},
 											run: (*parser).callonUnorderedListItemPrefix15,
 											expr: &litMatcher{
-												pos:        position{line: 759, col: 22, offset: 26135},
+												pos:        position{line: 780, col: 22, offset: 25272},
 												val:        "-",
 												ignoreCase: false,
 												want:       "\"-\"",
@@ -5511,9 +4464,9 @@ var g = &grammar{
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 761, col: 13, offset: 26221},
+							pos: position{line: 782, col: 13, offset: 25358},
 							expr: &ruleRefExpr{
-								pos:  position{line: 761, col: 13, offset: 26221},
+								pos:  position{line: 782, col: 13, offset: 25358},
 								name: "Space",
 							},
 						},
@@ -5523,53 +4476,53 @@ var g = &grammar{
 		},
 		{
 			name: "UnorderedListItemCheckStyle",
-			pos:  position{line: 765, col: 1, offset: 26257},
+			pos:  position{line: 786, col: 1, offset: 25394},
 			expr: &actionExpr{
-				pos: position{line: 765, col: 32, offset: 26288},
+				pos: position{line: 786, col: 32, offset: 25425},
 				run: (*parser).callonUnorderedListItemCheckStyle1,
 				expr: &seqExpr{
-					pos: position{line: 765, col: 32, offset: 26288},
+					pos: position{line: 786, col: 32, offset: 25425},
 					exprs: []interface{}{
 						&andExpr{
-							pos: position{line: 765, col: 32, offset: 26288},
+							pos: position{line: 786, col: 32, offset: 25425},
 							expr: &litMatcher{
-								pos:        position{line: 765, col: 33, offset: 26289},
+								pos:        position{line: 786, col: 33, offset: 25426},
 								val:        "[",
 								ignoreCase: false,
 								want:       "\"[\"",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 765, col: 37, offset: 26293},
+							pos:   position{line: 786, col: 37, offset: 25430},
 							label: "style",
 							expr: &choiceExpr{
-								pos: position{line: 766, col: 7, offset: 26307},
+								pos: position{line: 787, col: 7, offset: 25444},
 								alternatives: []interface{}{
 									&actionExpr{
-										pos: position{line: 766, col: 7, offset: 26307},
+										pos: position{line: 787, col: 7, offset: 25444},
 										run: (*parser).callonUnorderedListItemCheckStyle7,
 										expr: &litMatcher{
-											pos:        position{line: 766, col: 7, offset: 26307},
+											pos:        position{line: 787, col: 7, offset: 25444},
 											val:        "[ ]",
 											ignoreCase: false,
 											want:       "\"[ ]\"",
 										},
 									},
 									&actionExpr{
-										pos: position{line: 767, col: 7, offset: 26352},
+										pos: position{line: 788, col: 7, offset: 25489},
 										run: (*parser).callonUnorderedListItemCheckStyle9,
 										expr: &litMatcher{
-											pos:        position{line: 767, col: 7, offset: 26352},
+											pos:        position{line: 788, col: 7, offset: 25489},
 											val:        "[*]",
 											ignoreCase: false,
 											want:       "\"[*]\"",
 										},
 									},
 									&actionExpr{
-										pos: position{line: 768, col: 7, offset: 26395},
+										pos: position{line: 789, col: 7, offset: 25532},
 										run: (*parser).callonUnorderedListItemCheckStyle11,
 										expr: &litMatcher{
-											pos:        position{line: 768, col: 7, offset: 26395},
+											pos:        position{line: 789, col: 7, offset: 25532},
 											val:        "[x]",
 											ignoreCase: false,
 											want:       "\"[x]\"",
@@ -5579,9 +4532,9 @@ var g = &grammar{
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 769, col: 7, offset: 26437},
+							pos: position{line: 790, col: 7, offset: 25574},
 							expr: &ruleRefExpr{
-								pos:  position{line: 769, col: 7, offset: 26437},
+								pos:  position{line: 790, col: 7, offset: 25574},
 								name: "Space",
 							},
 						},
@@ -5591,17 +4544,17 @@ var g = &grammar{
 		},
 		{
 			name: "UnorderedListItemContent",
-			pos:  position{line: 773, col: 1, offset: 26479},
+			pos:  position{line: 794, col: 1, offset: 25616},
 			expr: &actionExpr{
-				pos: position{line: 773, col: 29, offset: 26507},
+				pos: position{line: 794, col: 29, offset: 25644},
 				run: (*parser).callonUnorderedListItemContent1,
 				expr: &labeledExpr{
-					pos:   position{line: 773, col: 29, offset: 26507},
+					pos:   position{line: 794, col: 29, offset: 25644},
 					label: "elements",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 773, col: 39, offset: 26517},
+						pos: position{line: 794, col: 39, offset: 25654},
 						expr: &ruleRefExpr{
-							pos:  position{line: 773, col: 39, offset: 26517},
+							pos:  position{line: 794, col: 39, offset: 25654},
 							name: "ListParagraph",
 						},
 					},
@@ -5610,47 +4563,47 @@ var g = &grammar{
 		},
 		{
 			name: "LabeledListItem",
-			pos:  position{line: 780, col: 1, offset: 26833},
+			pos:  position{line: 801, col: 1, offset: 25970},
 			expr: &actionExpr{
-				pos: position{line: 780, col: 20, offset: 26852},
+				pos: position{line: 801, col: 20, offset: 25989},
 				run: (*parser).callonLabeledListItem1,
 				expr: &seqExpr{
-					pos: position{line: 780, col: 20, offset: 26852},
+					pos: position{line: 801, col: 20, offset: 25989},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 780, col: 20, offset: 26852},
+							pos:   position{line: 801, col: 20, offset: 25989},
 							label: "attributes",
-							expr: &zeroOrMoreExpr{
-								pos: position{line: 780, col: 31, offset: 26863},
+							expr: &zeroOrOneExpr{
+								pos: position{line: 801, col: 31, offset: 26000},
 								expr: &ruleRefExpr{
-									pos:  position{line: 780, col: 32, offset: 26864},
-									name: "BlockAttribute",
+									pos:  position{line: 801, col: 32, offset: 26001},
+									name: "BlockAttributes",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 780, col: 49, offset: 26881},
+							pos:   position{line: 801, col: 50, offset: 26019},
 							label: "term",
 							expr: &ruleRefExpr{
-								pos:  position{line: 780, col: 55, offset: 26887},
+								pos:  position{line: 801, col: 56, offset: 26025},
 								name: "VerbatimLabeledListItemTerm",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 780, col: 84, offset: 26916},
+							pos:   position{line: 801, col: 85, offset: 26054},
 							label: "separator",
 							expr: &ruleRefExpr{
-								pos:  position{line: 780, col: 95, offset: 26927},
+								pos:  position{line: 801, col: 96, offset: 26065},
 								name: "LabeledListItemSeparator",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 780, col: 121, offset: 26953},
+							pos:   position{line: 801, col: 122, offset: 26091},
 							label: "description",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 780, col: 133, offset: 26965},
+								pos: position{line: 801, col: 134, offset: 26103},
 								expr: &ruleRefExpr{
-									pos:  position{line: 780, col: 134, offset: 26966},
+									pos:  position{line: 801, col: 135, offset: 26104},
 									name: "LabeledListItemDescription",
 								},
 							},
@@ -5661,16 +4614,16 @@ var g = &grammar{
 		},
 		{
 			name: "LabeledListItemPrefix",
-			pos:  position{line: 784, col: 1, offset: 27128},
+			pos:  position{line: 805, col: 1, offset: 26250},
 			expr: &seqExpr{
-				pos: position{line: 784, col: 26, offset: 27153},
+				pos: position{line: 805, col: 26, offset: 26275},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 784, col: 26, offset: 27153},
+						pos:  position{line: 805, col: 26, offset: 26275},
 						name: "VerbatimLabeledListItemTerm",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 784, col: 54, offset: 27181},
+						pos:  position{line: 805, col: 54, offset: 26303},
 						name: "LabeledListItemSeparator",
 					},
 				},
@@ -5678,14 +4631,14 @@ var g = &grammar{
 		},
 		{
 			name: "VerbatimLabeledListItemChars",
-			pos:  position{line: 786, col: 1, offset: 27207},
+			pos:  position{line: 807, col: 1, offset: 26329},
 			expr: &choiceExpr{
-				pos: position{line: 786, col: 33, offset: 27239},
+				pos: position{line: 807, col: 33, offset: 26361},
 				alternatives: []interface{}{
 					&oneOrMoreExpr{
-						pos: position{line: 786, col: 33, offset: 27239},
+						pos: position{line: 807, col: 33, offset: 26361},
 						expr: &charClassMatcher{
-							pos:        position{line: 786, col: 33, offset: 27239},
+							pos:        position{line: 807, col: 33, offset: 26361},
 							val:        "[^:\\r\\n]",
 							chars:      []rune{':', '\r', '\n'},
 							ignoreCase: false,
@@ -5693,18 +4646,18 @@ var g = &grammar{
 						},
 					},
 					&seqExpr{
-						pos: position{line: 786, col: 45, offset: 27251},
+						pos: position{line: 807, col: 45, offset: 26373},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 786, col: 45, offset: 27251},
+								pos:        position{line: 807, col: 45, offset: 26373},
 								val:        ":",
 								ignoreCase: false,
 								want:       "\":\"",
 							},
 							&notExpr{
-								pos: position{line: 786, col: 49, offset: 27255},
+								pos: position{line: 807, col: 49, offset: 26377},
 								expr: &litMatcher{
-									pos:        position{line: 786, col: 50, offset: 27256},
+									pos:        position{line: 807, col: 50, offset: 26378},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
@@ -5717,20 +4670,20 @@ var g = &grammar{
 		},
 		{
 			name: "VerbatimLabeledListItemTerm",
-			pos:  position{line: 787, col: 1, offset: 27260},
+			pos:  position{line: 808, col: 1, offset: 26382},
 			expr: &actionExpr{
-				pos: position{line: 787, col: 32, offset: 27291},
+				pos: position{line: 808, col: 32, offset: 26413},
 				run: (*parser).callonVerbatimLabeledListItemTerm1,
 				expr: &labeledExpr{
-					pos:   position{line: 787, col: 32, offset: 27291},
+					pos:   position{line: 808, col: 32, offset: 26413},
 					label: "content",
 					expr: &actionExpr{
-						pos: position{line: 787, col: 42, offset: 27301},
+						pos: position{line: 808, col: 42, offset: 26423},
 						run: (*parser).callonVerbatimLabeledListItemTerm3,
 						expr: &oneOrMoreExpr{
-							pos: position{line: 787, col: 42, offset: 27301},
+							pos: position{line: 808, col: 42, offset: 26423},
 							expr: &ruleRefExpr{
-								pos:  position{line: 787, col: 42, offset: 27301},
+								pos:  position{line: 808, col: 42, offset: 26423},
 								name: "VerbatimLabeledListItemChars",
 							},
 						},
@@ -5740,36 +4693,36 @@ var g = &grammar{
 		},
 		{
 			name: "LabeledListItemTerm",
-			pos:  position{line: 793, col: 1, offset: 27456},
+			pos:  position{line: 815, col: 1, offset: 26598},
 			expr: &actionExpr{
-				pos: position{line: 793, col: 24, offset: 27479},
+				pos: position{line: 815, col: 24, offset: 26621},
 				run: (*parser).callonLabeledListItemTerm1,
 				expr: &labeledExpr{
-					pos:   position{line: 793, col: 24, offset: 27479},
+					pos:   position{line: 815, col: 24, offset: 26621},
 					label: "elements",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 793, col: 33, offset: 27488},
+						pos: position{line: 815, col: 33, offset: 26630},
 						expr: &seqExpr{
-							pos: position{line: 793, col: 34, offset: 27489},
+							pos: position{line: 815, col: 34, offset: 26631},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 793, col: 34, offset: 27489},
+									pos: position{line: 815, col: 34, offset: 26631},
 									expr: &ruleRefExpr{
-										pos:  position{line: 793, col: 35, offset: 27490},
+										pos:  position{line: 815, col: 35, offset: 26632},
 										name: "Newline",
 									},
 								},
 								&notExpr{
-									pos: position{line: 793, col: 43, offset: 27498},
+									pos: position{line: 815, col: 43, offset: 26640},
 									expr: &litMatcher{
-										pos:        position{line: 793, col: 44, offset: 27499},
+										pos:        position{line: 815, col: 44, offset: 26641},
 										val:        "::",
 										ignoreCase: false,
 										want:       "\"::\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 793, col: 49, offset: 27504},
+									pos:  position{line: 815, col: 49, offset: 26646},
 									name: "LabeledListItemTermElement",
 								},
 							},
@@ -5780,85 +4733,85 @@ var g = &grammar{
 		},
 		{
 			name: "LabeledListItemTermElement",
-			pos:  position{line: 797, col: 1, offset: 27631},
+			pos:  position{line: 819, col: 1, offset: 26743},
 			expr: &actionExpr{
-				pos: position{line: 797, col: 31, offset: 27661},
+				pos: position{line: 819, col: 31, offset: 26773},
 				run: (*parser).callonLabeledListItemTermElement1,
 				expr: &labeledExpr{
-					pos:   position{line: 797, col: 31, offset: 27661},
+					pos:   position{line: 819, col: 31, offset: 26773},
 					label: "element",
 					expr: &choiceExpr{
-						pos: position{line: 797, col: 40, offset: 27670},
+						pos: position{line: 819, col: 40, offset: 26782},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 797, col: 40, offset: 27670},
+								pos:  position{line: 819, col: 40, offset: 26782},
 								name: "Word",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 798, col: 11, offset: 27685},
+								pos:  position{line: 820, col: 11, offset: 26797},
 								name: "LineBreak",
 							},
 							&oneOrMoreExpr{
-								pos: position{line: 799, col: 11, offset: 27734},
+								pos: position{line: 821, col: 11, offset: 26846},
 								expr: &ruleRefExpr{
-									pos:  position{line: 799, col: 11, offset: 27734},
+									pos:  position{line: 821, col: 11, offset: 26846},
 									name: "Space",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 800, col: 11, offset: 27752},
+								pos:  position{line: 822, col: 11, offset: 26864},
 								name: "CrossReference",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 801, col: 11, offset: 27777},
+								pos:  position{line: 823, col: 11, offset: 26889},
 								name: "ConcealedIndexTerm",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 802, col: 11, offset: 27806},
+								pos:  position{line: 824, col: 11, offset: 26918},
 								name: "IndexTerm",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 803, col: 11, offset: 27826},
+								pos:  position{line: 825, col: 11, offset: 26938},
 								name: "InlinePassthrough",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 804, col: 11, offset: 27915},
+								pos:  position{line: 826, col: 11, offset: 27027},
 								name: "InlineIcon",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 805, col: 11, offset: 27936},
+								pos:  position{line: 827, col: 11, offset: 27048},
 								name: "InlineImage",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 806, col: 11, offset: 27959},
+								pos:  position{line: 828, col: 11, offset: 27071},
 								name: "Link",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 807, col: 11, offset: 27974},
+								pos:  position{line: 829, col: 11, offset: 27086},
 								name: "InlineFootnote",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 808, col: 11, offset: 27999},
+								pos:  position{line: 830, col: 11, offset: 27111},
 								name: "QuotedString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 809, col: 11, offset: 28022},
+								pos:  position{line: 831, col: 11, offset: 27134},
 								name: "QuotedText",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 810, col: 11, offset: 28043},
+								pos:  position{line: 832, col: 11, offset: 27155},
 								name: "SpecialCharacter",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 811, col: 11, offset: 28070},
+								pos:  position{line: 833, col: 11, offset: 27182},
 								name: "Symbol",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 812, col: 11, offset: 28087},
+								pos:  position{line: 834, col: 11, offset: 27199},
 								name: "AttributeSubstitution",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 813, col: 11, offset: 28119},
+								pos:  position{line: 835, col: 11, offset: 27231},
 								name: "AnyChar",
 							},
 						},
@@ -5868,23 +4821,23 @@ var g = &grammar{
 		},
 		{
 			name: "LabeledListItemSeparator",
-			pos:  position{line: 817, col: 1, offset: 28158},
+			pos:  position{line: 839, col: 1, offset: 27270},
 			expr: &actionExpr{
-				pos: position{line: 818, col: 5, offset: 28191},
+				pos: position{line: 840, col: 5, offset: 27303},
 				run: (*parser).callonLabeledListItemSeparator1,
 				expr: &seqExpr{
-					pos: position{line: 818, col: 5, offset: 28191},
+					pos: position{line: 840, col: 5, offset: 27303},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 818, col: 5, offset: 28191},
+							pos:   position{line: 840, col: 5, offset: 27303},
 							label: "separator",
 							expr: &actionExpr{
-								pos: position{line: 818, col: 16, offset: 28202},
+								pos: position{line: 840, col: 16, offset: 27314},
 								run: (*parser).callonLabeledListItemSeparator4,
 								expr: &oneOrMoreExpr{
-									pos: position{line: 818, col: 16, offset: 28202},
+									pos: position{line: 840, col: 16, offset: 27314},
 									expr: &litMatcher{
-										pos:        position{line: 818, col: 17, offset: 28203},
+										pos:        position{line: 840, col: 17, offset: 27315},
 										val:        ":",
 										ignoreCase: false,
 										want:       "\":\"",
@@ -5893,30 +4846,30 @@ var g = &grammar{
 							},
 						},
 						&andCodeExpr{
-							pos: position{line: 821, col: 5, offset: 28261},
+							pos: position{line: 843, col: 5, offset: 27373},
 							run: (*parser).callonLabeledListItemSeparator7,
 						},
 						&choiceExpr{
-							pos: position{line: 825, col: 6, offset: 28437},
+							pos: position{line: 847, col: 6, offset: 27549},
 							alternatives: []interface{}{
 								&oneOrMoreExpr{
-									pos: position{line: 825, col: 6, offset: 28437},
+									pos: position{line: 847, col: 6, offset: 27549},
 									expr: &choiceExpr{
-										pos: position{line: 825, col: 7, offset: 28438},
+										pos: position{line: 847, col: 7, offset: 27550},
 										alternatives: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 825, col: 7, offset: 28438},
+												pos:  position{line: 847, col: 7, offset: 27550},
 												name: "Space",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 825, col: 15, offset: 28446},
+												pos:  position{line: 847, col: 15, offset: 27558},
 												name: "Newline",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 825, col: 27, offset: 28458},
+									pos:  position{line: 847, col: 27, offset: 27570},
 									name: "EOL",
 								},
 							},
@@ -5927,17 +4880,17 @@ var g = &grammar{
 		},
 		{
 			name: "LabeledListItemDescription",
-			pos:  position{line: 829, col: 1, offset: 28498},
+			pos:  position{line: 851, col: 1, offset: 27610},
 			expr: &actionExpr{
-				pos: position{line: 829, col: 31, offset: 28528},
+				pos: position{line: 851, col: 31, offset: 27640},
 				run: (*parser).callonLabeledListItemDescription1,
 				expr: &labeledExpr{
-					pos:   position{line: 829, col: 31, offset: 28528},
+					pos:   position{line: 851, col: 31, offset: 27640},
 					label: "elements",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 829, col: 40, offset: 28537},
+						pos: position{line: 851, col: 40, offset: 27649},
 						expr: &ruleRefExpr{
-							pos:  position{line: 829, col: 41, offset: 28538},
+							pos:  position{line: 851, col: 41, offset: 27650},
 							name: "ListParagraph",
 						},
 					},
@@ -5946,55 +4899,55 @@ var g = &grammar{
 		},
 		{
 			name: "AdmonitionKind",
-			pos:  position{line: 836, col: 1, offset: 28729},
+			pos:  position{line: 858, col: 1, offset: 27841},
 			expr: &choiceExpr{
-				pos: position{line: 836, col: 19, offset: 28747},
+				pos: position{line: 858, col: 19, offset: 27859},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 836, col: 19, offset: 28747},
+						pos: position{line: 858, col: 19, offset: 27859},
 						run: (*parser).callonAdmonitionKind2,
 						expr: &litMatcher{
-							pos:        position{line: 836, col: 19, offset: 28747},
+							pos:        position{line: 858, col: 19, offset: 27859},
 							val:        "TIP",
 							ignoreCase: false,
 							want:       "\"TIP\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 838, col: 5, offset: 28785},
+						pos: position{line: 860, col: 5, offset: 27897},
 						run: (*parser).callonAdmonitionKind4,
 						expr: &litMatcher{
-							pos:        position{line: 838, col: 5, offset: 28785},
+							pos:        position{line: 860, col: 5, offset: 27897},
 							val:        "NOTE",
 							ignoreCase: false,
 							want:       "\"NOTE\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 840, col: 5, offset: 28825},
+						pos: position{line: 862, col: 5, offset: 27937},
 						run: (*parser).callonAdmonitionKind6,
 						expr: &litMatcher{
-							pos:        position{line: 840, col: 5, offset: 28825},
+							pos:        position{line: 862, col: 5, offset: 27937},
 							val:        "IMPORTANT",
 							ignoreCase: false,
 							want:       "\"IMPORTANT\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 842, col: 5, offset: 28875},
+						pos: position{line: 864, col: 5, offset: 27987},
 						run: (*parser).callonAdmonitionKind8,
 						expr: &litMatcher{
-							pos:        position{line: 842, col: 5, offset: 28875},
+							pos:        position{line: 864, col: 5, offset: 27987},
 							val:        "WARNING",
 							ignoreCase: false,
 							want:       "\"WARNING\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 844, col: 5, offset: 28921},
+						pos: position{line: 866, col: 5, offset: 28033},
 						run: (*parser).callonAdmonitionKind10,
 						expr: &litMatcher{
-							pos:        position{line: 844, col: 5, offset: 28921},
+							pos:        position{line: 866, col: 5, offset: 28033},
 							val:        "CAUTION",
 							ignoreCase: false,
 							want:       "\"CAUTION\"",
@@ -6005,55 +4958,55 @@ var g = &grammar{
 		},
 		{
 			name: "RawParagraph",
-			pos:  position{line: 856, col: 1, offset: 29301},
+			pos:  position{line: 878, col: 1, offset: 28413},
 			expr: &choiceExpr{
-				pos: position{line: 858, col: 6, offset: 29352},
+				pos: position{line: 880, col: 6, offset: 28464},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 858, col: 6, offset: 29352},
+						pos: position{line: 880, col: 6, offset: 28464},
 						run: (*parser).callonRawParagraph2,
 						expr: &seqExpr{
-							pos: position{line: 858, col: 6, offset: 29352},
+							pos: position{line: 880, col: 6, offset: 28464},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 858, col: 6, offset: 29352},
+									pos:   position{line: 880, col: 6, offset: 28464},
 									label: "attributes",
-									expr: &zeroOrMoreExpr{
-										pos: position{line: 858, col: 17, offset: 29363},
+									expr: &zeroOrOneExpr{
+										pos: position{line: 880, col: 17, offset: 28475},
 										expr: &ruleRefExpr{
-											pos:  position{line: 858, col: 18, offset: 29364},
-											name: "ElementAttribute",
+											pos:  position{line: 880, col: 18, offset: 28476},
+											name: "BlockAttributes",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 858, col: 37, offset: 29383},
+									pos:   position{line: 880, col: 36, offset: 28494},
 									label: "t",
 									expr: &ruleRefExpr{
-										pos:  position{line: 858, col: 40, offset: 29386},
+										pos:  position{line: 880, col: 39, offset: 28497},
 										name: "AdmonitionKind",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 858, col: 56, offset: 29402},
+									pos:        position{line: 880, col: 55, offset: 28513},
 									val:        ": ",
 									ignoreCase: false,
 									want:       "\": \"",
 								},
 								&labeledExpr{
-									pos:   position{line: 858, col: 61, offset: 29407},
+									pos:   position{line: 880, col: 60, offset: 28518},
 									label: "lines",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 858, col: 67, offset: 29413},
+										pos: position{line: 880, col: 66, offset: 28524},
 										expr: &choiceExpr{
-											pos: position{line: 858, col: 68, offset: 29414},
+											pos: position{line: 880, col: 67, offset: 28525},
 											alternatives: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 858, col: 68, offset: 29414},
+													pos:  position{line: 880, col: 67, offset: 28525},
 													name: "SingleLineComment",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 858, col: 88, offset: 29434},
+													pos:  position{line: 880, col: 87, offset: 28545},
 													name: "RawParagraphLine",
 												},
 											},
@@ -6064,33 +5017,33 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 863, col: 5, offset: 29685},
+						pos: position{line: 885, col: 5, offset: 28766},
 						run: (*parser).callonRawParagraph15,
 						expr: &seqExpr{
-							pos: position{line: 863, col: 5, offset: 29685},
+							pos: position{line: 885, col: 5, offset: 28766},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 863, col: 5, offset: 29685},
+									pos:   position{line: 885, col: 5, offset: 28766},
 									label: "attributes",
-									expr: &zeroOrMoreExpr{
-										pos: position{line: 863, col: 16, offset: 29696},
+									expr: &zeroOrOneExpr{
+										pos: position{line: 885, col: 16, offset: 28777},
 										expr: &ruleRefExpr{
-											pos:  position{line: 863, col: 17, offset: 29697},
-											name: "ElementAttribute",
+											pos:  position{line: 885, col: 17, offset: 28778},
+											name: "BlockAttributes",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 863, col: 36, offset: 29716},
+									pos:        position{line: 885, col: 35, offset: 28796},
 									val:        "> ",
 									ignoreCase: false,
 									want:       "\"> \"",
 								},
 								&labeledExpr{
-									pos:   position{line: 863, col: 41, offset: 29721},
+									pos:   position{line: 885, col: 40, offset: 28801},
 									label: "content",
 									expr: &ruleRefExpr{
-										pos:  position{line: 863, col: 50, offset: 29730},
+										pos:  position{line: 885, col: 49, offset: 28810},
 										name: "MarkdownQuoteBlockRawContent",
 									},
 								},
@@ -6098,33 +5051,33 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 867, col: 5, offset: 29919},
+						pos: position{line: 889, col: 5, offset: 28983},
 						run: (*parser).callonRawParagraph23,
 						expr: &seqExpr{
-							pos: position{line: 867, col: 5, offset: 29919},
+							pos: position{line: 889, col: 5, offset: 28983},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 867, col: 5, offset: 29919},
+									pos:   position{line: 889, col: 5, offset: 28983},
 									label: "attributes",
-									expr: &zeroOrMoreExpr{
-										pos: position{line: 867, col: 16, offset: 29930},
+									expr: &zeroOrOneExpr{
+										pos: position{line: 889, col: 16, offset: 28994},
 										expr: &ruleRefExpr{
-											pos:  position{line: 867, col: 17, offset: 29931},
-											name: "ElementAttribute",
+											pos:  position{line: 889, col: 17, offset: 28995},
+											name: "BlockAttributes",
 										},
 									},
 								},
 								&andCodeExpr{
-									pos: position{line: 867, col: 36, offset: 29950},
+									pos: position{line: 889, col: 35, offset: 29013},
 									run: (*parser).callonRawParagraph28,
 								},
 								&labeledExpr{
-									pos:   position{line: 870, col: 7, offset: 30126},
+									pos:   position{line: 892, col: 7, offset: 29191},
 									label: "content",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 870, col: 15, offset: 30134},
+										pos: position{line: 892, col: 15, offset: 29199},
 										expr: &ruleRefExpr{
-											pos:  position{line: 870, col: 16, offset: 30135},
+											pos:  position{line: 892, col: 16, offset: 29200},
 											name: "RawParagraphLine",
 										},
 									},
@@ -6133,36 +5086,36 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 874, col: 5, offset: 30317},
+						pos: position{line: 896, col: 5, offset: 29366},
 						run: (*parser).callonRawParagraph32,
 						expr: &seqExpr{
-							pos: position{line: 874, col: 5, offset: 30317},
+							pos: position{line: 896, col: 5, offset: 29366},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 874, col: 5, offset: 30317},
+									pos:   position{line: 896, col: 5, offset: 29366},
 									label: "attributes",
-									expr: &zeroOrMoreExpr{
-										pos: position{line: 874, col: 16, offset: 30328},
+									expr: &zeroOrOneExpr{
+										pos: position{line: 896, col: 16, offset: 29377},
 										expr: &ruleRefExpr{
-											pos:  position{line: 874, col: 17, offset: 30329},
-											name: "ElementAttribute",
+											pos:  position{line: 896, col: 17, offset: 29378},
+											name: "BlockAttributes",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 874, col: 36, offset: 30348},
+									pos:   position{line: 896, col: 35, offset: 29396},
 									label: "lines",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 874, col: 42, offset: 30354},
+										pos: position{line: 896, col: 41, offset: 29402},
 										expr: &choiceExpr{
-											pos: position{line: 874, col: 43, offset: 30355},
+											pos: position{line: 896, col: 42, offset: 29403},
 											alternatives: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 874, col: 43, offset: 30355},
+													pos:  position{line: 896, col: 42, offset: 29403},
 													name: "SingleLineComment",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 874, col: 63, offset: 30375},
+													pos:  position{line: 896, col: 62, offset: 29423},
 													name: "RawParagraphLine",
 												},
 											},
@@ -6177,36 +5130,36 @@ var g = &grammar{
 		},
 		{
 			name: "MarkdownQuoteBlockRawContent",
-			pos:  position{line: 878, col: 1, offset: 30489},
+			pos:  position{line: 900, col: 1, offset: 29521},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 878, col: 33, offset: 30521},
+				pos: position{line: 900, col: 33, offset: 29553},
 				expr: &actionExpr{
-					pos: position{line: 878, col: 34, offset: 30522},
+					pos: position{line: 900, col: 34, offset: 29554},
 					run: (*parser).callonMarkdownQuoteBlockRawContent2,
 					expr: &seqExpr{
-						pos: position{line: 878, col: 34, offset: 30522},
+						pos: position{line: 900, col: 34, offset: 29554},
 						exprs: []interface{}{
 							&notExpr{
-								pos: position{line: 878, col: 34, offset: 30522},
+								pos: position{line: 900, col: 34, offset: 29554},
 								expr: &ruleRefExpr{
-									pos:  position{line: 878, col: 35, offset: 30523},
+									pos:  position{line: 900, col: 35, offset: 29555},
 									name: "BlankLine",
 								},
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 878, col: 45, offset: 30533},
+								pos: position{line: 900, col: 45, offset: 29565},
 								expr: &litMatcher{
-									pos:        position{line: 878, col: 45, offset: 30533},
+									pos:        position{line: 900, col: 45, offset: 29565},
 									val:        "> ",
 									ignoreCase: false,
 									want:       "\"> \"",
 								},
 							},
 							&labeledExpr{
-								pos:   position{line: 878, col: 51, offset: 30539},
+								pos:   position{line: 900, col: 51, offset: 29571},
 								label: "content",
 								expr: &ruleRefExpr{
-									pos:  position{line: 878, col: 60, offset: 30548},
+									pos:  position{line: 900, col: 60, offset: 29580},
 									name: "RawLine",
 								},
 							},
@@ -6217,34 +5170,34 @@ var g = &grammar{
 		},
 		{
 			name: "RawParagraphLine",
-			pos:  position{line: 882, col: 1, offset: 30589},
+			pos:  position{line: 904, col: 1, offset: 29621},
 			expr: &actionExpr{
-				pos: position{line: 882, col: 21, offset: 30609},
+				pos: position{line: 904, col: 21, offset: 29641},
 				run: (*parser).callonRawParagraphLine1,
 				expr: &seqExpr{
-					pos: position{line: 882, col: 21, offset: 30609},
+					pos: position{line: 904, col: 21, offset: 29641},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 882, col: 21, offset: 30609},
+							pos: position{line: 904, col: 21, offset: 29641},
 							expr: &ruleRefExpr{
-								pos:  position{line: 882, col: 22, offset: 30610},
+								pos:  position{line: 904, col: 22, offset: 29642},
 								name: "BlockDelimiter",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 883, col: 5, offset: 30630},
+							pos:   position{line: 905, col: 5, offset: 29662},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 883, col: 14, offset: 30639},
+								pos:  position{line: 905, col: 14, offset: 29671},
 								name: "RawParagraphLineContent",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 883, col: 39, offset: 30664},
+							pos:  position{line: 905, col: 39, offset: 29696},
 							name: "EOL",
 						},
 						&andCodeExpr{
-							pos: position{line: 883, col: 43, offset: 30668},
+							pos: position{line: 905, col: 43, offset: 29700},
 							run: (*parser).callonRawParagraphLine8,
 						},
 					},
@@ -6253,14 +5206,14 @@ var g = &grammar{
 		},
 		{
 			name: "RawParagraphLineContent",
-			pos:  position{line: 893, col: 1, offset: 30903},
+			pos:  position{line: 915, col: 1, offset: 29935},
 			expr: &actionExpr{
-				pos: position{line: 893, col: 28, offset: 30930},
+				pos: position{line: 915, col: 28, offset: 29962},
 				run: (*parser).callonRawParagraphLineContent1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 893, col: 28, offset: 30930},
+					pos: position{line: 915, col: 28, offset: 29962},
 					expr: &charClassMatcher{
-						pos:        position{line: 893, col: 28, offset: 30930},
+						pos:        position{line: 915, col: 28, offset: 29962},
 						val:        "[^\\r\\n]",
 						chars:      []rune{'\r', '\n'},
 						ignoreCase: false,
@@ -6271,50 +5224,50 @@ var g = &grammar{
 		},
 		{
 			name: "SimpleRawParagraph",
-			pos:  position{line: 898, col: 1, offset: 31047},
+			pos:  position{line: 920, col: 1, offset: 30079},
 			expr: &actionExpr{
-				pos: position{line: 898, col: 23, offset: 31069},
+				pos: position{line: 920, col: 23, offset: 30101},
 				run: (*parser).callonSimpleRawParagraph1,
 				expr: &seqExpr{
-					pos: position{line: 898, col: 23, offset: 31069},
+					pos: position{line: 920, col: 23, offset: 30101},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 898, col: 23, offset: 31069},
+							pos:   position{line: 920, col: 23, offset: 30101},
 							label: "attributes",
-							expr: &zeroOrMoreExpr{
-								pos: position{line: 898, col: 34, offset: 31080},
+							expr: &zeroOrOneExpr{
+								pos: position{line: 920, col: 34, offset: 30112},
 								expr: &ruleRefExpr{
-									pos:  position{line: 898, col: 35, offset: 31081},
-									name: "ElementAttribute",
+									pos:  position{line: 920, col: 35, offset: 30113},
+									name: "BlockAttributes",
 								},
 							},
 						},
 						&andCodeExpr{
-							pos: position{line: 899, col: 5, offset: 31105},
+							pos: position{line: 921, col: 5, offset: 30136},
 							run: (*parser).callonSimpleRawParagraph6,
 						},
 						&labeledExpr{
-							pos:   position{line: 902, col: 5, offset: 31215},
+							pos:   position{line: 924, col: 5, offset: 30248},
 							label: "firstLine",
 							expr: &ruleRefExpr{
-								pos:  position{line: 902, col: 16, offset: 31226},
+								pos:  position{line: 924, col: 16, offset: 30259},
 								name: "FirstParagraphRawLine",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 903, col: 5, offset: 31252},
+							pos:   position{line: 925, col: 5, offset: 30285},
 							label: "otherLines",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 903, col: 16, offset: 31263},
+								pos: position{line: 925, col: 16, offset: 30296},
 								expr: &choiceExpr{
-									pos: position{line: 903, col: 17, offset: 31264},
+									pos: position{line: 925, col: 17, offset: 30297},
 									alternatives: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 903, col: 17, offset: 31264},
+											pos:  position{line: 925, col: 17, offset: 30297},
 											name: "SingleLineComment",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 903, col: 37, offset: 31284},
+											pos:  position{line: 925, col: 37, offset: 30317},
 											name: "RawParagraphLine",
 										},
 									},
@@ -6327,34 +5280,34 @@ var g = &grammar{
 		},
 		{
 			name: "FirstParagraphRawLine",
-			pos:  position{line: 907, col: 1, offset: 31432},
+			pos:  position{line: 929, col: 1, offset: 30449},
 			expr: &actionExpr{
-				pos: position{line: 908, col: 5, offset: 31462},
+				pos: position{line: 930, col: 5, offset: 30479},
 				run: (*parser).callonFirstParagraphRawLine1,
 				expr: &seqExpr{
-					pos: position{line: 908, col: 5, offset: 31462},
+					pos: position{line: 930, col: 5, offset: 30479},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 908, col: 5, offset: 31462},
+							pos:   position{line: 930, col: 5, offset: 30479},
 							label: "content",
 							expr: &actionExpr{
-								pos: position{line: 908, col: 14, offset: 31471},
+								pos: position{line: 930, col: 14, offset: 30488},
 								run: (*parser).callonFirstParagraphRawLine4,
 								expr: &seqExpr{
-									pos: position{line: 908, col: 14, offset: 31471},
+									pos: position{line: 930, col: 14, offset: 30488},
 									exprs: []interface{}{
 										&labeledExpr{
-											pos:   position{line: 908, col: 14, offset: 31471},
+											pos:   position{line: 930, col: 14, offset: 30488},
 											label: "elements",
 											expr: &ruleRefExpr{
-												pos:  position{line: 908, col: 23, offset: 31480},
+												pos:  position{line: 930, col: 23, offset: 30497},
 												name: "Word",
 											},
 										},
 										&zeroOrMoreExpr{
-											pos: position{line: 908, col: 28, offset: 31485},
+											pos: position{line: 930, col: 28, offset: 30502},
 											expr: &charClassMatcher{
-												pos:        position{line: 908, col: 28, offset: 31485},
+												pos:        position{line: 930, col: 28, offset: 30502},
 												val:        "[^\\r\\n]",
 												chars:      []rune{'\r', '\n'},
 												ignoreCase: false,
@@ -6366,7 +5319,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 908, col: 68, offset: 31525},
+							pos:  position{line: 930, col: 68, offset: 30542},
 							name: "EOL",
 						},
 					},
@@ -6375,46 +5328,46 @@ var g = &grammar{
 		},
 		{
 			name: "ContinuedRawParagraph",
-			pos:  position{line: 919, col: 1, offset: 31777},
+			pos:  position{line: 941, col: 1, offset: 30794},
 			expr: &choiceExpr{
-				pos: position{line: 921, col: 5, offset: 31836},
+				pos: position{line: 943, col: 5, offset: 30853},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 921, col: 5, offset: 31836},
+						pos: position{line: 943, col: 5, offset: 30853},
 						run: (*parser).callonContinuedRawParagraph2,
 						expr: &seqExpr{
-							pos: position{line: 921, col: 5, offset: 31836},
+							pos: position{line: 943, col: 5, offset: 30853},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 921, col: 5, offset: 31836},
+									pos:   position{line: 943, col: 5, offset: 30853},
 									label: "attributes",
-									expr: &zeroOrMoreExpr{
-										pos: position{line: 921, col: 16, offset: 31847},
+									expr: &zeroOrOneExpr{
+										pos: position{line: 943, col: 16, offset: 30864},
 										expr: &ruleRefExpr{
-											pos:  position{line: 921, col: 17, offset: 31848},
-											name: "ElementAttribute",
+											pos:  position{line: 943, col: 17, offset: 30865},
+											name: "BlockAttributes",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 921, col: 36, offset: 31867},
+									pos:   position{line: 943, col: 35, offset: 30883},
 									label: "t",
 									expr: &ruleRefExpr{
-										pos:  position{line: 921, col: 39, offset: 31870},
+										pos:  position{line: 943, col: 38, offset: 30886},
 										name: "AdmonitionKind",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 921, col: 55, offset: 31886},
+									pos:        position{line: 943, col: 54, offset: 30902},
 									val:        ": ",
 									ignoreCase: false,
 									want:       "\": \"",
 								},
 								&labeledExpr{
-									pos:   position{line: 921, col: 60, offset: 31891},
+									pos:   position{line: 943, col: 59, offset: 30907},
 									label: "lines",
 									expr: &ruleRefExpr{
-										pos:  position{line: 921, col: 67, offset: 31898},
+										pos:  position{line: 943, col: 66, offset: 30914},
 										name: "ContinuedRawParagraphLines",
 									},
 								},
@@ -6422,27 +5375,27 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 925, col: 5, offset: 32117},
+						pos: position{line: 947, col: 5, offset: 31103},
 						run: (*parser).callonContinuedRawParagraph12,
 						expr: &seqExpr{
-							pos: position{line: 925, col: 5, offset: 32117},
+							pos: position{line: 947, col: 5, offset: 31103},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 925, col: 5, offset: 32117},
+									pos:   position{line: 947, col: 5, offset: 31103},
 									label: "attributes",
-									expr: &zeroOrMoreExpr{
-										pos: position{line: 925, col: 16, offset: 32128},
+									expr: &zeroOrOneExpr{
+										pos: position{line: 947, col: 16, offset: 31114},
 										expr: &ruleRefExpr{
-											pos:  position{line: 925, col: 17, offset: 32129},
-											name: "ElementAttribute",
+											pos:  position{line: 947, col: 17, offset: 31115},
+											name: "BlockAttributes",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 925, col: 36, offset: 32148},
+									pos:   position{line: 947, col: 35, offset: 31133},
 									label: "lines",
 									expr: &ruleRefExpr{
-										pos:  position{line: 925, col: 43, offset: 32155},
+										pos:  position{line: 947, col: 42, offset: 31140},
 										name: "ContinuedRawParagraphLines",
 									},
 								},
@@ -6454,51 +5407,51 @@ var g = &grammar{
 		},
 		{
 			name: "ContinuedRawParagraphLines",
-			pos:  position{line: 929, col: 1, offset: 32275},
+			pos:  position{line: 951, col: 1, offset: 31244},
 			expr: &actionExpr{
-				pos: position{line: 929, col: 31, offset: 32305},
+				pos: position{line: 951, col: 31, offset: 31274},
 				run: (*parser).callonContinuedRawParagraphLines1,
 				expr: &seqExpr{
-					pos: position{line: 929, col: 31, offset: 32305},
+					pos: position{line: 951, col: 31, offset: 31274},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 929, col: 31, offset: 32305},
+							pos:   position{line: 951, col: 31, offset: 31274},
 							label: "firstLine",
 							expr: &ruleRefExpr{
-								pos:  position{line: 929, col: 42, offset: 32316},
+								pos:  position{line: 951, col: 42, offset: 31285},
 								name: "FirstParagraphRawLine",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 929, col: 65, offset: 32339},
+							pos:   position{line: 951, col: 65, offset: 31308},
 							label: "otherLines",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 929, col: 76, offset: 32350},
+								pos: position{line: 951, col: 76, offset: 31319},
 								expr: &actionExpr{
-									pos: position{line: 929, col: 77, offset: 32351},
+									pos: position{line: 951, col: 77, offset: 31320},
 									run: (*parser).callonContinuedRawParagraphLines7,
 									expr: &seqExpr{
-										pos: position{line: 929, col: 77, offset: 32351},
+										pos: position{line: 951, col: 77, offset: 31320},
 										exprs: []interface{}{
 											&notExpr{
-												pos: position{line: 929, col: 77, offset: 32351},
+												pos: position{line: 951, col: 77, offset: 31320},
 												expr: &ruleRefExpr{
-													pos:  position{line: 929, col: 78, offset: 32352},
+													pos:  position{line: 951, col: 78, offset: 31321},
 													name: "ListItemContinuation",
 												},
 											},
 											&labeledExpr{
-												pos:   position{line: 929, col: 99, offset: 32373},
+												pos:   position{line: 951, col: 99, offset: 31342},
 												label: "line",
 												expr: &choiceExpr{
-													pos: position{line: 929, col: 105, offset: 32379},
+													pos: position{line: 951, col: 105, offset: 31348},
 													alternatives: []interface{}{
 														&ruleRefExpr{
-															pos:  position{line: 929, col: 105, offset: 32379},
+															pos:  position{line: 951, col: 105, offset: 31348},
 															name: "SingleLineComment",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 929, col: 125, offset: 32399},
+															pos:  position{line: 951, col: 125, offset: 31368},
 															name: "RawParagraphLine",
 														},
 													},
@@ -6515,57 +5468,57 @@ var g = &grammar{
 		},
 		{
 			name: "InlineElements",
-			pos:  position{line: 937, col: 1, offset: 32641},
+			pos:  position{line: 959, col: 1, offset: 31610},
 			expr: &actionExpr{
-				pos: position{line: 937, col: 19, offset: 32659},
+				pos: position{line: 959, col: 19, offset: 31628},
 				run: (*parser).callonInlineElements1,
 				expr: &seqExpr{
-					pos: position{line: 937, col: 19, offset: 32659},
+					pos: position{line: 959, col: 19, offset: 31628},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 937, col: 19, offset: 32659},
+							pos: position{line: 959, col: 19, offset: 31628},
 							expr: &ruleRefExpr{
-								pos:  position{line: 937, col: 20, offset: 32660},
+								pos:  position{line: 959, col: 20, offset: 31629},
 								name: "BlankLine",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 938, col: 5, offset: 32674},
+							pos:   position{line: 960, col: 5, offset: 31643},
 							label: "elements",
 							expr: &choiceExpr{
-								pos: position{line: 938, col: 15, offset: 32684},
+								pos: position{line: 960, col: 15, offset: 31653},
 								alternatives: []interface{}{
 									&actionExpr{
-										pos: position{line: 938, col: 15, offset: 32684},
+										pos: position{line: 960, col: 15, offset: 31653},
 										run: (*parser).callonInlineElements7,
 										expr: &labeledExpr{
-											pos:   position{line: 938, col: 15, offset: 32684},
+											pos:   position{line: 960, col: 15, offset: 31653},
 											label: "comment",
 											expr: &ruleRefExpr{
-												pos:  position{line: 938, col: 24, offset: 32693},
+												pos:  position{line: 960, col: 24, offset: 31662},
 												name: "SingleLineComment",
 											},
 										},
 									},
 									&actionExpr{
-										pos: position{line: 940, col: 9, offset: 32785},
+										pos: position{line: 962, col: 9, offset: 31754},
 										run: (*parser).callonInlineElements10,
 										expr: &seqExpr{
-											pos: position{line: 940, col: 9, offset: 32785},
+											pos: position{line: 962, col: 9, offset: 31754},
 											exprs: []interface{}{
 												&labeledExpr{
-													pos:   position{line: 940, col: 9, offset: 32785},
+													pos:   position{line: 962, col: 9, offset: 31754},
 													label: "elements",
 													expr: &oneOrMoreExpr{
-														pos: position{line: 940, col: 18, offset: 32794},
+														pos: position{line: 962, col: 18, offset: 31763},
 														expr: &ruleRefExpr{
-															pos:  position{line: 940, col: 19, offset: 32795},
+															pos:  position{line: 962, col: 19, offset: 31764},
 															name: "InlineElement",
 														},
 													},
 												},
 												&ruleRefExpr{
-													pos:  position{line: 940, col: 35, offset: 32811},
+													pos:  position{line: 962, col: 35, offset: 31780},
 													name: "EOL",
 												},
 											},
@@ -6580,110 +5533,110 @@ var g = &grammar{
 		},
 		{
 			name: "InlineElement",
-			pos:  position{line: 946, col: 1, offset: 32928},
+			pos:  position{line: 968, col: 1, offset: 31897},
 			expr: &actionExpr{
-				pos: position{line: 947, col: 5, offset: 32951},
+				pos: position{line: 969, col: 5, offset: 31920},
 				run: (*parser).callonInlineElement1,
 				expr: &labeledExpr{
-					pos:   position{line: 947, col: 5, offset: 32951},
+					pos:   position{line: 969, col: 5, offset: 31920},
 					label: "element",
 					expr: &choiceExpr{
-						pos: position{line: 947, col: 14, offset: 32960},
+						pos: position{line: 969, col: 14, offset: 31929},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 947, col: 14, offset: 32960},
+								pos:  position{line: 969, col: 14, offset: 31929},
 								name: "InlineWord",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 948, col: 11, offset: 33021},
+								pos:  position{line: 970, col: 11, offset: 31990},
 								name: "LineBreak",
 							},
 							&oneOrMoreExpr{
-								pos: position{line: 949, col: 11, offset: 33066},
+								pos: position{line: 971, col: 11, offset: 32035},
 								expr: &ruleRefExpr{
-									pos:  position{line: 949, col: 11, offset: 33066},
+									pos:  position{line: 971, col: 11, offset: 32035},
 									name: "Space",
 								},
 							},
 							&seqExpr{
-								pos: position{line: 950, col: 11, offset: 33084},
+								pos: position{line: 972, col: 11, offset: 32053},
 								exprs: []interface{}{
 									&notExpr{
-										pos: position{line: 950, col: 11, offset: 33084},
+										pos: position{line: 972, col: 11, offset: 32053},
 										expr: &ruleRefExpr{
-											pos:  position{line: 950, col: 12, offset: 33085},
+											pos:  position{line: 972, col: 12, offset: 32054},
 											name: "EOL",
 										},
 									},
 									&choiceExpr{
-										pos: position{line: 951, col: 13, offset: 33103},
+										pos: position{line: 973, col: 13, offset: 32072},
 										alternatives: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 951, col: 13, offset: 33103},
+												pos:  position{line: 973, col: 13, offset: 32072},
 												name: "QuotedString",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 952, col: 15, offset: 33130},
+												pos:  position{line: 974, col: 15, offset: 32099},
 												name: "QuotedText",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 953, col: 15, offset: 33155},
+												pos:  position{line: 975, col: 15, offset: 32124},
 												name: "InlineIcon",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 954, col: 15, offset: 33180},
+												pos:  position{line: 976, col: 15, offset: 32149},
 												name: "InlineImage",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 955, col: 15, offset: 33207},
+												pos:  position{line: 977, col: 15, offset: 32176},
 												name: "Link",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 956, col: 15, offset: 33227},
+												pos:  position{line: 978, col: 15, offset: 32196},
 												name: "InlinePassthrough",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 957, col: 15, offset: 33320},
+												pos:  position{line: 979, col: 15, offset: 32289},
 												name: "InlineFootnote",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 958, col: 15, offset: 33350},
+												pos:  position{line: 980, col: 15, offset: 32319},
 												name: "CrossReference",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 959, col: 15, offset: 33418},
+												pos:  position{line: 981, col: 15, offset: 32387},
 												name: "SpecialCharacter",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 960, col: 15, offset: 33449},
+												pos:  position{line: 982, col: 15, offset: 32418},
 												name: "Symbol",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 961, col: 15, offset: 33470},
+												pos:  position{line: 983, col: 15, offset: 32439},
 												name: "InlineUserMacro",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 962, col: 15, offset: 33501},
+												pos:  position{line: 984, col: 15, offset: 32470},
 												name: "AttributeSubstitution",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 963, col: 15, offset: 33538},
+												pos:  position{line: 985, col: 15, offset: 32507},
 												name: "InlineElementID",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 964, col: 15, offset: 33568},
+												pos:  position{line: 986, col: 15, offset: 32537},
 												name: "ConcealedIndexTerm",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 965, col: 15, offset: 33601},
+												pos:  position{line: 987, col: 15, offset: 32570},
 												name: "IndexTerm",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 966, col: 15, offset: 33625},
+												pos:  position{line: 988, col: 15, offset: 32594},
 												name: "ElementPlaceHolder",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 967, col: 15, offset: 33658},
+												pos:  position{line: 989, col: 15, offset: 32627},
 												name: "AnyChar",
 											},
 										},
@@ -6697,34 +5650,34 @@ var g = &grammar{
 		},
 		{
 			name: "LineBreak",
-			pos:  position{line: 974, col: 1, offset: 33881},
+			pos:  position{line: 996, col: 1, offset: 32850},
 			expr: &actionExpr{
-				pos: position{line: 974, col: 14, offset: 33894},
+				pos: position{line: 996, col: 14, offset: 32863},
 				run: (*parser).callonLineBreak1,
 				expr: &seqExpr{
-					pos: position{line: 974, col: 14, offset: 33894},
+					pos: position{line: 996, col: 14, offset: 32863},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 974, col: 14, offset: 33894},
+							pos:  position{line: 996, col: 14, offset: 32863},
 							name: "Space",
 						},
 						&litMatcher{
-							pos:        position{line: 974, col: 20, offset: 33900},
+							pos:        position{line: 996, col: 20, offset: 32869},
 							val:        "+",
 							ignoreCase: false,
 							want:       "\"+\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 974, col: 24, offset: 33904},
+							pos: position{line: 996, col: 24, offset: 32873},
 							expr: &ruleRefExpr{
-								pos:  position{line: 974, col: 24, offset: 33904},
+								pos:  position{line: 996, col: 24, offset: 32873},
 								name: "Space",
 							},
 						},
 						&andExpr{
-							pos: position{line: 974, col: 31, offset: 33911},
+							pos: position{line: 996, col: 31, offset: 32880},
 							expr: &ruleRefExpr{
-								pos:  position{line: 974, col: 32, offset: 33912},
+								pos:  position{line: 996, col: 32, offset: 32881},
 								name: "EOL",
 							},
 						},
@@ -6734,20 +5687,20 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedText",
-			pos:  position{line: 981, col: 1, offset: 34196},
+			pos:  position{line: 1003, col: 1, offset: 33165},
 			expr: &choiceExpr{
-				pos: position{line: 981, col: 15, offset: 34210},
+				pos: position{line: 1003, col: 15, offset: 33179},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 981, col: 15, offset: 34210},
+						pos:  position{line: 1003, col: 15, offset: 33179},
 						name: "UnconstrainedQuotedText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 981, col: 41, offset: 34236},
+						pos:  position{line: 1003, col: 41, offset: 33205},
 						name: "ConstrainedQuotedText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 981, col: 65, offset: 34260},
+						pos:  position{line: 1003, col: 65, offset: 33229},
 						name: "EscapedQuotedText",
 					},
 				},
@@ -6755,23 +5708,23 @@ var g = &grammar{
 		},
 		{
 			name: "ConstrainedQuotedTextMarker",
-			pos:  position{line: 983, col: 1, offset: 34279},
+			pos:  position{line: 1005, col: 1, offset: 33248},
 			expr: &choiceExpr{
-				pos: position{line: 983, col: 32, offset: 34310},
+				pos: position{line: 1005, col: 32, offset: 33279},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 983, col: 32, offset: 34310},
+						pos: position{line: 1005, col: 32, offset: 33279},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 983, col: 32, offset: 34310},
+								pos:        position{line: 1005, col: 32, offset: 33279},
 								val:        "*",
 								ignoreCase: false,
 								want:       "\"*\"",
 							},
 							&notExpr{
-								pos: position{line: 983, col: 36, offset: 34314},
+								pos: position{line: 1005, col: 36, offset: 33283},
 								expr: &litMatcher{
-									pos:        position{line: 983, col: 37, offset: 34315},
+									pos:        position{line: 1005, col: 37, offset: 33284},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
@@ -6780,18 +5733,18 @@ var g = &grammar{
 						},
 					},
 					&seqExpr{
-						pos: position{line: 983, col: 43, offset: 34321},
+						pos: position{line: 1005, col: 43, offset: 33290},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 983, col: 43, offset: 34321},
+								pos:        position{line: 1005, col: 43, offset: 33290},
 								val:        "_",
 								ignoreCase: false,
 								want:       "\"_\"",
 							},
 							&notExpr{
-								pos: position{line: 983, col: 47, offset: 34325},
+								pos: position{line: 1005, col: 47, offset: 33294},
 								expr: &litMatcher{
-									pos:        position{line: 983, col: 48, offset: 34326},
+									pos:        position{line: 1005, col: 48, offset: 33295},
 									val:        "_",
 									ignoreCase: false,
 									want:       "\"_\"",
@@ -6800,18 +5753,18 @@ var g = &grammar{
 						},
 					},
 					&seqExpr{
-						pos: position{line: 983, col: 54, offset: 34332},
+						pos: position{line: 1005, col: 54, offset: 33301},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 983, col: 54, offset: 34332},
+								pos:        position{line: 1005, col: 54, offset: 33301},
 								val:        "#",
 								ignoreCase: false,
 								want:       "\"#\"",
 							},
 							&notExpr{
-								pos: position{line: 983, col: 58, offset: 34336},
+								pos: position{line: 1005, col: 58, offset: 33305},
 								expr: &litMatcher{
-									pos:        position{line: 983, col: 59, offset: 34337},
+									pos:        position{line: 1005, col: 59, offset: 33306},
 									val:        "#",
 									ignoreCase: false,
 									want:       "\"#\"",
@@ -6820,18 +5773,18 @@ var g = &grammar{
 						},
 					},
 					&seqExpr{
-						pos: position{line: 983, col: 65, offset: 34343},
+						pos: position{line: 1005, col: 65, offset: 33312},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 983, col: 65, offset: 34343},
+								pos:        position{line: 1005, col: 65, offset: 33312},
 								val:        "`",
 								ignoreCase: false,
 								want:       "\"`\"",
 							},
 							&notExpr{
-								pos: position{line: 983, col: 69, offset: 34347},
+								pos: position{line: 1005, col: 69, offset: 33316},
 								expr: &litMatcher{
-									pos:        position{line: 983, col: 70, offset: 34348},
+									pos:        position{line: 1005, col: 70, offset: 33317},
 									val:        "`",
 									ignoreCase: false,
 									want:       "\"`\"",
@@ -6844,42 +5797,42 @@ var g = &grammar{
 		},
 		{
 			name: "UnconstrainedQuotedTextPrefix",
-			pos:  position{line: 985, col: 1, offset: 34353},
+			pos:  position{line: 1007, col: 1, offset: 33322},
 			expr: &choiceExpr{
-				pos: position{line: 985, col: 34, offset: 34386},
+				pos: position{line: 1007, col: 34, offset: 33355},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 985, col: 34, offset: 34386},
+						pos:        position{line: 1007, col: 34, offset: 33355},
 						val:        "**",
 						ignoreCase: false,
 						want:       "\"**\"",
 					},
 					&litMatcher{
-						pos:        position{line: 985, col: 41, offset: 34393},
+						pos:        position{line: 1007, col: 41, offset: 33362},
 						val:        "__",
 						ignoreCase: false,
 						want:       "\"__\"",
 					},
 					&litMatcher{
-						pos:        position{line: 985, col: 48, offset: 34400},
+						pos:        position{line: 1007, col: 48, offset: 33369},
 						val:        "``",
 						ignoreCase: false,
 						want:       "\"``\"",
 					},
 					&litMatcher{
-						pos:        position{line: 985, col: 55, offset: 34407},
+						pos:        position{line: 1007, col: 55, offset: 33376},
 						val:        "##",
 						ignoreCase: false,
 						want:       "\"##\"",
 					},
 					&litMatcher{
-						pos:        position{line: 985, col: 62, offset: 34414},
+						pos:        position{line: 1007, col: 62, offset: 33383},
 						val:        "^",
 						ignoreCase: false,
 						want:       "\"^\"",
 					},
 					&litMatcher{
-						pos:        position{line: 985, col: 68, offset: 34420},
+						pos:        position{line: 1007, col: 68, offset: 33389},
 						val:        "~",
 						ignoreCase: false,
 						want:       "\"~\"",
@@ -6889,42 +5842,42 @@ var g = &grammar{
 		},
 		{
 			name: "ConstrainedQuotedText",
-			pos:  position{line: 987, col: 1, offset: 34425},
+			pos:  position{line: 1009, col: 1, offset: 33394},
 			expr: &actionExpr{
-				pos: position{line: 987, col: 26, offset: 34450},
+				pos: position{line: 1009, col: 26, offset: 33419},
 				run: (*parser).callonConstrainedQuotedText1,
 				expr: &labeledExpr{
-					pos:   position{line: 987, col: 26, offset: 34450},
+					pos:   position{line: 1009, col: 26, offset: 33419},
 					label: "text",
 					expr: &choiceExpr{
-						pos: position{line: 987, col: 32, offset: 34456},
+						pos: position{line: 1009, col: 32, offset: 33425},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 987, col: 32, offset: 34456},
+								pos:  position{line: 1009, col: 32, offset: 33425},
 								name: "SingleQuoteBoldText",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 988, col: 15, offset: 34491},
+								pos:  position{line: 1010, col: 15, offset: 33460},
 								name: "SingleQuoteItalicText",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 989, col: 15, offset: 34527},
+								pos:  position{line: 1011, col: 15, offset: 33496},
 								name: "SingleQuoteMarkedText",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 990, col: 15, offset: 34563},
+								pos:  position{line: 1012, col: 15, offset: 33532},
 								name: "SingleQuoteMonospaceText",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 991, col: 15, offset: 34603},
+								pos:  position{line: 1013, col: 15, offset: 33572},
 								name: "SubscriptText",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 992, col: 15, offset: 34632},
+								pos:  position{line: 1014, col: 15, offset: 33601},
 								name: "SuperscriptText",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 993, col: 15, offset: 34663},
+								pos:  position{line: 1015, col: 15, offset: 33632},
 								name: "SubscriptOrSuperscriptPrefix",
 							},
 						},
@@ -6934,24 +5887,24 @@ var g = &grammar{
 		},
 		{
 			name: "UnconstrainedQuotedText",
-			pos:  position{line: 997, col: 1, offset: 34817},
+			pos:  position{line: 1019, col: 1, offset: 33786},
 			expr: &choiceExpr{
-				pos: position{line: 997, col: 28, offset: 34844},
+				pos: position{line: 1019, col: 28, offset: 33813},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 997, col: 28, offset: 34844},
+						pos:  position{line: 1019, col: 28, offset: 33813},
 						name: "DoubleQuoteBoldText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 998, col: 15, offset: 34878},
+						pos:  position{line: 1020, col: 15, offset: 33847},
 						name: "DoubleQuoteItalicText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 999, col: 15, offset: 34914},
+						pos:  position{line: 1021, col: 15, offset: 33883},
 						name: "DoubleQuoteMarkedText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1000, col: 15, offset: 34950},
+						pos:  position{line: 1022, col: 15, offset: 33919},
 						name: "DoubleQuoteMonospaceText",
 					},
 				},
@@ -6959,32 +5912,32 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedQuotedText",
-			pos:  position{line: 1002, col: 1, offset: 34976},
+			pos:  position{line: 1024, col: 1, offset: 33945},
 			expr: &choiceExpr{
-				pos: position{line: 1002, col: 22, offset: 34997},
+				pos: position{line: 1024, col: 22, offset: 33966},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1002, col: 22, offset: 34997},
+						pos:  position{line: 1024, col: 22, offset: 33966},
 						name: "EscapedBoldText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1003, col: 15, offset: 35028},
+						pos:  position{line: 1025, col: 15, offset: 33997},
 						name: "EscapedItalicText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1004, col: 15, offset: 35060},
+						pos:  position{line: 1026, col: 15, offset: 34029},
 						name: "EscapedMarkedText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1005, col: 15, offset: 35092},
+						pos:  position{line: 1027, col: 15, offset: 34061},
 						name: "EscapedMonospaceText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1006, col: 15, offset: 35128},
+						pos:  position{line: 1028, col: 15, offset: 34097},
 						name: "EscapedSubscriptText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1007, col: 15, offset: 35164},
+						pos:  position{line: 1029, col: 15, offset: 34133},
 						name: "EscapedSuperscriptText",
 					},
 				},
@@ -6992,21 +5945,21 @@ var g = &grammar{
 		},
 		{
 			name: "SubscriptOrSuperscriptPrefix",
-			pos:  position{line: 1009, col: 1, offset: 35188},
+			pos:  position{line: 1031, col: 1, offset: 34157},
 			expr: &choiceExpr{
-				pos: position{line: 1009, col: 33, offset: 35220},
+				pos: position{line: 1031, col: 33, offset: 34189},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1009, col: 33, offset: 35220},
+						pos:        position{line: 1031, col: 33, offset: 34189},
 						val:        "^",
 						ignoreCase: false,
 						want:       "\"^\"",
 					},
 					&actionExpr{
-						pos: position{line: 1009, col: 39, offset: 35226},
+						pos: position{line: 1031, col: 39, offset: 34195},
 						run: (*parser).callonSubscriptOrSuperscriptPrefix3,
 						expr: &litMatcher{
-							pos:        position{line: 1009, col: 39, offset: 35226},
+							pos:        position{line: 1031, col: 39, offset: 34195},
 							val:        "~",
 							ignoreCase: false,
 							want:       "\"~\"",
@@ -7017,14 +5970,14 @@ var g = &grammar{
 		},
 		{
 			name: "OneOrMoreBackslashes",
-			pos:  position{line: 1013, col: 1, offset: 35359},
+			pos:  position{line: 1035, col: 1, offset: 34328},
 			expr: &actionExpr{
-				pos: position{line: 1013, col: 25, offset: 35383},
+				pos: position{line: 1035, col: 25, offset: 34352},
 				run: (*parser).callonOneOrMoreBackslashes1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1013, col: 25, offset: 35383},
+					pos: position{line: 1035, col: 25, offset: 34352},
 					expr: &litMatcher{
-						pos:        position{line: 1013, col: 25, offset: 35383},
+						pos:        position{line: 1035, col: 25, offset: 34352},
 						val:        "\\",
 						ignoreCase: false,
 						want:       "\"\\\\\"",
@@ -7034,23 +5987,23 @@ var g = &grammar{
 		},
 		{
 			name: "TwoOrMoreBackslashes",
-			pos:  position{line: 1017, col: 1, offset: 35424},
+			pos:  position{line: 1039, col: 1, offset: 34393},
 			expr: &actionExpr{
-				pos: position{line: 1017, col: 25, offset: 35448},
+				pos: position{line: 1039, col: 25, offset: 34417},
 				run: (*parser).callonTwoOrMoreBackslashes1,
 				expr: &seqExpr{
-					pos: position{line: 1017, col: 25, offset: 35448},
+					pos: position{line: 1039, col: 25, offset: 34417},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1017, col: 25, offset: 35448},
+							pos:        position{line: 1039, col: 25, offset: 34417},
 							val:        "\\\\",
 							ignoreCase: false,
 							want:       "\"\\\\\\\\\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1017, col: 30, offset: 35453},
+							pos: position{line: 1039, col: 30, offset: 34422},
 							expr: &litMatcher{
-								pos:        position{line: 1017, col: 30, offset: 35453},
+								pos:        position{line: 1039, col: 30, offset: 34422},
 								val:        "\\",
 								ignoreCase: false,
 								want:       "\"\\\\\"",
@@ -7062,16 +6015,16 @@ var g = &grammar{
 		},
 		{
 			name: "BoldText",
-			pos:  position{line: 1025, col: 1, offset: 35550},
+			pos:  position{line: 1047, col: 1, offset: 34519},
 			expr: &choiceExpr{
-				pos: position{line: 1025, col: 13, offset: 35562},
+				pos: position{line: 1047, col: 13, offset: 34531},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1025, col: 13, offset: 35562},
+						pos:  position{line: 1047, col: 13, offset: 34531},
 						name: "DoubleQuoteBoldText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1025, col: 35, offset: 35584},
+						pos:  position{line: 1047, col: 35, offset: 34553},
 						name: "SingleQuoteBoldText",
 					},
 				},
@@ -7079,40 +6032,40 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteBoldText",
-			pos:  position{line: 1027, col: 1, offset: 35651},
+			pos:  position{line: 1049, col: 1, offset: 34620},
 			expr: &actionExpr{
-				pos: position{line: 1027, col: 24, offset: 35674},
+				pos: position{line: 1049, col: 24, offset: 34643},
 				run: (*parser).callonDoubleQuoteBoldText1,
 				expr: &seqExpr{
-					pos: position{line: 1027, col: 24, offset: 35674},
+					pos: position{line: 1049, col: 24, offset: 34643},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1027, col: 24, offset: 35674},
+							pos:   position{line: 1049, col: 24, offset: 34643},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1027, col: 35, offset: 35685},
+								pos: position{line: 1049, col: 35, offset: 34654},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1027, col: 36, offset: 35686},
-									name: "QuotedTextAttributes",
+									pos:  position{line: 1049, col: 36, offset: 34655},
+									name: "LongHandAttributes",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1027, col: 59, offset: 35709},
+							pos:        position{line: 1049, col: 57, offset: 34676},
 							val:        "**",
 							ignoreCase: false,
 							want:       "\"**\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1027, col: 64, offset: 35714},
+							pos:   position{line: 1049, col: 62, offset: 34681},
 							label: "elements",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1027, col: 74, offset: 35724},
+								pos:  position{line: 1049, col: 72, offset: 34691},
 								name: "DoubleQuoteBoldTextElements",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1027, col: 103, offset: 35753},
+							pos:        position{line: 1049, col: 101, offset: 34720},
 							val:        "**",
 							ignoreCase: false,
 							want:       "\"**\"",
@@ -7123,97 +6076,97 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteBoldTextElements",
-			pos:  position{line: 1031, col: 1, offset: 35845},
+			pos:  position{line: 1053, col: 1, offset: 34812},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1031, col: 32, offset: 35876},
+				pos: position{line: 1053, col: 32, offset: 34843},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1031, col: 32, offset: 35876},
+					pos:  position{line: 1053, col: 32, offset: 34843},
 					name: "DoubleQuoteBoldTextElement",
 				},
 			},
 		},
 		{
 			name: "DoubleQuoteBoldTextElement",
-			pos:  position{line: 1033, col: 1, offset: 35907},
+			pos:  position{line: 1055, col: 1, offset: 34874},
 			expr: &actionExpr{
-				pos: position{line: 1033, col: 31, offset: 35937},
+				pos: position{line: 1055, col: 31, offset: 34904},
 				run: (*parser).callonDoubleQuoteBoldTextElement1,
 				expr: &seqExpr{
-					pos: position{line: 1033, col: 31, offset: 35937},
+					pos: position{line: 1055, col: 31, offset: 34904},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1033, col: 31, offset: 35937},
+							pos: position{line: 1055, col: 31, offset: 34904},
 							expr: &litMatcher{
-								pos:        position{line: 1033, col: 33, offset: 35939},
+								pos:        position{line: 1055, col: 33, offset: 34906},
 								val:        "**",
 								ignoreCase: false,
 								want:       "\"**\"",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1033, col: 39, offset: 35945},
+							pos:   position{line: 1055, col: 39, offset: 34912},
 							label: "element",
 							expr: &choiceExpr{
-								pos: position{line: 1033, col: 48, offset: 35954},
+								pos: position{line: 1055, col: 48, offset: 34921},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1033, col: 48, offset: 35954},
+										pos:  position{line: 1055, col: 48, offset: 34921},
 										name: "Word",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1034, col: 11, offset: 35969},
+										pos:  position{line: 1056, col: 11, offset: 34936},
 										name: "Space",
 									},
 									&seqExpr{
-										pos: position{line: 1035, col: 11, offset: 36018},
+										pos: position{line: 1057, col: 11, offset: 34985},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1035, col: 11, offset: 36018},
+												pos:  position{line: 1057, col: 11, offset: 34985},
 												name: "Newline",
 											},
 											&notExpr{
-												pos: position{line: 1035, col: 19, offset: 36026},
+												pos: position{line: 1057, col: 19, offset: 34993},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1035, col: 20, offset: 36027},
+													pos:  position{line: 1057, col: 20, offset: 34994},
 													name: "Newline",
 												},
 											},
 										},
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1036, col: 11, offset: 36045},
+										pos:  position{line: 1058, col: 11, offset: 35012},
 										name: "SingleQuoteBoldText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1037, col: 11, offset: 36075},
+										pos:  position{line: 1059, col: 11, offset: 35042},
 										name: "QuotedString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1038, col: 11, offset: 36098},
+										pos:  position{line: 1060, col: 11, offset: 35065},
 										name: "ItalicText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1039, col: 11, offset: 36119},
+										pos:  position{line: 1061, col: 11, offset: 35086},
 										name: "MarkedText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1040, col: 11, offset: 36140},
+										pos:  position{line: 1062, col: 11, offset: 35107},
 										name: "MonospaceText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1041, col: 11, offset: 36164},
+										pos:  position{line: 1063, col: 11, offset: 35131},
 										name: "SubscriptText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1042, col: 11, offset: 36188},
+										pos:  position{line: 1064, col: 11, offset: 35155},
 										name: "SuperscriptText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1043, col: 11, offset: 36214},
+										pos:  position{line: 1065, col: 11, offset: 35181},
 										name: "ElementPlaceHolder",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1044, col: 11, offset: 36243},
+										pos:  position{line: 1066, col: 11, offset: 35210},
 										name: "DoubleQuoteBoldTextFallbackCharacter",
 									},
 								},
@@ -7225,31 +6178,31 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteBoldTextFallbackCharacter",
-			pos:  position{line: 1048, col: 1, offset: 36310},
+			pos:  position{line: 1070, col: 1, offset: 35277},
 			expr: &choiceExpr{
-				pos: position{line: 1049, col: 5, offset: 36354},
+				pos: position{line: 1071, col: 5, offset: 35321},
 				alternatives: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 1049, col: 5, offset: 36354},
+						pos:        position{line: 1071, col: 5, offset: 35321},
 						val:        "[^\\r\\n*]",
 						chars:      []rune{'\r', '\n', '*'},
 						ignoreCase: false,
 						inverted:   true,
 					},
 					&actionExpr{
-						pos: position{line: 1050, col: 7, offset: 36451},
+						pos: position{line: 1072, col: 7, offset: 35418},
 						run: (*parser).callonDoubleQuoteBoldTextFallbackCharacter3,
 						expr: &seqExpr{
-							pos: position{line: 1050, col: 7, offset: 36451},
+							pos: position{line: 1072, col: 7, offset: 35418},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1050, col: 7, offset: 36451},
+									pos:        position{line: 1072, col: 7, offset: 35418},
 									val:        "**",
 									ignoreCase: false,
 									want:       "\"**\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1050, col: 12, offset: 36456},
+									pos:  position{line: 1072, col: 12, offset: 35423},
 									name: "Alphanums",
 								},
 							},
@@ -7260,40 +6213,40 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteBoldText",
-			pos:  position{line: 1054, col: 1, offset: 36619},
+			pos:  position{line: 1076, col: 1, offset: 35586},
 			expr: &choiceExpr{
-				pos: position{line: 1054, col: 24, offset: 36642},
+				pos: position{line: 1076, col: 24, offset: 35609},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1054, col: 24, offset: 36642},
+						pos: position{line: 1076, col: 24, offset: 35609},
 						run: (*parser).callonSingleQuoteBoldText2,
 						expr: &seqExpr{
-							pos: position{line: 1054, col: 24, offset: 36642},
+							pos: position{line: 1076, col: 24, offset: 35609},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1054, col: 24, offset: 36642},
+									pos:   position{line: 1076, col: 24, offset: 35609},
 									label: "attributes",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1054, col: 35, offset: 36653},
+										pos: position{line: 1076, col: 35, offset: 35620},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1054, col: 36, offset: 36654},
-											name: "QuotedTextAttributes",
+											pos:  position{line: 1076, col: 36, offset: 35621},
+											name: "LongHandAttributes",
 										},
 									},
 								},
 								&seqExpr{
-									pos: position{line: 1054, col: 61, offset: 36679},
+									pos: position{line: 1076, col: 59, offset: 35644},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 1054, col: 61, offset: 36679},
+											pos:        position{line: 1076, col: 59, offset: 35644},
 											val:        "*",
 											ignoreCase: false,
 											want:       "\"*\"",
 										},
 										&notExpr{
-											pos: position{line: 1054, col: 65, offset: 36683},
+											pos: position{line: 1076, col: 63, offset: 35648},
 											expr: &litMatcher{
-												pos:        position{line: 1054, col: 66, offset: 36684},
+												pos:        position{line: 1076, col: 64, offset: 35649},
 												val:        "*",
 												ignoreCase: false,
 												want:       "\"*\"",
@@ -7302,25 +6255,25 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1054, col: 71, offset: 36689},
+									pos:   position{line: 1076, col: 69, offset: 35654},
 									label: "elements",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1054, col: 81, offset: 36699},
+										pos:  position{line: 1076, col: 79, offset: 35664},
 										name: "SingleQuoteBoldTextElements",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1054, col: 110, offset: 36728},
+									pos:        position{line: 1076, col: 108, offset: 35693},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
 								},
 								&andExpr{
-									pos: position{line: 1054, col: 114, offset: 36732},
+									pos: position{line: 1076, col: 112, offset: 35697},
 									expr: &notExpr{
-										pos: position{line: 1054, col: 116, offset: 36734},
+										pos: position{line: 1076, col: 114, offset: 35699},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1054, col: 117, offset: 36735},
+											pos:  position{line: 1076, col: 115, offset: 35700},
 											name: "Alphanum",
 										},
 									},
@@ -7329,49 +6282,49 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1056, col: 5, offset: 36934},
+						pos: position{line: 1078, col: 5, offset: 35899},
 						run: (*parser).callonSingleQuoteBoldText17,
 						expr: &seqExpr{
-							pos: position{line: 1056, col: 5, offset: 36934},
+							pos: position{line: 1078, col: 5, offset: 35899},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1056, col: 5, offset: 36934},
+									pos:   position{line: 1078, col: 5, offset: 35899},
 									label: "attributes",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1056, col: 16, offset: 36945},
+										pos: position{line: 1078, col: 16, offset: 35910},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1056, col: 17, offset: 36946},
-											name: "QuotedTextAttributes",
+											pos:  position{line: 1078, col: 17, offset: 35911},
+											name: "LongHandAttributes",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1056, col: 40, offset: 36969},
+									pos:        position{line: 1078, col: 38, offset: 35932},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1056, col: 44, offset: 36973},
+									pos:   position{line: 1078, col: 42, offset: 35936},
 									label: "elements",
 									expr: &seqExpr{
-										pos: position{line: 1056, col: 54, offset: 36983},
+										pos: position{line: 1078, col: 52, offset: 35946},
 										exprs: []interface{}{
 											&litMatcher{
-												pos:        position{line: 1056, col: 54, offset: 36983},
+												pos:        position{line: 1078, col: 52, offset: 35946},
 												val:        "*",
 												ignoreCase: false,
 												want:       "\"*\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1056, col: 58, offset: 36987},
+												pos:  position{line: 1078, col: 56, offset: 35950},
 												name: "SingleQuoteBoldTextElements",
 											},
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1056, col: 87, offset: 37016},
+									pos:        position{line: 1078, col: 85, offset: 35979},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
@@ -7384,21 +6337,21 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteBoldTextElements",
-			pos:  position{line: 1060, col: 1, offset: 37227},
+			pos:  position{line: 1082, col: 1, offset: 36190},
 			expr: &seqExpr{
-				pos: position{line: 1060, col: 32, offset: 37258},
+				pos: position{line: 1082, col: 32, offset: 36221},
 				exprs: []interface{}{
 					&notExpr{
-						pos: position{line: 1060, col: 32, offset: 37258},
+						pos: position{line: 1082, col: 32, offset: 36221},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1060, col: 33, offset: 37259},
+							pos:  position{line: 1082, col: 33, offset: 36222},
 							name: "Space",
 						},
 					},
 					&oneOrMoreExpr{
-						pos: position{line: 1060, col: 39, offset: 37265},
+						pos: position{line: 1082, col: 39, offset: 36228},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1060, col: 39, offset: 37265},
+							pos:  position{line: 1082, col: 39, offset: 36228},
 							name: "SingleQuoteBoldTextElement",
 						},
 					},
@@ -7407,63 +6360,63 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteBoldTextElement",
-			pos:  position{line: 1062, col: 1, offset: 37294},
+			pos:  position{line: 1084, col: 1, offset: 36257},
 			expr: &choiceExpr{
-				pos: position{line: 1062, col: 31, offset: 37324},
+				pos: position{line: 1084, col: 31, offset: 36287},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1062, col: 31, offset: 37324},
+						pos:  position{line: 1084, col: 31, offset: 36287},
 						name: "Word",
 					},
 					&seqExpr{
-						pos: position{line: 1063, col: 11, offset: 37339},
+						pos: position{line: 1085, col: 11, offset: 36302},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 1063, col: 11, offset: 37339},
+								pos:  position{line: 1085, col: 11, offset: 36302},
 								name: "Newline",
 							},
 							&notExpr{
-								pos: position{line: 1063, col: 19, offset: 37347},
+								pos: position{line: 1085, col: 19, offset: 36310},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1063, col: 20, offset: 37348},
+									pos:  position{line: 1085, col: 20, offset: 36311},
 									name: "Newline",
 								},
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1064, col: 11, offset: 37366},
+						pos:  position{line: 1086, col: 11, offset: 36329},
 						name: "DoubleQuoteBoldText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1065, col: 11, offset: 37396},
+						pos:  position{line: 1087, col: 11, offset: 36359},
 						name: "QuotedString",
 					},
 					&seqExpr{
-						pos: position{line: 1066, col: 11, offset: 37419},
+						pos: position{line: 1088, col: 11, offset: 36382},
 						exprs: []interface{}{
 							&oneOrMoreExpr{
-								pos: position{line: 1066, col: 11, offset: 37419},
+								pos: position{line: 1088, col: 11, offset: 36382},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1066, col: 11, offset: 37419},
+									pos:  position{line: 1088, col: 11, offset: 36382},
 									name: "Space",
 								},
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 1066, col: 18, offset: 37426},
+								pos: position{line: 1088, col: 18, offset: 36389},
 								expr: &seqExpr{
-									pos: position{line: 1066, col: 19, offset: 37427},
+									pos: position{line: 1088, col: 19, offset: 36390},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 1066, col: 19, offset: 37427},
+											pos:        position{line: 1088, col: 19, offset: 36390},
 											val:        "*",
 											ignoreCase: false,
 											want:       "\"*\"",
 										},
 										&notExpr{
-											pos: position{line: 1066, col: 23, offset: 37431},
+											pos: position{line: 1088, col: 23, offset: 36394},
 											expr: &litMatcher{
-												pos:        position{line: 1066, col: 24, offset: 37432},
+												pos:        position{line: 1088, col: 24, offset: 36395},
 												val:        "*",
 												ignoreCase: false,
 												want:       "\"*\"",
@@ -7475,31 +6428,31 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1067, col: 11, offset: 37448},
+						pos:  position{line: 1089, col: 11, offset: 36411},
 						name: "ItalicText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1068, col: 11, offset: 37469},
+						pos:  position{line: 1090, col: 11, offset: 36432},
 						name: "MarkedText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1069, col: 11, offset: 37490},
+						pos:  position{line: 1091, col: 11, offset: 36453},
 						name: "MonospaceText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1070, col: 11, offset: 37514},
+						pos:  position{line: 1092, col: 11, offset: 36477},
 						name: "SubscriptText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1071, col: 11, offset: 37538},
+						pos:  position{line: 1093, col: 11, offset: 36501},
 						name: "SuperscriptText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1072, col: 11, offset: 37564},
+						pos:  position{line: 1094, col: 11, offset: 36527},
 						name: "ElementPlaceHolder",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1073, col: 11, offset: 37593},
+						pos:  position{line: 1095, col: 11, offset: 36556},
 						name: "SingleQuoteBoldTextFallbackCharacter",
 					},
 				},
@@ -7507,31 +6460,31 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteBoldTextFallbackCharacter",
-			pos:  position{line: 1075, col: 1, offset: 37631},
+			pos:  position{line: 1097, col: 1, offset: 36594},
 			expr: &choiceExpr{
-				pos: position{line: 1076, col: 5, offset: 37675},
+				pos: position{line: 1098, col: 5, offset: 36638},
 				alternatives: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 1076, col: 5, offset: 37675},
+						pos:        position{line: 1098, col: 5, offset: 36638},
 						val:        "[^\\r\\n*]",
 						chars:      []rune{'\r', '\n', '*'},
 						ignoreCase: false,
 						inverted:   true,
 					},
 					&actionExpr{
-						pos: position{line: 1077, col: 7, offset: 37772},
+						pos: position{line: 1099, col: 7, offset: 36735},
 						run: (*parser).callonSingleQuoteBoldTextFallbackCharacter3,
 						expr: &seqExpr{
-							pos: position{line: 1077, col: 7, offset: 37772},
+							pos: position{line: 1099, col: 7, offset: 36735},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1077, col: 7, offset: 37772},
+									pos:        position{line: 1099, col: 7, offset: 36735},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1077, col: 11, offset: 37776},
+									pos:  position{line: 1099, col: 11, offset: 36739},
 									name: "Alphanums",
 								},
 							},
@@ -7542,40 +6495,40 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedBoldText",
-			pos:  position{line: 1081, col: 1, offset: 37939},
+			pos:  position{line: 1103, col: 1, offset: 36902},
 			expr: &choiceExpr{
-				pos: position{line: 1082, col: 5, offset: 37963},
+				pos: position{line: 1104, col: 5, offset: 36926},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1082, col: 5, offset: 37963},
+						pos: position{line: 1104, col: 5, offset: 36926},
 						run: (*parser).callonEscapedBoldText2,
 						expr: &seqExpr{
-							pos: position{line: 1082, col: 5, offset: 37963},
+							pos: position{line: 1104, col: 5, offset: 36926},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1082, col: 5, offset: 37963},
+									pos:   position{line: 1104, col: 5, offset: 36926},
 									label: "backslashes",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1082, col: 18, offset: 37976},
+										pos:  position{line: 1104, col: 18, offset: 36939},
 										name: "TwoOrMoreBackslashes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1082, col: 40, offset: 37998},
+									pos:        position{line: 1104, col: 40, offset: 36961},
 									val:        "**",
 									ignoreCase: false,
 									want:       "\"**\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1082, col: 45, offset: 38003},
+									pos:   position{line: 1104, col: 45, offset: 36966},
 									label: "elements",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1082, col: 55, offset: 38013},
+										pos:  position{line: 1104, col: 55, offset: 36976},
 										name: "DoubleQuoteBoldTextElements",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1082, col: 84, offset: 38042},
+									pos:        position{line: 1104, col: 84, offset: 37005},
 									val:        "**",
 									ignoreCase: false,
 									want:       "\"**\"",
@@ -7584,35 +6537,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1084, col: 9, offset: 38199},
+						pos: position{line: 1106, col: 9, offset: 37162},
 						run: (*parser).callonEscapedBoldText10,
 						expr: &seqExpr{
-							pos: position{line: 1084, col: 9, offset: 38199},
+							pos: position{line: 1106, col: 9, offset: 37162},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1084, col: 9, offset: 38199},
+									pos:   position{line: 1106, col: 9, offset: 37162},
 									label: "backslashes",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1084, col: 22, offset: 38212},
+										pos:  position{line: 1106, col: 22, offset: 37175},
 										name: "OneOrMoreBackslashes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1084, col: 44, offset: 38234},
+									pos:        position{line: 1106, col: 44, offset: 37197},
 									val:        "**",
 									ignoreCase: false,
 									want:       "\"**\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1084, col: 49, offset: 38239},
+									pos:   position{line: 1106, col: 49, offset: 37202},
 									label: "elements",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1084, col: 59, offset: 38249},
+										pos:  position{line: 1106, col: 59, offset: 37212},
 										name: "SingleQuoteBoldTextElements",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1084, col: 88, offset: 38278},
+									pos:        position{line: 1106, col: 88, offset: 37241},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
@@ -7621,35 +6574,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1087, col: 9, offset: 38478},
+						pos: position{line: 1109, col: 9, offset: 37441},
 						run: (*parser).callonEscapedBoldText18,
 						expr: &seqExpr{
-							pos: position{line: 1087, col: 9, offset: 38478},
+							pos: position{line: 1109, col: 9, offset: 37441},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1087, col: 9, offset: 38478},
+									pos:   position{line: 1109, col: 9, offset: 37441},
 									label: "backslashes",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1087, col: 22, offset: 38491},
+										pos:  position{line: 1109, col: 22, offset: 37454},
 										name: "OneOrMoreBackslashes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1087, col: 44, offset: 38513},
+									pos:        position{line: 1109, col: 44, offset: 37476},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1087, col: 48, offset: 38517},
+									pos:   position{line: 1109, col: 48, offset: 37480},
 									label: "elements",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1087, col: 58, offset: 38527},
+										pos:  position{line: 1109, col: 58, offset: 37490},
 										name: "SingleQuoteBoldTextElements",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1087, col: 87, offset: 38556},
+									pos:        position{line: 1109, col: 87, offset: 37519},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
@@ -7662,16 +6615,16 @@ var g = &grammar{
 		},
 		{
 			name: "ItalicText",
-			pos:  position{line: 1095, col: 1, offset: 38764},
+			pos:  position{line: 1117, col: 1, offset: 37727},
 			expr: &choiceExpr{
-				pos: position{line: 1095, col: 15, offset: 38778},
+				pos: position{line: 1117, col: 15, offset: 37741},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1095, col: 15, offset: 38778},
+						pos:  position{line: 1117, col: 15, offset: 37741},
 						name: "DoubleQuoteItalicText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1095, col: 39, offset: 38802},
+						pos:  position{line: 1117, col: 39, offset: 37765},
 						name: "SingleQuoteItalicText",
 					},
 				},
@@ -7679,40 +6632,40 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteItalicText",
-			pos:  position{line: 1097, col: 1, offset: 38825},
+			pos:  position{line: 1119, col: 1, offset: 37788},
 			expr: &actionExpr{
-				pos: position{line: 1097, col: 26, offset: 38850},
+				pos: position{line: 1119, col: 26, offset: 37813},
 				run: (*parser).callonDoubleQuoteItalicText1,
 				expr: &seqExpr{
-					pos: position{line: 1097, col: 26, offset: 38850},
+					pos: position{line: 1119, col: 26, offset: 37813},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1097, col: 26, offset: 38850},
+							pos:   position{line: 1119, col: 26, offset: 37813},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1097, col: 37, offset: 38861},
+								pos: position{line: 1119, col: 37, offset: 37824},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1097, col: 38, offset: 38862},
-									name: "QuotedTextAttributes",
+									pos:  position{line: 1119, col: 38, offset: 37825},
+									name: "LongHandAttributes",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1097, col: 61, offset: 38885},
+							pos:        position{line: 1119, col: 59, offset: 37846},
 							val:        "__",
 							ignoreCase: false,
 							want:       "\"__\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1097, col: 66, offset: 38890},
+							pos:   position{line: 1119, col: 64, offset: 37851},
 							label: "elements",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1097, col: 76, offset: 38900},
+								pos:  position{line: 1119, col: 74, offset: 37861},
 								name: "DoubleQuoteItalicTextElements",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1097, col: 107, offset: 38931},
+							pos:        position{line: 1119, col: 105, offset: 37892},
 							val:        "__",
 							ignoreCase: false,
 							want:       "\"__\"",
@@ -7723,97 +6676,97 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteItalicTextElements",
-			pos:  position{line: 1101, col: 1, offset: 39070},
+			pos:  position{line: 1123, col: 1, offset: 38031},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1101, col: 34, offset: 39103},
+				pos: position{line: 1123, col: 34, offset: 38064},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1101, col: 34, offset: 39103},
+					pos:  position{line: 1123, col: 34, offset: 38064},
 					name: "DoubleQuoteItalicTextElement",
 				},
 			},
 		},
 		{
 			name: "DoubleQuoteItalicTextElement",
-			pos:  position{line: 1103, col: 1, offset: 39135},
+			pos:  position{line: 1125, col: 1, offset: 38096},
 			expr: &actionExpr{
-				pos: position{line: 1103, col: 33, offset: 39167},
+				pos: position{line: 1125, col: 33, offset: 38128},
 				run: (*parser).callonDoubleQuoteItalicTextElement1,
 				expr: &seqExpr{
-					pos: position{line: 1103, col: 33, offset: 39167},
+					pos: position{line: 1125, col: 33, offset: 38128},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1103, col: 33, offset: 39167},
+							pos: position{line: 1125, col: 33, offset: 38128},
 							expr: &litMatcher{
-								pos:        position{line: 1103, col: 35, offset: 39169},
+								pos:        position{line: 1125, col: 35, offset: 38130},
 								val:        "__",
 								ignoreCase: false,
 								want:       "\"__\"",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1103, col: 41, offset: 39175},
+							pos:   position{line: 1125, col: 41, offset: 38136},
 							label: "element",
 							expr: &choiceExpr{
-								pos: position{line: 1103, col: 50, offset: 39184},
+								pos: position{line: 1125, col: 50, offset: 38145},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1103, col: 50, offset: 39184},
+										pos:  position{line: 1125, col: 50, offset: 38145},
 										name: "Word",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1104, col: 11, offset: 39199},
+										pos:  position{line: 1126, col: 11, offset: 38160},
 										name: "Space",
 									},
 									&seqExpr{
-										pos: position{line: 1105, col: 11, offset: 39248},
+										pos: position{line: 1127, col: 11, offset: 38209},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1105, col: 11, offset: 39248},
+												pos:  position{line: 1127, col: 11, offset: 38209},
 												name: "Newline",
 											},
 											&notExpr{
-												pos: position{line: 1105, col: 19, offset: 39256},
+												pos: position{line: 1127, col: 19, offset: 38217},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1105, col: 20, offset: 39257},
+													pos:  position{line: 1127, col: 20, offset: 38218},
 													name: "Newline",
 												},
 											},
 										},
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1106, col: 11, offset: 39275},
+										pos:  position{line: 1128, col: 11, offset: 38236},
 										name: "SingleQuoteItalicText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1107, col: 11, offset: 39307},
+										pos:  position{line: 1129, col: 11, offset: 38268},
 										name: "QuotedString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1108, col: 11, offset: 39330},
+										pos:  position{line: 1130, col: 11, offset: 38291},
 										name: "BoldText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1109, col: 11, offset: 39349},
+										pos:  position{line: 1131, col: 11, offset: 38310},
 										name: "MarkedText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1110, col: 11, offset: 39370},
+										pos:  position{line: 1132, col: 11, offset: 38331},
 										name: "MonospaceText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1111, col: 11, offset: 39394},
+										pos:  position{line: 1133, col: 11, offset: 38355},
 										name: "SubscriptText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1112, col: 11, offset: 39418},
+										pos:  position{line: 1134, col: 11, offset: 38379},
 										name: "SuperscriptText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1113, col: 11, offset: 39444},
+										pos:  position{line: 1135, col: 11, offset: 38405},
 										name: "ElementPlaceHolder",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1114, col: 11, offset: 39473},
+										pos:  position{line: 1136, col: 11, offset: 38434},
 										name: "DoubleQuoteItalicTextFallbackCharacter",
 									},
 								},
@@ -7825,31 +6778,31 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteItalicTextFallbackCharacter",
-			pos:  position{line: 1118, col: 1, offset: 39542},
+			pos:  position{line: 1140, col: 1, offset: 38503},
 			expr: &choiceExpr{
-				pos: position{line: 1119, col: 5, offset: 39588},
+				pos: position{line: 1141, col: 5, offset: 38549},
 				alternatives: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 1119, col: 5, offset: 39588},
+						pos:        position{line: 1141, col: 5, offset: 38549},
 						val:        "[^\\r\\n_]",
 						chars:      []rune{'\r', '\n', '_'},
 						ignoreCase: false,
 						inverted:   true,
 					},
 					&actionExpr{
-						pos: position{line: 1120, col: 7, offset: 39687},
+						pos: position{line: 1142, col: 7, offset: 38648},
 						run: (*parser).callonDoubleQuoteItalicTextFallbackCharacter3,
 						expr: &seqExpr{
-							pos: position{line: 1120, col: 7, offset: 39687},
+							pos: position{line: 1142, col: 7, offset: 38648},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1120, col: 7, offset: 39687},
+									pos:        position{line: 1142, col: 7, offset: 38648},
 									val:        "__",
 									ignoreCase: false,
 									want:       "\"__\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1120, col: 12, offset: 39692},
+									pos:  position{line: 1142, col: 12, offset: 38653},
 									name: "Alphanums",
 								},
 							},
@@ -7860,40 +6813,40 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteItalicText",
-			pos:  position{line: 1124, col: 1, offset: 39857},
+			pos:  position{line: 1146, col: 1, offset: 38818},
 			expr: &choiceExpr{
-				pos: position{line: 1124, col: 26, offset: 39882},
+				pos: position{line: 1146, col: 26, offset: 38843},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1124, col: 26, offset: 39882},
+						pos: position{line: 1146, col: 26, offset: 38843},
 						run: (*parser).callonSingleQuoteItalicText2,
 						expr: &seqExpr{
-							pos: position{line: 1124, col: 26, offset: 39882},
+							pos: position{line: 1146, col: 26, offset: 38843},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1124, col: 26, offset: 39882},
+									pos:   position{line: 1146, col: 26, offset: 38843},
 									label: "attributes",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1124, col: 37, offset: 39893},
+										pos: position{line: 1146, col: 37, offset: 38854},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1124, col: 38, offset: 39894},
-											name: "QuotedTextAttributes",
+											pos:  position{line: 1146, col: 38, offset: 38855},
+											name: "LongHandAttributes",
 										},
 									},
 								},
 								&seqExpr{
-									pos: position{line: 1124, col: 62, offset: 39918},
+									pos: position{line: 1146, col: 60, offset: 38877},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 1124, col: 62, offset: 39918},
+											pos:        position{line: 1146, col: 60, offset: 38877},
 											val:        "_",
 											ignoreCase: false,
 											want:       "\"_\"",
 										},
 										&notExpr{
-											pos: position{line: 1124, col: 66, offset: 39922},
+											pos: position{line: 1146, col: 64, offset: 38881},
 											expr: &litMatcher{
-												pos:        position{line: 1124, col: 67, offset: 39923},
+												pos:        position{line: 1146, col: 65, offset: 38882},
 												val:        "_",
 												ignoreCase: false,
 												want:       "\"_\"",
@@ -7902,15 +6855,15 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1124, col: 72, offset: 39928},
+									pos:   position{line: 1146, col: 70, offset: 38887},
 									label: "elements",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1124, col: 82, offset: 39938},
+										pos:  position{line: 1146, col: 80, offset: 38897},
 										name: "SingleQuoteItalicTextElements",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1124, col: 113, offset: 39969},
+									pos:        position{line: 1146, col: 111, offset: 38928},
 									val:        "_",
 									ignoreCase: false,
 									want:       "\"_\"",
@@ -7919,49 +6872,49 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1126, col: 5, offset: 40164},
+						pos: position{line: 1148, col: 5, offset: 39123},
 						run: (*parser).callonSingleQuoteItalicText14,
 						expr: &seqExpr{
-							pos: position{line: 1126, col: 5, offset: 40164},
+							pos: position{line: 1148, col: 5, offset: 39123},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1126, col: 5, offset: 40164},
+									pos:   position{line: 1148, col: 5, offset: 39123},
 									label: "attributes",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1126, col: 16, offset: 40175},
+										pos: position{line: 1148, col: 16, offset: 39134},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1126, col: 17, offset: 40176},
-											name: "QuotedTextAttributes",
+											pos:  position{line: 1148, col: 17, offset: 39135},
+											name: "LongHandAttributes",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1126, col: 40, offset: 40199},
+									pos:        position{line: 1148, col: 38, offset: 39156},
 									val:        "_",
 									ignoreCase: false,
 									want:       "\"_\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1126, col: 44, offset: 40203},
+									pos:   position{line: 1148, col: 42, offset: 39160},
 									label: "elements",
 									expr: &seqExpr{
-										pos: position{line: 1126, col: 54, offset: 40213},
+										pos: position{line: 1148, col: 52, offset: 39170},
 										exprs: []interface{}{
 											&litMatcher{
-												pos:        position{line: 1126, col: 54, offset: 40213},
+												pos:        position{line: 1148, col: 52, offset: 39170},
 												val:        "_",
 												ignoreCase: false,
 												want:       "\"_\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1126, col: 58, offset: 40217},
+												pos:  position{line: 1148, col: 56, offset: 39174},
 												name: "SingleQuoteItalicTextElements",
 											},
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1126, col: 89, offset: 40248},
+									pos:        position{line: 1148, col: 87, offset: 39205},
 									val:        "_",
 									ignoreCase: false,
 									want:       "\"_\"",
@@ -7974,21 +6927,21 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteItalicTextElements",
-			pos:  position{line: 1130, col: 1, offset: 40463},
+			pos:  position{line: 1152, col: 1, offset: 39420},
 			expr: &seqExpr{
-				pos: position{line: 1130, col: 34, offset: 40496},
+				pos: position{line: 1152, col: 34, offset: 39453},
 				exprs: []interface{}{
 					&notExpr{
-						pos: position{line: 1130, col: 34, offset: 40496},
+						pos: position{line: 1152, col: 34, offset: 39453},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1130, col: 35, offset: 40497},
+							pos:  position{line: 1152, col: 35, offset: 39454},
 							name: "Space",
 						},
 					},
 					&oneOrMoreExpr{
-						pos: position{line: 1130, col: 41, offset: 40503},
+						pos: position{line: 1152, col: 41, offset: 39460},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1130, col: 41, offset: 40503},
+							pos:  position{line: 1152, col: 41, offset: 39460},
 							name: "SingleQuoteItalicTextElement",
 						},
 					},
@@ -7997,63 +6950,63 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteItalicTextElement",
-			pos:  position{line: 1132, col: 1, offset: 40534},
+			pos:  position{line: 1154, col: 1, offset: 39491},
 			expr: &choiceExpr{
-				pos: position{line: 1132, col: 33, offset: 40566},
+				pos: position{line: 1154, col: 33, offset: 39523},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1132, col: 33, offset: 40566},
+						pos:  position{line: 1154, col: 33, offset: 39523},
 						name: "Word",
 					},
 					&seqExpr{
-						pos: position{line: 1133, col: 11, offset: 40581},
+						pos: position{line: 1155, col: 11, offset: 39538},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 1133, col: 11, offset: 40581},
+								pos:  position{line: 1155, col: 11, offset: 39538},
 								name: "Newline",
 							},
 							&notExpr{
-								pos: position{line: 1133, col: 19, offset: 40589},
+								pos: position{line: 1155, col: 19, offset: 39546},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1133, col: 20, offset: 40590},
+									pos:  position{line: 1155, col: 20, offset: 39547},
 									name: "Newline",
 								},
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1134, col: 11, offset: 40608},
+						pos:  position{line: 1156, col: 11, offset: 39565},
 						name: "DoubleQuoteItalicText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1135, col: 11, offset: 40640},
+						pos:  position{line: 1157, col: 11, offset: 39597},
 						name: "QuotedString",
 					},
 					&seqExpr{
-						pos: position{line: 1136, col: 11, offset: 40663},
+						pos: position{line: 1158, col: 11, offset: 39620},
 						exprs: []interface{}{
 							&oneOrMoreExpr{
-								pos: position{line: 1136, col: 11, offset: 40663},
+								pos: position{line: 1158, col: 11, offset: 39620},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1136, col: 11, offset: 40663},
+									pos:  position{line: 1158, col: 11, offset: 39620},
 									name: "Space",
 								},
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 1136, col: 18, offset: 40670},
+								pos: position{line: 1158, col: 18, offset: 39627},
 								expr: &seqExpr{
-									pos: position{line: 1136, col: 19, offset: 40671},
+									pos: position{line: 1158, col: 19, offset: 39628},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 1136, col: 19, offset: 40671},
+											pos:        position{line: 1158, col: 19, offset: 39628},
 											val:        "_",
 											ignoreCase: false,
 											want:       "\"_\"",
 										},
 										&notExpr{
-											pos: position{line: 1136, col: 23, offset: 40675},
+											pos: position{line: 1158, col: 23, offset: 39632},
 											expr: &litMatcher{
-												pos:        position{line: 1136, col: 24, offset: 40676},
+												pos:        position{line: 1158, col: 24, offset: 39633},
 												val:        "_",
 												ignoreCase: false,
 												want:       "\"_\"",
@@ -8065,31 +7018,31 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1137, col: 11, offset: 40692},
+						pos:  position{line: 1159, col: 11, offset: 39649},
 						name: "BoldText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1138, col: 11, offset: 40711},
+						pos:  position{line: 1160, col: 11, offset: 39668},
 						name: "MarkedText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1139, col: 11, offset: 40732},
+						pos:  position{line: 1161, col: 11, offset: 39689},
 						name: "MonospaceText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1140, col: 11, offset: 40756},
+						pos:  position{line: 1162, col: 11, offset: 39713},
 						name: "SubscriptText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1141, col: 11, offset: 40780},
+						pos:  position{line: 1163, col: 11, offset: 39737},
 						name: "SuperscriptText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1142, col: 11, offset: 40806},
+						pos:  position{line: 1164, col: 11, offset: 39763},
 						name: "ElementPlaceHolder",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1143, col: 11, offset: 40835},
+						pos:  position{line: 1165, col: 11, offset: 39792},
 						name: "SingleQuoteItalicTextFallbackCharacter",
 					},
 				},
@@ -8097,31 +7050,31 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteItalicTextFallbackCharacter",
-			pos:  position{line: 1145, col: 1, offset: 40875},
+			pos:  position{line: 1167, col: 1, offset: 39832},
 			expr: &choiceExpr{
-				pos: position{line: 1146, col: 5, offset: 40921},
+				pos: position{line: 1168, col: 5, offset: 39878},
 				alternatives: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 1146, col: 5, offset: 40921},
+						pos:        position{line: 1168, col: 5, offset: 39878},
 						val:        "[^\\r\\n_]",
 						chars:      []rune{'\r', '\n', '_'},
 						ignoreCase: false,
 						inverted:   true,
 					},
 					&actionExpr{
-						pos: position{line: 1147, col: 7, offset: 41020},
+						pos: position{line: 1169, col: 7, offset: 39977},
 						run: (*parser).callonSingleQuoteItalicTextFallbackCharacter3,
 						expr: &seqExpr{
-							pos: position{line: 1147, col: 7, offset: 41020},
+							pos: position{line: 1169, col: 7, offset: 39977},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1147, col: 7, offset: 41020},
+									pos:        position{line: 1169, col: 7, offset: 39977},
 									val:        "_",
 									ignoreCase: false,
 									want:       "\"_\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1147, col: 11, offset: 41024},
+									pos:  position{line: 1169, col: 11, offset: 39981},
 									name: "Alphanums",
 								},
 							},
@@ -8132,40 +7085,40 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedItalicText",
-			pos:  position{line: 1151, col: 1, offset: 41190},
+			pos:  position{line: 1173, col: 1, offset: 40147},
 			expr: &choiceExpr{
-				pos: position{line: 1152, col: 5, offset: 41216},
+				pos: position{line: 1174, col: 5, offset: 40173},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1152, col: 5, offset: 41216},
+						pos: position{line: 1174, col: 5, offset: 40173},
 						run: (*parser).callonEscapedItalicText2,
 						expr: &seqExpr{
-							pos: position{line: 1152, col: 5, offset: 41216},
+							pos: position{line: 1174, col: 5, offset: 40173},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1152, col: 5, offset: 41216},
+									pos:   position{line: 1174, col: 5, offset: 40173},
 									label: "backslashes",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1152, col: 18, offset: 41229},
+										pos:  position{line: 1174, col: 18, offset: 40186},
 										name: "TwoOrMoreBackslashes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1152, col: 40, offset: 41251},
+									pos:        position{line: 1174, col: 40, offset: 40208},
 									val:        "__",
 									ignoreCase: false,
 									want:       "\"__\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1152, col: 45, offset: 41256},
+									pos:   position{line: 1174, col: 45, offset: 40213},
 									label: "elements",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1152, col: 55, offset: 41266},
+										pos:  position{line: 1174, col: 55, offset: 40223},
 										name: "DoubleQuoteItalicTextElements",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1152, col: 86, offset: 41297},
+									pos:        position{line: 1174, col: 86, offset: 40254},
 									val:        "__",
 									ignoreCase: false,
 									want:       "\"__\"",
@@ -8174,35 +7127,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1154, col: 9, offset: 41454},
+						pos: position{line: 1176, col: 9, offset: 40411},
 						run: (*parser).callonEscapedItalicText10,
 						expr: &seqExpr{
-							pos: position{line: 1154, col: 9, offset: 41454},
+							pos: position{line: 1176, col: 9, offset: 40411},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1154, col: 9, offset: 41454},
+									pos:   position{line: 1176, col: 9, offset: 40411},
 									label: "backslashes",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1154, col: 22, offset: 41467},
+										pos:  position{line: 1176, col: 22, offset: 40424},
 										name: "OneOrMoreBackslashes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1154, col: 44, offset: 41489},
+									pos:        position{line: 1176, col: 44, offset: 40446},
 									val:        "__",
 									ignoreCase: false,
 									want:       "\"__\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1154, col: 49, offset: 41494},
+									pos:   position{line: 1176, col: 49, offset: 40451},
 									label: "elements",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1154, col: 59, offset: 41504},
+										pos:  position{line: 1176, col: 59, offset: 40461},
 										name: "SingleQuoteItalicTextElements",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1154, col: 90, offset: 41535},
+									pos:        position{line: 1176, col: 90, offset: 40492},
 									val:        "_",
 									ignoreCase: false,
 									want:       "\"_\"",
@@ -8211,35 +7164,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1157, col: 9, offset: 41735},
+						pos: position{line: 1179, col: 9, offset: 40692},
 						run: (*parser).callonEscapedItalicText18,
 						expr: &seqExpr{
-							pos: position{line: 1157, col: 9, offset: 41735},
+							pos: position{line: 1179, col: 9, offset: 40692},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1157, col: 9, offset: 41735},
+									pos:   position{line: 1179, col: 9, offset: 40692},
 									label: "backslashes",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1157, col: 22, offset: 41748},
+										pos:  position{line: 1179, col: 22, offset: 40705},
 										name: "OneOrMoreBackslashes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1157, col: 44, offset: 41770},
+									pos:        position{line: 1179, col: 44, offset: 40727},
 									val:        "_",
 									ignoreCase: false,
 									want:       "\"_\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1157, col: 48, offset: 41774},
+									pos:   position{line: 1179, col: 48, offset: 40731},
 									label: "elements",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1157, col: 58, offset: 41784},
+										pos:  position{line: 1179, col: 58, offset: 40741},
 										name: "SingleQuoteItalicTextElements",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1157, col: 89, offset: 41815},
+									pos:        position{line: 1179, col: 89, offset: 40772},
 									val:        "_",
 									ignoreCase: false,
 									want:       "\"_\"",
@@ -8252,16 +7205,16 @@ var g = &grammar{
 		},
 		{
 			name: "MonospaceText",
-			pos:  position{line: 1164, col: 1, offset: 42025},
+			pos:  position{line: 1186, col: 1, offset: 40982},
 			expr: &choiceExpr{
-				pos: position{line: 1164, col: 18, offset: 42042},
+				pos: position{line: 1186, col: 18, offset: 40999},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1164, col: 18, offset: 42042},
+						pos:  position{line: 1186, col: 18, offset: 40999},
 						name: "DoubleQuoteMonospaceText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1164, col: 45, offset: 42069},
+						pos:  position{line: 1186, col: 45, offset: 41026},
 						name: "SingleQuoteMonospaceText",
 					},
 				},
@@ -8269,40 +7222,40 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteMonospaceText",
-			pos:  position{line: 1166, col: 1, offset: 42095},
+			pos:  position{line: 1188, col: 1, offset: 41052},
 			expr: &actionExpr{
-				pos: position{line: 1166, col: 29, offset: 42123},
+				pos: position{line: 1188, col: 29, offset: 41080},
 				run: (*parser).callonDoubleQuoteMonospaceText1,
 				expr: &seqExpr{
-					pos: position{line: 1166, col: 29, offset: 42123},
+					pos: position{line: 1188, col: 29, offset: 41080},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1166, col: 29, offset: 42123},
+							pos:   position{line: 1188, col: 29, offset: 41080},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1166, col: 40, offset: 42134},
+								pos: position{line: 1188, col: 40, offset: 41091},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1166, col: 41, offset: 42135},
-									name: "QuotedTextAttributes",
+									pos:  position{line: 1188, col: 41, offset: 41092},
+									name: "LongHandAttributes",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1166, col: 64, offset: 42158},
+							pos:        position{line: 1188, col: 62, offset: 41113},
 							val:        "``",
 							ignoreCase: false,
 							want:       "\"``\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1166, col: 69, offset: 42163},
+							pos:   position{line: 1188, col: 67, offset: 41118},
 							label: "elements",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1166, col: 79, offset: 42173},
+								pos:  position{line: 1188, col: 77, offset: 41128},
 								name: "DoubleQuoteMonospaceTextElements",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1166, col: 113, offset: 42207},
+							pos:        position{line: 1188, col: 111, offset: 41162},
 							val:        "``",
 							ignoreCase: false,
 							want:       "\"``\"",
@@ -8313,105 +7266,105 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteMonospaceTextElements",
-			pos:  position{line: 1170, col: 1, offset: 42349},
+			pos:  position{line: 1192, col: 1, offset: 41304},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1170, col: 37, offset: 42385},
+				pos: position{line: 1192, col: 37, offset: 41340},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1170, col: 37, offset: 42385},
+					pos:  position{line: 1192, col: 37, offset: 41340},
 					name: "DoubleQuoteMonospaceTextElement",
 				},
 			},
 		},
 		{
 			name: "DoubleQuoteMonospaceTextElement",
-			pos:  position{line: 1172, col: 1, offset: 42452},
+			pos:  position{line: 1194, col: 1, offset: 41407},
 			expr: &actionExpr{
-				pos: position{line: 1172, col: 36, offset: 42487},
+				pos: position{line: 1194, col: 36, offset: 41442},
 				run: (*parser).callonDoubleQuoteMonospaceTextElement1,
 				expr: &seqExpr{
-					pos: position{line: 1172, col: 36, offset: 42487},
+					pos: position{line: 1194, col: 36, offset: 41442},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1172, col: 36, offset: 42487},
+							pos: position{line: 1194, col: 36, offset: 41442},
 							expr: &litMatcher{
-								pos:        position{line: 1172, col: 38, offset: 42489},
+								pos:        position{line: 1194, col: 38, offset: 41444},
 								val:        "``",
 								ignoreCase: false,
 								want:       "\"``\"",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1172, col: 44, offset: 42495},
+							pos:   position{line: 1194, col: 44, offset: 41450},
 							label: "element",
 							expr: &choiceExpr{
-								pos: position{line: 1172, col: 53, offset: 42504},
+								pos: position{line: 1194, col: 53, offset: 41459},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1172, col: 53, offset: 42504},
+										pos:  position{line: 1194, col: 53, offset: 41459},
 										name: "Word",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1173, col: 11, offset: 42519},
+										pos:  position{line: 1195, col: 11, offset: 41474},
 										name: "Space",
 									},
 									&seqExpr{
-										pos: position{line: 1174, col: 11, offset: 42568},
+										pos: position{line: 1196, col: 11, offset: 41523},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1174, col: 11, offset: 42568},
+												pos:  position{line: 1196, col: 11, offset: 41523},
 												name: "Newline",
 											},
 											&notExpr{
-												pos: position{line: 1174, col: 19, offset: 42576},
+												pos: position{line: 1196, col: 19, offset: 41531},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1174, col: 20, offset: 42577},
+													pos:  position{line: 1196, col: 20, offset: 41532},
 													name: "Newline",
 												},
 											},
 										},
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1175, col: 11, offset: 42595},
+										pos:  position{line: 1197, col: 11, offset: 41550},
 										name: "QuotedString",
 									},
 									&actionExpr{
-										pos: position{line: 1176, col: 11, offset: 42618},
+										pos: position{line: 1198, col: 11, offset: 41573},
 										run: (*parser).callonDoubleQuoteMonospaceTextElement14,
 										expr: &ruleRefExpr{
-											pos:  position{line: 1176, col: 11, offset: 42618},
+											pos:  position{line: 1198, col: 11, offset: 41573},
 											name: "Apostrophe",
 										},
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1180, col: 11, offset: 42802},
+										pos:  position{line: 1202, col: 11, offset: 41757},
 										name: "SingleQuoteMonospaceText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1181, col: 11, offset: 42837},
+										pos:  position{line: 1203, col: 11, offset: 41792},
 										name: "BoldText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1182, col: 11, offset: 42856},
+										pos:  position{line: 1204, col: 11, offset: 41811},
 										name: "ItalicText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1183, col: 11, offset: 42877},
+										pos:  position{line: 1205, col: 11, offset: 41832},
 										name: "MarkedText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1184, col: 11, offset: 42898},
+										pos:  position{line: 1206, col: 11, offset: 41853},
 										name: "SubscriptText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1185, col: 11, offset: 42922},
+										pos:  position{line: 1207, col: 11, offset: 41877},
 										name: "SuperscriptText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1186, col: 11, offset: 42948},
+										pos:  position{line: 1208, col: 11, offset: 41903},
 										name: "ElementPlaceHolder",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1187, col: 11, offset: 42977},
+										pos:  position{line: 1209, col: 11, offset: 41932},
 										name: "DoubleQuoteMonospaceTextFallbackCharacter",
 									},
 								},
@@ -8423,31 +7376,31 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteMonospaceTextFallbackCharacter",
-			pos:  position{line: 1191, col: 1, offset: 43049},
+			pos:  position{line: 1213, col: 1, offset: 42004},
 			expr: &choiceExpr{
-				pos: position{line: 1192, col: 5, offset: 43098},
+				pos: position{line: 1214, col: 5, offset: 42053},
 				alternatives: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 1192, col: 5, offset: 43098},
+						pos:        position{line: 1214, col: 5, offset: 42053},
 						val:        "[^\\r\\n`]",
 						chars:      []rune{'\r', '\n', '`'},
 						ignoreCase: false,
 						inverted:   true,
 					},
 					&actionExpr{
-						pos: position{line: 1193, col: 7, offset: 43200},
+						pos: position{line: 1215, col: 7, offset: 42155},
 						run: (*parser).callonDoubleQuoteMonospaceTextFallbackCharacter3,
 						expr: &seqExpr{
-							pos: position{line: 1193, col: 7, offset: 43200},
+							pos: position{line: 1215, col: 7, offset: 42155},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1193, col: 7, offset: 43200},
+									pos:        position{line: 1215, col: 7, offset: 42155},
 									val:        "``",
 									ignoreCase: false,
 									want:       "\"``\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1193, col: 12, offset: 43205},
+									pos:  position{line: 1215, col: 12, offset: 42160},
 									name: "Alphanums",
 								},
 							},
@@ -8458,40 +7411,40 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteMonospaceText",
-			pos:  position{line: 1197, col: 1, offset: 43373},
+			pos:  position{line: 1219, col: 1, offset: 42328},
 			expr: &choiceExpr{
-				pos: position{line: 1197, col: 29, offset: 43401},
+				pos: position{line: 1219, col: 29, offset: 42356},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1197, col: 29, offset: 43401},
+						pos: position{line: 1219, col: 29, offset: 42356},
 						run: (*parser).callonSingleQuoteMonospaceText2,
 						expr: &seqExpr{
-							pos: position{line: 1197, col: 29, offset: 43401},
+							pos: position{line: 1219, col: 29, offset: 42356},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1197, col: 29, offset: 43401},
+									pos:   position{line: 1219, col: 29, offset: 42356},
 									label: "attributes",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1197, col: 40, offset: 43412},
+										pos: position{line: 1219, col: 40, offset: 42367},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1197, col: 41, offset: 43413},
-											name: "QuotedTextAttributes",
+											pos:  position{line: 1219, col: 41, offset: 42368},
+											name: "LongHandAttributes",
 										},
 									},
 								},
 								&seqExpr{
-									pos: position{line: 1197, col: 65, offset: 43437},
+									pos: position{line: 1219, col: 63, offset: 42390},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 1197, col: 65, offset: 43437},
+											pos:        position{line: 1219, col: 63, offset: 42390},
 											val:        "`",
 											ignoreCase: false,
 											want:       "\"`\"",
 										},
 										&notExpr{
-											pos: position{line: 1197, col: 69, offset: 43441},
+											pos: position{line: 1219, col: 67, offset: 42394},
 											expr: &litMatcher{
-												pos:        position{line: 1197, col: 70, offset: 43442},
+												pos:        position{line: 1219, col: 68, offset: 42395},
 												val:        "`",
 												ignoreCase: false,
 												want:       "\"`\"",
@@ -8500,15 +7453,15 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1197, col: 75, offset: 43447},
+									pos:   position{line: 1219, col: 73, offset: 42400},
 									label: "elements",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1197, col: 85, offset: 43457},
+										pos:  position{line: 1219, col: 83, offset: 42410},
 										name: "SingleQuoteMonospaceTextElements",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1197, col: 119, offset: 43491},
+									pos:        position{line: 1219, col: 117, offset: 42444},
 									val:        "`",
 									ignoreCase: false,
 									want:       "\"`\"",
@@ -8517,49 +7470,49 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1199, col: 5, offset: 43689},
+						pos: position{line: 1221, col: 5, offset: 42642},
 						run: (*parser).callonSingleQuoteMonospaceText14,
 						expr: &seqExpr{
-							pos: position{line: 1199, col: 5, offset: 43689},
+							pos: position{line: 1221, col: 5, offset: 42642},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1199, col: 5, offset: 43689},
+									pos:   position{line: 1221, col: 5, offset: 42642},
 									label: "attributes",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1199, col: 16, offset: 43700},
+										pos: position{line: 1221, col: 16, offset: 42653},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1199, col: 17, offset: 43701},
-											name: "QuotedTextAttributes",
+											pos:  position{line: 1221, col: 17, offset: 42654},
+											name: "LongHandAttributes",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1199, col: 40, offset: 43724},
+									pos:        position{line: 1221, col: 38, offset: 42675},
 									val:        "`",
 									ignoreCase: false,
 									want:       "\"`\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1199, col: 44, offset: 43728},
+									pos:   position{line: 1221, col: 42, offset: 42679},
 									label: "elements",
 									expr: &seqExpr{
-										pos: position{line: 1199, col: 54, offset: 43738},
+										pos: position{line: 1221, col: 52, offset: 42689},
 										exprs: []interface{}{
 											&litMatcher{
-												pos:        position{line: 1199, col: 54, offset: 43738},
+												pos:        position{line: 1221, col: 52, offset: 42689},
 												val:        "`",
 												ignoreCase: false,
 												want:       "\"`\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1199, col: 58, offset: 43742},
+												pos:  position{line: 1221, col: 56, offset: 42693},
 												name: "SingleQuoteMonospaceTextElements",
 											},
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1199, col: 92, offset: 43776},
+									pos:        position{line: 1221, col: 90, offset: 42727},
 									val:        "`",
 									ignoreCase: false,
 									want:       "\"`\"",
@@ -8572,21 +7525,21 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteMonospaceTextElements",
-			pos:  position{line: 1203, col: 1, offset: 43995},
+			pos:  position{line: 1225, col: 1, offset: 42946},
 			expr: &seqExpr{
-				pos: position{line: 1203, col: 37, offset: 44031},
+				pos: position{line: 1225, col: 37, offset: 42982},
 				exprs: []interface{}{
 					&notExpr{
-						pos: position{line: 1203, col: 37, offset: 44031},
+						pos: position{line: 1225, col: 37, offset: 42982},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1203, col: 38, offset: 44032},
+							pos:  position{line: 1225, col: 38, offset: 42983},
 							name: "Space",
 						},
 					},
 					&oneOrMoreExpr{
-						pos: position{line: 1203, col: 44, offset: 44038},
+						pos: position{line: 1225, col: 44, offset: 42989},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1203, col: 44, offset: 44038},
+							pos:  position{line: 1225, col: 44, offset: 42989},
 							name: "SingleQuoteMonospaceTextElement",
 						},
 					},
@@ -8595,63 +7548,63 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteMonospaceTextElement",
-			pos:  position{line: 1205, col: 1, offset: 44072},
+			pos:  position{line: 1227, col: 1, offset: 43023},
 			expr: &choiceExpr{
-				pos: position{line: 1205, col: 37, offset: 44108},
+				pos: position{line: 1227, col: 37, offset: 43059},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1205, col: 37, offset: 44108},
+						pos:  position{line: 1227, col: 37, offset: 43059},
 						name: "Word",
 					},
 					&seqExpr{
-						pos: position{line: 1206, col: 11, offset: 44123},
+						pos: position{line: 1228, col: 11, offset: 43074},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 1206, col: 11, offset: 44123},
+								pos:  position{line: 1228, col: 11, offset: 43074},
 								name: "Newline",
 							},
 							&notExpr{
-								pos: position{line: 1206, col: 19, offset: 44131},
+								pos: position{line: 1228, col: 19, offset: 43082},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1206, col: 20, offset: 44132},
+									pos:  position{line: 1228, col: 20, offset: 43083},
 									name: "Newline",
 								},
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1207, col: 11, offset: 44150},
+						pos:  position{line: 1229, col: 11, offset: 43101},
 						name: "DoubleQuoteMonospaceText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1208, col: 11, offset: 44185},
+						pos:  position{line: 1230, col: 11, offset: 43136},
 						name: "QuotedString",
 					},
 					&seqExpr{
-						pos: position{line: 1209, col: 11, offset: 44208},
+						pos: position{line: 1231, col: 11, offset: 43159},
 						exprs: []interface{}{
 							&oneOrMoreExpr{
-								pos: position{line: 1209, col: 11, offset: 44208},
+								pos: position{line: 1231, col: 11, offset: 43159},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1209, col: 11, offset: 44208},
+									pos:  position{line: 1231, col: 11, offset: 43159},
 									name: "Space",
 								},
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 1209, col: 18, offset: 44215},
+								pos: position{line: 1231, col: 18, offset: 43166},
 								expr: &seqExpr{
-									pos: position{line: 1209, col: 19, offset: 44216},
+									pos: position{line: 1231, col: 19, offset: 43167},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 1209, col: 19, offset: 44216},
+											pos:        position{line: 1231, col: 19, offset: 43167},
 											val:        "`",
 											ignoreCase: false,
 											want:       "\"`\"",
 										},
 										&notExpr{
-											pos: position{line: 1209, col: 23, offset: 44220},
+											pos: position{line: 1231, col: 23, offset: 43171},
 											expr: &litMatcher{
-												pos:        position{line: 1209, col: 24, offset: 44221},
+												pos:        position{line: 1231, col: 24, offset: 43172},
 												val:        "`",
 												ignoreCase: false,
 												want:       "\"`\"",
@@ -8663,39 +7616,39 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1210, col: 11, offset: 44349},
+						pos:  position{line: 1232, col: 11, offset: 43300},
 						name: "BoldText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1211, col: 11, offset: 44368},
+						pos:  position{line: 1233, col: 11, offset: 43319},
 						name: "ItalicText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1212, col: 11, offset: 44389},
+						pos:  position{line: 1234, col: 11, offset: 43340},
 						name: "MarkedText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1213, col: 11, offset: 44410},
+						pos:  position{line: 1235, col: 11, offset: 43361},
 						name: "SubscriptText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1214, col: 11, offset: 44434},
+						pos:  position{line: 1236, col: 11, offset: 43385},
 						name: "SuperscriptText",
 					},
 					&actionExpr{
-						pos: position{line: 1215, col: 11, offset: 44460},
+						pos: position{line: 1237, col: 11, offset: 43411},
 						run: (*parser).callonSingleQuoteMonospaceTextElement22,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1215, col: 11, offset: 44460},
+							pos:  position{line: 1237, col: 11, offset: 43411},
 							name: "Apostrophe",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1219, col: 11, offset: 44601},
+						pos:  position{line: 1241, col: 11, offset: 43552},
 						name: "ElementPlaceHolder",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1220, col: 11, offset: 44630},
+						pos:  position{line: 1242, col: 11, offset: 43581},
 						name: "SingleQuoteMonospaceTextFallbackCharacter",
 					},
 				},
@@ -8703,31 +7656,31 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteMonospaceTextFallbackCharacter",
-			pos:  position{line: 1222, col: 1, offset: 44673},
+			pos:  position{line: 1244, col: 1, offset: 43624},
 			expr: &choiceExpr{
-				pos: position{line: 1223, col: 5, offset: 44722},
+				pos: position{line: 1245, col: 5, offset: 43673},
 				alternatives: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 1223, col: 5, offset: 44722},
+						pos:        position{line: 1245, col: 5, offset: 43673},
 						val:        "[^\\r\\n`]",
 						chars:      []rune{'\r', '\n', '`'},
 						ignoreCase: false,
 						inverted:   true,
 					},
 					&actionExpr{
-						pos: position{line: 1224, col: 7, offset: 44824},
+						pos: position{line: 1246, col: 7, offset: 43775},
 						run: (*parser).callonSingleQuoteMonospaceTextFallbackCharacter3,
 						expr: &seqExpr{
-							pos: position{line: 1224, col: 7, offset: 44824},
+							pos: position{line: 1246, col: 7, offset: 43775},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1224, col: 7, offset: 44824},
+									pos:        position{line: 1246, col: 7, offset: 43775},
 									val:        "`",
 									ignoreCase: false,
 									want:       "\"`\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1224, col: 11, offset: 44828},
+									pos:  position{line: 1246, col: 11, offset: 43779},
 									name: "Alphanums",
 								},
 							},
@@ -8738,40 +7691,40 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedMonospaceText",
-			pos:  position{line: 1228, col: 1, offset: 44997},
+			pos:  position{line: 1250, col: 1, offset: 43948},
 			expr: &choiceExpr{
-				pos: position{line: 1229, col: 5, offset: 45026},
+				pos: position{line: 1251, col: 5, offset: 43977},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1229, col: 5, offset: 45026},
+						pos: position{line: 1251, col: 5, offset: 43977},
 						run: (*parser).callonEscapedMonospaceText2,
 						expr: &seqExpr{
-							pos: position{line: 1229, col: 5, offset: 45026},
+							pos: position{line: 1251, col: 5, offset: 43977},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1229, col: 5, offset: 45026},
+									pos:   position{line: 1251, col: 5, offset: 43977},
 									label: "backslashes",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1229, col: 18, offset: 45039},
+										pos:  position{line: 1251, col: 18, offset: 43990},
 										name: "TwoOrMoreBackslashes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1229, col: 40, offset: 45061},
+									pos:        position{line: 1251, col: 40, offset: 44012},
 									val:        "``",
 									ignoreCase: false,
 									want:       "\"``\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1229, col: 45, offset: 45066},
+									pos:   position{line: 1251, col: 45, offset: 44017},
 									label: "elements",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1229, col: 55, offset: 45076},
+										pos:  position{line: 1251, col: 55, offset: 44027},
 										name: "DoubleQuoteMonospaceTextElements",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1229, col: 89, offset: 45110},
+									pos:        position{line: 1251, col: 89, offset: 44061},
 									val:        "``",
 									ignoreCase: false,
 									want:       "\"``\"",
@@ -8780,35 +7733,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1231, col: 9, offset: 45267},
+						pos: position{line: 1253, col: 9, offset: 44218},
 						run: (*parser).callonEscapedMonospaceText10,
 						expr: &seqExpr{
-							pos: position{line: 1231, col: 9, offset: 45267},
+							pos: position{line: 1253, col: 9, offset: 44218},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1231, col: 9, offset: 45267},
+									pos:   position{line: 1253, col: 9, offset: 44218},
 									label: "backslashes",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1231, col: 22, offset: 45280},
+										pos:  position{line: 1253, col: 22, offset: 44231},
 										name: "OneOrMoreBackslashes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1231, col: 44, offset: 45302},
+									pos:        position{line: 1253, col: 44, offset: 44253},
 									val:        "``",
 									ignoreCase: false,
 									want:       "\"``\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1231, col: 49, offset: 45307},
+									pos:   position{line: 1253, col: 49, offset: 44258},
 									label: "elements",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1231, col: 59, offset: 45317},
+										pos:  position{line: 1253, col: 59, offset: 44268},
 										name: "SingleQuoteMonospaceTextElements",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1231, col: 93, offset: 45351},
+									pos:        position{line: 1253, col: 93, offset: 44302},
 									val:        "`",
 									ignoreCase: false,
 									want:       "\"`\"",
@@ -8817,35 +7770,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1234, col: 9, offset: 45551},
+						pos: position{line: 1256, col: 9, offset: 44502},
 						run: (*parser).callonEscapedMonospaceText18,
 						expr: &seqExpr{
-							pos: position{line: 1234, col: 9, offset: 45551},
+							pos: position{line: 1256, col: 9, offset: 44502},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1234, col: 9, offset: 45551},
+									pos:   position{line: 1256, col: 9, offset: 44502},
 									label: "backslashes",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1234, col: 22, offset: 45564},
+										pos:  position{line: 1256, col: 22, offset: 44515},
 										name: "OneOrMoreBackslashes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1234, col: 44, offset: 45586},
+									pos:        position{line: 1256, col: 44, offset: 44537},
 									val:        "`",
 									ignoreCase: false,
 									want:       "\"`\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1234, col: 48, offset: 45590},
+									pos:   position{line: 1256, col: 48, offset: 44541},
 									label: "elements",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1234, col: 58, offset: 45600},
+										pos:  position{line: 1256, col: 58, offset: 44551},
 										name: "SingleQuoteMonospaceTextElements",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1234, col: 92, offset: 45634},
+									pos:        position{line: 1256, col: 92, offset: 44585},
 									val:        "`",
 									ignoreCase: false,
 									want:       "\"`\"",
@@ -8858,16 +7811,16 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedString",
-			pos:  position{line: 1242, col: 1, offset: 45959},
+			pos:  position{line: 1264, col: 1, offset: 44910},
 			expr: &choiceExpr{
-				pos: position{line: 1242, col: 17, offset: 45975},
+				pos: position{line: 1264, col: 17, offset: 44926},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1242, col: 17, offset: 45975},
+						pos:  position{line: 1264, col: 17, offset: 44926},
 						name: "SingleQuotedString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1242, col: 38, offset: 45996},
+						pos:  position{line: 1264, col: 38, offset: 44947},
 						name: "DoubleQuotedString",
 					},
 				},
@@ -8875,27 +7828,27 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedString",
-			pos:  position{line: 1244, col: 1, offset: 46016},
+			pos:  position{line: 1266, col: 1, offset: 44967},
 			expr: &actionExpr{
-				pos: position{line: 1244, col: 23, offset: 46038},
+				pos: position{line: 1266, col: 23, offset: 44989},
 				run: (*parser).callonSingleQuotedString1,
 				expr: &seqExpr{
-					pos: position{line: 1244, col: 23, offset: 46038},
+					pos: position{line: 1266, col: 23, offset: 44989},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1244, col: 23, offset: 46038},
+							pos:  position{line: 1266, col: 23, offset: 44989},
 							name: "SingleQuoteStringStart",
 						},
 						&labeledExpr{
-							pos:   position{line: 1244, col: 46, offset: 46061},
+							pos:   position{line: 1266, col: 46, offset: 45012},
 							label: "elements",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1244, col: 55, offset: 46070},
+								pos:  position{line: 1266, col: 55, offset: 45021},
 								name: "SingleQuotedStringElements",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1244, col: 82, offset: 46097},
+							pos:  position{line: 1266, col: 82, offset: 45048},
 							name: "SingleQuoteStringEnd",
 						},
 					},
@@ -8904,17 +7857,17 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedStringElements",
-			pos:  position{line: 1248, col: 1, offset: 46201},
+			pos:  position{line: 1270, col: 1, offset: 45152},
 			expr: &actionExpr{
-				pos: position{line: 1248, col: 31, offset: 46231},
+				pos: position{line: 1270, col: 31, offset: 45182},
 				run: (*parser).callonSingleQuotedStringElements1,
 				expr: &labeledExpr{
-					pos:   position{line: 1248, col: 31, offset: 46231},
+					pos:   position{line: 1270, col: 31, offset: 45182},
 					label: "elements",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 1248, col: 41, offset: 46241},
+						pos: position{line: 1270, col: 41, offset: 45192},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1248, col: 41, offset: 46241},
+							pos:  position{line: 1270, col: 41, offset: 45192},
 							name: "SingleQuotedStringElement",
 						},
 					},
@@ -8923,20 +7876,20 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteStringStart",
-			pos:  position{line: 1252, col: 1, offset: 46319},
+			pos:  position{line: 1274, col: 1, offset: 45270},
 			expr: &seqExpr{
-				pos: position{line: 1252, col: 27, offset: 46345},
+				pos: position{line: 1274, col: 27, offset: 45296},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1252, col: 27, offset: 46345},
+						pos:        position{line: 1274, col: 27, offset: 45296},
 						val:        "'`",
 						ignoreCase: false,
 						want:       "\"'`\"",
 					},
 					&notExpr{
-						pos: position{line: 1252, col: 32, offset: 46350},
+						pos: position{line: 1274, col: 32, offset: 45301},
 						expr: &charClassMatcher{
-							pos:        position{line: 1252, col: 33, offset: 46351},
+							pos:        position{line: 1274, col: 33, offset: 45302},
 							val:        "[ \\t\\r\\n]",
 							chars:      []rune{' ', '\t', '\r', '\n'},
 							ignoreCase: false,
@@ -8948,9 +7901,9 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteStringEnd",
-			pos:  position{line: 1254, col: 1, offset: 46362},
+			pos:  position{line: 1276, col: 1, offset: 45313},
 			expr: &litMatcher{
-				pos:        position{line: 1254, col: 25, offset: 46386},
+				pos:        position{line: 1276, col: 25, offset: 45337},
 				val:        "`'",
 				ignoreCase: false,
 				want:       "\"`'\"",
@@ -8958,113 +7911,113 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedStringElement",
-			pos:  position{line: 1257, col: 1, offset: 46474},
+			pos:  position{line: 1279, col: 1, offset: 45425},
 			expr: &actionExpr{
-				pos: position{line: 1257, col: 30, offset: 46503},
+				pos: position{line: 1279, col: 30, offset: 45454},
 				run: (*parser).callonSingleQuotedStringElement1,
 				expr: &labeledExpr{
-					pos:   position{line: 1257, col: 30, offset: 46503},
+					pos:   position{line: 1279, col: 30, offset: 45454},
 					label: "element",
 					expr: &choiceExpr{
-						pos: position{line: 1258, col: 9, offset: 46521},
+						pos: position{line: 1280, col: 9, offset: 45472},
 						alternatives: []interface{}{
 							&seqExpr{
-								pos: position{line: 1258, col: 9, offset: 46521},
+								pos: position{line: 1280, col: 9, offset: 45472},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1258, col: 9, offset: 46521},
+										pos:  position{line: 1280, col: 9, offset: 45472},
 										name: "LineBreak",
 									},
 									&notExpr{
-										pos: position{line: 1258, col: 19, offset: 46531},
+										pos: position{line: 1280, col: 19, offset: 45482},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1258, col: 20, offset: 46532},
+											pos:  position{line: 1280, col: 20, offset: 45483},
 											name: "SingleQuoteStringEnd",
 										},
 									},
 								},
 							},
 							&seqExpr{
-								pos: position{line: 1259, col: 11, offset: 46588},
+								pos: position{line: 1281, col: 11, offset: 45539},
 								exprs: []interface{}{
 									&oneOrMoreExpr{
-										pos: position{line: 1259, col: 11, offset: 46588},
+										pos: position{line: 1281, col: 11, offset: 45539},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1259, col: 11, offset: 46588},
+											pos:  position{line: 1281, col: 11, offset: 45539},
 											name: "Space",
 										},
 									},
 									&notExpr{
-										pos: position{line: 1259, col: 18, offset: 46595},
+										pos: position{line: 1281, col: 18, offset: 45546},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1259, col: 19, offset: 46596},
+											pos:  position{line: 1281, col: 19, offset: 45547},
 											name: "SingleQuoteStringEnd",
 										},
 									},
 								},
 							},
 							&seqExpr{
-								pos: position{line: 1260, col: 11, offset: 46627},
+								pos: position{line: 1282, col: 11, offset: 45578},
 								exprs: []interface{}{
 									&notExpr{
-										pos: position{line: 1260, col: 11, offset: 46627},
+										pos: position{line: 1282, col: 11, offset: 45578},
 										expr: &litMatcher{
-											pos:        position{line: 1260, col: 12, offset: 46628},
+											pos:        position{line: 1282, col: 12, offset: 45579},
 											val:        "`",
 											ignoreCase: false,
 											want:       "\"`\"",
 										},
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1260, col: 16, offset: 46632},
+										pos:  position{line: 1282, col: 16, offset: 45583},
 										name: "Symbol",
 									},
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1261, col: 11, offset: 46680},
+								pos:  position{line: 1283, col: 11, offset: 45631},
 								name: "BoldText",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1262, col: 11, offset: 46699},
+								pos:  position{line: 1284, col: 11, offset: 45650},
 								name: "ItalicText",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1263, col: 11, offset: 46720},
+								pos:  position{line: 1285, col: 11, offset: 45671},
 								name: "MarkedText",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1264, col: 11, offset: 46741},
+								pos:  position{line: 1286, col: 11, offset: 45692},
 								name: "SubscriptText",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1265, col: 11, offset: 46765},
+								pos:  position{line: 1287, col: 11, offset: 45716},
 								name: "SuperscriptText",
 							},
 							&seqExpr{
-								pos: position{line: 1266, col: 11, offset: 46791},
+								pos: position{line: 1288, col: 11, offset: 45742},
 								exprs: []interface{}{
 									&notExpr{
-										pos: position{line: 1266, col: 11, offset: 46791},
+										pos: position{line: 1288, col: 11, offset: 45742},
 										expr: &litMatcher{
-											pos:        position{line: 1266, col: 12, offset: 46792},
+											pos:        position{line: 1288, col: 12, offset: 45743},
 											val:        "`'",
 											ignoreCase: false,
 											want:       "\"`'\"",
 										},
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1266, col: 17, offset: 46797},
+										pos:  position{line: 1288, col: 17, offset: 45748},
 										name: "MonospaceText",
 									},
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1267, col: 11, offset: 46821},
+								pos:  position{line: 1289, col: 11, offset: 45772},
 								name: "DoubleQuotedString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1268, col: 11, offset: 46850},
+								pos:  position{line: 1290, col: 11, offset: 45801},
 								name: "SingleQuotedStringFallbackCharacter",
 							},
 						},
@@ -9074,33 +8027,33 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedStringFallbackCharacter",
-			pos:  position{line: 1272, col: 1, offset: 46916},
+			pos:  position{line: 1294, col: 1, offset: 45867},
 			expr: &choiceExpr{
-				pos: position{line: 1272, col: 41, offset: 46956},
+				pos: position{line: 1294, col: 41, offset: 45907},
 				alternatives: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 1272, col: 41, offset: 46956},
+						pos:        position{line: 1294, col: 41, offset: 45907},
 						val:        "[^\\r\\n\\t `]",
 						chars:      []rune{'\r', '\n', '\t', ' ', '`'},
 						ignoreCase: false,
 						inverted:   true,
 					},
 					&actionExpr{
-						pos: position{line: 1272, col: 55, offset: 46970},
+						pos: position{line: 1294, col: 55, offset: 45921},
 						run: (*parser).callonSingleQuotedStringFallbackCharacter3,
 						expr: &seqExpr{
-							pos: position{line: 1272, col: 55, offset: 46970},
+							pos: position{line: 1294, col: 55, offset: 45921},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1272, col: 55, offset: 46970},
+									pos:        position{line: 1294, col: 55, offset: 45921},
 									val:        "`",
 									ignoreCase: false,
 									want:       "\"`\"",
 								},
 								&notExpr{
-									pos: position{line: 1272, col: 59, offset: 46974},
+									pos: position{line: 1294, col: 59, offset: 45925},
 									expr: &litMatcher{
-										pos:        position{line: 1272, col: 60, offset: 46975},
+										pos:        position{line: 1294, col: 60, offset: 45926},
 										val:        "'",
 										ignoreCase: false,
 										want:       "\"'\"",
@@ -9114,27 +8067,27 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedString",
-			pos:  position{line: 1276, col: 1, offset: 47034},
+			pos:  position{line: 1298, col: 1, offset: 45985},
 			expr: &actionExpr{
-				pos: position{line: 1276, col: 23, offset: 47056},
+				pos: position{line: 1298, col: 23, offset: 46007},
 				run: (*parser).callonDoubleQuotedString1,
 				expr: &seqExpr{
-					pos: position{line: 1276, col: 23, offset: 47056},
+					pos: position{line: 1298, col: 23, offset: 46007},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1276, col: 23, offset: 47056},
+							pos:  position{line: 1298, col: 23, offset: 46007},
 							name: "DoubleQuoteStringStart",
 						},
 						&labeledExpr{
-							pos:   position{line: 1276, col: 46, offset: 47079},
+							pos:   position{line: 1298, col: 46, offset: 46030},
 							label: "elements",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1276, col: 55, offset: 47088},
+								pos:  position{line: 1298, col: 55, offset: 46039},
 								name: "DoubleQuotedStringElements",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1276, col: 82, offset: 47115},
+							pos:  position{line: 1298, col: 82, offset: 46066},
 							name: "DoubleQuoteStringEnd",
 						},
 					},
@@ -9143,17 +8096,17 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedStringElements",
-			pos:  position{line: 1280, col: 1, offset: 47219},
+			pos:  position{line: 1302, col: 1, offset: 46170},
 			expr: &actionExpr{
-				pos: position{line: 1280, col: 31, offset: 47249},
+				pos: position{line: 1302, col: 31, offset: 46200},
 				run: (*parser).callonDoubleQuotedStringElements1,
 				expr: &labeledExpr{
-					pos:   position{line: 1280, col: 31, offset: 47249},
+					pos:   position{line: 1302, col: 31, offset: 46200},
 					label: "elements",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 1280, col: 41, offset: 47259},
+						pos: position{line: 1302, col: 41, offset: 46210},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1280, col: 41, offset: 47259},
+							pos:  position{line: 1302, col: 41, offset: 46210},
 							name: "DoubleQuotedStringElement",
 						},
 					},
@@ -9162,95 +8115,95 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedStringElement",
-			pos:  position{line: 1285, col: 1, offset: 47419},
+			pos:  position{line: 1307, col: 1, offset: 46370},
 			expr: &actionExpr{
-				pos: position{line: 1285, col: 30, offset: 47448},
+				pos: position{line: 1307, col: 30, offset: 46399},
 				run: (*parser).callonDoubleQuotedStringElement1,
 				expr: &labeledExpr{
-					pos:   position{line: 1285, col: 30, offset: 47448},
+					pos:   position{line: 1307, col: 30, offset: 46399},
 					label: "element",
 					expr: &choiceExpr{
-						pos: position{line: 1286, col: 9, offset: 47466},
+						pos: position{line: 1308, col: 9, offset: 46417},
 						alternatives: []interface{}{
 							&seqExpr{
-								pos: position{line: 1286, col: 9, offset: 47466},
+								pos: position{line: 1308, col: 9, offset: 46417},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1286, col: 9, offset: 47466},
+										pos:  position{line: 1308, col: 9, offset: 46417},
 										name: "LineBreak",
 									},
 									&notExpr{
-										pos: position{line: 1286, col: 19, offset: 47476},
+										pos: position{line: 1308, col: 19, offset: 46427},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1286, col: 20, offset: 47477},
+											pos:  position{line: 1308, col: 20, offset: 46428},
 											name: "DoubleQuoteStringEnd",
 										},
 									},
 								},
 							},
 							&seqExpr{
-								pos: position{line: 1287, col: 11, offset: 47533},
+								pos: position{line: 1309, col: 11, offset: 46484},
 								exprs: []interface{}{
 									&oneOrMoreExpr{
-										pos: position{line: 1287, col: 11, offset: 47533},
+										pos: position{line: 1309, col: 11, offset: 46484},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1287, col: 11, offset: 47533},
+											pos:  position{line: 1309, col: 11, offset: 46484},
 											name: "Space",
 										},
 									},
 									&notExpr{
-										pos: position{line: 1287, col: 18, offset: 47540},
+										pos: position{line: 1309, col: 18, offset: 46491},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1287, col: 19, offset: 47541},
+											pos:  position{line: 1309, col: 19, offset: 46492},
 											name: "DoubleQuoteStringEnd",
 										},
 									},
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1288, col: 11, offset: 47572},
+								pos:  position{line: 1310, col: 11, offset: 46523},
 								name: "BoldText",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1289, col: 11, offset: 47591},
+								pos:  position{line: 1311, col: 11, offset: 46542},
 								name: "ItalicText",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1290, col: 11, offset: 47612},
+								pos:  position{line: 1312, col: 11, offset: 46563},
 								name: "MarkedText",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1291, col: 11, offset: 47633},
+								pos:  position{line: 1313, col: 11, offset: 46584},
 								name: "SubscriptText",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1292, col: 11, offset: 47657},
+								pos:  position{line: 1314, col: 11, offset: 46608},
 								name: "SuperscriptText",
 							},
 							&seqExpr{
-								pos: position{line: 1293, col: 11, offset: 47683},
+								pos: position{line: 1315, col: 11, offset: 46634},
 								exprs: []interface{}{
 									&notExpr{
-										pos: position{line: 1293, col: 11, offset: 47683},
+										pos: position{line: 1315, col: 11, offset: 46634},
 										expr: &litMatcher{
-											pos:        position{line: 1293, col: 12, offset: 47684},
+											pos:        position{line: 1315, col: 12, offset: 46635},
 											val:        "`\"",
 											ignoreCase: false,
 											want:       "\"`\\\"\"",
 										},
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1293, col: 18, offset: 47690},
+										pos:  position{line: 1315, col: 18, offset: 46641},
 										name: "MonospaceText",
 									},
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1294, col: 10, offset: 47713},
+								pos:  position{line: 1316, col: 10, offset: 46664},
 								name: "SingleQuotedString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1295, col: 11, offset: 47742},
+								pos:  position{line: 1317, col: 11, offset: 46693},
 								name: "DoubleQuotedStringFallbackCharacter",
 							},
 						},
@@ -9260,20 +8213,20 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteStringStart",
-			pos:  position{line: 1299, col: 1, offset: 47816},
+			pos:  position{line: 1321, col: 1, offset: 46767},
 			expr: &seqExpr{
-				pos: position{line: 1299, col: 27, offset: 47842},
+				pos: position{line: 1321, col: 27, offset: 46793},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1299, col: 27, offset: 47842},
+						pos:        position{line: 1321, col: 27, offset: 46793},
 						val:        "\"`",
 						ignoreCase: false,
 						want:       "\"\\\"`\"",
 					},
 					&notExpr{
-						pos: position{line: 1299, col: 33, offset: 47848},
+						pos: position{line: 1321, col: 33, offset: 46799},
 						expr: &charClassMatcher{
-							pos:        position{line: 1299, col: 34, offset: 47849},
+							pos:        position{line: 1321, col: 34, offset: 46800},
 							val:        "[ \\t\\r\\n]",
 							chars:      []rune{' ', '\t', '\r', '\n'},
 							ignoreCase: false,
@@ -9285,9 +8238,9 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteStringEnd",
-			pos:  position{line: 1301, col: 1, offset: 47860},
+			pos:  position{line: 1323, col: 1, offset: 46811},
 			expr: &litMatcher{
-				pos:        position{line: 1301, col: 25, offset: 47884},
+				pos:        position{line: 1323, col: 25, offset: 46835},
 				val:        "`\"",
 				ignoreCase: false,
 				want:       "\"`\\\"\"",
@@ -9295,33 +8248,33 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedStringFallbackCharacter",
-			pos:  position{line: 1303, col: 1, offset: 47891},
+			pos:  position{line: 1325, col: 1, offset: 46842},
 			expr: &actionExpr{
-				pos: position{line: 1303, col: 41, offset: 47931},
+				pos: position{line: 1325, col: 41, offset: 46882},
 				run: (*parser).callonDoubleQuotedStringFallbackCharacter1,
 				expr: &choiceExpr{
-					pos: position{line: 1303, col: 42, offset: 47932},
+					pos: position{line: 1325, col: 42, offset: 46883},
 					alternatives: []interface{}{
 						&charClassMatcher{
-							pos:        position{line: 1303, col: 42, offset: 47932},
+							pos:        position{line: 1325, col: 42, offset: 46883},
 							val:        "[^\\r\\n\\t `]",
 							chars:      []rune{'\r', '\n', '\t', ' ', '`'},
 							ignoreCase: false,
 							inverted:   true,
 						},
 						&seqExpr{
-							pos: position{line: 1303, col: 56, offset: 47946},
+							pos: position{line: 1325, col: 56, offset: 46897},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1303, col: 56, offset: 47946},
+									pos:        position{line: 1325, col: 56, offset: 46897},
 									val:        "`",
 									ignoreCase: false,
 									want:       "\"`\"",
 								},
 								&notExpr{
-									pos: position{line: 1303, col: 60, offset: 47950},
+									pos: position{line: 1325, col: 60, offset: 46901},
 									expr: &litMatcher{
-										pos:        position{line: 1303, col: 61, offset: 47951},
+										pos:        position{line: 1325, col: 61, offset: 46902},
 										val:        "\"",
 										ignoreCase: false,
 										want:       "\"\\\"\"",
@@ -9335,16 +8288,16 @@ var g = &grammar{
 		},
 		{
 			name: "MarkedText",
-			pos:  position{line: 1312, col: 1, offset: 48071},
+			pos:  position{line: 1334, col: 1, offset: 47022},
 			expr: &choiceExpr{
-				pos: position{line: 1312, col: 15, offset: 48085},
+				pos: position{line: 1334, col: 15, offset: 47036},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1312, col: 15, offset: 48085},
+						pos:  position{line: 1334, col: 15, offset: 47036},
 						name: "DoubleQuoteMarkedText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1312, col: 39, offset: 48109},
+						pos:  position{line: 1334, col: 39, offset: 47060},
 						name: "SingleQuoteMarkedText",
 					},
 				},
@@ -9352,40 +8305,40 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteMarkedText",
-			pos:  position{line: 1314, col: 1, offset: 48132},
+			pos:  position{line: 1336, col: 1, offset: 47083},
 			expr: &actionExpr{
-				pos: position{line: 1314, col: 26, offset: 48157},
+				pos: position{line: 1336, col: 26, offset: 47108},
 				run: (*parser).callonDoubleQuoteMarkedText1,
 				expr: &seqExpr{
-					pos: position{line: 1314, col: 26, offset: 48157},
+					pos: position{line: 1336, col: 26, offset: 47108},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1314, col: 26, offset: 48157},
+							pos:   position{line: 1336, col: 26, offset: 47108},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1314, col: 37, offset: 48168},
+								pos: position{line: 1336, col: 37, offset: 47119},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1314, col: 38, offset: 48169},
-									name: "QuotedTextAttributes",
+									pos:  position{line: 1336, col: 38, offset: 47120},
+									name: "LongHandAttributes",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1314, col: 61, offset: 48192},
+							pos:        position{line: 1336, col: 59, offset: 47141},
 							val:        "##",
 							ignoreCase: false,
 							want:       "\"##\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1314, col: 66, offset: 48197},
+							pos:   position{line: 1336, col: 64, offset: 47146},
 							label: "elements",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1314, col: 76, offset: 48207},
+								pos:  position{line: 1336, col: 74, offset: 47156},
 								name: "DoubleQuoteMarkedTextElements",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1314, col: 107, offset: 48238},
+							pos:        position{line: 1336, col: 105, offset: 47187},
 							val:        "##",
 							ignoreCase: false,
 							want:       "\"##\"",
@@ -9396,37 +8349,37 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteMarkedTextElements",
-			pos:  position{line: 1318, col: 1, offset: 48377},
+			pos:  position{line: 1340, col: 1, offset: 47326},
 			expr: &seqExpr{
-				pos: position{line: 1318, col: 34, offset: 48410},
+				pos: position{line: 1340, col: 34, offset: 47359},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1318, col: 34, offset: 48410},
+						pos:  position{line: 1340, col: 34, offset: 47359},
 						name: "DoubleQuoteMarkedTextElement",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1318, col: 63, offset: 48439},
+						pos: position{line: 1340, col: 63, offset: 47388},
 						expr: &seqExpr{
-							pos: position{line: 1318, col: 64, offset: 48440},
+							pos: position{line: 1340, col: 64, offset: 47389},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1318, col: 64, offset: 48440},
+									pos: position{line: 1340, col: 64, offset: 47389},
 									expr: &litMatcher{
-										pos:        position{line: 1318, col: 66, offset: 48442},
+										pos:        position{line: 1340, col: 66, offset: 47391},
 										val:        "##",
 										ignoreCase: false,
 										want:       "\"##\"",
 									},
 								},
 								&choiceExpr{
-									pos: position{line: 1318, col: 73, offset: 48449},
+									pos: position{line: 1340, col: 73, offset: 47398},
 									alternatives: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 1318, col: 73, offset: 48449},
+											pos:  position{line: 1340, col: 73, offset: 47398},
 											name: "Space",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1318, col: 81, offset: 48457},
+											pos:  position{line: 1340, col: 81, offset: 47406},
 											name: "DoubleQuoteMarkedTextElement",
 										},
 									},
@@ -9439,64 +8392,64 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteMarkedTextElement",
-			pos:  position{line: 1320, col: 1, offset: 48524},
+			pos:  position{line: 1342, col: 1, offset: 47473},
 			expr: &choiceExpr{
-				pos: position{line: 1320, col: 33, offset: 48556},
+				pos: position{line: 1342, col: 33, offset: 47505},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1320, col: 33, offset: 48556},
+						pos:  position{line: 1342, col: 33, offset: 47505},
 						name: "Word",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1321, col: 11, offset: 48571},
+						pos:  position{line: 1343, col: 11, offset: 47520},
 						name: "SingleQuoteMarkedText",
 					},
 					&seqExpr{
-						pos: position{line: 1322, col: 11, offset: 48603},
+						pos: position{line: 1344, col: 11, offset: 47552},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 1322, col: 11, offset: 48603},
+								pos:  position{line: 1344, col: 11, offset: 47552},
 								name: "Newline",
 							},
 							&notExpr{
-								pos: position{line: 1322, col: 19, offset: 48611},
+								pos: position{line: 1344, col: 19, offset: 47560},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1322, col: 20, offset: 48612},
+									pos:  position{line: 1344, col: 20, offset: 47561},
 									name: "Newline",
 								},
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1323, col: 11, offset: 48630},
+						pos:  position{line: 1345, col: 11, offset: 47579},
 						name: "QuotedString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1324, col: 11, offset: 48653},
+						pos:  position{line: 1346, col: 11, offset: 47602},
 						name: "BoldText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1325, col: 11, offset: 48672},
+						pos:  position{line: 1347, col: 11, offset: 47621},
 						name: "ItalicText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1326, col: 11, offset: 48693},
+						pos:  position{line: 1348, col: 11, offset: 47642},
 						name: "MonospaceText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1327, col: 11, offset: 48717},
+						pos:  position{line: 1349, col: 11, offset: 47666},
 						name: "SubscriptText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1328, col: 11, offset: 48741},
+						pos:  position{line: 1350, col: 11, offset: 47690},
 						name: "SuperscriptText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1329, col: 11, offset: 48767},
+						pos:  position{line: 1351, col: 11, offset: 47716},
 						name: "ElementPlaceHolder",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1330, col: 11, offset: 48796},
+						pos:  position{line: 1352, col: 11, offset: 47745},
 						name: "DoubleQuoteMarkedTextFallbackCharacter",
 					},
 				},
@@ -9504,31 +8457,31 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteMarkedTextFallbackCharacter",
-			pos:  position{line: 1332, col: 1, offset: 48836},
+			pos:  position{line: 1354, col: 1, offset: 47785},
 			expr: &choiceExpr{
-				pos: position{line: 1333, col: 5, offset: 48882},
+				pos: position{line: 1355, col: 5, offset: 47831},
 				alternatives: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 1333, col: 5, offset: 48882},
+						pos:        position{line: 1355, col: 5, offset: 47831},
 						val:        "[^\\r\\n#]",
 						chars:      []rune{'\r', '\n', '#'},
 						ignoreCase: false,
 						inverted:   true,
 					},
 					&actionExpr{
-						pos: position{line: 1334, col: 7, offset: 48981},
+						pos: position{line: 1356, col: 7, offset: 47930},
 						run: (*parser).callonDoubleQuoteMarkedTextFallbackCharacter3,
 						expr: &seqExpr{
-							pos: position{line: 1334, col: 7, offset: 48981},
+							pos: position{line: 1356, col: 7, offset: 47930},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1334, col: 7, offset: 48981},
+									pos:        position{line: 1356, col: 7, offset: 47930},
 									val:        "##",
 									ignoreCase: false,
 									want:       "\"##\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1334, col: 12, offset: 48986},
+									pos:  position{line: 1356, col: 12, offset: 47935},
 									name: "Alphanums",
 								},
 							},
@@ -9539,40 +8492,40 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteMarkedText",
-			pos:  position{line: 1338, col: 1, offset: 49151},
+			pos:  position{line: 1360, col: 1, offset: 48100},
 			expr: &choiceExpr{
-				pos: position{line: 1338, col: 26, offset: 49176},
+				pos: position{line: 1360, col: 26, offset: 48125},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1338, col: 26, offset: 49176},
+						pos: position{line: 1360, col: 26, offset: 48125},
 						run: (*parser).callonSingleQuoteMarkedText2,
 						expr: &seqExpr{
-							pos: position{line: 1338, col: 26, offset: 49176},
+							pos: position{line: 1360, col: 26, offset: 48125},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1338, col: 26, offset: 49176},
+									pos:   position{line: 1360, col: 26, offset: 48125},
 									label: "attributes",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1338, col: 37, offset: 49187},
+										pos: position{line: 1360, col: 37, offset: 48136},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1338, col: 38, offset: 49188},
-											name: "QuotedTextAttributes",
+											pos:  position{line: 1360, col: 38, offset: 48137},
+											name: "LongHandAttributes",
 										},
 									},
 								},
 								&seqExpr{
-									pos: position{line: 1338, col: 62, offset: 49212},
+									pos: position{line: 1360, col: 60, offset: 48159},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 1338, col: 62, offset: 49212},
+											pos:        position{line: 1360, col: 60, offset: 48159},
 											val:        "#",
 											ignoreCase: false,
 											want:       "\"#\"",
 										},
 										&notExpr{
-											pos: position{line: 1338, col: 66, offset: 49216},
+											pos: position{line: 1360, col: 64, offset: 48163},
 											expr: &litMatcher{
-												pos:        position{line: 1338, col: 67, offset: 49217},
+												pos:        position{line: 1360, col: 65, offset: 48164},
 												val:        "#",
 												ignoreCase: false,
 												want:       "\"#\"",
@@ -9581,15 +8534,15 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1338, col: 72, offset: 49222},
+									pos:   position{line: 1360, col: 70, offset: 48169},
 									label: "elements",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1338, col: 82, offset: 49232},
+										pos:  position{line: 1360, col: 80, offset: 48179},
 										name: "SingleQuoteMarkedTextElements",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1338, col: 113, offset: 49263},
+									pos:        position{line: 1360, col: 111, offset: 48210},
 									val:        "#",
 									ignoreCase: false,
 									want:       "\"#\"",
@@ -9598,49 +8551,49 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1340, col: 5, offset: 49458},
+						pos: position{line: 1362, col: 5, offset: 48405},
 						run: (*parser).callonSingleQuoteMarkedText14,
 						expr: &seqExpr{
-							pos: position{line: 1340, col: 5, offset: 49458},
+							pos: position{line: 1362, col: 5, offset: 48405},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1340, col: 5, offset: 49458},
+									pos:   position{line: 1362, col: 5, offset: 48405},
 									label: "attributes",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1340, col: 16, offset: 49469},
+										pos: position{line: 1362, col: 16, offset: 48416},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1340, col: 17, offset: 49470},
-											name: "QuotedTextAttributes",
+											pos:  position{line: 1362, col: 17, offset: 48417},
+											name: "LongHandAttributes",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1340, col: 40, offset: 49493},
+									pos:        position{line: 1362, col: 38, offset: 48438},
 									val:        "#",
 									ignoreCase: false,
 									want:       "\"#\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1340, col: 44, offset: 49497},
+									pos:   position{line: 1362, col: 42, offset: 48442},
 									label: "elements",
 									expr: &seqExpr{
-										pos: position{line: 1340, col: 54, offset: 49507},
+										pos: position{line: 1362, col: 52, offset: 48452},
 										exprs: []interface{}{
 											&litMatcher{
-												pos:        position{line: 1340, col: 54, offset: 49507},
+												pos:        position{line: 1362, col: 52, offset: 48452},
 												val:        "#",
 												ignoreCase: false,
 												want:       "\"#\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1340, col: 58, offset: 49511},
+												pos:  position{line: 1362, col: 56, offset: 48456},
 												name: "SingleQuoteMarkedTextElements",
 											},
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1340, col: 89, offset: 49542},
+									pos:        position{line: 1362, col: 87, offset: 48487},
 									val:        "#",
 									ignoreCase: false,
 									want:       "\"#\"",
@@ -9653,21 +8606,21 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteMarkedTextElements",
-			pos:  position{line: 1344, col: 1, offset: 49756},
+			pos:  position{line: 1366, col: 1, offset: 48701},
 			expr: &seqExpr{
-				pos: position{line: 1344, col: 34, offset: 49789},
+				pos: position{line: 1366, col: 34, offset: 48734},
 				exprs: []interface{}{
 					&notExpr{
-						pos: position{line: 1344, col: 34, offset: 49789},
+						pos: position{line: 1366, col: 34, offset: 48734},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1344, col: 35, offset: 49790},
+							pos:  position{line: 1366, col: 35, offset: 48735},
 							name: "Space",
 						},
 					},
 					&oneOrMoreExpr{
-						pos: position{line: 1344, col: 41, offset: 49796},
+						pos: position{line: 1366, col: 41, offset: 48741},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1344, col: 41, offset: 49796},
+							pos:  position{line: 1366, col: 41, offset: 48741},
 							name: "SingleQuoteMarkedTextElement",
 						},
 					},
@@ -9676,63 +8629,63 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteMarkedTextElement",
-			pos:  position{line: 1346, col: 1, offset: 49827},
+			pos:  position{line: 1368, col: 1, offset: 48772},
 			expr: &choiceExpr{
-				pos: position{line: 1346, col: 33, offset: 49859},
+				pos: position{line: 1368, col: 33, offset: 48804},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1346, col: 33, offset: 49859},
+						pos:  position{line: 1368, col: 33, offset: 48804},
 						name: "Word",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1347, col: 11, offset: 49874},
+						pos:  position{line: 1369, col: 11, offset: 48819},
 						name: "DoubleQuoteMarkedText",
 					},
 					&seqExpr{
-						pos: position{line: 1348, col: 11, offset: 49906},
+						pos: position{line: 1370, col: 11, offset: 48851},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 1348, col: 11, offset: 49906},
+								pos:  position{line: 1370, col: 11, offset: 48851},
 								name: "Newline",
 							},
 							&notExpr{
-								pos: position{line: 1348, col: 19, offset: 49914},
+								pos: position{line: 1370, col: 19, offset: 48859},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1348, col: 20, offset: 49915},
+									pos:  position{line: 1370, col: 20, offset: 48860},
 									name: "Newline",
 								},
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1349, col: 11, offset: 49933},
+						pos:  position{line: 1371, col: 11, offset: 48878},
 						name: "QuotedString",
 					},
 					&seqExpr{
-						pos: position{line: 1350, col: 11, offset: 49956},
+						pos: position{line: 1372, col: 11, offset: 48901},
 						exprs: []interface{}{
 							&oneOrMoreExpr{
-								pos: position{line: 1350, col: 11, offset: 49956},
+								pos: position{line: 1372, col: 11, offset: 48901},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1350, col: 11, offset: 49956},
+									pos:  position{line: 1372, col: 11, offset: 48901},
 									name: "Space",
 								},
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 1350, col: 18, offset: 49963},
+								pos: position{line: 1372, col: 18, offset: 48908},
 								expr: &seqExpr{
-									pos: position{line: 1350, col: 19, offset: 49964},
+									pos: position{line: 1372, col: 19, offset: 48909},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 1350, col: 19, offset: 49964},
+											pos:        position{line: 1372, col: 19, offset: 48909},
 											val:        "#",
 											ignoreCase: false,
 											want:       "\"#\"",
 										},
 										&notExpr{
-											pos: position{line: 1350, col: 23, offset: 49968},
+											pos: position{line: 1372, col: 23, offset: 48913},
 											expr: &litMatcher{
-												pos:        position{line: 1350, col: 24, offset: 49969},
+												pos:        position{line: 1372, col: 24, offset: 48914},
 												val:        "#",
 												ignoreCase: false,
 												want:       "\"#\"",
@@ -9744,31 +8697,31 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1351, col: 11, offset: 49985},
+						pos:  position{line: 1373, col: 11, offset: 48930},
 						name: "BoldText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1352, col: 11, offset: 50004},
+						pos:  position{line: 1374, col: 11, offset: 48949},
 						name: "ItalicText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1353, col: 11, offset: 50025},
+						pos:  position{line: 1375, col: 11, offset: 48970},
 						name: "MonospaceText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1354, col: 11, offset: 50049},
+						pos:  position{line: 1376, col: 11, offset: 48994},
 						name: "SubscriptText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1355, col: 11, offset: 50073},
+						pos:  position{line: 1377, col: 11, offset: 49018},
 						name: "SuperscriptText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1356, col: 11, offset: 50099},
+						pos:  position{line: 1378, col: 11, offset: 49044},
 						name: "ElementPlaceHolder",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1357, col: 11, offset: 50128},
+						pos:  position{line: 1379, col: 11, offset: 49073},
 						name: "SingleQuoteMarkedTextFallbackCharacter",
 					},
 				},
@@ -9776,31 +8729,31 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteMarkedTextFallbackCharacter",
-			pos:  position{line: 1359, col: 1, offset: 50168},
+			pos:  position{line: 1381, col: 1, offset: 49113},
 			expr: &choiceExpr{
-				pos: position{line: 1360, col: 5, offset: 50214},
+				pos: position{line: 1382, col: 5, offset: 49159},
 				alternatives: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 1360, col: 5, offset: 50214},
+						pos:        position{line: 1382, col: 5, offset: 49159},
 						val:        "[^\\r\\n#]",
 						chars:      []rune{'\r', '\n', '#'},
 						ignoreCase: false,
 						inverted:   true,
 					},
 					&actionExpr{
-						pos: position{line: 1361, col: 7, offset: 50311},
+						pos: position{line: 1383, col: 7, offset: 49256},
 						run: (*parser).callonSingleQuoteMarkedTextFallbackCharacter3,
 						expr: &seqExpr{
-							pos: position{line: 1361, col: 7, offset: 50311},
+							pos: position{line: 1383, col: 7, offset: 49256},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1361, col: 7, offset: 50311},
+									pos:        position{line: 1383, col: 7, offset: 49256},
 									val:        "#",
 									ignoreCase: false,
 									want:       "\"#\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1361, col: 11, offset: 50315},
+									pos:  position{line: 1383, col: 11, offset: 49260},
 									name: "Alphanums",
 								},
 							},
@@ -9811,40 +8764,40 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedMarkedText",
-			pos:  position{line: 1365, col: 1, offset: 50478},
+			pos:  position{line: 1387, col: 1, offset: 49423},
 			expr: &choiceExpr{
-				pos: position{line: 1366, col: 5, offset: 50503},
+				pos: position{line: 1388, col: 5, offset: 49448},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1366, col: 5, offset: 50503},
+						pos: position{line: 1388, col: 5, offset: 49448},
 						run: (*parser).callonEscapedMarkedText2,
 						expr: &seqExpr{
-							pos: position{line: 1366, col: 5, offset: 50503},
+							pos: position{line: 1388, col: 5, offset: 49448},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1366, col: 5, offset: 50503},
+									pos:   position{line: 1388, col: 5, offset: 49448},
 									label: "backslashes",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1366, col: 18, offset: 50516},
+										pos:  position{line: 1388, col: 18, offset: 49461},
 										name: "TwoOrMoreBackslashes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1366, col: 40, offset: 50538},
+									pos:        position{line: 1388, col: 40, offset: 49483},
 									val:        "##",
 									ignoreCase: false,
 									want:       "\"##\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1366, col: 45, offset: 50543},
+									pos:   position{line: 1388, col: 45, offset: 49488},
 									label: "elements",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1366, col: 55, offset: 50553},
+										pos:  position{line: 1388, col: 55, offset: 49498},
 										name: "DoubleQuoteMarkedTextElements",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1366, col: 86, offset: 50584},
+									pos:        position{line: 1388, col: 86, offset: 49529},
 									val:        "##",
 									ignoreCase: false,
 									want:       "\"##\"",
@@ -9853,35 +8806,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1368, col: 9, offset: 50741},
+						pos: position{line: 1390, col: 9, offset: 49686},
 						run: (*parser).callonEscapedMarkedText10,
 						expr: &seqExpr{
-							pos: position{line: 1368, col: 9, offset: 50741},
+							pos: position{line: 1390, col: 9, offset: 49686},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1368, col: 9, offset: 50741},
+									pos:   position{line: 1390, col: 9, offset: 49686},
 									label: "backslashes",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1368, col: 22, offset: 50754},
+										pos:  position{line: 1390, col: 22, offset: 49699},
 										name: "OneOrMoreBackslashes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1368, col: 44, offset: 50776},
+									pos:        position{line: 1390, col: 44, offset: 49721},
 									val:        "##",
 									ignoreCase: false,
 									want:       "\"##\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1368, col: 49, offset: 50781},
+									pos:   position{line: 1390, col: 49, offset: 49726},
 									label: "elements",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1368, col: 59, offset: 50791},
+										pos:  position{line: 1390, col: 59, offset: 49736},
 										name: "SingleQuoteMarkedTextElements",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1368, col: 90, offset: 50822},
+									pos:        position{line: 1390, col: 90, offset: 49767},
 									val:        "#",
 									ignoreCase: false,
 									want:       "\"#\"",
@@ -9890,35 +8843,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1371, col: 9, offset: 51022},
+						pos: position{line: 1393, col: 9, offset: 49967},
 						run: (*parser).callonEscapedMarkedText18,
 						expr: &seqExpr{
-							pos: position{line: 1371, col: 9, offset: 51022},
+							pos: position{line: 1393, col: 9, offset: 49967},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1371, col: 9, offset: 51022},
+									pos:   position{line: 1393, col: 9, offset: 49967},
 									label: "backslashes",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1371, col: 22, offset: 51035},
+										pos:  position{line: 1393, col: 22, offset: 49980},
 										name: "OneOrMoreBackslashes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1371, col: 44, offset: 51057},
+									pos:        position{line: 1393, col: 44, offset: 50002},
 									val:        "#",
 									ignoreCase: false,
 									want:       "\"#\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1371, col: 48, offset: 51061},
+									pos:   position{line: 1393, col: 48, offset: 50006},
 									label: "elements",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1371, col: 58, offset: 51071},
+										pos:  position{line: 1393, col: 58, offset: 50016},
 										name: "SingleQuoteMarkedTextElements",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1371, col: 89, offset: 51102},
+									pos:        position{line: 1393, col: 89, offset: 50047},
 									val:        "#",
 									ignoreCase: false,
 									want:       "\"#\"",
@@ -9931,40 +8884,40 @@ var g = &grammar{
 		},
 		{
 			name: "SubscriptText",
-			pos:  position{line: 1376, col: 1, offset: 51252},
+			pos:  position{line: 1398, col: 1, offset: 50197},
 			expr: &actionExpr{
-				pos: position{line: 1376, col: 18, offset: 51269},
+				pos: position{line: 1398, col: 18, offset: 50214},
 				run: (*parser).callonSubscriptText1,
 				expr: &seqExpr{
-					pos: position{line: 1376, col: 18, offset: 51269},
+					pos: position{line: 1398, col: 18, offset: 50214},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1376, col: 18, offset: 51269},
+							pos:   position{line: 1398, col: 18, offset: 50214},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1376, col: 29, offset: 51280},
+								pos: position{line: 1398, col: 29, offset: 50225},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1376, col: 30, offset: 51281},
-									name: "QuotedTextAttributes",
+									pos:  position{line: 1398, col: 30, offset: 50226},
+									name: "LongHandAttributes",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1376, col: 53, offset: 51304},
+							pos:        position{line: 1398, col: 51, offset: 50247},
 							val:        "~",
 							ignoreCase: false,
 							want:       "\"~\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1376, col: 57, offset: 51308},
+							pos:   position{line: 1398, col: 55, offset: 50251},
 							label: "element",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1376, col: 66, offset: 51317},
+								pos:  position{line: 1398, col: 64, offset: 50260},
 								name: "SubscriptTextElement",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1376, col: 88, offset: 51339},
+							pos:        position{line: 1398, col: 86, offset: 50282},
 							val:        "~",
 							ignoreCase: false,
 							want:       "\"~\"",
@@ -9975,16 +8928,16 @@ var g = &grammar{
 		},
 		{
 			name: "SubscriptTextElement",
-			pos:  position{line: 1380, col: 1, offset: 51440},
+			pos:  position{line: 1402, col: 1, offset: 50383},
 			expr: &choiceExpr{
-				pos: position{line: 1380, col: 25, offset: 51464},
+				pos: position{line: 1402, col: 25, offset: 50407},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1380, col: 25, offset: 51464},
+						pos:  position{line: 1402, col: 25, offset: 50407},
 						name: "QuotedText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1380, col: 38, offset: 51477},
+						pos:  position{line: 1402, col: 38, offset: 50420},
 						name: "NonSubscriptText",
 					},
 				},
@@ -9992,14 +8945,14 @@ var g = &grammar{
 		},
 		{
 			name: "NonSubscriptText",
-			pos:  position{line: 1382, col: 1, offset: 51496},
+			pos:  position{line: 1404, col: 1, offset: 50439},
 			expr: &actionExpr{
-				pos: position{line: 1382, col: 21, offset: 51516},
+				pos: position{line: 1404, col: 21, offset: 50459},
 				run: (*parser).callonNonSubscriptText1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1382, col: 21, offset: 51516},
+					pos: position{line: 1404, col: 21, offset: 50459},
 					expr: &charClassMatcher{
-						pos:        position{line: 1382, col: 21, offset: 51516},
+						pos:        position{line: 1404, col: 21, offset: 50459},
 						val:        "[^\\r\\n ~]",
 						chars:      []rune{'\r', '\n', ' ', '~'},
 						ignoreCase: false,
@@ -10010,37 +8963,37 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedSubscriptText",
-			pos:  position{line: 1386, col: 1, offset: 51593},
+			pos:  position{line: 1408, col: 1, offset: 50536},
 			expr: &actionExpr{
-				pos: position{line: 1386, col: 25, offset: 51617},
+				pos: position{line: 1408, col: 25, offset: 50560},
 				run: (*parser).callonEscapedSubscriptText1,
 				expr: &seqExpr{
-					pos: position{line: 1386, col: 25, offset: 51617},
+					pos: position{line: 1408, col: 25, offset: 50560},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1386, col: 25, offset: 51617},
+							pos:   position{line: 1408, col: 25, offset: 50560},
 							label: "backslashes",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1386, col: 38, offset: 51630},
+								pos:  position{line: 1408, col: 38, offset: 50573},
 								name: "OneOrMoreBackslashes",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1386, col: 60, offset: 51652},
+							pos:        position{line: 1408, col: 60, offset: 50595},
 							val:        "~",
 							ignoreCase: false,
 							want:       "\"~\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1386, col: 64, offset: 51656},
+							pos:   position{line: 1408, col: 64, offset: 50599},
 							label: "element",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1386, col: 73, offset: 51665},
+								pos:  position{line: 1408, col: 73, offset: 50608},
 								name: "SubscriptTextElement",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1386, col: 95, offset: 51687},
+							pos:        position{line: 1408, col: 95, offset: 50630},
 							val:        "~",
 							ignoreCase: false,
 							want:       "\"~\"",
@@ -10051,40 +9004,40 @@ var g = &grammar{
 		},
 		{
 			name: "SuperscriptText",
-			pos:  position{line: 1390, col: 1, offset: 51816},
+			pos:  position{line: 1412, col: 1, offset: 50759},
 			expr: &actionExpr{
-				pos: position{line: 1390, col: 20, offset: 51835},
+				pos: position{line: 1412, col: 20, offset: 50778},
 				run: (*parser).callonSuperscriptText1,
 				expr: &seqExpr{
-					pos: position{line: 1390, col: 20, offset: 51835},
+					pos: position{line: 1412, col: 20, offset: 50778},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1390, col: 20, offset: 51835},
+							pos:   position{line: 1412, col: 20, offset: 50778},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1390, col: 31, offset: 51846},
+								pos: position{line: 1412, col: 31, offset: 50789},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1390, col: 32, offset: 51847},
-									name: "QuotedTextAttributes",
+									pos:  position{line: 1412, col: 32, offset: 50790},
+									name: "LongHandAttributes",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1390, col: 55, offset: 51870},
+							pos:        position{line: 1412, col: 53, offset: 50811},
 							val:        "^",
 							ignoreCase: false,
 							want:       "\"^\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1390, col: 59, offset: 51874},
+							pos:   position{line: 1412, col: 57, offset: 50815},
 							label: "element",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1390, col: 68, offset: 51883},
+								pos:  position{line: 1412, col: 66, offset: 50824},
 								name: "SuperscriptTextElement",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1390, col: 92, offset: 51907},
+							pos:        position{line: 1412, col: 90, offset: 50848},
 							val:        "^",
 							ignoreCase: false,
 							want:       "\"^\"",
@@ -10095,16 +9048,16 @@ var g = &grammar{
 		},
 		{
 			name: "SuperscriptTextElement",
-			pos:  position{line: 1394, col: 1, offset: 52010},
+			pos:  position{line: 1416, col: 1, offset: 50951},
 			expr: &choiceExpr{
-				pos: position{line: 1394, col: 27, offset: 52036},
+				pos: position{line: 1416, col: 27, offset: 50977},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1394, col: 27, offset: 52036},
+						pos:  position{line: 1416, col: 27, offset: 50977},
 						name: "QuotedText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1394, col: 40, offset: 52049},
+						pos:  position{line: 1416, col: 40, offset: 50990},
 						name: "NonSuperscriptText",
 					},
 				},
@@ -10112,14 +9065,14 @@ var g = &grammar{
 		},
 		{
 			name: "NonSuperscriptText",
-			pos:  position{line: 1396, col: 1, offset: 52070},
+			pos:  position{line: 1418, col: 1, offset: 51011},
 			expr: &actionExpr{
-				pos: position{line: 1396, col: 23, offset: 52092},
+				pos: position{line: 1418, col: 23, offset: 51033},
 				run: (*parser).callonNonSuperscriptText1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1396, col: 23, offset: 52092},
+					pos: position{line: 1418, col: 23, offset: 51033},
 					expr: &charClassMatcher{
-						pos:        position{line: 1396, col: 23, offset: 52092},
+						pos:        position{line: 1418, col: 23, offset: 51033},
 						val:        "[^\\r\\n ^]",
 						chars:      []rune{'\r', '\n', ' ', '^'},
 						ignoreCase: false,
@@ -10130,37 +9083,37 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedSuperscriptText",
-			pos:  position{line: 1400, col: 1, offset: 52169},
+			pos:  position{line: 1422, col: 1, offset: 51110},
 			expr: &actionExpr{
-				pos: position{line: 1400, col: 27, offset: 52195},
+				pos: position{line: 1422, col: 27, offset: 51136},
 				run: (*parser).callonEscapedSuperscriptText1,
 				expr: &seqExpr{
-					pos: position{line: 1400, col: 27, offset: 52195},
+					pos: position{line: 1422, col: 27, offset: 51136},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1400, col: 27, offset: 52195},
+							pos:   position{line: 1422, col: 27, offset: 51136},
 							label: "backslashes",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1400, col: 40, offset: 52208},
+								pos:  position{line: 1422, col: 40, offset: 51149},
 								name: "OneOrMoreBackslashes",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1400, col: 62, offset: 52230},
+							pos:        position{line: 1422, col: 62, offset: 51171},
 							val:        "^",
 							ignoreCase: false,
 							want:       "\"^\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1400, col: 66, offset: 52234},
+							pos:   position{line: 1422, col: 66, offset: 51175},
 							label: "element",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1400, col: 75, offset: 52243},
+								pos:  position{line: 1422, col: 75, offset: 51184},
 								name: "SuperscriptTextElement",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1400, col: 99, offset: 52267},
+							pos:        position{line: 1422, col: 99, offset: 51208},
 							val:        "^",
 							ignoreCase: false,
 							want:       "\"^\"",
@@ -10171,20 +9124,20 @@ var g = &grammar{
 		},
 		{
 			name: "InlinePassthrough",
-			pos:  position{line: 1407, col: 1, offset: 52509},
+			pos:  position{line: 1429, col: 1, offset: 51450},
 			expr: &choiceExpr{
-				pos: position{line: 1407, col: 22, offset: 52530},
+				pos: position{line: 1429, col: 22, offset: 51471},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1407, col: 22, offset: 52530},
+						pos:  position{line: 1429, col: 22, offset: 51471},
 						name: "TriplePlusPassthrough",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1407, col: 46, offset: 52554},
+						pos:  position{line: 1429, col: 46, offset: 51495},
 						name: "SinglePlusPassthrough",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1407, col: 70, offset: 52578},
+						pos:  position{line: 1429, col: 70, offset: 51519},
 						name: "PassthroughMacro",
 					},
 				},
@@ -10192,9 +9145,9 @@ var g = &grammar{
 		},
 		{
 			name: "SinglePlusPassthroughPrefix",
-			pos:  position{line: 1409, col: 1, offset: 52596},
+			pos:  position{line: 1431, col: 1, offset: 51537},
 			expr: &litMatcher{
-				pos:        position{line: 1409, col: 32, offset: 52627},
+				pos:        position{line: 1431, col: 32, offset: 51568},
 				val:        "+",
 				ignoreCase: false,
 				want:       "\"+\"",
@@ -10202,33 +9155,33 @@ var g = &grammar{
 		},
 		{
 			name: "SinglePlusPassthrough",
-			pos:  position{line: 1411, col: 1, offset: 52632},
+			pos:  position{line: 1433, col: 1, offset: 51573},
 			expr: &actionExpr{
-				pos: position{line: 1411, col: 26, offset: 52657},
+				pos: position{line: 1433, col: 26, offset: 51598},
 				run: (*parser).callonSinglePlusPassthrough1,
 				expr: &seqExpr{
-					pos: position{line: 1411, col: 26, offset: 52657},
+					pos: position{line: 1433, col: 26, offset: 51598},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1411, col: 26, offset: 52657},
+							pos:  position{line: 1433, col: 26, offset: 51598},
 							name: "SinglePlusPassthroughPrefix",
 						},
 						&labeledExpr{
-							pos:   position{line: 1411, col: 54, offset: 52685},
+							pos:   position{line: 1433, col: 54, offset: 51626},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1411, col: 63, offset: 52694},
+								pos:  position{line: 1433, col: 63, offset: 51635},
 								name: "SinglePlusPassthroughContent",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1411, col: 93, offset: 52724},
+							pos:  position{line: 1433, col: 93, offset: 51665},
 							name: "SinglePlusPassthroughPrefix",
 						},
 						&notExpr{
-							pos: position{line: 1411, col: 121, offset: 52752},
+							pos: position{line: 1433, col: 121, offset: 51693},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1411, col: 122, offset: 52753},
+								pos:  position{line: 1433, col: 122, offset: 51694},
 								name: "Alphanum",
 							},
 						},
@@ -10238,85 +9191,85 @@ var g = &grammar{
 		},
 		{
 			name: "SinglePlusPassthroughContent",
-			pos:  position{line: 1415, col: 1, offset: 52858},
+			pos:  position{line: 1437, col: 1, offset: 51799},
 			expr: &choiceExpr{
-				pos: position{line: 1415, col: 33, offset: 52890},
+				pos: position{line: 1437, col: 33, offset: 51831},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1415, col: 34, offset: 52891},
+						pos: position{line: 1437, col: 34, offset: 51832},
 						run: (*parser).callonSinglePlusPassthroughContent2,
 						expr: &seqExpr{
-							pos: position{line: 1415, col: 34, offset: 52891},
+							pos: position{line: 1437, col: 34, offset: 51832},
 							exprs: []interface{}{
 								&seqExpr{
-									pos: position{line: 1415, col: 35, offset: 52892},
+									pos: position{line: 1437, col: 35, offset: 51833},
 									exprs: []interface{}{
 										&notExpr{
-											pos: position{line: 1415, col: 35, offset: 52892},
+											pos: position{line: 1437, col: 35, offset: 51833},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1415, col: 36, offset: 52893},
+												pos:  position{line: 1437, col: 36, offset: 51834},
 												name: "SinglePlusPassthroughPrefix",
 											},
 										},
 										&notExpr{
-											pos: position{line: 1415, col: 64, offset: 52921},
+											pos: position{line: 1437, col: 64, offset: 51862},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1415, col: 65, offset: 52922},
+												pos:  position{line: 1437, col: 65, offset: 51863},
 												name: "Space",
 											},
 										},
 										&notExpr{
-											pos: position{line: 1415, col: 71, offset: 52928},
+											pos: position{line: 1437, col: 71, offset: 51869},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1415, col: 72, offset: 52929},
+												pos:  position{line: 1437, col: 72, offset: 51870},
 												name: "Newline",
 											},
 										},
 										&anyMatcher{
-											line: 1415, col: 80, offset: 52937,
+											line: 1437, col: 80, offset: 51878,
 										},
 									},
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1415, col: 83, offset: 52940},
+									pos: position{line: 1437, col: 83, offset: 51881},
 									expr: &seqExpr{
-										pos: position{line: 1415, col: 84, offset: 52941},
+										pos: position{line: 1437, col: 84, offset: 51882},
 										exprs: []interface{}{
 											&notExpr{
-												pos: position{line: 1415, col: 84, offset: 52941},
+												pos: position{line: 1437, col: 84, offset: 51882},
 												expr: &seqExpr{
-													pos: position{line: 1415, col: 86, offset: 52943},
+													pos: position{line: 1437, col: 86, offset: 51884},
 													exprs: []interface{}{
 														&oneOrMoreExpr{
-															pos: position{line: 1415, col: 86, offset: 52943},
+															pos: position{line: 1437, col: 86, offset: 51884},
 															expr: &ruleRefExpr{
-																pos:  position{line: 1415, col: 86, offset: 52943},
+																pos:  position{line: 1437, col: 86, offset: 51884},
 																name: "Space",
 															},
 														},
 														&ruleRefExpr{
-															pos:  position{line: 1415, col: 93, offset: 52950},
+															pos:  position{line: 1437, col: 93, offset: 51891},
 															name: "SinglePlusPassthroughPrefix",
 														},
 													},
 												},
 											},
 											&notExpr{
-												pos: position{line: 1415, col: 122, offset: 52979},
+												pos: position{line: 1437, col: 122, offset: 51920},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1415, col: 123, offset: 52980},
+													pos:  position{line: 1437, col: 123, offset: 51921},
 													name: "SinglePlusPassthroughPrefix",
 												},
 											},
 											&notExpr{
-												pos: position{line: 1415, col: 151, offset: 53008},
+												pos: position{line: 1437, col: 151, offset: 51949},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1415, col: 152, offset: 53009},
+													pos:  position{line: 1437, col: 152, offset: 51950},
 													name: "Newline",
 												},
 											},
 											&anyMatcher{
-												line: 1415, col: 160, offset: 53017,
+												line: 1437, col: 160, offset: 51958,
 											},
 										},
 									},
@@ -10325,34 +9278,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1417, col: 7, offset: 53159},
+						pos: position{line: 1439, col: 7, offset: 52100},
 						run: (*parser).callonSinglePlusPassthroughContent24,
 						expr: &seqExpr{
-							pos: position{line: 1417, col: 8, offset: 53160},
+							pos: position{line: 1439, col: 8, offset: 52101},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1417, col: 8, offset: 53160},
+									pos: position{line: 1439, col: 8, offset: 52101},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1417, col: 9, offset: 53161},
+										pos:  position{line: 1439, col: 9, offset: 52102},
 										name: "Space",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1417, col: 15, offset: 53167},
+									pos: position{line: 1439, col: 15, offset: 52108},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1417, col: 16, offset: 53168},
+										pos:  position{line: 1439, col: 16, offset: 52109},
 										name: "Newline",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1417, col: 24, offset: 53176},
+									pos: position{line: 1439, col: 24, offset: 52117},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1417, col: 25, offset: 53177},
+										pos:  position{line: 1439, col: 25, offset: 52118},
 										name: "SinglePlusPassthroughPrefix",
 									},
 								},
 								&anyMatcher{
-									line: 1417, col: 53, offset: 53205,
+									line: 1439, col: 53, offset: 52146,
 								},
 							},
 						},
@@ -10362,9 +9315,9 @@ var g = &grammar{
 		},
 		{
 			name: "TriplePlusPassthroughPrefix",
-			pos:  position{line: 1421, col: 1, offset: 53287},
+			pos:  position{line: 1443, col: 1, offset: 52228},
 			expr: &litMatcher{
-				pos:        position{line: 1421, col: 32, offset: 53318},
+				pos:        position{line: 1443, col: 32, offset: 52259},
 				val:        "+++",
 				ignoreCase: false,
 				want:       "\"+++\"",
@@ -10372,33 +9325,33 @@ var g = &grammar{
 		},
 		{
 			name: "TriplePlusPassthrough",
-			pos:  position{line: 1423, col: 1, offset: 53325},
+			pos:  position{line: 1445, col: 1, offset: 52266},
 			expr: &actionExpr{
-				pos: position{line: 1423, col: 26, offset: 53350},
+				pos: position{line: 1445, col: 26, offset: 52291},
 				run: (*parser).callonTriplePlusPassthrough1,
 				expr: &seqExpr{
-					pos: position{line: 1423, col: 26, offset: 53350},
+					pos: position{line: 1445, col: 26, offset: 52291},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1423, col: 26, offset: 53350},
+							pos:  position{line: 1445, col: 26, offset: 52291},
 							name: "TriplePlusPassthroughPrefix",
 						},
 						&labeledExpr{
-							pos:   position{line: 1423, col: 54, offset: 53378},
+							pos:   position{line: 1445, col: 54, offset: 52319},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1423, col: 63, offset: 53387},
+								pos:  position{line: 1445, col: 63, offset: 52328},
 								name: "TriplePlusPassthroughContent",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1423, col: 93, offset: 53417},
+							pos:  position{line: 1445, col: 93, offset: 52358},
 							name: "TriplePlusPassthroughPrefix",
 						},
 						&notExpr{
-							pos: position{line: 1423, col: 121, offset: 53445},
+							pos: position{line: 1445, col: 121, offset: 52386},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1423, col: 122, offset: 53446},
+								pos:  position{line: 1445, col: 122, offset: 52387},
 								name: "Alphanum",
 							},
 						},
@@ -10408,63 +9361,63 @@ var g = &grammar{
 		},
 		{
 			name: "TriplePlusPassthroughContent",
-			pos:  position{line: 1427, col: 1, offset: 53551},
+			pos:  position{line: 1449, col: 1, offset: 52492},
 			expr: &choiceExpr{
-				pos: position{line: 1427, col: 33, offset: 53583},
+				pos: position{line: 1449, col: 33, offset: 52524},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1427, col: 34, offset: 53584},
+						pos: position{line: 1449, col: 34, offset: 52525},
 						run: (*parser).callonTriplePlusPassthroughContent2,
 						expr: &zeroOrMoreExpr{
-							pos: position{line: 1427, col: 34, offset: 53584},
+							pos: position{line: 1449, col: 34, offset: 52525},
 							expr: &seqExpr{
-								pos: position{line: 1427, col: 35, offset: 53585},
+								pos: position{line: 1449, col: 35, offset: 52526},
 								exprs: []interface{}{
 									&notExpr{
-										pos: position{line: 1427, col: 35, offset: 53585},
+										pos: position{line: 1449, col: 35, offset: 52526},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1427, col: 36, offset: 53586},
+											pos:  position{line: 1449, col: 36, offset: 52527},
 											name: "TriplePlusPassthroughPrefix",
 										},
 									},
 									&anyMatcher{
-										line: 1427, col: 64, offset: 53614,
+										line: 1449, col: 64, offset: 52555,
 									},
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1429, col: 7, offset: 53779},
+						pos: position{line: 1451, col: 7, offset: 52720},
 						run: (*parser).callonTriplePlusPassthroughContent8,
 						expr: &zeroOrOneExpr{
-							pos: position{line: 1429, col: 7, offset: 53779},
+							pos: position{line: 1451, col: 7, offset: 52720},
 							expr: &seqExpr{
-								pos: position{line: 1429, col: 8, offset: 53780},
+								pos: position{line: 1451, col: 8, offset: 52721},
 								exprs: []interface{}{
 									&notExpr{
-										pos: position{line: 1429, col: 8, offset: 53780},
+										pos: position{line: 1451, col: 8, offset: 52721},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1429, col: 9, offset: 53781},
+											pos:  position{line: 1451, col: 9, offset: 52722},
 											name: "Space",
 										},
 									},
 									&notExpr{
-										pos: position{line: 1429, col: 15, offset: 53787},
+										pos: position{line: 1451, col: 15, offset: 52728},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1429, col: 16, offset: 53788},
+											pos:  position{line: 1451, col: 16, offset: 52729},
 											name: "Newline",
 										},
 									},
 									&notExpr{
-										pos: position{line: 1429, col: 24, offset: 53796},
+										pos: position{line: 1451, col: 24, offset: 52737},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1429, col: 25, offset: 53797},
+											pos:  position{line: 1451, col: 25, offset: 52738},
 											name: "TriplePlusPassthroughPrefix",
 										},
 									},
 									&anyMatcher{
-										line: 1429, col: 53, offset: 53825,
+										line: 1451, col: 53, offset: 52766,
 									},
 								},
 							},
@@ -10475,35 +9428,35 @@ var g = &grammar{
 		},
 		{
 			name: "PassthroughMacro",
-			pos:  position{line: 1433, col: 1, offset: 53908},
+			pos:  position{line: 1455, col: 1, offset: 52849},
 			expr: &choiceExpr{
-				pos: position{line: 1433, col: 21, offset: 53928},
+				pos: position{line: 1455, col: 21, offset: 52869},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1433, col: 21, offset: 53928},
+						pos: position{line: 1455, col: 21, offset: 52869},
 						run: (*parser).callonPassthroughMacro2,
 						expr: &seqExpr{
-							pos: position{line: 1433, col: 21, offset: 53928},
+							pos: position{line: 1455, col: 21, offset: 52869},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1433, col: 21, offset: 53928},
+									pos:        position{line: 1455, col: 21, offset: 52869},
 									val:        "pass:[",
 									ignoreCase: false,
 									want:       "\"pass:[\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1433, col: 30, offset: 53937},
+									pos:   position{line: 1455, col: 30, offset: 52878},
 									label: "content",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1433, col: 38, offset: 53945},
+										pos: position{line: 1455, col: 38, offset: 52886},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1433, col: 39, offset: 53946},
+											pos:  position{line: 1455, col: 39, offset: 52887},
 											name: "PassthroughMacroCharacter",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1433, col: 67, offset: 53974},
+									pos:        position{line: 1455, col: 67, offset: 52915},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -10512,31 +9465,31 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1435, col: 5, offset: 54070},
+						pos: position{line: 1457, col: 5, offset: 53011},
 						run: (*parser).callonPassthroughMacro9,
 						expr: &seqExpr{
-							pos: position{line: 1435, col: 5, offset: 54070},
+							pos: position{line: 1457, col: 5, offset: 53011},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1435, col: 5, offset: 54070},
+									pos:        position{line: 1457, col: 5, offset: 53011},
 									val:        "pass:q[",
 									ignoreCase: false,
 									want:       "\"pass:q[\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1435, col: 15, offset: 54080},
+									pos:   position{line: 1457, col: 15, offset: 53021},
 									label: "content",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1435, col: 23, offset: 54088},
+										pos: position{line: 1457, col: 23, offset: 53029},
 										expr: &choiceExpr{
-											pos: position{line: 1435, col: 24, offset: 54089},
+											pos: position{line: 1457, col: 24, offset: 53030},
 											alternatives: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 1435, col: 24, offset: 54089},
+													pos:  position{line: 1457, col: 24, offset: 53030},
 													name: "QuotedText",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1435, col: 37, offset: 54102},
+													pos:  position{line: 1457, col: 37, offset: 53043},
 													name: "PassthroughMacroCharacter",
 												},
 											},
@@ -10544,7 +9497,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1435, col: 65, offset: 54130},
+									pos:        position{line: 1457, col: 65, offset: 53071},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -10557,12 +9510,12 @@ var g = &grammar{
 		},
 		{
 			name: "PassthroughMacroCharacter",
-			pos:  position{line: 1439, col: 1, offset: 54226},
+			pos:  position{line: 1461, col: 1, offset: 53167},
 			expr: &actionExpr{
-				pos: position{line: 1439, col: 30, offset: 54255},
+				pos: position{line: 1461, col: 30, offset: 53196},
 				run: (*parser).callonPassthroughMacroCharacter1,
 				expr: &charClassMatcher{
-					pos:        position{line: 1439, col: 30, offset: 54255},
+					pos:        position{line: 1461, col: 30, offset: 53196},
 					val:        "[^\\]]",
 					chars:      []rune{']'},
 					ignoreCase: false,
@@ -10572,16 +9525,16 @@ var g = &grammar{
 		},
 		{
 			name: "CrossReference",
-			pos:  position{line: 1446, col: 1, offset: 54428},
+			pos:  position{line: 1468, col: 1, offset: 53369},
 			expr: &choiceExpr{
-				pos: position{line: 1446, col: 19, offset: 54446},
+				pos: position{line: 1468, col: 19, offset: 53387},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1446, col: 19, offset: 54446},
+						pos:  position{line: 1468, col: 19, offset: 53387},
 						name: "InternalCrossReference",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1446, col: 44, offset: 54471},
+						pos:  position{line: 1468, col: 44, offset: 53412},
 						name: "ExternalCrossReference",
 					},
 				},
@@ -10589,53 +9542,53 @@ var g = &grammar{
 		},
 		{
 			name: "InternalCrossReference",
-			pos:  position{line: 1448, col: 1, offset: 54496},
+			pos:  position{line: 1470, col: 1, offset: 53437},
 			expr: &choiceExpr{
-				pos: position{line: 1448, col: 27, offset: 54522},
+				pos: position{line: 1470, col: 27, offset: 53463},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1448, col: 27, offset: 54522},
+						pos: position{line: 1470, col: 27, offset: 53463},
 						run: (*parser).callonInternalCrossReference2,
 						expr: &seqExpr{
-							pos: position{line: 1448, col: 27, offset: 54522},
+							pos: position{line: 1470, col: 27, offset: 53463},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1448, col: 27, offset: 54522},
+									pos:        position{line: 1470, col: 27, offset: 53463},
 									val:        "<<",
 									ignoreCase: false,
 									want:       "\"<<\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1448, col: 32, offset: 54527},
+									pos:   position{line: 1470, col: 32, offset: 53468},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1448, col: 36, offset: 54531},
+										pos:  position{line: 1470, col: 36, offset: 53472},
 										name: "Id",
 									},
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1448, col: 40, offset: 54535},
+									pos: position{line: 1470, col: 40, offset: 53476},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1448, col: 40, offset: 54535},
+										pos:  position{line: 1470, col: 40, offset: 53476},
 										name: "Space",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1448, col: 47, offset: 54542},
+									pos:        position{line: 1470, col: 47, offset: 53483},
 									val:        ",",
 									ignoreCase: false,
 									want:       "\",\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1448, col: 51, offset: 54546},
+									pos:   position{line: 1470, col: 51, offset: 53487},
 									label: "label",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1448, col: 58, offset: 54553},
+										pos:  position{line: 1470, col: 58, offset: 53494},
 										name: "CrossReferenceLabel",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1448, col: 79, offset: 54574},
+									pos:        position{line: 1470, col: 79, offset: 53515},
 									val:        ">>",
 									ignoreCase: false,
 									want:       "\">>\"",
@@ -10644,27 +9597,27 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1450, col: 5, offset: 54639},
+						pos: position{line: 1472, col: 5, offset: 53580},
 						run: (*parser).callonInternalCrossReference13,
 						expr: &seqExpr{
-							pos: position{line: 1450, col: 5, offset: 54639},
+							pos: position{line: 1472, col: 5, offset: 53580},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1450, col: 5, offset: 54639},
+									pos:        position{line: 1472, col: 5, offset: 53580},
 									val:        "<<",
 									ignoreCase: false,
 									want:       "\"<<\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1450, col: 10, offset: 54644},
+									pos:   position{line: 1472, col: 10, offset: 53585},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1450, col: 14, offset: 54648},
+										pos:  position{line: 1472, col: 14, offset: 53589},
 										name: "Id",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1450, col: 18, offset: 54652},
+									pos:        position{line: 1472, col: 18, offset: 53593},
 									val:        ">>",
 									ignoreCase: false,
 									want:       "\">>\"",
@@ -10677,33 +9630,33 @@ var g = &grammar{
 		},
 		{
 			name: "ExternalCrossReference",
-			pos:  position{line: 1454, col: 1, offset: 54715},
+			pos:  position{line: 1476, col: 1, offset: 53656},
 			expr: &actionExpr{
-				pos: position{line: 1454, col: 27, offset: 54741},
+				pos: position{line: 1476, col: 27, offset: 53682},
 				run: (*parser).callonExternalCrossReference1,
 				expr: &seqExpr{
-					pos: position{line: 1454, col: 27, offset: 54741},
+					pos: position{line: 1476, col: 27, offset: 53682},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1454, col: 27, offset: 54741},
+							pos:        position{line: 1476, col: 27, offset: 53682},
 							val:        "xref:",
 							ignoreCase: false,
 							want:       "\"xref:\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1454, col: 35, offset: 54749},
+							pos:   position{line: 1476, col: 35, offset: 53690},
 							label: "url",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1454, col: 40, offset: 54754},
+								pos:  position{line: 1476, col: 40, offset: 53695},
 								name: "FileLocation",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1454, col: 54, offset: 54768},
+							pos:   position{line: 1476, col: 54, offset: 53709},
 							label: "inlineAttributes",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1454, col: 72, offset: 54786},
-								name: "LinkAttributes",
+								pos:  position{line: 1476, col: 72, offset: 53727},
+								name: "InlineAttributes",
 							},
 						},
 					},
@@ -10712,24 +9665,69 @@ var g = &grammar{
 		},
 		{
 			name: "CrossReferenceLabel",
-			pos:  position{line: 1458, col: 1, offset: 54909},
-			expr: &ruleRefExpr{
-				pos:  position{line: 1458, col: 24, offset: 54932},
-				name: "ElementTitleContent",
+			pos:  position{line: 1480, col: 1, offset: 53852},
+			expr: &oneOrMoreExpr{
+				pos: position{line: 1480, col: 24, offset: 53875},
+				expr: &choiceExpr{
+					pos: position{line: 1481, col: 5, offset: 53881},
+					alternatives: []interface{}{
+						&actionExpr{
+							pos: position{line: 1481, col: 6, offset: 53882},
+							run: (*parser).callonCrossReferenceLabel3,
+							expr: &seqExpr{
+								pos: position{line: 1481, col: 6, offset: 53882},
+								exprs: []interface{}{
+									&charClassMatcher{
+										pos:        position{line: 1481, col: 6, offset: 53882},
+										val:        "[\\pL0-9]",
+										ranges:     []rune{'0', '9'},
+										classes:    []*unicode.RangeTable{rangeTable("L")},
+										ignoreCase: false,
+										inverted:   false,
+									},
+									&oneOrMoreExpr{
+										pos: position{line: 1481, col: 14, offset: 53890},
+										expr: &charClassMatcher{
+											pos:        position{line: 1481, col: 14, offset: 53890},
+											val:        "[^\\r\\n{<>]",
+											chars:      []rune{'\r', '\n', '{', '<', '>'},
+											ignoreCase: false,
+											inverted:   true,
+										},
+									},
+								},
+							},
+						},
+						&ruleRefExpr{
+							pos:  position{line: 1484, col: 5, offset: 54085},
+							name: "AttrSub",
+						},
+						&actionExpr{
+							pos: position{line: 1485, col: 6, offset: 54100},
+							run: (*parser).callonCrossReferenceLabel9,
+							expr: &litMatcher{
+								pos:        position{line: 1485, col: 6, offset: 54100},
+								val:        "{",
+								ignoreCase: false,
+								want:       "\"{\"",
+							},
+						},
+					},
+				},
 			},
 		},
 		{
 			name: "Link",
-			pos:  position{line: 1463, col: 1, offset: 55054},
+			pos:  position{line: 1493, col: 1, offset: 54277},
 			expr: &choiceExpr{
-				pos: position{line: 1463, col: 9, offset: 55062},
+				pos: position{line: 1493, col: 9, offset: 54285},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1463, col: 9, offset: 55062},
+						pos:  position{line: 1493, col: 9, offset: 54285},
 						name: "RelativeLink",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1463, col: 24, offset: 55077},
+						pos:  position{line: 1493, col: 24, offset: 54300},
 						name: "ExternalLink",
 					},
 				},
@@ -10737,33 +9735,33 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeLink",
-			pos:  position{line: 1466, col: 1, offset: 55158},
+			pos:  position{line: 1496, col: 1, offset: 54381},
 			expr: &actionExpr{
-				pos: position{line: 1466, col: 17, offset: 55174},
+				pos: position{line: 1496, col: 17, offset: 54397},
 				run: (*parser).callonRelativeLink1,
 				expr: &seqExpr{
-					pos: position{line: 1466, col: 17, offset: 55174},
+					pos: position{line: 1496, col: 17, offset: 54397},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1466, col: 17, offset: 55174},
+							pos:        position{line: 1496, col: 17, offset: 54397},
 							val:        "link:",
 							ignoreCase: false,
 							want:       "\"link:\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1466, col: 25, offset: 55182},
+							pos:   position{line: 1496, col: 25, offset: 54405},
 							label: "url",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1466, col: 30, offset: 55187},
+								pos:  position{line: 1496, col: 30, offset: 54410},
 								name: "Location",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1466, col: 40, offset: 55197},
+							pos:   position{line: 1496, col: 40, offset: 54420},
 							label: "inlineAttributes",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1466, col: 58, offset: 55215},
-								name: "LinkAttributes",
+								pos:  position{line: 1496, col: 58, offset: 54438},
+								name: "InlineAttributes",
 							},
 						},
 					},
@@ -10772,523 +9770,91 @@ var g = &grammar{
 		},
 		{
 			name: "ExternalLink",
-			pos:  position{line: 1470, col: 1, offset: 55326},
+			pos:  position{line: 1500, col: 1, offset: 54551},
 			expr: &actionExpr{
-				pos: position{line: 1470, col: 17, offset: 55342},
+				pos: position{line: 1500, col: 17, offset: 54567},
 				run: (*parser).callonExternalLink1,
 				expr: &seqExpr{
-					pos: position{line: 1470, col: 17, offset: 55342},
+					pos: position{line: 1500, col: 17, offset: 54567},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1470, col: 17, offset: 55342},
+							pos:   position{line: 1500, col: 17, offset: 54567},
 							label: "url",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1470, col: 22, offset: 55347},
+								pos:  position{line: 1500, col: 22, offset: 54572},
 								name: "LocationWithScheme",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1470, col: 42, offset: 55367},
+							pos:   position{line: 1500, col: 42, offset: 54592},
 							label: "inlineAttributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1470, col: 59, offset: 55384},
+								pos: position{line: 1500, col: 59, offset: 54609},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1470, col: 60, offset: 55385},
-									name: "LinkAttributes",
+									pos:  position{line: 1500, col: 60, offset: 54610},
+									name: "InlineAttributes",
 								},
 							},
 						},
 					},
-				},
-			},
-		},
-		{
-			name: "LinkAttributes",
-			pos:  position{line: 1474, col: 1, offset: 55478},
-			expr: &actionExpr{
-				pos: position{line: 1474, col: 19, offset: 55496},
-				run: (*parser).callonLinkAttributes1,
-				expr: &seqExpr{
-					pos: position{line: 1474, col: 19, offset: 55496},
-					exprs: []interface{}{
-						&litMatcher{
-							pos:        position{line: 1474, col: 19, offset: 55496},
-							val:        "[",
-							ignoreCase: false,
-							want:       "\"[\"",
-						},
-						&labeledExpr{
-							pos:   position{line: 1474, col: 23, offset: 55500},
-							label: "firstAttr",
-							expr: &zeroOrMoreExpr{
-								pos: position{line: 1474, col: 33, offset: 55510},
-								expr: &ruleRefExpr{
-									pos:  position{line: 1474, col: 34, offset: 55511},
-									name: "FirstLinkAttributeElement",
-								},
-							},
-						},
-						&zeroOrMoreExpr{
-							pos: position{line: 1475, col: 5, offset: 55543},
-							expr: &ruleRefExpr{
-								pos:  position{line: 1475, col: 5, offset: 55543},
-								name: "Space",
-							},
-						},
-						&labeledExpr{
-							pos:   position{line: 1475, col: 12, offset: 55550},
-							label: "otherAttrs",
-							expr: &zeroOrMoreExpr{
-								pos: position{line: 1475, col: 23, offset: 55561},
-								expr: &ruleRefExpr{
-									pos:  position{line: 1475, col: 24, offset: 55562},
-									name: "NamedAttribute",
-								},
-							},
-						},
-						&litMatcher{
-							pos:        position{line: 1475, col: 41, offset: 55579},
-							val:        "]",
-							ignoreCase: false,
-							want:       "\"]\"",
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "FirstLinkAttributeElement",
-			pos:  position{line: 1479, col: 1, offset: 55696},
-			expr: &actionExpr{
-				pos: position{line: 1479, col: 30, offset: 55725},
-				run: (*parser).callonFirstLinkAttributeElement1,
-				expr: &labeledExpr{
-					pos:   position{line: 1479, col: 30, offset: 55725},
-					label: "element",
-					expr: &choiceExpr{
-						pos: position{line: 1481, col: 5, offset: 55776},
-						alternatives: []interface{}{
-							&actionExpr{
-								pos: position{line: 1481, col: 6, offset: 55777},
-								run: (*parser).callonFirstLinkAttributeElement4,
-								expr: &seqExpr{
-									pos: position{line: 1481, col: 6, offset: 55777},
-									exprs: []interface{}{
-										&litMatcher{
-											pos:        position{line: 1481, col: 6, offset: 55777},
-											val:        "\"",
-											ignoreCase: false,
-											want:       "\"\\\"\"",
-										},
-										&labeledExpr{
-											pos:   position{line: 1481, col: 11, offset: 55782},
-											label: "elements",
-											expr: &oneOrMoreExpr{
-												pos: position{line: 1481, col: 20, offset: 55791},
-												expr: &choiceExpr{
-													pos: position{line: 1481, col: 21, offset: 55792},
-													alternatives: []interface{}{
-														&ruleRefExpr{
-															pos:  position{line: 1481, col: 21, offset: 55792},
-															name: "QuotedString",
-														},
-														&ruleRefExpr{
-															pos:  position{line: 1481, col: 36, offset: 55807},
-															name: "QuotedText",
-														},
-														&ruleRefExpr{
-															pos:  position{line: 1481, col: 49, offset: 55820},
-															name: "ElementPlaceHolder",
-														},
-														&ruleRefExpr{
-															pos:  position{line: 1481, col: 70, offset: 55841},
-															name: "QuotedAttributeChar",
-														},
-													},
-												},
-											},
-										},
-										&litMatcher{
-											pos:        position{line: 1481, col: 92, offset: 55863},
-											val:        "\"",
-											ignoreCase: false,
-											want:       "\"\\\"\"",
-										},
-										&andExpr{
-											pos: position{line: 1481, col: 97, offset: 55868},
-											expr: &notExpr{
-												pos: position{line: 1481, col: 99, offset: 55870},
-												expr: &litMatcher{
-													pos:        position{line: 1481, col: 100, offset: 55871},
-													val:        "=",
-													ignoreCase: false,
-													want:       "\"=\"",
-												},
-											},
-										},
-										&zeroOrOneExpr{
-											pos: position{line: 1481, col: 105, offset: 55876},
-											expr: &litMatcher{
-												pos:        position{line: 1481, col: 105, offset: 55876},
-												val:        ",",
-												ignoreCase: false,
-												want:       "\",\"",
-											},
-										},
-									},
-								},
-							},
-							&actionExpr{
-								pos: position{line: 1485, col: 6, offset: 56003},
-								run: (*parser).callonFirstLinkAttributeElement20,
-								expr: &seqExpr{
-									pos: position{line: 1485, col: 6, offset: 56003},
-									exprs: []interface{}{
-										&labeledExpr{
-											pos:   position{line: 1485, col: 6, offset: 56003},
-											label: "elements",
-											expr: &oneOrMoreExpr{
-												pos: position{line: 1485, col: 15, offset: 56012},
-												expr: &choiceExpr{
-													pos: position{line: 1485, col: 16, offset: 56013},
-													alternatives: []interface{}{
-														&ruleRefExpr{
-															pos:  position{line: 1485, col: 16, offset: 56013},
-															name: "QuotedString",
-														},
-														&ruleRefExpr{
-															pos:  position{line: 1485, col: 31, offset: 56028},
-															name: "QuotedText",
-														},
-														&ruleRefExpr{
-															pos:  position{line: 1485, col: 44, offset: 56041},
-															name: "ElementPlaceHolder",
-														},
-														&ruleRefExpr{
-															pos:  position{line: 1485, col: 65, offset: 56062},
-															name: "UnquotedAttributeChar",
-														},
-													},
-												},
-											},
-										},
-										&andExpr{
-											pos: position{line: 1485, col: 89, offset: 56086},
-											expr: &notExpr{
-												pos: position{line: 1485, col: 91, offset: 56088},
-												expr: &litMatcher{
-													pos:        position{line: 1485, col: 92, offset: 56089},
-													val:        "=",
-													ignoreCase: false,
-													want:       "\"=\"",
-												},
-											},
-										},
-										&zeroOrOneExpr{
-											pos: position{line: 1485, col: 97, offset: 56094},
-											expr: &litMatcher{
-												pos:        position{line: 1485, col: 97, offset: 56094},
-												val:        ",",
-												ignoreCase: false,
-												want:       "\",\"",
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "AttributeChar",
-			pos:  position{line: 1491, col: 1, offset: 56208},
-			expr: &actionExpr{
-				pos: position{line: 1491, col: 18, offset: 56225},
-				run: (*parser).callonAttributeChar1,
-				expr: &charClassMatcher{
-					pos:        position{line: 1491, col: 18, offset: 56225},
-					val:        "[^\\r\\n\"=\\],]",
-					chars:      []rune{'\r', '\n', '"', '=', ']', ','},
-					ignoreCase: false,
-					inverted:   true,
-				},
-			},
-		},
-		{
-			name: "QuotedAttributeChar",
-			pos:  position{line: 1495, col: 1, offset: 56311},
-			expr: &actionExpr{
-				pos: position{line: 1495, col: 24, offset: 56334},
-				run: (*parser).callonQuotedAttributeChar1,
-				expr: &charClassMatcher{
-					pos:        position{line: 1495, col: 24, offset: 56334},
-					val:        "[^\\r\\n\"=\\]]",
-					chars:      []rune{'\r', '\n', '"', '=', ']'},
-					ignoreCase: false,
-					inverted:   true,
-				},
-			},
-		},
-		{
-			name: "UnquotedAttributeChar",
-			pos:  position{line: 1499, col: 1, offset: 56427},
-			expr: &actionExpr{
-				pos: position{line: 1499, col: 26, offset: 56452},
-				run: (*parser).callonUnquotedAttributeChar1,
-				expr: &charClassMatcher{
-					pos:        position{line: 1499, col: 26, offset: 56452},
-					val:        "[^\\r\\n\"=\\],]",
-					chars:      []rune{'\r', '\n', '"', '=', ']', ','},
-					ignoreCase: false,
-					inverted:   true,
 				},
 			},
 		},
 		{
 			name: "ImageBlock",
-			pos:  position{line: 1506, col: 1, offset: 56640},
+			pos:  position{line: 1507, col: 1, offset: 54807},
 			expr: &actionExpr{
-				pos: position{line: 1506, col: 15, offset: 56654},
+				pos: position{line: 1508, col: 5, offset: 54826},
 				run: (*parser).callonImageBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1506, col: 15, offset: 56654},
+					pos: position{line: 1508, col: 5, offset: 54826},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1506, col: 15, offset: 56654},
+							pos:   position{line: 1508, col: 5, offset: 54826},
 							label: "attributes",
-							expr: &ruleRefExpr{
-								pos:  position{line: 1506, col: 27, offset: 56666},
-								name: "ImageBlockAttributes",
+							expr: &zeroOrOneExpr{
+								pos: position{line: 1508, col: 16, offset: 54837},
+								expr: &ruleRefExpr{
+									pos:  position{line: 1508, col: 17, offset: 54838},
+									name: "BlockAttributes",
+								},
 							},
 						},
+						&andCodeExpr{
+							pos: position{line: 1509, col: 5, offset: 54861},
+							run: (*parser).callonImageBlock6,
+						},
 						&litMatcher{
-							pos:        position{line: 1506, col: 49, offset: 56688},
+							pos:        position{line: 1513, col: 5, offset: 54994},
 							val:        "image::",
 							ignoreCase: false,
 							want:       "\"image::\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1506, col: 59, offset: 56698},
+							pos:   position{line: 1513, col: 15, offset: 55004},
 							label: "path",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1506, col: 65, offset: 56704},
+								pos:  position{line: 1513, col: 21, offset: 55010},
 								name: "Location",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1506, col: 75, offset: 56714},
+							pos:   position{line: 1513, col: 31, offset: 55020},
 							label: "inlineAttributes",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1506, col: 93, offset: 56732},
-								name: "InlineImageAttributes",
+								pos:  position{line: 1513, col: 49, offset: 55038},
+								name: "InlineAttributes",
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1506, col: 116, offset: 56755},
+							pos: position{line: 1513, col: 67, offset: 55056},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1506, col: 116, offset: 56755},
+								pos:  position{line: 1513, col: 67, offset: 55056},
 								name: "Space",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1506, col: 123, offset: 56762},
-							name: "EOL",
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "ImageBlockAttributes",
-			pos:  position{line: 1511, col: 1, offset: 56993},
-			expr: &zeroOrMoreExpr{
-				pos: position{line: 1511, col: 25, offset: 57017},
-				expr: &actionExpr{
-					pos: position{line: 1511, col: 26, offset: 57018},
-					run: (*parser).callonImageBlockAttributes2,
-					expr: &seqExpr{
-						pos: position{line: 1511, col: 26, offset: 57018},
-						exprs: []interface{}{
-							&notExpr{
-								pos: position{line: 1511, col: 26, offset: 57018},
-								expr: &ruleRefExpr{
-									pos:  position{line: 1511, col: 27, offset: 57019},
-									name: "VerseAttributes",
-								},
-							},
-							&labeledExpr{
-								pos:   position{line: 1511, col: 43, offset: 57035},
-								label: "attribute",
-								expr: &choiceExpr{
-									pos: position{line: 1511, col: 54, offset: 57046},
-									alternatives: []interface{}{
-										&ruleRefExpr{
-											pos:  position{line: 1511, col: 54, offset: 57046},
-											name: "ElementShortHandAttributes",
-										},
-										&ruleRefExpr{
-											pos:  position{line: 1511, col: 83, offset: 57075},
-											name: "ElementTitle",
-										},
-										&ruleRefExpr{
-											pos:  position{line: 1511, col: 98, offset: 57090},
-											name: "ElementID",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "ImageAttrList",
-			pos:  position{line: 1513, col: 1, offset: 57131},
-			expr: &actionExpr{
-				pos: position{line: 1513, col: 18, offset: 57148},
-				run: (*parser).callonImageAttrList1,
-				expr: &seqExpr{
-					pos: position{line: 1513, col: 18, offset: 57148},
-					exprs: []interface{}{
-						&litMatcher{
-							pos:        position{line: 1513, col: 18, offset: 57148},
-							val:        "[",
-							ignoreCase: false,
-							want:       "\"[\"",
-						},
-						&labeledExpr{
-							pos:   position{line: 1513, col: 22, offset: 57152},
-							label: "alt",
-							expr: &zeroOrOneExpr{
-								pos: position{line: 1513, col: 26, offset: 57156},
-								expr: &ruleRefExpr{
-									pos:  position{line: 1513, col: 27, offset: 57157},
-									name: "ImageAlt",
-								},
-							},
-						},
-						&labeledExpr{
-							pos:   position{line: 1513, col: 38, offset: 57168},
-							label: "shortHands",
-							expr: &zeroOrMoreExpr{
-								pos: position{line: 1513, col: 49, offset: 57179},
-								expr: &ruleRefExpr{
-									pos:  position{line: 1513, col: 50, offset: 57180},
-									name: "ShortHandAttr",
-								},
-							},
-						},
-						&zeroOrOneExpr{
-							pos: position{line: 1513, col: 66, offset: 57196},
-							expr: &seqExpr{
-								pos: position{line: 1513, col: 67, offset: 57197},
-								exprs: []interface{}{
-									&litMatcher{
-										pos:        position{line: 1513, col: 67, offset: 57197},
-										val:        ",",
-										ignoreCase: false,
-										want:       "\",\"",
-									},
-									&zeroOrMoreExpr{
-										pos: position{line: 1513, col: 71, offset: 57201},
-										expr: &ruleRefExpr{
-											pos:  position{line: 1513, col: 71, offset: 57201},
-											name: "Space",
-										},
-									},
-								},
-							},
-						},
-						&labeledExpr{
-							pos:   position{line: 1513, col: 80, offset: 57210},
-							label: "width",
-							expr: &zeroOrOneExpr{
-								pos: position{line: 1513, col: 86, offset: 57216},
-								expr: &ruleRefExpr{
-									pos:  position{line: 1513, col: 87, offset: 57217},
-									name: "ImageWidth",
-								},
-							},
-						},
-						&zeroOrOneExpr{
-							pos: position{line: 1513, col: 100, offset: 57230},
-							expr: &seqExpr{
-								pos: position{line: 1513, col: 101, offset: 57231},
-								exprs: []interface{}{
-									&litMatcher{
-										pos:        position{line: 1513, col: 101, offset: 57231},
-										val:        ",",
-										ignoreCase: false,
-										want:       "\",\"",
-									},
-									&zeroOrMoreExpr{
-										pos: position{line: 1513, col: 105, offset: 57235},
-										expr: &ruleRefExpr{
-											pos:  position{line: 1513, col: 105, offset: 57235},
-											name: "Space",
-										},
-									},
-								},
-							},
-						},
-						&labeledExpr{
-							pos:   position{line: 1513, col: 114, offset: 57244},
-							label: "height",
-							expr: &zeroOrOneExpr{
-								pos: position{line: 1513, col: 121, offset: 57251},
-								expr: &ruleRefExpr{
-									pos:  position{line: 1513, col: 122, offset: 57252},
-									name: "ImageHeight",
-								},
-							},
-						},
-						&zeroOrOneExpr{
-							pos: position{line: 1513, col: 136, offset: 57266},
-							expr: &seqExpr{
-								pos: position{line: 1513, col: 137, offset: 57267},
-								exprs: []interface{}{
-									&litMatcher{
-										pos:        position{line: 1513, col: 137, offset: 57267},
-										val:        ",",
-										ignoreCase: false,
-										want:       "\",\"",
-									},
-									&zeroOrMoreExpr{
-										pos: position{line: 1513, col: 141, offset: 57271},
-										expr: &ruleRefExpr{
-											pos:  position{line: 1513, col: 141, offset: 57271},
-											name: "Space",
-										},
-									},
-								},
-							},
-						},
-						&labeledExpr{
-							pos:   position{line: 1513, col: 150, offset: 57280},
-							label: "others",
-							expr: &ruleRefExpr{
-								pos:  position{line: 1513, col: 158, offset: 57288},
-								name: "NamedAttributes",
-							},
-						},
-						&litMatcher{
-							pos:        position{line: 1513, col: 175, offset: 57305},
-							val:        "]",
-							ignoreCase: false,
-							want:       "\"]\"",
-						},
-						&zeroOrMoreExpr{
-							pos: position{line: 1513, col: 179, offset: 57309},
-							expr: &ruleRefExpr{
-								pos:  position{line: 1513, col: 179, offset: 57309},
-								name: "Space",
-							},
-						},
-						&ruleRefExpr{
-							pos:  position{line: 1513, col: 186, offset: 57316},
+							pos:  position{line: 1513, col: 74, offset: 55063},
 							name: "EOL",
 						},
 					},
@@ -11297,257 +9863,73 @@ var g = &grammar{
 		},
 		{
 			name: "InlineImage",
-			pos:  position{line: 1517, col: 1, offset: 57388},
+			pos:  position{line: 1518, col: 1, offset: 55278},
 			expr: &actionExpr{
-				pos: position{line: 1517, col: 16, offset: 57403},
+				pos: position{line: 1518, col: 16, offset: 55293},
 				run: (*parser).callonInlineImage1,
 				expr: &seqExpr{
-					pos: position{line: 1517, col: 16, offset: 57403},
+					pos: position{line: 1518, col: 16, offset: 55293},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1517, col: 16, offset: 57403},
+							pos:        position{line: 1518, col: 16, offset: 55293},
 							val:        "image:",
 							ignoreCase: false,
 							want:       "\"image:\"",
 						},
 						&notExpr{
-							pos: position{line: 1517, col: 25, offset: 57412},
+							pos: position{line: 1518, col: 25, offset: 55302},
 							expr: &litMatcher{
-								pos:        position{line: 1517, col: 26, offset: 57413},
+								pos:        position{line: 1518, col: 26, offset: 55303},
 								val:        ":",
 								ignoreCase: false,
 								want:       "\":\"",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1517, col: 30, offset: 57417},
+							pos:   position{line: 1518, col: 30, offset: 55307},
 							label: "path",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1517, col: 36, offset: 57423},
+								pos:  position{line: 1518, col: 36, offset: 55313},
 								name: "Location",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1517, col: 46, offset: 57433},
+							pos:   position{line: 1518, col: 46, offset: 55323},
 							label: "inlineAttributes",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1517, col: 64, offset: 57451},
-								name: "InlineImageAttributes",
+								pos:  position{line: 1518, col: 64, offset: 55341},
+								name: "InlineAttributes",
 							},
 						},
-					},
-				},
-			},
-		},
-		{
-			name: "InlineImageAttributes",
-			pos:  position{line: 1521, col: 1, offset: 57599},
-			expr: &actionExpr{
-				pos: position{line: 1521, col: 26, offset: 57624},
-				run: (*parser).callonInlineImageAttributes1,
-				expr: &seqExpr{
-					pos: position{line: 1521, col: 26, offset: 57624},
-					exprs: []interface{}{
-						&litMatcher{
-							pos:        position{line: 1521, col: 26, offset: 57624},
-							val:        "[",
-							ignoreCase: false,
-							want:       "\"[\"",
-						},
-						&zeroOrMoreExpr{
-							pos: position{line: 1521, col: 30, offset: 57628},
-							expr: &ruleRefExpr{
-								pos:  position{line: 1521, col: 30, offset: 57628},
-								name: "Space",
-							},
-						},
-						&labeledExpr{
-							pos:   position{line: 1521, col: 37, offset: 57635},
-							label: "alt",
-							expr: &zeroOrOneExpr{
-								pos: position{line: 1521, col: 41, offset: 57639},
-								expr: &ruleRefExpr{
-									pos:  position{line: 1521, col: 42, offset: 57640},
-									name: "ImageAlt",
-								},
-							},
-						},
-						&zeroOrOneExpr{
-							pos: position{line: 1521, col: 53, offset: 57651},
-							expr: &seqExpr{
-								pos: position{line: 1521, col: 54, offset: 57652},
-								exprs: []interface{}{
-									&litMatcher{
-										pos:        position{line: 1521, col: 54, offset: 57652},
-										val:        ",",
-										ignoreCase: false,
-										want:       "\",\"",
-									},
-									&zeroOrMoreExpr{
-										pos: position{line: 1521, col: 58, offset: 57656},
-										expr: &ruleRefExpr{
-											pos:  position{line: 1521, col: 58, offset: 57656},
-											name: "Space",
-										},
-									},
-								},
-							},
-						},
-						&labeledExpr{
-							pos:   position{line: 1521, col: 67, offset: 57665},
-							label: "width",
-							expr: &zeroOrOneExpr{
-								pos: position{line: 1521, col: 73, offset: 57671},
-								expr: &ruleRefExpr{
-									pos:  position{line: 1521, col: 74, offset: 57672},
-									name: "ImageWidth",
-								},
-							},
-						},
-						&zeroOrOneExpr{
-							pos: position{line: 1521, col: 87, offset: 57685},
-							expr: &seqExpr{
-								pos: position{line: 1521, col: 88, offset: 57686},
-								exprs: []interface{}{
-									&litMatcher{
-										pos:        position{line: 1521, col: 88, offset: 57686},
-										val:        ",",
-										ignoreCase: false,
-										want:       "\",\"",
-									},
-									&zeroOrMoreExpr{
-										pos: position{line: 1521, col: 92, offset: 57690},
-										expr: &ruleRefExpr{
-											pos:  position{line: 1521, col: 92, offset: 57690},
-											name: "Space",
-										},
-									},
-								},
-							},
-						},
-						&labeledExpr{
-							pos:   position{line: 1521, col: 101, offset: 57699},
-							label: "height",
-							expr: &zeroOrOneExpr{
-								pos: position{line: 1521, col: 108, offset: 57706},
-								expr: &ruleRefExpr{
-									pos:  position{line: 1521, col: 109, offset: 57707},
-									name: "ImageHeight",
-								},
-							},
-						},
-						&zeroOrOneExpr{
-							pos: position{line: 1521, col: 123, offset: 57721},
-							expr: &seqExpr{
-								pos: position{line: 1521, col: 124, offset: 57722},
-								exprs: []interface{}{
-									&litMatcher{
-										pos:        position{line: 1521, col: 124, offset: 57722},
-										val:        ",",
-										ignoreCase: false,
-										want:       "\",\"",
-									},
-									&zeroOrMoreExpr{
-										pos: position{line: 1521, col: 128, offset: 57726},
-										expr: &ruleRefExpr{
-											pos:  position{line: 1521, col: 128, offset: 57726},
-											name: "Space",
-										},
-									},
-								},
-							},
-						},
-						&labeledExpr{
-							pos:   position{line: 1521, col: 137, offset: 57735},
-							label: "others",
-							expr: &ruleRefExpr{
-								pos:  position{line: 1521, col: 145, offset: 57743},
-								name: "NamedAttributes",
-							},
-						},
-						&litMatcher{
-							pos:        position{line: 1521, col: 162, offset: 57760},
-							val:        "]",
-							ignoreCase: false,
-							want:       "\"]\"",
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "ImageAlt",
-			pos:  position{line: 1525, col: 1, offset: 57832},
-			expr: &actionExpr{
-				pos: position{line: 1525, col: 13, offset: 57844},
-				run: (*parser).callonImageAlt1,
-				expr: &labeledExpr{
-					pos:   position{line: 1525, col: 13, offset: 57844},
-					label: "value",
-					expr: &ruleRefExpr{
-						pos:  position{line: 1525, col: 20, offset: 57851},
-						name: "AttributeValue",
-					},
-				},
-			},
-		},
-		{
-			name: "ImageWidth",
-			pos:  position{line: 1529, col: 1, offset: 57935},
-			expr: &actionExpr{
-				pos: position{line: 1529, col: 15, offset: 57949},
-				run: (*parser).callonImageWidth1,
-				expr: &labeledExpr{
-					pos:   position{line: 1529, col: 15, offset: 57949},
-					label: "value",
-					expr: &ruleRefExpr{
-						pos:  position{line: 1529, col: 22, offset: 57956},
-						name: "AttributeValue",
-					},
-				},
-			},
-		},
-		{
-			name: "ImageHeight",
-			pos:  position{line: 1533, col: 1, offset: 58037},
-			expr: &actionExpr{
-				pos: position{line: 1533, col: 16, offset: 58052},
-				run: (*parser).callonImageHeight1,
-				expr: &labeledExpr{
-					pos:   position{line: 1533, col: 16, offset: 58052},
-					label: "value",
-					expr: &ruleRefExpr{
-						pos:  position{line: 1533, col: 23, offset: 58059},
-						name: "AttributeValue",
 					},
 				},
 			},
 		},
 		{
 			name: "InlineIcon",
-			pos:  position{line: 1540, col: 1, offset: 58338},
+			pos:  position{line: 1525, col: 1, offset: 55676},
 			expr: &actionExpr{
-				pos: position{line: 1540, col: 15, offset: 58352},
+				pos: position{line: 1525, col: 15, offset: 55690},
 				run: (*parser).callonInlineIcon1,
 				expr: &seqExpr{
-					pos: position{line: 1540, col: 15, offset: 58352},
+					pos: position{line: 1525, col: 15, offset: 55690},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1540, col: 15, offset: 58352},
+							pos:        position{line: 1525, col: 15, offset: 55690},
 							val:        "icon:",
 							ignoreCase: false,
 							want:       "\"icon:\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1540, col: 23, offset: 58360},
+							pos:   position{line: 1525, col: 23, offset: 55698},
 							label: "icon",
 							expr: &actionExpr{
-								pos: position{line: 1540, col: 29, offset: 58366},
+								pos: position{line: 1525, col: 29, offset: 55704},
 								run: (*parser).callonInlineIcon5,
 								expr: &oneOrMoreExpr{
-									pos: position{line: 1540, col: 29, offset: 58366},
+									pos: position{line: 1525, col: 29, offset: 55704},
 									expr: &charClassMatcher{
-										pos:        position{line: 1540, col: 29, offset: 58366},
+										pos:        position{line: 1525, col: 29, offset: 55704},
 										val:        "[\\pL0-9_-]",
 										chars:      []rune{'_', '-'},
 										ranges:     []rune{'0', '9'},
@@ -11559,97 +9941,11 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1540, col: 73, offset: 58410},
+							pos:   position{line: 1525, col: 73, offset: 55748},
 							label: "attributes",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1540, col: 85, offset: 58422},
-								name: "IconAttributes",
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "IconAttributes",
-			pos:  position{line: 1544, col: 1, offset: 58514},
-			expr: &actionExpr{
-				pos: position{line: 1544, col: 19, offset: 58532},
-				run: (*parser).callonIconAttributes1,
-				expr: &seqExpr{
-					pos: position{line: 1544, col: 19, offset: 58532},
-					exprs: []interface{}{
-						&litMatcher{
-							pos:        position{line: 1544, col: 19, offset: 58532},
-							val:        "[",
-							ignoreCase: false,
-							want:       "\"[\"",
-						},
-						&labeledExpr{
-							pos:   position{line: 1544, col: 23, offset: 58536},
-							label: "size",
-							expr: &zeroOrOneExpr{
-								pos: position{line: 1544, col: 28, offset: 58541},
-								expr: &ruleRefExpr{
-									pos:  position{line: 1544, col: 29, offset: 58542},
-									name: "IconSize",
-								},
-							},
-						},
-						&labeledExpr{
-							pos:   position{line: 1544, col: 40, offset: 58553},
-							label: "others",
-							expr: &ruleRefExpr{
-								pos:  position{line: 1544, col: 48, offset: 58561},
-								name: "NamedAttributes",
-							},
-						},
-						&litMatcher{
-							pos:        position{line: 1544, col: 65, offset: 58578},
-							val:        "]",
-							ignoreCase: false,
-							want:       "\"]\"",
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "IconSize",
-			pos:  position{line: 1549, col: 1, offset: 58671},
-			expr: &actionExpr{
-				pos: position{line: 1549, col: 13, offset: 58683},
-				run: (*parser).callonIconSize1,
-				expr: &seqExpr{
-					pos: position{line: 1549, col: 13, offset: 58683},
-					exprs: []interface{}{
-						&labeledExpr{
-							pos:   position{line: 1549, col: 13, offset: 58683},
-							label: "value",
-							expr: &ruleRefExpr{
-								pos:  position{line: 1549, col: 20, offset: 58690},
-								name: "AttributeValue",
-							},
-						},
-						&zeroOrOneExpr{
-							pos: position{line: 1549, col: 36, offset: 58706},
-							expr: &seqExpr{
-								pos: position{line: 1549, col: 37, offset: 58707},
-								exprs: []interface{}{
-									&litMatcher{
-										pos:        position{line: 1549, col: 37, offset: 58707},
-										val:        ",",
-										ignoreCase: false,
-										want:       "\",\"",
-									},
-									&zeroOrMoreExpr{
-										pos: position{line: 1549, col: 41, offset: 58711},
-										expr: &ruleRefExpr{
-											pos:  position{line: 1549, col: 41, offset: 58711},
-											name: "Space",
-										},
-									},
-								},
+								pos:  position{line: 1525, col: 85, offset: 55760},
+								name: "InlineAttributes",
 							},
 						},
 					},
@@ -11658,32 +9954,32 @@ var g = &grammar{
 		},
 		{
 			name: "InlineFootnote",
-			pos:  position{line: 1556, col: 1, offset: 58985},
+			pos:  position{line: 1532, col: 1, offset: 56032},
 			expr: &choiceExpr{
-				pos: position{line: 1556, col: 19, offset: 59003},
+				pos: position{line: 1532, col: 19, offset: 56050},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1556, col: 19, offset: 59003},
+						pos: position{line: 1532, col: 19, offset: 56050},
 						run: (*parser).callonInlineFootnote2,
 						expr: &seqExpr{
-							pos: position{line: 1556, col: 19, offset: 59003},
+							pos: position{line: 1532, col: 19, offset: 56050},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1556, col: 19, offset: 59003},
+									pos:        position{line: 1532, col: 19, offset: 56050},
 									val:        "footnote:[",
 									ignoreCase: false,
 									want:       "\"footnote:[\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1556, col: 32, offset: 59016},
+									pos:   position{line: 1532, col: 32, offset: 56063},
 									label: "content",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1556, col: 41, offset: 59025},
+										pos:  position{line: 1532, col: 41, offset: 56072},
 										name: "FootnoteContent",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1556, col: 58, offset: 59042},
+									pos:        position{line: 1532, col: 58, offset: 56089},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -11692,44 +9988,44 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1558, col: 5, offset: 59110},
+						pos: position{line: 1534, col: 5, offset: 56157},
 						run: (*parser).callonInlineFootnote8,
 						expr: &seqExpr{
-							pos: position{line: 1558, col: 5, offset: 59110},
+							pos: position{line: 1534, col: 5, offset: 56157},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1558, col: 5, offset: 59110},
+									pos:        position{line: 1534, col: 5, offset: 56157},
 									val:        "footnote:",
 									ignoreCase: false,
 									want:       "\"footnote:\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1558, col: 17, offset: 59122},
+									pos:   position{line: 1534, col: 17, offset: 56169},
 									label: "ref",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1558, col: 22, offset: 59127},
+										pos:  position{line: 1534, col: 22, offset: 56174},
 										name: "FootnoteRef",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1558, col: 35, offset: 59140},
+									pos:        position{line: 1534, col: 35, offset: 56187},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1558, col: 39, offset: 59144},
+									pos:   position{line: 1534, col: 39, offset: 56191},
 									label: "content",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1558, col: 47, offset: 59152},
+										pos: position{line: 1534, col: 47, offset: 56199},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1558, col: 48, offset: 59153},
+											pos:  position{line: 1534, col: 48, offset: 56200},
 											name: "FootnoteContent",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1558, col: 66, offset: 59171},
+									pos:        position{line: 1534, col: 66, offset: 56218},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -11742,37 +10038,37 @@ var g = &grammar{
 		},
 		{
 			name: "FootnoteRef",
-			pos:  position{line: 1562, col: 1, offset: 59232},
+			pos:  position{line: 1538, col: 1, offset: 56279},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1562, col: 16, offset: 59247},
+				pos:  position{line: 1538, col: 16, offset: 56294},
 				name: "Alphanums",
 			},
 		},
 		{
 			name: "FootnoteContent",
-			pos:  position{line: 1564, col: 1, offset: 59258},
+			pos:  position{line: 1540, col: 1, offset: 56305},
 			expr: &actionExpr{
-				pos: position{line: 1564, col: 20, offset: 59277},
+				pos: position{line: 1540, col: 20, offset: 56324},
 				run: (*parser).callonFootnoteContent1,
 				expr: &labeledExpr{
-					pos:   position{line: 1564, col: 20, offset: 59277},
+					pos:   position{line: 1540, col: 20, offset: 56324},
 					label: "elements",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 1564, col: 29, offset: 59286},
+						pos: position{line: 1540, col: 29, offset: 56333},
 						expr: &seqExpr{
-							pos: position{line: 1564, col: 30, offset: 59287},
+							pos: position{line: 1540, col: 30, offset: 56334},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1564, col: 30, offset: 59287},
+									pos: position{line: 1540, col: 30, offset: 56334},
 									expr: &litMatcher{
-										pos:        position{line: 1564, col: 31, offset: 59288},
+										pos:        position{line: 1540, col: 31, offset: 56335},
 										val:        "]",
 										ignoreCase: false,
 										want:       "\"]\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1564, col: 35, offset: 59292},
+									pos:  position{line: 1540, col: 35, offset: 56339},
 									name: "InlineElement",
 								},
 							},
@@ -11783,29 +10079,29 @@ var g = &grammar{
 		},
 		{
 			name: "Callout",
-			pos:  position{line: 1572, col: 1, offset: 59608},
+			pos:  position{line: 1548, col: 1, offset: 56655},
 			expr: &actionExpr{
-				pos: position{line: 1572, col: 12, offset: 59619},
+				pos: position{line: 1548, col: 12, offset: 56666},
 				run: (*parser).callonCallout1,
 				expr: &seqExpr{
-					pos: position{line: 1572, col: 12, offset: 59619},
+					pos: position{line: 1548, col: 12, offset: 56666},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1572, col: 12, offset: 59619},
+							pos:        position{line: 1548, col: 12, offset: 56666},
 							val:        "<",
 							ignoreCase: false,
 							want:       "\"<\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1572, col: 16, offset: 59623},
+							pos:   position{line: 1548, col: 16, offset: 56670},
 							label: "ref",
 							expr: &actionExpr{
-								pos: position{line: 1572, col: 21, offset: 59628},
+								pos: position{line: 1548, col: 21, offset: 56675},
 								run: (*parser).callonCallout5,
 								expr: &oneOrMoreExpr{
-									pos: position{line: 1572, col: 21, offset: 59628},
+									pos: position{line: 1548, col: 21, offset: 56675},
 									expr: &charClassMatcher{
-										pos:        position{line: 1572, col: 21, offset: 59628},
+										pos:        position{line: 1548, col: 21, offset: 56675},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -11815,29 +10111,29 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1572, col: 69, offset: 59676},
+							pos:        position{line: 1548, col: 69, offset: 56723},
 							val:        ">",
 							ignoreCase: false,
 							want:       "\">\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1572, col: 73, offset: 59680},
+							pos: position{line: 1548, col: 73, offset: 56727},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1572, col: 73, offset: 59680},
+								pos:  position{line: 1548, col: 73, offset: 56727},
 								name: "Space",
 							},
 						},
 						&andExpr{
-							pos: position{line: 1572, col: 80, offset: 59687},
+							pos: position{line: 1548, col: 80, offset: 56734},
 							expr: &choiceExpr{
-								pos: position{line: 1572, col: 82, offset: 59689},
+								pos: position{line: 1548, col: 82, offset: 56736},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1572, col: 82, offset: 59689},
+										pos:  position{line: 1548, col: 82, offset: 56736},
 										name: "EOL",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1572, col: 88, offset: 59695},
+										pos:  position{line: 1548, col: 88, offset: 56742},
 										name: "Callout",
 									},
 								},
@@ -11849,28 +10145,28 @@ var g = &grammar{
 		},
 		{
 			name: "CalloutListItem",
-			pos:  position{line: 1576, col: 1, offset: 59748},
+			pos:  position{line: 1552, col: 1, offset: 56795},
 			expr: &actionExpr{
-				pos: position{line: 1576, col: 20, offset: 59767},
+				pos: position{line: 1552, col: 20, offset: 56814},
 				run: (*parser).callonCalloutListItem1,
 				expr: &seqExpr{
-					pos: position{line: 1576, col: 20, offset: 59767},
+					pos: position{line: 1552, col: 20, offset: 56814},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1576, col: 20, offset: 59767},
+							pos:   position{line: 1552, col: 20, offset: 56814},
 							label: "ref",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1576, col: 25, offset: 59772},
+								pos:  position{line: 1552, col: 25, offset: 56819},
 								name: "CalloutListItemPrefix",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1576, col: 48, offset: 59795},
+							pos:   position{line: 1552, col: 48, offset: 56842},
 							label: "description",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1576, col: 61, offset: 59808},
+								pos: position{line: 1552, col: 61, offset: 56855},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1576, col: 61, offset: 59808},
+									pos:  position{line: 1552, col: 61, offset: 56855},
 									name: "ListParagraph",
 								},
 							},
@@ -11881,29 +10177,29 @@ var g = &grammar{
 		},
 		{
 			name: "CalloutListItemPrefix",
-			pos:  position{line: 1580, col: 1, offset: 59905},
+			pos:  position{line: 1556, col: 1, offset: 56952},
 			expr: &actionExpr{
-				pos: position{line: 1580, col: 26, offset: 59930},
+				pos: position{line: 1556, col: 26, offset: 56977},
 				run: (*parser).callonCalloutListItemPrefix1,
 				expr: &seqExpr{
-					pos: position{line: 1580, col: 26, offset: 59930},
+					pos: position{line: 1556, col: 26, offset: 56977},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1580, col: 26, offset: 59930},
+							pos:        position{line: 1556, col: 26, offset: 56977},
 							val:        "<",
 							ignoreCase: false,
 							want:       "\"<\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1580, col: 30, offset: 59934},
+							pos:   position{line: 1556, col: 30, offset: 56981},
 							label: "ref",
 							expr: &actionExpr{
-								pos: position{line: 1580, col: 35, offset: 59939},
+								pos: position{line: 1556, col: 35, offset: 56986},
 								run: (*parser).callonCalloutListItemPrefix5,
 								expr: &oneOrMoreExpr{
-									pos: position{line: 1580, col: 35, offset: 59939},
+									pos: position{line: 1556, col: 35, offset: 56986},
 									expr: &charClassMatcher{
-										pos:        position{line: 1580, col: 35, offset: 59939},
+										pos:        position{line: 1556, col: 35, offset: 56986},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -11913,15 +10209,15 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1580, col: 83, offset: 59987},
+							pos:        position{line: 1556, col: 83, offset: 57034},
 							val:        ">",
 							ignoreCase: false,
 							want:       "\">\"",
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 1580, col: 87, offset: 59991},
+							pos: position{line: 1556, col: 87, offset: 57038},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1580, col: 87, offset: 59991},
+								pos:  position{line: 1556, col: 87, offset: 57038},
 								name: "Space",
 							},
 						},
@@ -11931,48 +10227,48 @@ var g = &grammar{
 		},
 		{
 			name: "ThematicBreak",
-			pos:  position{line: 1589, col: 1, offset: 60238},
+			pos:  position{line: 1565, col: 1, offset: 57285},
 			expr: &actionExpr{
-				pos: position{line: 1589, col: 18, offset: 60255},
+				pos: position{line: 1565, col: 18, offset: 57302},
 				run: (*parser).callonThematicBreak1,
 				expr: &seqExpr{
-					pos: position{line: 1589, col: 18, offset: 60255},
+					pos: position{line: 1565, col: 18, offset: 57302},
 					exprs: []interface{}{
 						&choiceExpr{
-							pos: position{line: 1589, col: 19, offset: 60256},
+							pos: position{line: 1565, col: 19, offset: 57303},
 							alternatives: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1589, col: 19, offset: 60256},
+									pos:        position{line: 1565, col: 19, offset: 57303},
 									val:        "***",
 									ignoreCase: false,
 									want:       "\"***\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1589, col: 27, offset: 60264},
+									pos:        position{line: 1565, col: 27, offset: 57311},
 									val:        "* * *",
 									ignoreCase: false,
 									want:       "\"* * *\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1589, col: 37, offset: 60274},
+									pos:        position{line: 1565, col: 37, offset: 57321},
 									val:        "---",
 									ignoreCase: false,
 									want:       "\"---\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1589, col: 45, offset: 60282},
+									pos:        position{line: 1565, col: 45, offset: 57329},
 									val:        "- - -",
 									ignoreCase: false,
 									want:       "\"- - -\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1589, col: 55, offset: 60292},
+									pos:        position{line: 1565, col: 55, offset: 57339},
 									val:        "___",
 									ignoreCase: false,
 									want:       "\"___\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1589, col: 63, offset: 60300},
+									pos:        position{line: 1565, col: 63, offset: 57347},
 									val:        "_ _ _",
 									ignoreCase: false,
 									want:       "\"_ _ _\"",
@@ -11980,7 +10276,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1589, col: 72, offset: 60309},
+							pos:  position{line: 1565, col: 72, offset: 57356},
 							name: "EOL",
 						},
 					},
@@ -11989,56 +10285,56 @@ var g = &grammar{
 		},
 		{
 			name: "DelimitedBlock",
-			pos:  position{line: 1599, col: 1, offset: 60559},
+			pos:  position{line: 1575, col: 1, offset: 57606},
 			expr: &actionExpr{
-				pos: position{line: 1599, col: 19, offset: 60577},
+				pos: position{line: 1575, col: 19, offset: 57624},
 				run: (*parser).callonDelimitedBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1599, col: 19, offset: 60577},
+					pos: position{line: 1575, col: 19, offset: 57624},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1599, col: 19, offset: 60577},
+							pos: position{line: 1575, col: 19, offset: 57624},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1599, col: 20, offset: 60578},
+								pos:  position{line: 1575, col: 20, offset: 57625},
 								name: "Alphanum",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1600, col: 5, offset: 60666},
+							pos:   position{line: 1576, col: 5, offset: 57713},
 							label: "block",
 							expr: &choiceExpr{
-								pos: position{line: 1600, col: 12, offset: 60673},
+								pos: position{line: 1576, col: 12, offset: 57720},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1600, col: 12, offset: 60673},
+										pos:  position{line: 1576, col: 12, offset: 57720},
 										name: "FencedBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1601, col: 11, offset: 60696},
+										pos:  position{line: 1577, col: 11, offset: 57743},
 										name: "ListingBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1602, col: 11, offset: 60720},
+										pos:  position{line: 1578, col: 11, offset: 57767},
 										name: "ExampleBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1603, col: 11, offset: 60744},
+										pos:  position{line: 1579, col: 11, offset: 57791},
 										name: "VerseBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1604, col: 11, offset: 60765},
+										pos:  position{line: 1580, col: 11, offset: 57812},
 										name: "QuoteBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1605, col: 11, offset: 60786},
+										pos:  position{line: 1581, col: 11, offset: 57833},
 										name: "SidebarBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1606, col: 11, offset: 60809},
+										pos:  position{line: 1582, col: 11, offset: 57856},
 										name: "PassthroughBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1607, col: 11, offset: 60836},
+										pos:  position{line: 1583, col: 11, offset: 57883},
 										name: "CommentBlock",
 									},
 								},
@@ -12050,52 +10346,52 @@ var g = &grammar{
 		},
 		{
 			name: "BlockDelimiter",
-			pos:  position{line: 1611, col: 1, offset: 60877},
+			pos:  position{line: 1587, col: 1, offset: 57924},
 			expr: &choiceExpr{
-				pos: position{line: 1611, col: 19, offset: 60895},
+				pos: position{line: 1587, col: 19, offset: 57942},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 1611, col: 19, offset: 60895},
+						pos: position{line: 1587, col: 19, offset: 57942},
 						exprs: []interface{}{
 							&notExpr{
-								pos: position{line: 1611, col: 19, offset: 60895},
+								pos: position{line: 1587, col: 19, offset: 57942},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1611, col: 21, offset: 60897},
+									pos:  position{line: 1587, col: 21, offset: 57944},
 									name: "Alphanum",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1611, col: 31, offset: 60907},
+								pos:  position{line: 1587, col: 31, offset: 57954},
 								name: "LiteralBlockDelimiter",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1612, col: 19, offset: 60978},
+						pos:  position{line: 1588, col: 19, offset: 58025},
 						name: "FencedBlockDelimiter",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1613, col: 19, offset: 61018},
+						pos:  position{line: 1589, col: 19, offset: 58065},
 						name: "ListingBlockDelimiter",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1614, col: 19, offset: 61059},
+						pos:  position{line: 1590, col: 19, offset: 58106},
 						name: "ExampleBlockDelimiter",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1615, col: 19, offset: 61100},
+						pos:  position{line: 1591, col: 19, offset: 58147},
 						name: "CommentBlockDelimiter",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1616, col: 19, offset: 61141},
+						pos:  position{line: 1592, col: 19, offset: 58188},
 						name: "QuoteBlockDelimiter",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1617, col: 19, offset: 61179},
+						pos:  position{line: 1593, col: 19, offset: 58226},
 						name: "SidebarBlockDelimiter",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1618, col: 19, offset: 61219},
+						pos:  position{line: 1594, col: 19, offset: 58266},
 						name: "PassthroughBlockDelimiter",
 					},
 				},
@@ -12103,38 +10399,38 @@ var g = &grammar{
 		},
 		{
 			name: "ExampleBlock",
-			pos:  position{line: 1623, col: 1, offset: 61442},
+			pos:  position{line: 1599, col: 1, offset: 58489},
 			expr: &actionExpr{
-				pos: position{line: 1623, col: 17, offset: 61458},
+				pos: position{line: 1599, col: 17, offset: 58505},
 				run: (*parser).callonExampleBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1623, col: 17, offset: 61458},
+					pos: position{line: 1599, col: 17, offset: 58505},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1623, col: 17, offset: 61458},
+							pos:   position{line: 1599, col: 17, offset: 58505},
 							label: "attributes",
-							expr: &zeroOrMoreExpr{
-								pos: position{line: 1623, col: 28, offset: 61469},
+							expr: &zeroOrOneExpr{
+								pos: position{line: 1599, col: 28, offset: 58516},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1623, col: 29, offset: 61470},
-									name: "ElementAttribute",
+									pos:  position{line: 1599, col: 29, offset: 58517},
+									name: "BlockAttributes",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1623, col: 48, offset: 61489},
+							pos:  position{line: 1599, col: 47, offset: 58535},
 							name: "ExampleBlockStartDelimiter",
 						},
 						&labeledExpr{
-							pos:   position{line: 1623, col: 75, offset: 61516},
+							pos:   position{line: 1599, col: 74, offset: 58562},
 							label: "blocks",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1623, col: 83, offset: 61524},
+								pos:  position{line: 1599, col: 82, offset: 58570},
 								name: "ExampleBlockRawContent",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1623, col: 107, offset: 61548},
+							pos:  position{line: 1599, col: 106, offset: 58594},
 							name: "ExampleBlockEndDelimiter",
 						},
 					},
@@ -12143,25 +10439,25 @@ var g = &grammar{
 		},
 		{
 			name: "ExampleBlockDelimiter",
-			pos:  position{line: 1627, col: 1, offset: 61663},
+			pos:  position{line: 1603, col: 1, offset: 58693},
 			expr: &seqExpr{
-				pos: position{line: 1627, col: 26, offset: 61688},
+				pos: position{line: 1603, col: 26, offset: 58718},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1627, col: 26, offset: 61688},
+						pos:        position{line: 1603, col: 26, offset: 58718},
 						val:        "====",
 						ignoreCase: false,
 						want:       "\"====\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1627, col: 33, offset: 61695},
+						pos: position{line: 1603, col: 33, offset: 58725},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1627, col: 33, offset: 61695},
+							pos:  position{line: 1603, col: 33, offset: 58725},
 							name: "Space",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1627, col: 40, offset: 61702},
+						pos:  position{line: 1603, col: 40, offset: 58732},
 						name: "EOL",
 					},
 				},
@@ -12169,25 +10465,25 @@ var g = &grammar{
 		},
 		{
 			name: "ExampleBlockStartDelimiter",
-			pos:  position{line: 1629, col: 1, offset: 61707},
+			pos:  position{line: 1605, col: 1, offset: 58737},
 			expr: &seqExpr{
-				pos: position{line: 1629, col: 31, offset: 61737},
+				pos: position{line: 1605, col: 31, offset: 58767},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1629, col: 31, offset: 61737},
+						pos:        position{line: 1605, col: 31, offset: 58767},
 						val:        "====",
 						ignoreCase: false,
 						want:       "\"====\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1629, col: 38, offset: 61744},
+						pos: position{line: 1605, col: 38, offset: 58774},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1629, col: 38, offset: 61744},
+							pos:  position{line: 1605, col: 38, offset: 58774},
 							name: "Space",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1629, col: 45, offset: 61751},
+						pos:  position{line: 1605, col: 45, offset: 58781},
 						name: "EOL",
 					},
 				},
@@ -12195,34 +10491,34 @@ var g = &grammar{
 		},
 		{
 			name: "ExampleBlockEndDelimiter",
-			pos:  position{line: 1631, col: 1, offset: 61756},
+			pos:  position{line: 1607, col: 1, offset: 58786},
 			expr: &choiceExpr{
-				pos: position{line: 1631, col: 29, offset: 61784},
+				pos: position{line: 1607, col: 29, offset: 58814},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 1631, col: 30, offset: 61785},
+						pos: position{line: 1607, col: 30, offset: 58815},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 1631, col: 30, offset: 61785},
+								pos:        position{line: 1607, col: 30, offset: 58815},
 								val:        "====",
 								ignoreCase: false,
 								want:       "\"====\"",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 1631, col: 37, offset: 61792},
+								pos: position{line: 1607, col: 37, offset: 58822},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1631, col: 37, offset: 61792},
+									pos:  position{line: 1607, col: 37, offset: 58822},
 									name: "Space",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1631, col: 44, offset: 61799},
+								pos:  position{line: 1607, col: 44, offset: 58829},
 								name: "EOL",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1631, col: 51, offset: 61806},
+						pos:  position{line: 1607, col: 51, offset: 58836},
 						name: "EOF",
 					},
 				},
@@ -12230,102 +10526,102 @@ var g = &grammar{
 		},
 		{
 			name: "ExampleBlockRawContent",
-			pos:  position{line: 1633, col: 1, offset: 61811},
+			pos:  position{line: 1609, col: 1, offset: 58841},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1633, col: 27, offset: 61837},
+				pos: position{line: 1609, col: 27, offset: 58867},
 				expr: &actionExpr{
-					pos: position{line: 1634, col: 8, offset: 61846},
+					pos: position{line: 1610, col: 8, offset: 58876},
 					run: (*parser).callonExampleBlockRawContent2,
 					expr: &seqExpr{
-						pos: position{line: 1634, col: 8, offset: 61846},
+						pos: position{line: 1610, col: 8, offset: 58876},
 						exprs: []interface{}{
 							&notExpr{
-								pos: position{line: 1634, col: 8, offset: 61846},
+								pos: position{line: 1610, col: 8, offset: 58876},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1634, col: 9, offset: 61847},
+									pos:  position{line: 1610, col: 9, offset: 58877},
 									name: "ExampleBlockEndDelimiter",
 								},
 							},
 							&labeledExpr{
-								pos:   position{line: 1635, col: 8, offset: 61880},
+								pos:   position{line: 1611, col: 8, offset: 58910},
 								label: "element",
 								expr: &choiceExpr{
-									pos: position{line: 1635, col: 17, offset: 61889},
+									pos: position{line: 1611, col: 17, offset: 58919},
 									alternatives: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 1635, col: 17, offset: 61889},
+											pos:  position{line: 1611, col: 17, offset: 58919},
 											name: "BlankLine",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1636, col: 15, offset: 61913},
+											pos:  position{line: 1612, col: 15, offset: 58943},
 											name: "ImageBlock",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1637, col: 15, offset: 61938},
+											pos:  position{line: 1613, col: 15, offset: 58968},
 											name: "ThematicBreak",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1638, col: 15, offset: 61966},
+											pos:  position{line: 1614, col: 15, offset: 58996},
 											name: "OrderedListItem",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1639, col: 15, offset: 61997},
+											pos:  position{line: 1615, col: 15, offset: 59027},
 											name: "UnorderedListItem",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1640, col: 15, offset: 62030},
+											pos:  position{line: 1616, col: 15, offset: 59060},
 											name: "LabeledListItem",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1641, col: 15, offset: 62061},
+											pos:  position{line: 1617, col: 15, offset: 59091},
 											name: "ContinuedListItemElement",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1642, col: 15, offset: 62100},
+											pos:  position{line: 1618, col: 15, offset: 59130},
 											name: "FencedBlock",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1643, col: 15, offset: 62127},
+											pos:  position{line: 1619, col: 15, offset: 59157},
 											name: "ListingBlock",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1644, col: 15, offset: 62155},
+											pos:  position{line: 1620, col: 15, offset: 59185},
 											name: "VerseBlock",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1645, col: 15, offset: 62180},
+											pos:  position{line: 1621, col: 15, offset: 59210},
 											name: "QuoteBlock",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1646, col: 15, offset: 62205},
+											pos:  position{line: 1622, col: 15, offset: 59235},
 											name: "SidebarBlock",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1647, col: 15, offset: 62232},
+											pos:  position{line: 1623, col: 15, offset: 59262},
 											name: "SingleLineComment",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1648, col: 15, offset: 62264},
+											pos:  position{line: 1624, col: 15, offset: 59294},
 											name: "PassthroughBlock",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1649, col: 15, offset: 62295},
+											pos:  position{line: 1625, col: 15, offset: 59325},
 											name: "Table",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1650, col: 15, offset: 62315},
+											pos:  position{line: 1626, col: 15, offset: 59345},
 											name: "CommentBlock",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1651, col: 15, offset: 62342},
+											pos:  position{line: 1627, col: 15, offset: 59372},
 											name: "LiteralBlock",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1652, col: 15, offset: 62370},
+											pos:  position{line: 1628, col: 15, offset: 59400},
 											name: "RawParagraph",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1653, col: 15, offset: 62397},
+											pos:  position{line: 1629, col: 15, offset: 59427},
 											name: "StandaloneAttributes",
 										},
 									},
@@ -12338,42 +10634,42 @@ var g = &grammar{
 		},
 		{
 			name: "QuoteBlock",
-			pos:  position{line: 1660, col: 1, offset: 62653},
+			pos:  position{line: 1636, col: 1, offset: 59683},
 			expr: &actionExpr{
-				pos: position{line: 1660, col: 15, offset: 62667},
+				pos: position{line: 1636, col: 15, offset: 59697},
 				run: (*parser).callonQuoteBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1660, col: 15, offset: 62667},
+					pos: position{line: 1636, col: 15, offset: 59697},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1660, col: 15, offset: 62667},
+							pos:   position{line: 1636, col: 15, offset: 59697},
 							label: "attributes",
-							expr: &zeroOrMoreExpr{
-								pos: position{line: 1660, col: 26, offset: 62678},
+							expr: &zeroOrOneExpr{
+								pos: position{line: 1636, col: 26, offset: 59708},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1660, col: 27, offset: 62679},
-									name: "ElementAttribute",
+									pos:  position{line: 1636, col: 27, offset: 59709},
+									name: "BlockAttributes",
 								},
 							},
 						},
 						&andCodeExpr{
-							pos: position{line: 1661, col: 5, offset: 62703},
+							pos: position{line: 1637, col: 5, offset: 59732},
 							run: (*parser).callonQuoteBlock6,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1669, col: 5, offset: 63007},
+							pos:  position{line: 1645, col: 5, offset: 60042},
 							name: "QuoteBlockStartDelimiter",
 						},
 						&labeledExpr{
-							pos:   position{line: 1669, col: 30, offset: 63032},
+							pos:   position{line: 1645, col: 30, offset: 60067},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1669, col: 39, offset: 63041},
+								pos:  position{line: 1645, col: 39, offset: 60076},
 								name: "QuoteBlockRawContent",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1669, col: 61, offset: 63063},
+							pos:  position{line: 1645, col: 61, offset: 60098},
 							name: "QuoteBlockEndDelimiter",
 						},
 					},
@@ -12382,25 +10678,25 @@ var g = &grammar{
 		},
 		{
 			name: "QuoteBlockDelimiter",
-			pos:  position{line: 1673, col: 1, offset: 63183},
+			pos:  position{line: 1649, col: 1, offset: 60202},
 			expr: &seqExpr{
-				pos: position{line: 1673, col: 24, offset: 63206},
+				pos: position{line: 1649, col: 24, offset: 60225},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1673, col: 24, offset: 63206},
+						pos:        position{line: 1649, col: 24, offset: 60225},
 						val:        "____",
 						ignoreCase: false,
 						want:       "\"____\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1673, col: 31, offset: 63213},
+						pos: position{line: 1649, col: 31, offset: 60232},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1673, col: 31, offset: 63213},
+							pos:  position{line: 1649, col: 31, offset: 60232},
 							name: "Space",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1673, col: 38, offset: 63220},
+						pos:  position{line: 1649, col: 38, offset: 60239},
 						name: "EOL",
 					},
 				},
@@ -12408,25 +10704,25 @@ var g = &grammar{
 		},
 		{
 			name: "QuoteBlockStartDelimiter",
-			pos:  position{line: 1675, col: 1, offset: 63250},
+			pos:  position{line: 1651, col: 1, offset: 60269},
 			expr: &seqExpr{
-				pos: position{line: 1675, col: 29, offset: 63278},
+				pos: position{line: 1651, col: 29, offset: 60297},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1675, col: 29, offset: 63278},
+						pos:        position{line: 1651, col: 29, offset: 60297},
 						val:        "____",
 						ignoreCase: false,
 						want:       "\"____\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1675, col: 36, offset: 63285},
+						pos: position{line: 1651, col: 36, offset: 60304},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1675, col: 36, offset: 63285},
+							pos:  position{line: 1651, col: 36, offset: 60304},
 							name: "Space",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1675, col: 43, offset: 63292},
+						pos:  position{line: 1651, col: 43, offset: 60311},
 						name: "EOL",
 					},
 				},
@@ -12434,34 +10730,34 @@ var g = &grammar{
 		},
 		{
 			name: "QuoteBlockEndDelimiter",
-			pos:  position{line: 1677, col: 1, offset: 63322},
+			pos:  position{line: 1653, col: 1, offset: 60341},
 			expr: &choiceExpr{
-				pos: position{line: 1677, col: 27, offset: 63348},
+				pos: position{line: 1653, col: 27, offset: 60367},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 1677, col: 28, offset: 63349},
+						pos: position{line: 1653, col: 28, offset: 60368},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 1677, col: 28, offset: 63349},
+								pos:        position{line: 1653, col: 28, offset: 60368},
 								val:        "____",
 								ignoreCase: false,
 								want:       "\"____\"",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 1677, col: 35, offset: 63356},
+								pos: position{line: 1653, col: 35, offset: 60375},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1677, col: 35, offset: 63356},
+									pos:  position{line: 1653, col: 35, offset: 60375},
 									name: "Space",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1677, col: 42, offset: 63363},
+								pos:  position{line: 1653, col: 42, offset: 60382},
 								name: "EOL",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1677, col: 49, offset: 63370},
+						pos:  position{line: 1653, col: 49, offset: 60389},
 						name: "EOF",
 					},
 				},
@@ -12469,102 +10765,102 @@ var g = &grammar{
 		},
 		{
 			name: "QuoteBlockRawContent",
-			pos:  position{line: 1679, col: 1, offset: 63400},
+			pos:  position{line: 1655, col: 1, offset: 60419},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1679, col: 25, offset: 63424},
+				pos: position{line: 1655, col: 25, offset: 60443},
 				expr: &actionExpr{
-					pos: position{line: 1680, col: 8, offset: 63433},
+					pos: position{line: 1656, col: 8, offset: 60452},
 					run: (*parser).callonQuoteBlockRawContent2,
 					expr: &seqExpr{
-						pos: position{line: 1680, col: 8, offset: 63433},
+						pos: position{line: 1656, col: 8, offset: 60452},
 						exprs: []interface{}{
 							&notExpr{
-								pos: position{line: 1680, col: 8, offset: 63433},
+								pos: position{line: 1656, col: 8, offset: 60452},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1680, col: 9, offset: 63434},
+									pos:  position{line: 1656, col: 9, offset: 60453},
 									name: "QuoteBlockEndDelimiter",
 								},
 							},
 							&labeledExpr{
-								pos:   position{line: 1681, col: 8, offset: 63465},
+								pos:   position{line: 1657, col: 8, offset: 60484},
 								label: "element",
 								expr: &choiceExpr{
-									pos: position{line: 1681, col: 17, offset: 63474},
+									pos: position{line: 1657, col: 17, offset: 60493},
 									alternatives: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 1681, col: 17, offset: 63474},
+											pos:  position{line: 1657, col: 17, offset: 60493},
 											name: "BlankLine",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1682, col: 15, offset: 63498},
+											pos:  position{line: 1658, col: 15, offset: 60517},
 											name: "ImageBlock",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1683, col: 15, offset: 63523},
+											pos:  position{line: 1659, col: 15, offset: 60542},
 											name: "ThematicBreak",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1684, col: 15, offset: 63551},
+											pos:  position{line: 1660, col: 15, offset: 60570},
 											name: "OrderedListItem",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1685, col: 15, offset: 63582},
+											pos:  position{line: 1661, col: 15, offset: 60601},
 											name: "UnorderedListItem",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1686, col: 15, offset: 63615},
+											pos:  position{line: 1662, col: 15, offset: 60634},
 											name: "LabeledListItem",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1687, col: 15, offset: 63646},
+											pos:  position{line: 1663, col: 15, offset: 60665},
 											name: "ContinuedListItemElement",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1688, col: 15, offset: 63685},
+											pos:  position{line: 1664, col: 15, offset: 60704},
 											name: "FencedBlock",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1689, col: 15, offset: 63712},
+											pos:  position{line: 1665, col: 15, offset: 60731},
 											name: "ListingBlock",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1690, col: 15, offset: 63740},
+											pos:  position{line: 1666, col: 15, offset: 60759},
 											name: "VerseBlock",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1691, col: 15, offset: 63765},
+											pos:  position{line: 1667, col: 15, offset: 60784},
 											name: "ExampleBlock",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1692, col: 15, offset: 63792},
+											pos:  position{line: 1668, col: 15, offset: 60811},
 											name: "SidebarBlock",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1693, col: 15, offset: 63819},
+											pos:  position{line: 1669, col: 15, offset: 60838},
 											name: "SingleLineComment",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1694, col: 15, offset: 63851},
+											pos:  position{line: 1670, col: 15, offset: 60870},
 											name: "PassthroughBlock",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1695, col: 15, offset: 63882},
+											pos:  position{line: 1671, col: 15, offset: 60901},
 											name: "Table",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1696, col: 15, offset: 63902},
+											pos:  position{line: 1672, col: 15, offset: 60921},
 											name: "CommentBlock",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1697, col: 15, offset: 63929},
+											pos:  position{line: 1673, col: 15, offset: 60948},
 											name: "LiteralBlock",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1698, col: 15, offset: 63957},
+											pos:  position{line: 1674, col: 15, offset: 60976},
 											name: "RawParagraph",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1699, col: 15, offset: 63984},
+											pos:  position{line: 1675, col: 15, offset: 61003},
 											name: "StandaloneAttributes",
 										},
 									},
@@ -12577,38 +10873,38 @@ var g = &grammar{
 		},
 		{
 			name: "SidebarBlock",
-			pos:  position{line: 1706, col: 1, offset: 64242},
+			pos:  position{line: 1682, col: 1, offset: 61261},
 			expr: &actionExpr{
-				pos: position{line: 1706, col: 17, offset: 64258},
+				pos: position{line: 1682, col: 17, offset: 61277},
 				run: (*parser).callonSidebarBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1706, col: 17, offset: 64258},
+					pos: position{line: 1682, col: 17, offset: 61277},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1706, col: 17, offset: 64258},
+							pos:   position{line: 1682, col: 17, offset: 61277},
 							label: "attributes",
-							expr: &zeroOrMoreExpr{
-								pos: position{line: 1706, col: 28, offset: 64269},
+							expr: &zeroOrOneExpr{
+								pos: position{line: 1682, col: 28, offset: 61288},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1706, col: 29, offset: 64270},
-									name: "ElementAttribute",
+									pos:  position{line: 1682, col: 29, offset: 61289},
+									name: "BlockAttributes",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1706, col: 48, offset: 64289},
+							pos:  position{line: 1682, col: 47, offset: 61307},
 							name: "SidebarBlockStartDelimiter",
 						},
 						&labeledExpr{
-							pos:   position{line: 1706, col: 75, offset: 64316},
+							pos:   position{line: 1682, col: 74, offset: 61334},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1706, col: 84, offset: 64325},
+								pos:  position{line: 1682, col: 83, offset: 61343},
 								name: "SidebarBlockRawContent",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1706, col: 108, offset: 64349},
+							pos:  position{line: 1682, col: 107, offset: 61367},
 							name: "SidebarBlockEndDelimiter",
 						},
 					},
@@ -12617,25 +10913,25 @@ var g = &grammar{
 		},
 		{
 			name: "SidebarBlockDelimiter",
-			pos:  position{line: 1710, col: 1, offset: 64465},
+			pos:  position{line: 1686, col: 1, offset: 61467},
 			expr: &seqExpr{
-				pos: position{line: 1710, col: 26, offset: 64490},
+				pos: position{line: 1686, col: 26, offset: 61492},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1710, col: 26, offset: 64490},
+						pos:        position{line: 1686, col: 26, offset: 61492},
 						val:        "****",
 						ignoreCase: false,
 						want:       "\"****\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1710, col: 33, offset: 64497},
+						pos: position{line: 1686, col: 33, offset: 61499},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1710, col: 33, offset: 64497},
+							pos:  position{line: 1686, col: 33, offset: 61499},
 							name: "Space",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1710, col: 40, offset: 64504},
+						pos:  position{line: 1686, col: 40, offset: 61506},
 						name: "EOL",
 					},
 				},
@@ -12643,25 +10939,25 @@ var g = &grammar{
 		},
 		{
 			name: "SidebarBlockStartDelimiter",
-			pos:  position{line: 1712, col: 1, offset: 64509},
+			pos:  position{line: 1688, col: 1, offset: 61511},
 			expr: &seqExpr{
-				pos: position{line: 1712, col: 31, offset: 64539},
+				pos: position{line: 1688, col: 31, offset: 61541},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1712, col: 31, offset: 64539},
+						pos:        position{line: 1688, col: 31, offset: 61541},
 						val:        "****",
 						ignoreCase: false,
 						want:       "\"****\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1712, col: 38, offset: 64546},
+						pos: position{line: 1688, col: 38, offset: 61548},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1712, col: 38, offset: 64546},
+							pos:  position{line: 1688, col: 38, offset: 61548},
 							name: "Space",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1712, col: 45, offset: 64553},
+						pos:  position{line: 1688, col: 45, offset: 61555},
 						name: "EOL",
 					},
 				},
@@ -12669,34 +10965,34 @@ var g = &grammar{
 		},
 		{
 			name: "SidebarBlockEndDelimiter",
-			pos:  position{line: 1714, col: 1, offset: 64558},
+			pos:  position{line: 1690, col: 1, offset: 61560},
 			expr: &choiceExpr{
-				pos: position{line: 1714, col: 29, offset: 64586},
+				pos: position{line: 1690, col: 29, offset: 61588},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 1714, col: 30, offset: 64587},
+						pos: position{line: 1690, col: 30, offset: 61589},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 1714, col: 30, offset: 64587},
+								pos:        position{line: 1690, col: 30, offset: 61589},
 								val:        "****",
 								ignoreCase: false,
 								want:       "\"****\"",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 1714, col: 37, offset: 64594},
+								pos: position{line: 1690, col: 37, offset: 61596},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1714, col: 37, offset: 64594},
+									pos:  position{line: 1690, col: 37, offset: 61596},
 									name: "Space",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1714, col: 44, offset: 64601},
+								pos:  position{line: 1690, col: 44, offset: 61603},
 								name: "EOL",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1714, col: 51, offset: 64608},
+						pos:  position{line: 1690, col: 51, offset: 61610},
 						name: "EOF",
 					},
 				},
@@ -12704,102 +11000,102 @@ var g = &grammar{
 		},
 		{
 			name: "SidebarBlockRawContent",
-			pos:  position{line: 1716, col: 1, offset: 64613},
+			pos:  position{line: 1692, col: 1, offset: 61615},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1716, col: 27, offset: 64639},
+				pos: position{line: 1692, col: 27, offset: 61641},
 				expr: &actionExpr{
-					pos: position{line: 1717, col: 8, offset: 64648},
+					pos: position{line: 1693, col: 8, offset: 61650},
 					run: (*parser).callonSidebarBlockRawContent2,
 					expr: &seqExpr{
-						pos: position{line: 1717, col: 8, offset: 64648},
+						pos: position{line: 1693, col: 8, offset: 61650},
 						exprs: []interface{}{
 							&notExpr{
-								pos: position{line: 1717, col: 8, offset: 64648},
+								pos: position{line: 1693, col: 8, offset: 61650},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1717, col: 9, offset: 64649},
+									pos:  position{line: 1693, col: 9, offset: 61651},
 									name: "SidebarBlockEndDelimiter",
 								},
 							},
 							&labeledExpr{
-								pos:   position{line: 1718, col: 8, offset: 64682},
+								pos:   position{line: 1694, col: 8, offset: 61684},
 								label: "element",
 								expr: &choiceExpr{
-									pos: position{line: 1718, col: 17, offset: 64691},
+									pos: position{line: 1694, col: 17, offset: 61693},
 									alternatives: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 1718, col: 17, offset: 64691},
+											pos:  position{line: 1694, col: 17, offset: 61693},
 											name: "BlankLine",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1719, col: 15, offset: 64715},
+											pos:  position{line: 1695, col: 15, offset: 61717},
 											name: "ImageBlock",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1720, col: 15, offset: 64740},
+											pos:  position{line: 1696, col: 15, offset: 61742},
 											name: "ThematicBreak",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1721, col: 15, offset: 64768},
+											pos:  position{line: 1697, col: 15, offset: 61770},
 											name: "OrderedListItem",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1722, col: 15, offset: 64799},
+											pos:  position{line: 1698, col: 15, offset: 61801},
 											name: "UnorderedListItem",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1723, col: 15, offset: 64832},
+											pos:  position{line: 1699, col: 15, offset: 61834},
 											name: "LabeledListItem",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1724, col: 15, offset: 64863},
+											pos:  position{line: 1700, col: 15, offset: 61865},
 											name: "ContinuedListItemElement",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1725, col: 15, offset: 64902},
+											pos:  position{line: 1701, col: 15, offset: 61904},
 											name: "FencedBlock",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1726, col: 15, offset: 64929},
+											pos:  position{line: 1702, col: 15, offset: 61931},
 											name: "ListingBlock",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1727, col: 15, offset: 64956},
+											pos:  position{line: 1703, col: 15, offset: 61958},
 											name: "VerseBlock",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1728, col: 15, offset: 64982},
+											pos:  position{line: 1704, col: 15, offset: 61984},
 											name: "ExampleBlock",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1729, col: 15, offset: 65009},
+											pos:  position{line: 1705, col: 15, offset: 62011},
 											name: "QuoteBlock",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1730, col: 15, offset: 65034},
+											pos:  position{line: 1706, col: 15, offset: 62036},
 											name: "SingleLineComment",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1731, col: 15, offset: 65066},
+											pos:  position{line: 1707, col: 15, offset: 62068},
 											name: "PassthroughBlock",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1732, col: 15, offset: 65097},
+											pos:  position{line: 1708, col: 15, offset: 62099},
 											name: "Table",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1733, col: 15, offset: 65117},
+											pos:  position{line: 1709, col: 15, offset: 62119},
 											name: "CommentBlock",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1734, col: 15, offset: 65144},
+											pos:  position{line: 1710, col: 15, offset: 62146},
 											name: "LiteralBlock",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1735, col: 15, offset: 65172},
+											pos:  position{line: 1711, col: 15, offset: 62174},
 											name: "RawParagraph",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1736, col: 15, offset: 65199},
+											pos:  position{line: 1712, col: 15, offset: 62201},
 											name: "StandaloneAttributes",
 										},
 									},
@@ -12812,38 +11108,38 @@ var g = &grammar{
 		},
 		{
 			name: "FencedBlock",
-			pos:  position{line: 1743, col: 1, offset: 65456},
+			pos:  position{line: 1719, col: 1, offset: 62458},
 			expr: &actionExpr{
-				pos: position{line: 1743, col: 16, offset: 65471},
+				pos: position{line: 1719, col: 16, offset: 62473},
 				run: (*parser).callonFencedBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1743, col: 16, offset: 65471},
+					pos: position{line: 1719, col: 16, offset: 62473},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1743, col: 16, offset: 65471},
+							pos:   position{line: 1719, col: 16, offset: 62473},
 							label: "attributes",
-							expr: &zeroOrMoreExpr{
-								pos: position{line: 1743, col: 27, offset: 65482},
+							expr: &zeroOrOneExpr{
+								pos: position{line: 1719, col: 27, offset: 62484},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1743, col: 28, offset: 65483},
-									name: "ElementAttribute",
+									pos:  position{line: 1719, col: 28, offset: 62485},
+									name: "BlockAttributes",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1743, col: 47, offset: 65502},
+							pos:  position{line: 1719, col: 46, offset: 62503},
 							name: "FencedBlockStartDelimiter",
 						},
 						&labeledExpr{
-							pos:   position{line: 1743, col: 73, offset: 65528},
+							pos:   position{line: 1719, col: 72, offset: 62529},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1743, col: 82, offset: 65537},
+								pos:  position{line: 1719, col: 81, offset: 62538},
 								name: "FencedBlockRawContent",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1743, col: 105, offset: 65560},
+							pos:  position{line: 1719, col: 104, offset: 62561},
 							name: "FencedBlockEndDelimiter",
 						},
 					},
@@ -12852,25 +11148,25 @@ var g = &grammar{
 		},
 		{
 			name: "FencedBlockDelimiter",
-			pos:  position{line: 1747, col: 1, offset: 65674},
+			pos:  position{line: 1723, col: 1, offset: 62659},
 			expr: &seqExpr{
-				pos: position{line: 1747, col: 25, offset: 65698},
+				pos: position{line: 1723, col: 25, offset: 62683},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1747, col: 25, offset: 65698},
+						pos:        position{line: 1723, col: 25, offset: 62683},
 						val:        "```",
 						ignoreCase: false,
 						want:       "\"```\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1747, col: 31, offset: 65704},
+						pos: position{line: 1723, col: 31, offset: 62689},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1747, col: 31, offset: 65704},
+							pos:  position{line: 1723, col: 31, offset: 62689},
 							name: "Space",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1747, col: 38, offset: 65711},
+						pos:  position{line: 1723, col: 38, offset: 62696},
 						name: "EOL",
 					},
 				},
@@ -12878,25 +11174,25 @@ var g = &grammar{
 		},
 		{
 			name: "FencedBlockStartDelimiter",
-			pos:  position{line: 1749, col: 1, offset: 65771},
+			pos:  position{line: 1725, col: 1, offset: 62756},
 			expr: &seqExpr{
-				pos: position{line: 1749, col: 30, offset: 65800},
+				pos: position{line: 1725, col: 30, offset: 62785},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1749, col: 30, offset: 65800},
+						pos:        position{line: 1725, col: 30, offset: 62785},
 						val:        "```",
 						ignoreCase: false,
 						want:       "\"```\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1749, col: 36, offset: 65806},
+						pos: position{line: 1725, col: 36, offset: 62791},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1749, col: 36, offset: 65806},
+							pos:  position{line: 1725, col: 36, offset: 62791},
 							name: "Space",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1749, col: 43, offset: 65813},
+						pos:  position{line: 1725, col: 43, offset: 62798},
 						name: "EOL",
 					},
 				},
@@ -12904,34 +11200,34 @@ var g = &grammar{
 		},
 		{
 			name: "FencedBlockEndDelimiter",
-			pos:  position{line: 1751, col: 1, offset: 65818},
+			pos:  position{line: 1727, col: 1, offset: 62803},
 			expr: &choiceExpr{
-				pos: position{line: 1751, col: 28, offset: 65845},
+				pos: position{line: 1727, col: 28, offset: 62830},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 1751, col: 29, offset: 65846},
+						pos: position{line: 1727, col: 29, offset: 62831},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 1751, col: 29, offset: 65846},
+								pos:        position{line: 1727, col: 29, offset: 62831},
 								val:        "```",
 								ignoreCase: false,
 								want:       "\"```\"",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 1751, col: 35, offset: 65852},
+								pos: position{line: 1727, col: 35, offset: 62837},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1751, col: 35, offset: 65852},
+									pos:  position{line: 1727, col: 35, offset: 62837},
 									name: "Space",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1751, col: 42, offset: 65859},
+								pos:  position{line: 1727, col: 42, offset: 62844},
 								name: "EOL",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1751, col: 49, offset: 65866},
+						pos:  position{line: 1727, col: 49, offset: 62851},
 						name: "EOF",
 					},
 				},
@@ -12939,27 +11235,27 @@ var g = &grammar{
 		},
 		{
 			name: "FencedBlockRawContent",
-			pos:  position{line: 1753, col: 1, offset: 65871},
+			pos:  position{line: 1729, col: 1, offset: 62856},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1753, col: 26, offset: 65896},
+				pos: position{line: 1729, col: 26, offset: 62881},
 				expr: &actionExpr{
-					pos: position{line: 1753, col: 27, offset: 65897},
+					pos: position{line: 1729, col: 27, offset: 62882},
 					run: (*parser).callonFencedBlockRawContent2,
 					expr: &seqExpr{
-						pos: position{line: 1753, col: 27, offset: 65897},
+						pos: position{line: 1729, col: 27, offset: 62882},
 						exprs: []interface{}{
 							&notExpr{
-								pos: position{line: 1753, col: 27, offset: 65897},
+								pos: position{line: 1729, col: 27, offset: 62882},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1753, col: 28, offset: 65898},
+									pos:  position{line: 1729, col: 28, offset: 62883},
 									name: "FencedBlockEndDelimiter",
 								},
 							},
 							&labeledExpr{
-								pos:   position{line: 1753, col: 52, offset: 65922},
+								pos:   position{line: 1729, col: 52, offset: 62907},
 								label: "line",
 								expr: &ruleRefExpr{
-									pos:  position{line: 1753, col: 58, offset: 65928},
+									pos:  position{line: 1729, col: 58, offset: 62913},
 									name: "RawLine",
 								},
 							},
@@ -12970,38 +11266,38 @@ var g = &grammar{
 		},
 		{
 			name: "ListingBlock",
-			pos:  position{line: 1760, col: 1, offset: 66162},
+			pos:  position{line: 1736, col: 1, offset: 63147},
 			expr: &actionExpr{
-				pos: position{line: 1760, col: 17, offset: 66178},
+				pos: position{line: 1736, col: 17, offset: 63163},
 				run: (*parser).callonListingBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1760, col: 17, offset: 66178},
+					pos: position{line: 1736, col: 17, offset: 63163},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1760, col: 17, offset: 66178},
+							pos:   position{line: 1736, col: 17, offset: 63163},
 							label: "attributes",
-							expr: &zeroOrMoreExpr{
-								pos: position{line: 1760, col: 28, offset: 66189},
+							expr: &zeroOrOneExpr{
+								pos: position{line: 1736, col: 28, offset: 63174},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1760, col: 29, offset: 66190},
-									name: "ElementAttribute",
+									pos:  position{line: 1736, col: 29, offset: 63175},
+									name: "BlockAttributes",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1760, col: 48, offset: 66209},
+							pos:  position{line: 1736, col: 47, offset: 63193},
 							name: "ListingBlockStartDelimiter",
 						},
 						&labeledExpr{
-							pos:   position{line: 1760, col: 75, offset: 66236},
+							pos:   position{line: 1736, col: 74, offset: 63220},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1760, col: 84, offset: 66245},
+								pos:  position{line: 1736, col: 83, offset: 63229},
 								name: "ListingBlockRawContent",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1760, col: 108, offset: 66269},
+							pos:  position{line: 1736, col: 107, offset: 63253},
 							name: "ListingBlockEndDelimiter",
 						},
 					},
@@ -13010,25 +11306,25 @@ var g = &grammar{
 		},
 		{
 			name: "ListingBlockDelimiter",
-			pos:  position{line: 1764, col: 1, offset: 66385},
+			pos:  position{line: 1740, col: 1, offset: 63353},
 			expr: &seqExpr{
-				pos: position{line: 1764, col: 26, offset: 66410},
+				pos: position{line: 1740, col: 26, offset: 63378},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1764, col: 26, offset: 66410},
+						pos:        position{line: 1740, col: 26, offset: 63378},
 						val:        "----",
 						ignoreCase: false,
 						want:       "\"----\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1764, col: 33, offset: 66417},
+						pos: position{line: 1740, col: 33, offset: 63385},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1764, col: 33, offset: 66417},
+							pos:  position{line: 1740, col: 33, offset: 63385},
 							name: "Space",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1764, col: 40, offset: 66424},
+						pos:  position{line: 1740, col: 40, offset: 63392},
 						name: "EOL",
 					},
 				},
@@ -13036,25 +11332,25 @@ var g = &grammar{
 		},
 		{
 			name: "ListingBlockStartDelimiter",
-			pos:  position{line: 1766, col: 1, offset: 66429},
+			pos:  position{line: 1742, col: 1, offset: 63397},
 			expr: &seqExpr{
-				pos: position{line: 1766, col: 31, offset: 66459},
+				pos: position{line: 1742, col: 31, offset: 63427},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1766, col: 31, offset: 66459},
+						pos:        position{line: 1742, col: 31, offset: 63427},
 						val:        "----",
 						ignoreCase: false,
 						want:       "\"----\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1766, col: 38, offset: 66466},
+						pos: position{line: 1742, col: 38, offset: 63434},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1766, col: 38, offset: 66466},
+							pos:  position{line: 1742, col: 38, offset: 63434},
 							name: "Space",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1766, col: 45, offset: 66473},
+						pos:  position{line: 1742, col: 45, offset: 63441},
 						name: "EOL",
 					},
 				},
@@ -13062,34 +11358,34 @@ var g = &grammar{
 		},
 		{
 			name: "ListingBlockEndDelimiter",
-			pos:  position{line: 1768, col: 1, offset: 66478},
+			pos:  position{line: 1744, col: 1, offset: 63446},
 			expr: &choiceExpr{
-				pos: position{line: 1768, col: 29, offset: 66506},
+				pos: position{line: 1744, col: 29, offset: 63474},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 1768, col: 30, offset: 66507},
+						pos: position{line: 1744, col: 30, offset: 63475},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 1768, col: 30, offset: 66507},
+								pos:        position{line: 1744, col: 30, offset: 63475},
 								val:        "----",
 								ignoreCase: false,
 								want:       "\"----\"",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 1768, col: 37, offset: 66514},
+								pos: position{line: 1744, col: 37, offset: 63482},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1768, col: 37, offset: 66514},
+									pos:  position{line: 1744, col: 37, offset: 63482},
 									name: "Space",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1768, col: 44, offset: 66521},
+								pos:  position{line: 1744, col: 44, offset: 63489},
 								name: "EOL",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1768, col: 51, offset: 66528},
+						pos:  position{line: 1744, col: 51, offset: 63496},
 						name: "EOF",
 					},
 				},
@@ -13097,27 +11393,27 @@ var g = &grammar{
 		},
 		{
 			name: "ListingBlockRawContent",
-			pos:  position{line: 1770, col: 1, offset: 66533},
+			pos:  position{line: 1746, col: 1, offset: 63501},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1770, col: 27, offset: 66559},
+				pos: position{line: 1746, col: 27, offset: 63527},
 				expr: &actionExpr{
-					pos: position{line: 1770, col: 28, offset: 66560},
+					pos: position{line: 1746, col: 28, offset: 63528},
 					run: (*parser).callonListingBlockRawContent2,
 					expr: &seqExpr{
-						pos: position{line: 1770, col: 28, offset: 66560},
+						pos: position{line: 1746, col: 28, offset: 63528},
 						exprs: []interface{}{
 							&notExpr{
-								pos: position{line: 1770, col: 28, offset: 66560},
+								pos: position{line: 1746, col: 28, offset: 63528},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1770, col: 29, offset: 66561},
+									pos:  position{line: 1746, col: 29, offset: 63529},
 									name: "ListingBlockEndDelimiter",
 								},
 							},
 							&labeledExpr{
-								pos:   position{line: 1770, col: 54, offset: 66586},
+								pos:   position{line: 1746, col: 54, offset: 63554},
 								label: "line",
 								expr: &ruleRefExpr{
-									pos:  position{line: 1770, col: 60, offset: 66592},
+									pos:  position{line: 1746, col: 60, offset: 63560},
 									name: "RawLine",
 								},
 							},
@@ -13128,42 +11424,42 @@ var g = &grammar{
 		},
 		{
 			name: "VerseBlock",
-			pos:  position{line: 1777, col: 1, offset: 66824},
+			pos:  position{line: 1753, col: 1, offset: 63792},
 			expr: &actionExpr{
-				pos: position{line: 1777, col: 15, offset: 66838},
+				pos: position{line: 1753, col: 15, offset: 63806},
 				run: (*parser).callonVerseBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1777, col: 15, offset: 66838},
+					pos: position{line: 1753, col: 15, offset: 63806},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1777, col: 15, offset: 66838},
+							pos:   position{line: 1753, col: 15, offset: 63806},
 							label: "attributes",
-							expr: &zeroOrMoreExpr{
-								pos: position{line: 1777, col: 26, offset: 66849},
+							expr: &zeroOrOneExpr{
+								pos: position{line: 1753, col: 26, offset: 63817},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1777, col: 27, offset: 66850},
-									name: "ElementAttribute",
+									pos:  position{line: 1753, col: 27, offset: 63818},
+									name: "BlockAttributes",
 								},
 							},
 						},
 						&andCodeExpr{
-							pos: position{line: 1778, col: 5, offset: 66874},
+							pos: position{line: 1754, col: 5, offset: 63841},
 							run: (*parser).callonVerseBlock6,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1782, col: 5, offset: 67031},
+							pos:  position{line: 1758, col: 5, offset: 64002},
 							name: "QuoteBlockStartDelimiter",
 						},
 						&labeledExpr{
-							pos:   position{line: 1782, col: 30, offset: 67056},
+							pos:   position{line: 1758, col: 30, offset: 64027},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1782, col: 39, offset: 67065},
+								pos:  position{line: 1758, col: 39, offset: 64036},
 								name: "VerseBlockRawContent",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1782, col: 61, offset: 67087},
+							pos:  position{line: 1758, col: 61, offset: 64058},
 							name: "QuoteBlockEndDelimiter",
 						},
 					},
@@ -13172,27 +11468,27 @@ var g = &grammar{
 		},
 		{
 			name: "VerseBlockRawContent",
-			pos:  position{line: 1786, col: 1, offset: 67207},
+			pos:  position{line: 1762, col: 1, offset: 64162},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1786, col: 25, offset: 67231},
+				pos: position{line: 1762, col: 25, offset: 64186},
 				expr: &actionExpr{
-					pos: position{line: 1786, col: 26, offset: 67232},
+					pos: position{line: 1762, col: 26, offset: 64187},
 					run: (*parser).callonVerseBlockRawContent2,
 					expr: &seqExpr{
-						pos: position{line: 1786, col: 26, offset: 67232},
+						pos: position{line: 1762, col: 26, offset: 64187},
 						exprs: []interface{}{
 							&notExpr{
-								pos: position{line: 1786, col: 26, offset: 67232},
+								pos: position{line: 1762, col: 26, offset: 64187},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1786, col: 27, offset: 67233},
+									pos:  position{line: 1762, col: 27, offset: 64188},
 									name: "QuoteBlockEndDelimiter",
 								},
 							},
 							&labeledExpr{
-								pos:   position{line: 1786, col: 50, offset: 67256},
+								pos:   position{line: 1762, col: 50, offset: 64211},
 								label: "line",
 								expr: &ruleRefExpr{
-									pos:  position{line: 1786, col: 56, offset: 67262},
+									pos:  position{line: 1762, col: 56, offset: 64217},
 									name: "RawLine",
 								},
 							},
@@ -13203,38 +11499,38 @@ var g = &grammar{
 		},
 		{
 			name: "PassthroughBlock",
-			pos:  position{line: 1793, col: 1, offset: 67500},
+			pos:  position{line: 1769, col: 1, offset: 64455},
 			expr: &actionExpr{
-				pos: position{line: 1793, col: 21, offset: 67520},
+				pos: position{line: 1769, col: 21, offset: 64475},
 				run: (*parser).callonPassthroughBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1793, col: 21, offset: 67520},
+					pos: position{line: 1769, col: 21, offset: 64475},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1793, col: 21, offset: 67520},
+							pos:   position{line: 1769, col: 21, offset: 64475},
 							label: "attributes",
-							expr: &zeroOrMoreExpr{
-								pos: position{line: 1793, col: 32, offset: 67531},
+							expr: &zeroOrOneExpr{
+								pos: position{line: 1769, col: 32, offset: 64486},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1793, col: 33, offset: 67532},
-									name: "ElementAttribute",
+									pos:  position{line: 1769, col: 33, offset: 64487},
+									name: "BlockAttributes",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1793, col: 52, offset: 67551},
+							pos:  position{line: 1769, col: 51, offset: 64505},
 							name: "PassthroughBlockStartDelimiter",
 						},
 						&labeledExpr{
-							pos:   position{line: 1793, col: 83, offset: 67582},
+							pos:   position{line: 1769, col: 82, offset: 64536},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1793, col: 92, offset: 67591},
+								pos:  position{line: 1769, col: 91, offset: 64545},
 								name: "PassthroughBlockRawContent",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1793, col: 120, offset: 67619},
+							pos:  position{line: 1769, col: 119, offset: 64573},
 							name: "PassthroughBlockEndDelimiter",
 						},
 					},
@@ -13243,25 +11539,25 @@ var g = &grammar{
 		},
 		{
 			name: "PassthroughBlockDelimiter",
-			pos:  position{line: 1797, col: 1, offset: 67743},
+			pos:  position{line: 1773, col: 1, offset: 64681},
 			expr: &seqExpr{
-				pos: position{line: 1797, col: 30, offset: 67772},
+				pos: position{line: 1773, col: 30, offset: 64710},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1797, col: 30, offset: 67772},
+						pos:        position{line: 1773, col: 30, offset: 64710},
 						val:        "++++",
 						ignoreCase: false,
 						want:       "\"++++\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1797, col: 37, offset: 67779},
+						pos: position{line: 1773, col: 37, offset: 64717},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1797, col: 37, offset: 67779},
+							pos:  position{line: 1773, col: 37, offset: 64717},
 							name: "Space",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1797, col: 44, offset: 67786},
+						pos:  position{line: 1773, col: 44, offset: 64724},
 						name: "EOL",
 					},
 				},
@@ -13269,25 +11565,25 @@ var g = &grammar{
 		},
 		{
 			name: "PassthroughBlockStartDelimiter",
-			pos:  position{line: 1799, col: 1, offset: 67791},
+			pos:  position{line: 1775, col: 1, offset: 64729},
 			expr: &seqExpr{
-				pos: position{line: 1799, col: 35, offset: 67825},
+				pos: position{line: 1775, col: 35, offset: 64763},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1799, col: 35, offset: 67825},
+						pos:        position{line: 1775, col: 35, offset: 64763},
 						val:        "++++",
 						ignoreCase: false,
 						want:       "\"++++\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1799, col: 42, offset: 67832},
+						pos: position{line: 1775, col: 42, offset: 64770},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1799, col: 42, offset: 67832},
+							pos:  position{line: 1775, col: 42, offset: 64770},
 							name: "Space",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1799, col: 49, offset: 67839},
+						pos:  position{line: 1775, col: 49, offset: 64777},
 						name: "EOL",
 					},
 				},
@@ -13295,34 +11591,34 @@ var g = &grammar{
 		},
 		{
 			name: "PassthroughBlockEndDelimiter",
-			pos:  position{line: 1801, col: 1, offset: 67844},
+			pos:  position{line: 1777, col: 1, offset: 64782},
 			expr: &choiceExpr{
-				pos: position{line: 1801, col: 33, offset: 67876},
+				pos: position{line: 1777, col: 33, offset: 64814},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 1801, col: 34, offset: 67877},
+						pos: position{line: 1777, col: 34, offset: 64815},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 1801, col: 34, offset: 67877},
+								pos:        position{line: 1777, col: 34, offset: 64815},
 								val:        "++++",
 								ignoreCase: false,
 								want:       "\"++++\"",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 1801, col: 41, offset: 67884},
+								pos: position{line: 1777, col: 41, offset: 64822},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1801, col: 41, offset: 67884},
+									pos:  position{line: 1777, col: 41, offset: 64822},
 									name: "Space",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1801, col: 48, offset: 67891},
+								pos:  position{line: 1777, col: 48, offset: 64829},
 								name: "EOL",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1801, col: 55, offset: 67898},
+						pos:  position{line: 1777, col: 55, offset: 64836},
 						name: "EOF",
 					},
 				},
@@ -13330,27 +11626,27 @@ var g = &grammar{
 		},
 		{
 			name: "PassthroughBlockRawContent",
-			pos:  position{line: 1803, col: 1, offset: 67903},
+			pos:  position{line: 1779, col: 1, offset: 64841},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1803, col: 31, offset: 67933},
+				pos: position{line: 1779, col: 31, offset: 64871},
 				expr: &actionExpr{
-					pos: position{line: 1803, col: 32, offset: 67934},
+					pos: position{line: 1779, col: 32, offset: 64872},
 					run: (*parser).callonPassthroughBlockRawContent2,
 					expr: &seqExpr{
-						pos: position{line: 1803, col: 32, offset: 67934},
+						pos: position{line: 1779, col: 32, offset: 64872},
 						exprs: []interface{}{
 							&notExpr{
-								pos: position{line: 1803, col: 32, offset: 67934},
+								pos: position{line: 1779, col: 32, offset: 64872},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1803, col: 33, offset: 67935},
+									pos:  position{line: 1779, col: 33, offset: 64873},
 									name: "PassthroughBlockEndDelimiter",
 								},
 							},
 							&labeledExpr{
-								pos:   position{line: 1803, col: 62, offset: 67964},
+								pos:   position{line: 1779, col: 62, offset: 64902},
 								label: "line",
 								expr: &ruleRefExpr{
-									pos:  position{line: 1803, col: 68, offset: 67970},
+									pos:  position{line: 1779, col: 68, offset: 64908},
 									name: "RawLine",
 								},
 							},
@@ -13361,25 +11657,25 @@ var g = &grammar{
 		},
 		{
 			name: "CommentBlockDelimiter",
-			pos:  position{line: 1810, col: 1, offset: 68204},
+			pos:  position{line: 1786, col: 1, offset: 65142},
 			expr: &seqExpr{
-				pos: position{line: 1810, col: 26, offset: 68229},
+				pos: position{line: 1786, col: 26, offset: 65167},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1810, col: 26, offset: 68229},
+						pos:        position{line: 1786, col: 26, offset: 65167},
 						val:        "////",
 						ignoreCase: false,
 						want:       "\"////\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1810, col: 33, offset: 68236},
+						pos: position{line: 1786, col: 33, offset: 65174},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1810, col: 33, offset: 68236},
+							pos:  position{line: 1786, col: 33, offset: 65174},
 							name: "Space",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1810, col: 40, offset: 68243},
+						pos:  position{line: 1786, col: 40, offset: 65181},
 						name: "EOL",
 					},
 				},
@@ -13387,25 +11683,25 @@ var g = &grammar{
 		},
 		{
 			name: "CommentBlockStartDelimiter",
-			pos:  position{line: 1812, col: 1, offset: 68248},
+			pos:  position{line: 1788, col: 1, offset: 65186},
 			expr: &seqExpr{
-				pos: position{line: 1812, col: 31, offset: 68278},
+				pos: position{line: 1788, col: 31, offset: 65216},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1812, col: 31, offset: 68278},
+						pos:        position{line: 1788, col: 31, offset: 65216},
 						val:        "////",
 						ignoreCase: false,
 						want:       "\"////\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1812, col: 38, offset: 68285},
+						pos: position{line: 1788, col: 38, offset: 65223},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1812, col: 38, offset: 68285},
+							pos:  position{line: 1788, col: 38, offset: 65223},
 							name: "Space",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1812, col: 45, offset: 68292},
+						pos:  position{line: 1788, col: 45, offset: 65230},
 						name: "EOL",
 					},
 				},
@@ -13413,34 +11709,34 @@ var g = &grammar{
 		},
 		{
 			name: "CommentBlockEndDelimiter",
-			pos:  position{line: 1814, col: 1, offset: 68297},
+			pos:  position{line: 1790, col: 1, offset: 65235},
 			expr: &choiceExpr{
-				pos: position{line: 1814, col: 29, offset: 68325},
+				pos: position{line: 1790, col: 29, offset: 65263},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 1814, col: 30, offset: 68326},
+						pos: position{line: 1790, col: 30, offset: 65264},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 1814, col: 30, offset: 68326},
+								pos:        position{line: 1790, col: 30, offset: 65264},
 								val:        "////",
 								ignoreCase: false,
 								want:       "\"////\"",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 1814, col: 37, offset: 68333},
+								pos: position{line: 1790, col: 37, offset: 65271},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1814, col: 37, offset: 68333},
+									pos:  position{line: 1790, col: 37, offset: 65271},
 									name: "Space",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1814, col: 44, offset: 68340},
+								pos:  position{line: 1790, col: 44, offset: 65278},
 								name: "EOL",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1814, col: 51, offset: 68347},
+						pos:  position{line: 1790, col: 51, offset: 65285},
 						name: "EOF",
 					},
 				},
@@ -13448,27 +11744,27 @@ var g = &grammar{
 		},
 		{
 			name: "CommentBlock",
-			pos:  position{line: 1816, col: 1, offset: 68352},
+			pos:  position{line: 1792, col: 1, offset: 65290},
 			expr: &actionExpr{
-				pos: position{line: 1816, col: 17, offset: 68368},
+				pos: position{line: 1792, col: 17, offset: 65306},
 				run: (*parser).callonCommentBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1816, col: 17, offset: 68368},
+					pos: position{line: 1792, col: 17, offset: 65306},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1816, col: 17, offset: 68368},
+							pos:  position{line: 1792, col: 17, offset: 65306},
 							name: "CommentBlockStartDelimiter",
 						},
 						&labeledExpr{
-							pos:   position{line: 1816, col: 44, offset: 68395},
+							pos:   position{line: 1792, col: 44, offset: 65333},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1816, col: 53, offset: 68404},
+								pos:  position{line: 1792, col: 53, offset: 65342},
 								name: "CommentBlockRawContent",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1816, col: 78, offset: 68429},
+							pos:  position{line: 1792, col: 78, offset: 65367},
 							name: "CommentBlockEndDelimiter",
 						},
 					},
@@ -13477,27 +11773,27 @@ var g = &grammar{
 		},
 		{
 			name: "CommentBlockRawContent",
-			pos:  position{line: 1820, col: 1, offset: 68522},
+			pos:  position{line: 1796, col: 1, offset: 65460},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1820, col: 27, offset: 68548},
+				pos: position{line: 1796, col: 27, offset: 65486},
 				expr: &actionExpr{
-					pos: position{line: 1820, col: 28, offset: 68549},
+					pos: position{line: 1796, col: 28, offset: 65487},
 					run: (*parser).callonCommentBlockRawContent2,
 					expr: &seqExpr{
-						pos: position{line: 1820, col: 28, offset: 68549},
+						pos: position{line: 1796, col: 28, offset: 65487},
 						exprs: []interface{}{
 							&notExpr{
-								pos: position{line: 1820, col: 28, offset: 68549},
+								pos: position{line: 1796, col: 28, offset: 65487},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1820, col: 29, offset: 68550},
+									pos:  position{line: 1796, col: 29, offset: 65488},
 									name: "CommentBlockEndDelimiter",
 								},
 							},
 							&labeledExpr{
-								pos:   position{line: 1820, col: 54, offset: 68575},
+								pos:   position{line: 1796, col: 54, offset: 65513},
 								label: "line",
 								expr: &ruleRefExpr{
-									pos:  position{line: 1820, col: 60, offset: 68581},
+									pos:  position{line: 1796, col: 60, offset: 65519},
 									name: "RawLine",
 								},
 							},
@@ -13508,36 +11804,36 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineComment",
-			pos:  position{line: 1824, col: 1, offset: 68619},
+			pos:  position{line: 1800, col: 1, offset: 65557},
 			expr: &actionExpr{
-				pos: position{line: 1824, col: 22, offset: 68640},
+				pos: position{line: 1800, col: 22, offset: 65578},
 				run: (*parser).callonSingleLineComment1,
 				expr: &seqExpr{
-					pos: position{line: 1824, col: 22, offset: 68640},
+					pos: position{line: 1800, col: 22, offset: 65578},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1824, col: 22, offset: 68640},
+							pos: position{line: 1800, col: 22, offset: 65578},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1824, col: 23, offset: 68641},
+								pos:  position{line: 1800, col: 23, offset: 65579},
 								name: "CommentBlockDelimiter",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1824, col: 45, offset: 68663},
+							pos:        position{line: 1800, col: 45, offset: 65601},
 							val:        "//",
 							ignoreCase: false,
 							want:       "\"//\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1824, col: 50, offset: 68668},
+							pos:   position{line: 1800, col: 50, offset: 65606},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1824, col: 59, offset: 68677},
+								pos:  position{line: 1800, col: 59, offset: 65615},
 								name: "SingleLineCommentContent",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1824, col: 85, offset: 68703},
+							pos:  position{line: 1800, col: 85, offset: 65641},
 							name: "EOL",
 						},
 					},
@@ -13546,14 +11842,14 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineCommentContent",
-			pos:  position{line: 1828, col: 1, offset: 68768},
+			pos:  position{line: 1804, col: 1, offset: 65706},
 			expr: &actionExpr{
-				pos: position{line: 1828, col: 29, offset: 68796},
+				pos: position{line: 1804, col: 29, offset: 65734},
 				run: (*parser).callonSingleLineCommentContent1,
 				expr: &zeroOrMoreExpr{
-					pos: position{line: 1828, col: 29, offset: 68796},
+					pos: position{line: 1804, col: 29, offset: 65734},
 					expr: &charClassMatcher{
-						pos:        position{line: 1828, col: 29, offset: 68796},
+						pos:        position{line: 1804, col: 29, offset: 65734},
 						val:        "[^\\r\\n]",
 						chars:      []rune{'\r', '\n'},
 						ignoreCase: false,
@@ -13564,48 +11860,48 @@ var g = &grammar{
 		},
 		{
 			name: "InlineMacros",
-			pos:  position{line: 1836, col: 1, offset: 69085},
+			pos:  position{line: 1812, col: 1, offset: 66023},
 			expr: &choiceExpr{
-				pos: position{line: 1836, col: 17, offset: 69101},
+				pos: position{line: 1812, col: 17, offset: 66039},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1836, col: 17, offset: 69101},
+						pos:  position{line: 1812, col: 17, offset: 66039},
 						name: "InlineIcon",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1837, col: 19, offset: 69130},
+						pos:  position{line: 1813, col: 19, offset: 66068},
 						name: "InlineImage",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1838, col: 19, offset: 69161},
+						pos:  position{line: 1814, col: 19, offset: 66099},
 						name: "Link",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1839, col: 19, offset: 69185},
+						pos:  position{line: 1815, col: 19, offset: 66123},
 						name: "InlinePassthrough",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1840, col: 19, offset: 69222},
+						pos:  position{line: 1816, col: 19, offset: 66160},
 						name: "InlineFootnote",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1841, col: 19, offset: 69256},
+						pos:  position{line: 1817, col: 19, offset: 66194},
 						name: "CrossReference",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1842, col: 19, offset: 69290},
+						pos:  position{line: 1818, col: 19, offset: 66228},
 						name: "InlineUserMacro",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1843, col: 19, offset: 69325},
+						pos:  position{line: 1819, col: 19, offset: 66263},
 						name: "InlineElementID",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1844, col: 19, offset: 69359},
+						pos:  position{line: 1820, col: 19, offset: 66297},
 						name: "ConcealedIndexTerm",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1845, col: 19, offset: 69396},
+						pos:  position{line: 1821, col: 19, offset: 66334},
 						name: "IndexTerm",
 					},
 				},
@@ -13613,29 +11909,29 @@ var g = &grammar{
 		},
 		{
 			name: "ElementPlaceHolder",
-			pos:  position{line: 1847, col: 1, offset: 69407},
+			pos:  position{line: 1823, col: 1, offset: 66345},
 			expr: &actionExpr{
-				pos: position{line: 1847, col: 23, offset: 69429},
+				pos: position{line: 1823, col: 23, offset: 66367},
 				run: (*parser).callonElementPlaceHolder1,
 				expr: &seqExpr{
-					pos: position{line: 1847, col: 23, offset: 69429},
+					pos: position{line: 1823, col: 23, offset: 66367},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1847, col: 23, offset: 69429},
+							pos:        position{line: 1823, col: 23, offset: 66367},
 							val:        "�",
 							ignoreCase: false,
 							want:       "\"�\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1847, col: 32, offset: 69438},
+							pos:   position{line: 1823, col: 32, offset: 66376},
 							label: "ref",
 							expr: &actionExpr{
-								pos: position{line: 1847, col: 37, offset: 69443},
+								pos: position{line: 1823, col: 37, offset: 66381},
 								run: (*parser).callonElementPlaceHolder5,
 								expr: &oneOrMoreExpr{
-									pos: position{line: 1847, col: 37, offset: 69443},
+									pos: position{line: 1823, col: 37, offset: 66381},
 									expr: &charClassMatcher{
-										pos:        position{line: 1847, col: 37, offset: 69443},
+										pos:        position{line: 1823, col: 37, offset: 66381},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -13645,7 +11941,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1847, col: 76, offset: 69482},
+							pos:        position{line: 1823, col: 76, offset: 66420},
 							val:        "�",
 							ignoreCase: false,
 							want:       "\"�\"",
@@ -13656,47 +11952,47 @@ var g = &grammar{
 		},
 		{
 			name: "InlinePassthroughSubs",
-			pos:  position{line: 1852, col: 1, offset: 69634},
+			pos:  position{line: 1828, col: 1, offset: 66572},
 			expr: &seqExpr{
-				pos: position{line: 1853, col: 5, offset: 69664},
+				pos: position{line: 1829, col: 5, offset: 66602},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1853, col: 5, offset: 69664},
+						pos: position{line: 1829, col: 5, offset: 66602},
 						expr: &choiceExpr{
-							pos: position{line: 1853, col: 6, offset: 69665},
+							pos: position{line: 1829, col: 6, offset: 66603},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 1853, col: 6, offset: 69665},
+									pos:  position{line: 1829, col: 6, offset: 66603},
 									name: "InlinePassthrough",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1854, col: 11, offset: 69694},
+									pos:  position{line: 1830, col: 11, offset: 66632},
 									name: "InlineWord",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1855, col: 11, offset: 69755},
+									pos:  position{line: 1831, col: 11, offset: 66693},
 									name: "ElementPlaceHolder",
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1856, col: 11, offset: 69784},
+									pos: position{line: 1832, col: 11, offset: 66722},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1856, col: 11, offset: 69784},
+										pos:  position{line: 1832, col: 11, offset: 66722},
 										name: "Space",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1857, col: 11, offset: 69802},
+									pos:  position{line: 1833, col: 11, offset: 66740},
 									name: "AnyChar",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1858, col: 11, offset: 69820},
+									pos:  position{line: 1834, col: 11, offset: 66758},
 									name: "Newline",
 								},
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1858, col: 21, offset: 69830},
+						pos:  position{line: 1834, col: 21, offset: 66768},
 						name: "EOF",
 					},
 				},
@@ -13704,47 +12000,47 @@ var g = &grammar{
 		},
 		{
 			name: "SpecialCharacterSubs",
-			pos:  position{line: 1861, col: 1, offset: 69951},
+			pos:  position{line: 1837, col: 1, offset: 66889},
 			expr: &seqExpr{
-				pos: position{line: 1862, col: 5, offset: 69980},
+				pos: position{line: 1838, col: 5, offset: 66918},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1862, col: 5, offset: 69980},
+						pos: position{line: 1838, col: 5, offset: 66918},
 						expr: &choiceExpr{
-							pos: position{line: 1862, col: 6, offset: 69981},
+							pos: position{line: 1838, col: 6, offset: 66919},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 1862, col: 6, offset: 69981},
+									pos:  position{line: 1838, col: 6, offset: 66919},
 									name: "InlineWord",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1863, col: 11, offset: 70042},
+									pos:  position{line: 1839, col: 11, offset: 66980},
 									name: "SpecialCharacter",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1864, col: 11, offset: 70069},
+									pos:  position{line: 1840, col: 11, offset: 67007},
 									name: "ElementPlaceHolder",
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1865, col: 11, offset: 70098},
+									pos: position{line: 1841, col: 11, offset: 67036},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1865, col: 11, offset: 70098},
+										pos:  position{line: 1841, col: 11, offset: 67036},
 										name: "Space",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1866, col: 11, offset: 70115},
+									pos:  position{line: 1842, col: 11, offset: 67053},
 									name: "AnyChar",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1867, col: 11, offset: 70133},
+									pos:  position{line: 1843, col: 11, offset: 67071},
 									name: "Newline",
 								},
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1867, col: 21, offset: 70143},
+						pos:  position{line: 1843, col: 21, offset: 67081},
 						name: "EOF",
 					},
 				},
@@ -13752,51 +12048,51 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedTextSubs",
-			pos:  position{line: 1870, col: 1, offset: 70197},
+			pos:  position{line: 1846, col: 1, offset: 67135},
 			expr: &seqExpr{
-				pos: position{line: 1871, col: 5, offset: 70220},
+				pos: position{line: 1847, col: 5, offset: 67158},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1871, col: 5, offset: 70220},
+						pos: position{line: 1847, col: 5, offset: 67158},
 						expr: &choiceExpr{
-							pos: position{line: 1871, col: 6, offset: 70221},
+							pos: position{line: 1847, col: 6, offset: 67159},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 1871, col: 6, offset: 70221},
+									pos:  position{line: 1847, col: 6, offset: 67159},
 									name: "InlineWord",
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1872, col: 11, offset: 70282},
+									pos: position{line: 1848, col: 11, offset: 67220},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1872, col: 11, offset: 70282},
+										pos:  position{line: 1848, col: 11, offset: 67220},
 										name: "Space",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1873, col: 11, offset: 70300},
+									pos:  position{line: 1849, col: 11, offset: 67238},
 									name: "QuotedText",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1874, col: 11, offset: 70322},
+									pos:  position{line: 1850, col: 11, offset: 67260},
 									name: "QuotedString",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1875, col: 11, offset: 70345},
+									pos:  position{line: 1851, col: 11, offset: 67283},
 									name: "ElementPlaceHolder",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1876, col: 11, offset: 70374},
+									pos:  position{line: 1852, col: 11, offset: 67312},
 									name: "AnyChar",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1877, col: 11, offset: 70392},
+									pos:  position{line: 1853, col: 11, offset: 67330},
 									name: "Newline",
 								},
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1877, col: 21, offset: 70402},
+						pos:  position{line: 1853, col: 21, offset: 67340},
 						name: "EOF",
 					},
 				},
@@ -13804,47 +12100,47 @@ var g = &grammar{
 		},
 		{
 			name: "AttributeSubs",
-			pos:  position{line: 1880, col: 1, offset: 70460},
+			pos:  position{line: 1856, col: 1, offset: 67398},
 			expr: &seqExpr{
-				pos: position{line: 1881, col: 5, offset: 70482},
+				pos: position{line: 1857, col: 5, offset: 67420},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1881, col: 5, offset: 70482},
+						pos: position{line: 1857, col: 5, offset: 67420},
 						expr: &choiceExpr{
-							pos: position{line: 1881, col: 6, offset: 70483},
+							pos: position{line: 1857, col: 6, offset: 67421},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 1881, col: 6, offset: 70483},
+									pos:  position{line: 1857, col: 6, offset: 67421},
 									name: "InlineWord",
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1882, col: 11, offset: 70544},
+									pos: position{line: 1858, col: 11, offset: 67482},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1882, col: 11, offset: 70544},
+										pos:  position{line: 1858, col: 11, offset: 67482},
 										name: "Space",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1883, col: 11, offset: 70562},
+									pos:  position{line: 1859, col: 11, offset: 67500},
 									name: "AttributeSubstitution",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1884, col: 11, offset: 70594},
+									pos:  position{line: 1860, col: 11, offset: 67532},
 									name: "ElementPlaceHolder",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1885, col: 11, offset: 70623},
+									pos:  position{line: 1861, col: 11, offset: 67561},
 									name: "AnyChar",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1886, col: 11, offset: 70641},
+									pos:  position{line: 1862, col: 11, offset: 67579},
 									name: "Newline",
 								},
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1886, col: 21, offset: 70651},
+						pos:  position{line: 1862, col: 21, offset: 67589},
 						name: "EOF",
 					},
 				},
@@ -13852,47 +12148,47 @@ var g = &grammar{
 		},
 		{
 			name: "InlineMacroSubs",
-			pos:  position{line: 1889, col: 1, offset: 70705},
+			pos:  position{line: 1865, col: 1, offset: 67643},
 			expr: &seqExpr{
-				pos: position{line: 1890, col: 5, offset: 70729},
+				pos: position{line: 1866, col: 5, offset: 67667},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1890, col: 5, offset: 70729},
+						pos: position{line: 1866, col: 5, offset: 67667},
 						expr: &choiceExpr{
-							pos: position{line: 1890, col: 6, offset: 70730},
+							pos: position{line: 1866, col: 6, offset: 67668},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 1890, col: 6, offset: 70730},
+									pos:  position{line: 1866, col: 6, offset: 67668},
 									name: "InlineWord",
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1891, col: 11, offset: 70791},
+									pos: position{line: 1867, col: 11, offset: 67729},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1891, col: 11, offset: 70791},
+										pos:  position{line: 1867, col: 11, offset: 67729},
 										name: "Space",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1892, col: 11, offset: 70809},
+									pos:  position{line: 1868, col: 11, offset: 67747},
 									name: "InlineMacros",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1893, col: 11, offset: 70832},
+									pos:  position{line: 1869, col: 11, offset: 67770},
 									name: "ElementPlaceHolder",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1894, col: 11, offset: 70861},
+									pos:  position{line: 1870, col: 11, offset: 67799},
 									name: "AnyChar",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1895, col: 11, offset: 70879},
+									pos:  position{line: 1871, col: 11, offset: 67817},
 									name: "Newline",
 								},
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1895, col: 21, offset: 70889},
+						pos:  position{line: 1871, col: 21, offset: 67827},
 						name: "EOF",
 					},
 				},
@@ -13900,26 +12196,26 @@ var g = &grammar{
 		},
 		{
 			name: "MarkdownQuoteMacroSubs",
-			pos:  position{line: 1898, col: 1, offset: 70969},
+			pos:  position{line: 1874, col: 1, offset: 67907},
 			expr: &actionExpr{
-				pos: position{line: 1898, col: 27, offset: 70995},
+				pos: position{line: 1874, col: 27, offset: 67933},
 				run: (*parser).callonMarkdownQuoteMacroSubs1,
 				expr: &seqExpr{
-					pos: position{line: 1898, col: 27, offset: 70995},
+					pos: position{line: 1874, col: 27, offset: 67933},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1898, col: 27, offset: 70995},
+							pos:   position{line: 1874, col: 27, offset: 67933},
 							label: "lines",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1898, col: 33, offset: 71001},
+								pos: position{line: 1874, col: 33, offset: 67939},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1898, col: 34, offset: 71002},
+									pos:  position{line: 1874, col: 34, offset: 67940},
 									name: "MarkdownQuoteLine",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1898, col: 54, offset: 71022},
+							pos:  position{line: 1874, col: 54, offset: 67960},
 							name: "EOF",
 						},
 					},
@@ -13928,42 +12224,42 @@ var g = &grammar{
 		},
 		{
 			name: "MarkdownQuoteLine",
-			pos:  position{line: 1902, col: 1, offset: 71089},
+			pos:  position{line: 1878, col: 1, offset: 68027},
 			expr: &actionExpr{
-				pos: position{line: 1903, col: 5, offset: 71115},
+				pos: position{line: 1879, col: 5, offset: 68053},
 				run: (*parser).callonMarkdownQuoteLine1,
 				expr: &seqExpr{
-					pos: position{line: 1903, col: 5, offset: 71115},
+					pos: position{line: 1879, col: 5, offset: 68053},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1903, col: 5, offset: 71115},
+							pos:   position{line: 1879, col: 5, offset: 68053},
 							label: "elements",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1903, col: 14, offset: 71124},
+								pos: position{line: 1879, col: 14, offset: 68062},
 								expr: &choiceExpr{
-									pos: position{line: 1903, col: 15, offset: 71125},
+									pos: position{line: 1879, col: 15, offset: 68063},
 									alternatives: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 1903, col: 15, offset: 71125},
+											pos:  position{line: 1879, col: 15, offset: 68063},
 											name: "InlineWord",
 										},
 										&oneOrMoreExpr{
-											pos: position{line: 1904, col: 11, offset: 71186},
+											pos: position{line: 1880, col: 11, offset: 68124},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1904, col: 11, offset: 71186},
+												pos:  position{line: 1880, col: 11, offset: 68124},
 												name: "Space",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1905, col: 11, offset: 71204},
+											pos:  position{line: 1881, col: 11, offset: 68142},
 											name: "InlineMacros",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1906, col: 11, offset: 71227},
+											pos:  position{line: 1882, col: 11, offset: 68165},
 											name: "ElementPlaceHolder",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1907, col: 11, offset: 71256},
+											pos:  position{line: 1883, col: 11, offset: 68194},
 											name: "AnyChar",
 										},
 									},
@@ -13971,7 +12267,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1907, col: 21, offset: 71266},
+							pos:  position{line: 1883, col: 21, offset: 68204},
 							name: "EOL",
 						},
 					},
@@ -13980,29 +12276,29 @@ var g = &grammar{
 		},
 		{
 			name: "MarkdownQuoteAttribution",
-			pos:  position{line: 1911, col: 1, offset: 71337},
+			pos:  position{line: 1887, col: 1, offset: 68275},
 			expr: &actionExpr{
-				pos: position{line: 1911, col: 29, offset: 71365},
+				pos: position{line: 1887, col: 29, offset: 68303},
 				run: (*parser).callonMarkdownQuoteAttribution1,
 				expr: &seqExpr{
-					pos: position{line: 1911, col: 29, offset: 71365},
+					pos: position{line: 1887, col: 29, offset: 68303},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1911, col: 29, offset: 71365},
+							pos:        position{line: 1887, col: 29, offset: 68303},
 							val:        "-- ",
 							ignoreCase: false,
 							want:       "\"-- \"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1911, col: 35, offset: 71371},
+							pos:   position{line: 1887, col: 35, offset: 68309},
 							label: "author",
 							expr: &actionExpr{
-								pos: position{line: 1911, col: 43, offset: 71379},
+								pos: position{line: 1887, col: 43, offset: 68317},
 								run: (*parser).callonMarkdownQuoteAttribution5,
 								expr: &oneOrMoreExpr{
-									pos: position{line: 1911, col: 44, offset: 71380},
+									pos: position{line: 1887, col: 44, offset: 68318},
 									expr: &charClassMatcher{
-										pos:        position{line: 1911, col: 44, offset: 71380},
+										pos:        position{line: 1887, col: 44, offset: 68318},
 										val:        "[^\\r\\n]",
 										chars:      []rune{'\r', '\n'},
 										ignoreCase: false,
@@ -14012,7 +12308,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1913, col: 8, offset: 71430},
+							pos:  position{line: 1889, col: 8, offset: 68368},
 							name: "EOL",
 						},
 					},
@@ -14021,47 +12317,47 @@ var g = &grammar{
 		},
 		{
 			name: "ReplacementSubs",
-			pos:  position{line: 1918, col: 1, offset: 71517},
+			pos:  position{line: 1894, col: 1, offset: 68455},
 			expr: &seqExpr{
-				pos: position{line: 1919, col: 5, offset: 71541},
+				pos: position{line: 1895, col: 5, offset: 68479},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1919, col: 5, offset: 71541},
+						pos: position{line: 1895, col: 5, offset: 68479},
 						expr: &choiceExpr{
-							pos: position{line: 1919, col: 6, offset: 71542},
+							pos: position{line: 1895, col: 6, offset: 68480},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 1919, col: 6, offset: 71542},
+									pos:  position{line: 1895, col: 6, offset: 68480},
 									name: "InlineWord",
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1920, col: 11, offset: 71603},
+									pos: position{line: 1896, col: 11, offset: 68541},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1920, col: 11, offset: 71603},
+										pos:  position{line: 1896, col: 11, offset: 68541},
 										name: "Space",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1921, col: 11, offset: 71621},
+									pos:  position{line: 1897, col: 11, offset: 68559},
 									name: "Symbol",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1922, col: 11, offset: 71639},
+									pos:  position{line: 1898, col: 11, offset: 68577},
 									name: "ElementPlaceHolder",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1923, col: 11, offset: 71668},
+									pos:  position{line: 1899, col: 11, offset: 68606},
 									name: "AnyChar",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1924, col: 11, offset: 71686},
+									pos:  position{line: 1900, col: 11, offset: 68624},
 									name: "Newline",
 								},
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1924, col: 21, offset: 71696},
+						pos:  position{line: 1900, col: 21, offset: 68634},
 						name: "EOF",
 					},
 				},
@@ -14069,47 +12365,47 @@ var g = &grammar{
 		},
 		{
 			name: "PostReplacementSubs",
-			pos:  position{line: 1928, col: 1, offset: 71844},
+			pos:  position{line: 1904, col: 1, offset: 68782},
 			expr: &seqExpr{
-				pos: position{line: 1928, col: 24, offset: 71867},
+				pos: position{line: 1904, col: 24, offset: 68805},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1928, col: 24, offset: 71867},
+						pos: position{line: 1904, col: 24, offset: 68805},
 						expr: &choiceExpr{
-							pos: position{line: 1929, col: 5, offset: 71873},
+							pos: position{line: 1905, col: 5, offset: 68811},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 1929, col: 5, offset: 71873},
+									pos:  position{line: 1905, col: 5, offset: 68811},
 									name: "InlineWord",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1930, col: 7, offset: 71930},
+									pos:  position{line: 1906, col: 7, offset: 68868},
 									name: "ElementPlaceHolder",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1931, col: 7, offset: 71955},
+									pos:  position{line: 1907, col: 7, offset: 68893},
 									name: "LineBreak",
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1932, col: 7, offset: 71998},
+									pos: position{line: 1908, col: 7, offset: 68936},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1932, col: 7, offset: 71998},
+										pos:  position{line: 1908, col: 7, offset: 68936},
 										name: "Space",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1933, col: 7, offset: 72012},
+									pos:  position{line: 1909, col: 7, offset: 68950},
 									name: "AnyChar",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1934, col: 7, offset: 72026},
+									pos:  position{line: 1910, col: 7, offset: 68964},
 									name: "Newline",
 								},
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1934, col: 17, offset: 72036},
+						pos:  position{line: 1910, col: 17, offset: 68974},
 						name: "EOF",
 					},
 				},
@@ -14117,47 +12413,47 @@ var g = &grammar{
 		},
 		{
 			name: "CalloutSubs",
-			pos:  position{line: 1937, col: 1, offset: 72093},
+			pos:  position{line: 1913, col: 1, offset: 69031},
 			expr: &seqExpr{
-				pos: position{line: 1938, col: 5, offset: 72113},
+				pos: position{line: 1914, col: 5, offset: 69051},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1938, col: 5, offset: 72113},
+						pos: position{line: 1914, col: 5, offset: 69051},
 						expr: &choiceExpr{
-							pos: position{line: 1938, col: 6, offset: 72114},
+							pos: position{line: 1914, col: 6, offset: 69052},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 1938, col: 6, offset: 72114},
+									pos:  position{line: 1914, col: 6, offset: 69052},
 									name: "InlineWord",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1939, col: 11, offset: 72175},
+									pos:  position{line: 1915, col: 11, offset: 69113},
 									name: "ElementPlaceHolder",
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1940, col: 11, offset: 72204},
+									pos: position{line: 1916, col: 11, offset: 69142},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1940, col: 11, offset: 72204},
+										pos:  position{line: 1916, col: 11, offset: 69142},
 										name: "Space",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1941, col: 11, offset: 72221},
+									pos:  position{line: 1917, col: 11, offset: 69159},
 									name: "Callout",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1942, col: 11, offset: 72239},
+									pos:  position{line: 1918, col: 11, offset: 69177},
 									name: "AnyChar",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1943, col: 11, offset: 72257},
+									pos:  position{line: 1919, col: 11, offset: 69195},
 									name: "Newline",
 								},
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1943, col: 21, offset: 72267},
+						pos:  position{line: 1919, col: 21, offset: 69205},
 						name: "EOF",
 					},
 				},
@@ -14165,36 +12461,36 @@ var g = &grammar{
 		},
 		{
 			name: "NoneSubs",
-			pos:  position{line: 1946, col: 1, offset: 72319},
+			pos:  position{line: 1922, col: 1, offset: 69257},
 			expr: &seqExpr{
-				pos: position{line: 1946, col: 13, offset: 72331},
+				pos: position{line: 1922, col: 13, offset: 69269},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1946, col: 13, offset: 72331},
+						pos: position{line: 1922, col: 13, offset: 69269},
 						expr: &choiceExpr{
-							pos: position{line: 1947, col: 5, offset: 72337},
+							pos: position{line: 1923, col: 5, offset: 69275},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 1947, col: 5, offset: 72337},
+									pos:  position{line: 1923, col: 5, offset: 69275},
 									name: "ElementPlaceHolder",
 								},
 								&actionExpr{
-									pos: position{line: 1948, col: 8, offset: 72364},
+									pos: position{line: 1924, col: 8, offset: 69302},
 									run: (*parser).callonNoneSubs5,
 									expr: &seqExpr{
-										pos: position{line: 1948, col: 8, offset: 72364},
+										pos: position{line: 1924, col: 8, offset: 69302},
 										exprs: []interface{}{
 											&notExpr{
-												pos: position{line: 1948, col: 8, offset: 72364},
+												pos: position{line: 1924, col: 8, offset: 69302},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1948, col: 9, offset: 72365},
+													pos:  position{line: 1924, col: 9, offset: 69303},
 													name: "EOF",
 												},
 											},
 											&zeroOrMoreExpr{
-												pos: position{line: 1948, col: 13, offset: 72369},
+												pos: position{line: 1924, col: 13, offset: 69307},
 												expr: &charClassMatcher{
-													pos:        position{line: 1948, col: 13, offset: 72369},
+													pos:        position{line: 1924, col: 13, offset: 69307},
 													val:        "[^\\r\\n]",
 													chars:      []rune{'\r', '\n'},
 													ignoreCase: false,
@@ -14202,7 +12498,7 @@ var g = &grammar{
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1948, col: 22, offset: 72378},
+												pos:  position{line: 1924, col: 22, offset: 69316},
 												name: "EOL",
 											},
 										},
@@ -14212,7 +12508,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1950, col: 10, offset: 72483},
+						pos:  position{line: 1926, col: 10, offset: 69421},
 						name: "EOF",
 					},
 				},
@@ -14220,59 +12516,59 @@ var g = &grammar{
 		},
 		{
 			name: "Table",
-			pos:  position{line: 1955, col: 1, offset: 72676},
+			pos:  position{line: 1931, col: 1, offset: 69614},
 			expr: &actionExpr{
-				pos: position{line: 1955, col: 10, offset: 72685},
+				pos: position{line: 1931, col: 10, offset: 69623},
 				run: (*parser).callonTable1,
 				expr: &seqExpr{
-					pos: position{line: 1955, col: 10, offset: 72685},
+					pos: position{line: 1931, col: 10, offset: 69623},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1955, col: 10, offset: 72685},
+							pos:   position{line: 1931, col: 10, offset: 69623},
 							label: "attributes",
-							expr: &zeroOrMoreExpr{
-								pos: position{line: 1955, col: 21, offset: 72696},
+							expr: &zeroOrOneExpr{
+								pos: position{line: 1931, col: 21, offset: 69634},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1955, col: 22, offset: 72697},
-									name: "BlockAttribute",
+									pos:  position{line: 1931, col: 22, offset: 69635},
+									name: "BlockAttributes",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1955, col: 39, offset: 72714},
+							pos:  position{line: 1931, col: 40, offset: 69653},
 							name: "TableDelimiter",
 						},
 						&labeledExpr{
-							pos:   position{line: 1956, col: 5, offset: 72733},
+							pos:   position{line: 1932, col: 5, offset: 69672},
 							label: "header",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1956, col: 12, offset: 72740},
+								pos: position{line: 1932, col: 12, offset: 69679},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1956, col: 13, offset: 72741},
+									pos:  position{line: 1932, col: 13, offset: 69680},
 									name: "TableLineHeader",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1957, col: 5, offset: 72763},
+							pos:   position{line: 1933, col: 5, offset: 69702},
 							label: "lines",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1957, col: 11, offset: 72769},
+								pos: position{line: 1933, col: 11, offset: 69708},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1957, col: 12, offset: 72770},
+									pos:  position{line: 1933, col: 12, offset: 69709},
 									name: "TableLine",
 								},
 							},
 						},
 						&choiceExpr{
-							pos: position{line: 1958, col: 6, offset: 72787},
+							pos: position{line: 1934, col: 6, offset: 69726},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 1958, col: 6, offset: 72787},
+									pos:  position{line: 1934, col: 6, offset: 69726},
 									name: "TableDelimiter",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1958, col: 23, offset: 72804},
+									pos:  position{line: 1934, col: 23, offset: 69743},
 									name: "EOF",
 								},
 							},
@@ -14283,20 +12579,20 @@ var g = &grammar{
 		},
 		{
 			name: "TableCellSeparator",
-			pos:  position{line: 1962, col: 1, offset: 72939},
+			pos:  position{line: 1938, col: 1, offset: 69862},
 			expr: &seqExpr{
-				pos: position{line: 1962, col: 23, offset: 72961},
+				pos: position{line: 1938, col: 23, offset: 69884},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1962, col: 23, offset: 72961},
+						pos:        position{line: 1938, col: 23, offset: 69884},
 						val:        "|",
 						ignoreCase: false,
 						want:       "\"|\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1962, col: 27, offset: 72965},
+						pos: position{line: 1938, col: 27, offset: 69888},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1962, col: 27, offset: 72965},
+							pos:  position{line: 1938, col: 27, offset: 69888},
 							name: "Space",
 						},
 					},
@@ -14305,25 +12601,25 @@ var g = &grammar{
 		},
 		{
 			name: "TableDelimiter",
-			pos:  position{line: 1964, col: 1, offset: 72973},
+			pos:  position{line: 1940, col: 1, offset: 69896},
 			expr: &seqExpr{
-				pos: position{line: 1964, col: 19, offset: 72991},
+				pos: position{line: 1940, col: 19, offset: 69914},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1964, col: 19, offset: 72991},
+						pos:        position{line: 1940, col: 19, offset: 69914},
 						val:        "|===",
 						ignoreCase: false,
 						want:       "\"|===\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1964, col: 26, offset: 72998},
+						pos: position{line: 1940, col: 26, offset: 69921},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1964, col: 26, offset: 72998},
+							pos:  position{line: 1940, col: 26, offset: 69921},
 							name: "Space",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1964, col: 33, offset: 73005},
+						pos:  position{line: 1940, col: 33, offset: 69928},
 						name: "EOL",
 					},
 				},
@@ -14331,37 +12627,37 @@ var g = &grammar{
 		},
 		{
 			name: "TableLineHeader",
-			pos:  position{line: 1967, col: 1, offset: 73073},
+			pos:  position{line: 1943, col: 1, offset: 69996},
 			expr: &actionExpr{
-				pos: position{line: 1967, col: 20, offset: 73092},
+				pos: position{line: 1943, col: 20, offset: 70015},
 				run: (*parser).callonTableLineHeader1,
 				expr: &seqExpr{
-					pos: position{line: 1967, col: 20, offset: 73092},
+					pos: position{line: 1943, col: 20, offset: 70015},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1967, col: 20, offset: 73092},
+							pos: position{line: 1943, col: 20, offset: 70015},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1967, col: 21, offset: 73093},
+								pos:  position{line: 1943, col: 21, offset: 70016},
 								name: "TableDelimiter",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1967, col: 36, offset: 73108},
+							pos:   position{line: 1943, col: 36, offset: 70031},
 							label: "cells",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1967, col: 42, offset: 73114},
+								pos: position{line: 1943, col: 42, offset: 70037},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1967, col: 43, offset: 73115},
+									pos:  position{line: 1943, col: 43, offset: 70038},
 									name: "TableCell",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1967, col: 55, offset: 73127},
+							pos:  position{line: 1943, col: 55, offset: 70050},
 							name: "EOL",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1967, col: 59, offset: 73131},
+							pos:  position{line: 1943, col: 59, offset: 70054},
 							name: "BlankLine",
 						},
 					},
@@ -14370,39 +12666,39 @@ var g = &grammar{
 		},
 		{
 			name: "TableLine",
-			pos:  position{line: 1971, col: 1, offset: 73199},
+			pos:  position{line: 1947, col: 1, offset: 70122},
 			expr: &actionExpr{
-				pos: position{line: 1971, col: 14, offset: 73212},
+				pos: position{line: 1947, col: 14, offset: 70135},
 				run: (*parser).callonTableLine1,
 				expr: &seqExpr{
-					pos: position{line: 1971, col: 14, offset: 73212},
+					pos: position{line: 1947, col: 14, offset: 70135},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1971, col: 14, offset: 73212},
+							pos: position{line: 1947, col: 14, offset: 70135},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1971, col: 15, offset: 73213},
+								pos:  position{line: 1947, col: 15, offset: 70136},
 								name: "TableDelimiter",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1971, col: 30, offset: 73228},
+							pos:   position{line: 1947, col: 30, offset: 70151},
 							label: "cells",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1971, col: 36, offset: 73234},
+								pos: position{line: 1947, col: 36, offset: 70157},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1971, col: 37, offset: 73235},
+									pos:  position{line: 1947, col: 37, offset: 70158},
 									name: "TableCell",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1971, col: 49, offset: 73247},
+							pos:  position{line: 1947, col: 49, offset: 70170},
 							name: "EOL",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1971, col: 53, offset: 73251},
+							pos: position{line: 1947, col: 53, offset: 70174},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1971, col: 53, offset: 73251},
+								pos:  position{line: 1947, col: 53, offset: 70174},
 								name: "BlankLine",
 							},
 						},
@@ -14412,54 +12708,54 @@ var g = &grammar{
 		},
 		{
 			name: "TableCell",
-			pos:  position{line: 1975, col: 1, offset: 73320},
+			pos:  position{line: 1951, col: 1, offset: 70243},
 			expr: &actionExpr{
-				pos: position{line: 1975, col: 14, offset: 73333},
+				pos: position{line: 1951, col: 14, offset: 70256},
 				run: (*parser).callonTableCell1,
 				expr: &seqExpr{
-					pos: position{line: 1975, col: 14, offset: 73333},
+					pos: position{line: 1951, col: 14, offset: 70256},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1975, col: 14, offset: 73333},
+							pos:  position{line: 1951, col: 14, offset: 70256},
 							name: "TableCellSeparator",
 						},
 						&labeledExpr{
-							pos:   position{line: 1975, col: 33, offset: 73352},
+							pos:   position{line: 1951, col: 33, offset: 70275},
 							label: "elements",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1975, col: 42, offset: 73361},
+								pos: position{line: 1951, col: 42, offset: 70284},
 								expr: &seqExpr{
-									pos: position{line: 1975, col: 43, offset: 73362},
+									pos: position{line: 1951, col: 43, offset: 70285},
 									exprs: []interface{}{
 										&notExpr{
-											pos: position{line: 1975, col: 43, offset: 73362},
+											pos: position{line: 1951, col: 43, offset: 70285},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1975, col: 44, offset: 73363},
+												pos:  position{line: 1951, col: 44, offset: 70286},
 												name: "TableCellSeparator",
 											},
 										},
 										&notExpr{
-											pos: position{line: 1975, col: 63, offset: 73382},
+											pos: position{line: 1951, col: 63, offset: 70305},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1975, col: 64, offset: 73383},
+												pos:  position{line: 1951, col: 64, offset: 70306},
 												name: "EOL",
 											},
 										},
 										&zeroOrMoreExpr{
-											pos: position{line: 1975, col: 68, offset: 73387},
+											pos: position{line: 1951, col: 68, offset: 70310},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1975, col: 68, offset: 73387},
+												pos:  position{line: 1951, col: 68, offset: 70310},
 												name: "Space",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1975, col: 75, offset: 73394},
+											pos:  position{line: 1951, col: 75, offset: 70317},
 											name: "InlineElement",
 										},
 										&zeroOrMoreExpr{
-											pos: position{line: 1975, col: 89, offset: 73408},
+											pos: position{line: 1951, col: 89, offset: 70331},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1975, col: 89, offset: 73408},
+												pos:  position{line: 1951, col: 89, offset: 70331},
 												name: "Space",
 											},
 										},
@@ -14473,20 +12769,20 @@ var g = &grammar{
 		},
 		{
 			name: "LiteralBlock",
-			pos:  position{line: 1982, col: 1, offset: 73734},
+			pos:  position{line: 1958, col: 1, offset: 70657},
 			expr: &choiceExpr{
-				pos: position{line: 1982, col: 17, offset: 73750},
+				pos: position{line: 1958, col: 17, offset: 70673},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1982, col: 17, offset: 73750},
+						pos:  position{line: 1958, col: 17, offset: 70673},
 						name: "ParagraphWithLiteralAttribute",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1982, col: 49, offset: 73782},
+						pos:  position{line: 1958, col: 49, offset: 70705},
 						name: "ParagraphWithHeadingSpaces",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1982, col: 78, offset: 73811},
+						pos:  position{line: 1958, col: 78, offset: 70734},
 						name: "ParagraphWithLiteralBlockDelimiter",
 					},
 				},
@@ -14494,9 +12790,9 @@ var g = &grammar{
 		},
 		{
 			name: "LiteralBlockDelimiter",
-			pos:  position{line: 1984, col: 1, offset: 73847},
+			pos:  position{line: 1960, col: 1, offset: 70770},
 			expr: &litMatcher{
-				pos:        position{line: 1984, col: 26, offset: 73872},
+				pos:        position{line: 1960, col: 26, offset: 70795},
 				val:        "....",
 				ignoreCase: false,
 				want:       "\"....\"",
@@ -14504,29 +12800,29 @@ var g = &grammar{
 		},
 		{
 			name: "ParagraphWithHeadingSpaces",
-			pos:  position{line: 1987, col: 1, offset: 73944},
+			pos:  position{line: 1963, col: 1, offset: 70867},
 			expr: &actionExpr{
-				pos: position{line: 1987, col: 31, offset: 73974},
+				pos: position{line: 1963, col: 31, offset: 70897},
 				run: (*parser).callonParagraphWithHeadingSpaces1,
 				expr: &seqExpr{
-					pos: position{line: 1987, col: 31, offset: 73974},
+					pos: position{line: 1963, col: 31, offset: 70897},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1987, col: 31, offset: 73974},
+							pos:   position{line: 1963, col: 31, offset: 70897},
 							label: "attributes",
-							expr: &zeroOrMoreExpr{
-								pos: position{line: 1987, col: 42, offset: 73985},
+							expr: &zeroOrOneExpr{
+								pos: position{line: 1963, col: 42, offset: 70908},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1987, col: 43, offset: 73986},
-									name: "ElementAttribute",
+									pos:  position{line: 1963, col: 43, offset: 70909},
+									name: "BlockAttributes",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1987, col: 62, offset: 74005},
+							pos:   position{line: 1963, col: 61, offset: 70927},
 							label: "lines",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1987, col: 69, offset: 74012},
+								pos:  position{line: 1963, col: 68, offset: 70934},
 								name: "ParagraphWithHeadingSpacesLines",
 							},
 						},
@@ -14536,28 +12832,28 @@ var g = &grammar{
 		},
 		{
 			name: "ParagraphWithHeadingSpacesLines",
-			pos:  position{line: 1992, col: 1, offset: 74258},
+			pos:  position{line: 1968, col: 1, offset: 71164},
 			expr: &actionExpr{
-				pos: position{line: 1993, col: 5, offset: 74298},
+				pos: position{line: 1969, col: 5, offset: 71204},
 				run: (*parser).callonParagraphWithHeadingSpacesLines1,
 				expr: &seqExpr{
-					pos: position{line: 1993, col: 5, offset: 74298},
+					pos: position{line: 1969, col: 5, offset: 71204},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1993, col: 5, offset: 74298},
+							pos:   position{line: 1969, col: 5, offset: 71204},
 							label: "firstLine",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1993, col: 16, offset: 74309},
+								pos:  position{line: 1969, col: 16, offset: 71215},
 								name: "ParagraphWithHeadingSpacesLine",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1994, col: 5, offset: 74345},
+							pos:   position{line: 1970, col: 5, offset: 71251},
 							label: "otherLines",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1994, col: 16, offset: 74356},
+								pos: position{line: 1970, col: 16, offset: 71262},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1994, col: 17, offset: 74357},
+									pos:  position{line: 1970, col: 17, offset: 71263},
 									name: "LiteralParagraphLine",
 								},
 							},
@@ -14568,33 +12864,33 @@ var g = &grammar{
 		},
 		{
 			name: "ParagraphWithHeadingSpacesLine",
-			pos:  position{line: 1998, col: 1, offset: 74466},
+			pos:  position{line: 1974, col: 1, offset: 71372},
 			expr: &actionExpr{
-				pos: position{line: 1998, col: 35, offset: 74500},
+				pos: position{line: 1974, col: 35, offset: 71406},
 				run: (*parser).callonParagraphWithHeadingSpacesLine1,
 				expr: &seqExpr{
-					pos: position{line: 1998, col: 35, offset: 74500},
+					pos: position{line: 1974, col: 35, offset: 71406},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1998, col: 35, offset: 74500},
+							pos:   position{line: 1974, col: 35, offset: 71406},
 							label: "line",
 							expr: &actionExpr{
-								pos: position{line: 1998, col: 41, offset: 74506},
+								pos: position{line: 1974, col: 41, offset: 71412},
 								run: (*parser).callonParagraphWithHeadingSpacesLine4,
 								expr: &seqExpr{
-									pos: position{line: 1998, col: 41, offset: 74506},
+									pos: position{line: 1974, col: 41, offset: 71412},
 									exprs: []interface{}{
 										&oneOrMoreExpr{
-											pos: position{line: 1998, col: 41, offset: 74506},
+											pos: position{line: 1974, col: 41, offset: 71412},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1998, col: 41, offset: 74506},
+												pos:  position{line: 1974, col: 41, offset: 71412},
 												name: "Space",
 											},
 										},
 										&oneOrMoreExpr{
-											pos: position{line: 1998, col: 48, offset: 74513},
+											pos: position{line: 1974, col: 48, offset: 71419},
 											expr: &charClassMatcher{
-												pos:        position{line: 1998, col: 48, offset: 74513},
+												pos:        position{line: 1974, col: 48, offset: 71419},
 												val:        "[^\\r\\n]",
 												chars:      []rune{'\r', '\n'},
 												ignoreCase: false,
@@ -14606,7 +12902,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2000, col: 8, offset: 74579},
+							pos:  position{line: 1976, col: 8, offset: 71485},
 							name: "EOL",
 						},
 					},
@@ -14615,72 +12911,72 @@ var g = &grammar{
 		},
 		{
 			name: "ParagraphWithLiteralBlockDelimiter",
-			pos:  position{line: 2005, col: 1, offset: 74719},
+			pos:  position{line: 1981, col: 1, offset: 71625},
 			expr: &actionExpr{
-				pos: position{line: 2005, col: 39, offset: 74757},
+				pos: position{line: 1981, col: 39, offset: 71663},
 				run: (*parser).callonParagraphWithLiteralBlockDelimiter1,
 				expr: &seqExpr{
-					pos: position{line: 2005, col: 39, offset: 74757},
+					pos: position{line: 1981, col: 39, offset: 71663},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 2005, col: 39, offset: 74757},
+							pos:   position{line: 1981, col: 39, offset: 71663},
 							label: "attributes",
-							expr: &zeroOrMoreExpr{
-								pos: position{line: 2005, col: 50, offset: 74768},
+							expr: &zeroOrOneExpr{
+								pos: position{line: 1981, col: 50, offset: 71674},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2005, col: 51, offset: 74769},
-									name: "ElementAttribute",
+									pos:  position{line: 1981, col: 51, offset: 71675},
+									name: "BlockAttributes",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2006, col: 9, offset: 74796},
+							pos:  position{line: 1982, col: 9, offset: 71701},
 							name: "LiteralBlockDelimiter",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 2006, col: 31, offset: 74818},
+							pos: position{line: 1982, col: 31, offset: 71723},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2006, col: 31, offset: 74818},
+								pos:  position{line: 1982, col: 31, offset: 71723},
 								name: "Space",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2006, col: 38, offset: 74825},
+							pos:  position{line: 1982, col: 38, offset: 71730},
 							name: "Newline",
 						},
 						&labeledExpr{
-							pos:   position{line: 2006, col: 46, offset: 74833},
+							pos:   position{line: 1982, col: 46, offset: 71738},
 							label: "lines",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2006, col: 53, offset: 74840},
+								pos:  position{line: 1982, col: 53, offset: 71745},
 								name: "ParagraphWithLiteralBlockDelimiterLines",
 							},
 						},
 						&choiceExpr{
-							pos: position{line: 2006, col: 95, offset: 74882},
+							pos: position{line: 1982, col: 95, offset: 71787},
 							alternatives: []interface{}{
 								&seqExpr{
-									pos: position{line: 2006, col: 96, offset: 74883},
+									pos: position{line: 1982, col: 96, offset: 71788},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 2006, col: 96, offset: 74883},
+											pos:  position{line: 1982, col: 96, offset: 71788},
 											name: "LiteralBlockDelimiter",
 										},
 										&zeroOrMoreExpr{
-											pos: position{line: 2006, col: 118, offset: 74905},
+											pos: position{line: 1982, col: 118, offset: 71810},
 											expr: &ruleRefExpr{
-												pos:  position{line: 2006, col: 118, offset: 74905},
+												pos:  position{line: 1982, col: 118, offset: 71810},
 												name: "Space",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2006, col: 125, offset: 74912},
+											pos:  position{line: 1982, col: 125, offset: 71817},
 											name: "EOL",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2006, col: 132, offset: 74919},
+									pos:  position{line: 1982, col: 132, offset: 71824},
 									name: "EOF",
 								},
 							},
@@ -14691,17 +12987,17 @@ var g = &grammar{
 		},
 		{
 			name: "ParagraphWithLiteralBlockDelimiterLines",
-			pos:  position{line: 2011, col: 1, offset: 75094},
+			pos:  position{line: 1987, col: 1, offset: 71983},
 			expr: &actionExpr{
-				pos: position{line: 2011, col: 44, offset: 75137},
+				pos: position{line: 1987, col: 44, offset: 72026},
 				run: (*parser).callonParagraphWithLiteralBlockDelimiterLines1,
 				expr: &labeledExpr{
-					pos:   position{line: 2011, col: 44, offset: 75137},
+					pos:   position{line: 1987, col: 44, offset: 72026},
 					label: "lines",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 2011, col: 50, offset: 75143},
+						pos: position{line: 1987, col: 50, offset: 72032},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2011, col: 51, offset: 75144},
+							pos:  position{line: 1987, col: 51, offset: 72033},
 							name: "ParagraphWithLiteralBlockDelimiterLine",
 						},
 					},
@@ -14710,33 +13006,33 @@ var g = &grammar{
 		},
 		{
 			name: "ParagraphWithLiteralBlockDelimiterLine",
-			pos:  position{line: 2015, col: 1, offset: 75228},
+			pos:  position{line: 1991, col: 1, offset: 72117},
 			expr: &actionExpr{
-				pos: position{line: 2016, col: 5, offset: 75283},
+				pos: position{line: 1992, col: 5, offset: 72172},
 				run: (*parser).callonParagraphWithLiteralBlockDelimiterLine1,
 				expr: &seqExpr{
-					pos: position{line: 2016, col: 5, offset: 75283},
+					pos: position{line: 1992, col: 5, offset: 72172},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 2016, col: 5, offset: 75283},
+							pos:   position{line: 1992, col: 5, offset: 72172},
 							label: "line",
 							expr: &actionExpr{
-								pos: position{line: 2016, col: 11, offset: 75289},
+								pos: position{line: 1992, col: 11, offset: 72178},
 								run: (*parser).callonParagraphWithLiteralBlockDelimiterLine4,
 								expr: &seqExpr{
-									pos: position{line: 2016, col: 11, offset: 75289},
+									pos: position{line: 1992, col: 11, offset: 72178},
 									exprs: []interface{}{
 										&notExpr{
-											pos: position{line: 2016, col: 11, offset: 75289},
+											pos: position{line: 1992, col: 11, offset: 72178},
 											expr: &ruleRefExpr{
-												pos:  position{line: 2016, col: 12, offset: 75290},
+												pos:  position{line: 1992, col: 12, offset: 72179},
 												name: "LiteralBlockDelimiter",
 											},
 										},
 										&zeroOrMoreExpr{
-											pos: position{line: 2016, col: 34, offset: 75312},
+											pos: position{line: 1992, col: 34, offset: 72201},
 											expr: &charClassMatcher{
-												pos:        position{line: 2016, col: 34, offset: 75312},
+												pos:        position{line: 1992, col: 34, offset: 72201},
 												val:        "[^\\r\\n]",
 												chars:      []rune{'\r', '\n'},
 												ignoreCase: false,
@@ -14748,7 +13044,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2018, col: 8, offset: 75378},
+							pos:  position{line: 1994, col: 8, offset: 72267},
 							name: "EOL",
 						},
 					},
@@ -14757,35 +13053,35 @@ var g = &grammar{
 		},
 		{
 			name: "ParagraphWithLiteralAttribute",
-			pos:  position{line: 2023, col: 1, offset: 75504},
+			pos:  position{line: 1999, col: 1, offset: 72393},
 			expr: &actionExpr{
-				pos: position{line: 2024, col: 5, offset: 75542},
+				pos: position{line: 2000, col: 5, offset: 72431},
 				run: (*parser).callonParagraphWithLiteralAttribute1,
 				expr: &seqExpr{
-					pos: position{line: 2024, col: 5, offset: 75542},
+					pos: position{line: 2000, col: 5, offset: 72431},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 2024, col: 5, offset: 75542},
+							pos:   position{line: 2000, col: 5, offset: 72431},
 							label: "attributes",
-							expr: &zeroOrMoreExpr{
-								pos: position{line: 2024, col: 16, offset: 75553},
+							expr: &zeroOrOneExpr{
+								pos: position{line: 2000, col: 16, offset: 72442},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2024, col: 17, offset: 75554},
-									name: "ElementAttribute",
+									pos:  position{line: 2000, col: 17, offset: 72443},
+									name: "BlockAttributes",
 								},
 							},
 						},
 						&andCodeExpr{
-							pos: position{line: 2025, col: 5, offset: 75577},
+							pos: position{line: 2001, col: 5, offset: 72465},
 							run: (*parser).callonParagraphWithLiteralAttribute6,
 						},
 						&labeledExpr{
-							pos:   position{line: 2028, col: 5, offset: 75686},
+							pos:   position{line: 2004, col: 5, offset: 72576},
 							label: "lines",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 2028, col: 11, offset: 75692},
+								pos: position{line: 2004, col: 11, offset: 72582},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2028, col: 12, offset: 75693},
+									pos:  position{line: 2004, col: 12, offset: 72583},
 									name: "LiteralParagraphLine",
 								},
 							},
@@ -14796,12 +13092,12 @@ var g = &grammar{
 		},
 		{
 			name: "LiteralKind",
-			pos:  position{line: 2032, col: 1, offset: 75846},
+			pos:  position{line: 2008, col: 1, offset: 72720},
 			expr: &actionExpr{
-				pos: position{line: 2032, col: 16, offset: 75861},
+				pos: position{line: 2008, col: 16, offset: 72735},
 				run: (*parser).callonLiteralKind1,
 				expr: &litMatcher{
-					pos:        position{line: 2032, col: 16, offset: 75861},
+					pos:        position{line: 2008, col: 16, offset: 72735},
 					val:        "literal",
 					ignoreCase: false,
 					want:       "\"literal\"",
@@ -14810,30 +13106,30 @@ var g = &grammar{
 		},
 		{
 			name: "LiteralParagraphLine",
-			pos:  position{line: 2036, col: 1, offset: 75907},
+			pos:  position{line: 2012, col: 1, offset: 72781},
 			expr: &actionExpr{
-				pos: position{line: 2036, col: 25, offset: 75931},
+				pos: position{line: 2012, col: 25, offset: 72805},
 				run: (*parser).callonLiteralParagraphLine1,
 				expr: &seqExpr{
-					pos: position{line: 2036, col: 25, offset: 75931},
+					pos: position{line: 2012, col: 25, offset: 72805},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 2036, col: 25, offset: 75931},
+							pos: position{line: 2012, col: 25, offset: 72805},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2036, col: 26, offset: 75932},
+								pos:  position{line: 2012, col: 26, offset: 72806},
 								name: "BlankLine",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2036, col: 36, offset: 75942},
+							pos:   position{line: 2012, col: 36, offset: 72816},
 							label: "content",
 							expr: &actionExpr{
-								pos: position{line: 2036, col: 45, offset: 75951},
+								pos: position{line: 2012, col: 45, offset: 72825},
 								run: (*parser).callonLiteralParagraphLine6,
 								expr: &oneOrMoreExpr{
-									pos: position{line: 2036, col: 45, offset: 75951},
+									pos: position{line: 2012, col: 45, offset: 72825},
 									expr: &charClassMatcher{
-										pos:        position{line: 2036, col: 45, offset: 75951},
+										pos:        position{line: 2012, col: 45, offset: 72825},
 										val:        "[^\\r\\n]",
 										chars:      []rune{'\r', '\n'},
 										ignoreCase: false,
@@ -14843,7 +13139,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2038, col: 4, offset: 76009},
+							pos:  position{line: 2014, col: 4, offset: 72883},
 							name: "EOL",
 						},
 					},
@@ -14852,29 +13148,29 @@ var g = &grammar{
 		},
 		{
 			name: "IndexTerm",
-			pos:  position{line: 2045, col: 1, offset: 76186},
+			pos:  position{line: 2021, col: 1, offset: 73060},
 			expr: &actionExpr{
-				pos: position{line: 2045, col: 14, offset: 76199},
+				pos: position{line: 2021, col: 14, offset: 73073},
 				run: (*parser).callonIndexTerm1,
 				expr: &seqExpr{
-					pos: position{line: 2045, col: 14, offset: 76199},
+					pos: position{line: 2021, col: 14, offset: 73073},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 2045, col: 14, offset: 76199},
+							pos:        position{line: 2021, col: 14, offset: 73073},
 							val:        "((",
 							ignoreCase: false,
 							want:       "\"((\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 2045, col: 19, offset: 76204},
+							pos:   position{line: 2021, col: 19, offset: 73078},
 							label: "term",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2045, col: 25, offset: 76210},
+								pos:  position{line: 2021, col: 25, offset: 73084},
 								name: "IndexTermContent",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 2045, col: 43, offset: 76228},
+							pos:        position{line: 2021, col: 43, offset: 73102},
 							val:        "))",
 							ignoreCase: false,
 							want:       "\"))\"",
@@ -14885,59 +13181,59 @@ var g = &grammar{
 		},
 		{
 			name: "IndexTermContent",
-			pos:  position{line: 2049, col: 1, offset: 76293},
+			pos:  position{line: 2025, col: 1, offset: 73167},
 			expr: &actionExpr{
-				pos: position{line: 2049, col: 21, offset: 76313},
+				pos: position{line: 2025, col: 21, offset: 73187},
 				run: (*parser).callonIndexTermContent1,
 				expr: &labeledExpr{
-					pos:   position{line: 2049, col: 21, offset: 76313},
+					pos:   position{line: 2025, col: 21, offset: 73187},
 					label: "elements",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 2049, col: 30, offset: 76322},
+						pos: position{line: 2025, col: 30, offset: 73196},
 						expr: &choiceExpr{
-							pos: position{line: 2049, col: 31, offset: 76323},
+							pos: position{line: 2025, col: 31, offset: 73197},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 2049, col: 31, offset: 76323},
+									pos:  position{line: 2025, col: 31, offset: 73197},
 									name: "Word",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2049, col: 38, offset: 76330},
+									pos:  position{line: 2025, col: 38, offset: 73204},
 									name: "QuotedString",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2049, col: 53, offset: 76345},
+									pos:  position{line: 2025, col: 53, offset: 73219},
 									name: "QuotedText",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2049, col: 66, offset: 76358},
+									pos:  position{line: 2025, col: 66, offset: 73232},
 									name: "Space",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2049, col: 74, offset: 76366},
+									pos:  position{line: 2025, col: 74, offset: 73240},
 									name: "SpecialCharacter",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2049, col: 93, offset: 76385},
+									pos:  position{line: 2025, col: 93, offset: 73259},
 									name: "ElementPlaceHolder",
 								},
 								&actionExpr{
-									pos: position{line: 2049, col: 114, offset: 76406},
+									pos: position{line: 2025, col: 114, offset: 73280},
 									run: (*parser).callonIndexTermContent11,
 									expr: &seqExpr{
-										pos: position{line: 2049, col: 115, offset: 76407},
+										pos: position{line: 2025, col: 115, offset: 73281},
 										exprs: []interface{}{
 											&notExpr{
-												pos: position{line: 2049, col: 115, offset: 76407},
+												pos: position{line: 2025, col: 115, offset: 73281},
 												expr: &litMatcher{
-													pos:        position{line: 2049, col: 116, offset: 76408},
+													pos:        position{line: 2025, col: 116, offset: 73282},
 													val:        "))",
 													ignoreCase: false,
 													want:       "\"))\"",
 												},
 											},
 											&anyMatcher{
-												line: 2049, col: 121, offset: 76413,
+												line: 2025, col: 121, offset: 73287,
 											},
 										},
 									},
@@ -14950,63 +13246,63 @@ var g = &grammar{
 		},
 		{
 			name: "ConcealedIndexTerm",
-			pos:  position{line: 2055, col: 1, offset: 76519},
+			pos:  position{line: 2031, col: 1, offset: 73393},
 			expr: &actionExpr{
-				pos: position{line: 2055, col: 23, offset: 76541},
+				pos: position{line: 2031, col: 23, offset: 73415},
 				run: (*parser).callonConcealedIndexTerm1,
 				expr: &seqExpr{
-					pos: position{line: 2055, col: 23, offset: 76541},
+					pos: position{line: 2031, col: 23, offset: 73415},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 2055, col: 23, offset: 76541},
+							pos:        position{line: 2031, col: 23, offset: 73415},
 							val:        "(((",
 							ignoreCase: false,
 							want:       "\"(((\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 2055, col: 29, offset: 76547},
+							pos:   position{line: 2031, col: 29, offset: 73421},
 							label: "term1",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2055, col: 36, offset: 76554},
+								pos:  position{line: 2031, col: 36, offset: 73428},
 								name: "ConcealedIndexTermContent",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2056, col: 5, offset: 76586},
+							pos:   position{line: 2032, col: 5, offset: 73460},
 							label: "term2",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2056, col: 11, offset: 76592},
+								pos: position{line: 2032, col: 11, offset: 73466},
 								expr: &actionExpr{
-									pos: position{line: 2056, col: 12, offset: 76593},
+									pos: position{line: 2032, col: 12, offset: 73467},
 									run: (*parser).callonConcealedIndexTerm8,
 									expr: &seqExpr{
-										pos: position{line: 2056, col: 12, offset: 76593},
+										pos: position{line: 2032, col: 12, offset: 73467},
 										exprs: []interface{}{
 											&zeroOrMoreExpr{
-												pos: position{line: 2056, col: 12, offset: 76593},
+												pos: position{line: 2032, col: 12, offset: 73467},
 												expr: &ruleRefExpr{
-													pos:  position{line: 2056, col: 12, offset: 76593},
+													pos:  position{line: 2032, col: 12, offset: 73467},
 													name: "Space",
 												},
 											},
 											&litMatcher{
-												pos:        position{line: 2056, col: 19, offset: 76600},
+												pos:        position{line: 2032, col: 19, offset: 73474},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&zeroOrMoreExpr{
-												pos: position{line: 2056, col: 23, offset: 76604},
+												pos: position{line: 2032, col: 23, offset: 73478},
 												expr: &ruleRefExpr{
-													pos:  position{line: 2056, col: 23, offset: 76604},
+													pos:  position{line: 2032, col: 23, offset: 73478},
 													name: "Space",
 												},
 											},
 											&labeledExpr{
-												pos:   position{line: 2056, col: 30, offset: 76611},
+												pos:   position{line: 2032, col: 30, offset: 73485},
 												label: "content",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2056, col: 39, offset: 76620},
+													pos:  position{line: 2032, col: 39, offset: 73494},
 													name: "ConcealedIndexTermContent",
 												},
 											},
@@ -15016,41 +13312,41 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2057, col: 5, offset: 76678},
+							pos:   position{line: 2033, col: 5, offset: 73552},
 							label: "term3",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2057, col: 11, offset: 76684},
+								pos: position{line: 2033, col: 11, offset: 73558},
 								expr: &actionExpr{
-									pos: position{line: 2057, col: 12, offset: 76685},
+									pos: position{line: 2033, col: 12, offset: 73559},
 									run: (*parser).callonConcealedIndexTerm19,
 									expr: &seqExpr{
-										pos: position{line: 2057, col: 12, offset: 76685},
+										pos: position{line: 2033, col: 12, offset: 73559},
 										exprs: []interface{}{
 											&zeroOrMoreExpr{
-												pos: position{line: 2057, col: 12, offset: 76685},
+												pos: position{line: 2033, col: 12, offset: 73559},
 												expr: &ruleRefExpr{
-													pos:  position{line: 2057, col: 12, offset: 76685},
+													pos:  position{line: 2033, col: 12, offset: 73559},
 													name: "Space",
 												},
 											},
 											&litMatcher{
-												pos:        position{line: 2057, col: 19, offset: 76692},
+												pos:        position{line: 2033, col: 19, offset: 73566},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&zeroOrMoreExpr{
-												pos: position{line: 2057, col: 23, offset: 76696},
+												pos: position{line: 2033, col: 23, offset: 73570},
 												expr: &ruleRefExpr{
-													pos:  position{line: 2057, col: 23, offset: 76696},
+													pos:  position{line: 2033, col: 23, offset: 73570},
 													name: "Space",
 												},
 											},
 											&labeledExpr{
-												pos:   position{line: 2057, col: 30, offset: 76703},
+												pos:   position{line: 2033, col: 30, offset: 73577},
 												label: "content",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2057, col: 39, offset: 76712},
+													pos:  position{line: 2033, col: 39, offset: 73586},
 													name: "ConcealedIndexTermContent",
 												},
 											},
@@ -15060,7 +13356,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 2058, col: 5, offset: 76770},
+							pos:        position{line: 2034, col: 5, offset: 73644},
 							val:        ")))",
 							ignoreCase: false,
 							want:       "\")))\"",
@@ -15071,21 +13367,21 @@ var g = &grammar{
 		},
 		{
 			name: "ConcealedIndexTermContent",
-			pos:  position{line: 2062, col: 1, offset: 76849},
+			pos:  position{line: 2038, col: 1, offset: 73723},
 			expr: &actionExpr{
-				pos: position{line: 2062, col: 30, offset: 76878},
+				pos: position{line: 2038, col: 30, offset: 73752},
 				run: (*parser).callonConcealedIndexTermContent1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 2062, col: 30, offset: 76878},
+					pos: position{line: 2038, col: 30, offset: 73752},
 					expr: &choiceExpr{
-						pos: position{line: 2062, col: 31, offset: 76879},
+						pos: position{line: 2038, col: 31, offset: 73753},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 2062, col: 31, offset: 76879},
+								pos:  position{line: 2038, col: 31, offset: 73753},
 								name: "Alphanum",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2062, col: 42, offset: 76890},
+								pos:  position{line: 2038, col: 42, offset: 73764},
 								name: "Space",
 							},
 						},
@@ -15095,29 +13391,29 @@ var g = &grammar{
 		},
 		{
 			name: "BlankLine",
-			pos:  position{line: 2069, col: 1, offset: 77039},
+			pos:  position{line: 2045, col: 1, offset: 73913},
 			expr: &actionExpr{
-				pos: position{line: 2069, col: 14, offset: 77052},
+				pos: position{line: 2045, col: 14, offset: 73926},
 				run: (*parser).callonBlankLine1,
 				expr: &seqExpr{
-					pos: position{line: 2069, col: 14, offset: 77052},
+					pos: position{line: 2045, col: 14, offset: 73926},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 2069, col: 14, offset: 77052},
+							pos: position{line: 2045, col: 14, offset: 73926},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2069, col: 15, offset: 77053},
+								pos:  position{line: 2045, col: 15, offset: 73927},
 								name: "EOF",
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 2069, col: 19, offset: 77057},
+							pos: position{line: 2045, col: 19, offset: 73931},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2069, col: 19, offset: 77057},
+								pos:  position{line: 2045, col: 19, offset: 73931},
 								name: "Space",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2069, col: 26, offset: 77064},
+							pos:  position{line: 2045, col: 26, offset: 73938},
 							name: "EOL",
 						},
 					},
@@ -15126,32 +13422,32 @@ var g = &grammar{
 		},
 		{
 			name: "Symbol",
-			pos:  position{line: 2077, col: 1, offset: 77209},
+			pos:  position{line: 2053, col: 1, offset: 74083},
 			expr: &choiceExpr{
-				pos: position{line: 2077, col: 11, offset: 77219},
+				pos: position{line: 2053, col: 11, offset: 74093},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 2077, col: 11, offset: 77219},
+						pos:  position{line: 2053, col: 11, offset: 74093},
 						name: "Apostrophe",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2077, col: 24, offset: 77232},
+						pos:  position{line: 2053, col: 24, offset: 74106},
 						name: "Copyright",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2077, col: 36, offset: 77244},
+						pos:  position{line: 2053, col: 36, offset: 74118},
 						name: "Trademark",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2077, col: 48, offset: 77256},
+						pos:  position{line: 2053, col: 48, offset: 74130},
 						name: "Registered",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2077, col: 61, offset: 77269},
+						pos:  position{line: 2053, col: 61, offset: 74143},
 						name: "Ellipsis",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2077, col: 72, offset: 77280},
+						pos:  position{line: 2053, col: 72, offset: 74154},
 						name: "ImpliedApostrophe",
 					},
 				},
@@ -15159,12 +13455,12 @@ var g = &grammar{
 		},
 		{
 			name: "Apostrophe",
-			pos:  position{line: 2079, col: 1, offset: 77299},
+			pos:  position{line: 2055, col: 1, offset: 74173},
 			expr: &actionExpr{
-				pos: position{line: 2079, col: 15, offset: 77313},
+				pos: position{line: 2055, col: 15, offset: 74187},
 				run: (*parser).callonApostrophe1,
 				expr: &litMatcher{
-					pos:        position{line: 2079, col: 15, offset: 77313},
+					pos:        position{line: 2055, col: 15, offset: 74187},
 					val:        "`'",
 					ignoreCase: false,
 					want:       "\"`'\"",
@@ -15173,12 +13469,12 @@ var g = &grammar{
 		},
 		{
 			name: "Copyright",
-			pos:  position{line: 2082, col: 1, offset: 77366},
+			pos:  position{line: 2058, col: 1, offset: 74240},
 			expr: &actionExpr{
-				pos: position{line: 2082, col: 14, offset: 77379},
+				pos: position{line: 2058, col: 14, offset: 74253},
 				run: (*parser).callonCopyright1,
 				expr: &litMatcher{
-					pos:        position{line: 2082, col: 14, offset: 77379},
+					pos:        position{line: 2058, col: 14, offset: 74253},
 					val:        "(C)",
 					ignoreCase: false,
 					want:       "\"(C)\"",
@@ -15187,12 +13483,12 @@ var g = &grammar{
 		},
 		{
 			name: "Trademark",
-			pos:  position{line: 2085, col: 1, offset: 77433},
+			pos:  position{line: 2061, col: 1, offset: 74307},
 			expr: &actionExpr{
-				pos: position{line: 2085, col: 14, offset: 77446},
+				pos: position{line: 2061, col: 14, offset: 74320},
 				run: (*parser).callonTrademark1,
 				expr: &litMatcher{
-					pos:        position{line: 2085, col: 14, offset: 77446},
+					pos:        position{line: 2061, col: 14, offset: 74320},
 					val:        "(TM)",
 					ignoreCase: false,
 					want:       "\"(TM)\"",
@@ -15201,12 +13497,12 @@ var g = &grammar{
 		},
 		{
 			name: "Registered",
-			pos:  position{line: 2088, col: 1, offset: 77501},
+			pos:  position{line: 2064, col: 1, offset: 74375},
 			expr: &actionExpr{
-				pos: position{line: 2088, col: 15, offset: 77515},
+				pos: position{line: 2064, col: 15, offset: 74389},
 				run: (*parser).callonRegistered1,
 				expr: &litMatcher{
-					pos:        position{line: 2088, col: 15, offset: 77515},
+					pos:        position{line: 2064, col: 15, offset: 74389},
 					val:        "(R)",
 					ignoreCase: false,
 					want:       "\"(R)\"",
@@ -15215,12 +13511,12 @@ var g = &grammar{
 		},
 		{
 			name: "Ellipsis",
-			pos:  position{line: 2091, col: 1, offset: 77569},
+			pos:  position{line: 2067, col: 1, offset: 74443},
 			expr: &actionExpr{
-				pos: position{line: 2091, col: 13, offset: 77581},
+				pos: position{line: 2067, col: 13, offset: 74455},
 				run: (*parser).callonEllipsis1,
 				expr: &litMatcher{
-					pos:        position{line: 2091, col: 13, offset: 77581},
+					pos:        position{line: 2067, col: 13, offset: 74455},
 					val:        "...",
 					ignoreCase: false,
 					want:       "\"...\"",
@@ -15229,27 +13525,27 @@ var g = &grammar{
 		},
 		{
 			name: "ImpliedApostrophe",
-			pos:  position{line: 2099, col: 1, offset: 77858},
+			pos:  position{line: 2075, col: 1, offset: 74732},
 			expr: &actionExpr{
-				pos: position{line: 2099, col: 22, offset: 77879},
+				pos: position{line: 2075, col: 22, offset: 74753},
 				run: (*parser).callonImpliedApostrophe1,
 				expr: &seqExpr{
-					pos: position{line: 2099, col: 22, offset: 77879},
+					pos: position{line: 2075, col: 22, offset: 74753},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 2099, col: 22, offset: 77879},
+							pos:  position{line: 2075, col: 22, offset: 74753},
 							name: "Alphanum",
 						},
 						&litMatcher{
-							pos:        position{line: 2099, col: 31, offset: 77888},
+							pos:        position{line: 2075, col: 31, offset: 74762},
 							val:        "'",
 							ignoreCase: false,
 							want:       "\"'\"",
 						},
 						&andExpr{
-							pos: position{line: 2099, col: 35, offset: 77892},
+							pos: position{line: 2075, col: 35, offset: 74766},
 							expr: &charClassMatcher{
-								pos:        position{line: 2099, col: 36, offset: 77893},
+								pos:        position{line: 2075, col: 36, offset: 74767},
 								val:        "[\\pL]",
 								classes:    []*unicode.RangeTable{rangeTable("L")},
 								ignoreCase: false,
@@ -15262,38 +13558,38 @@ var g = &grammar{
 		},
 		{
 			name: "SpecialCharacter",
-			pos:  position{line: 2108, col: 1, offset: 78255},
+			pos:  position{line: 2084, col: 1, offset: 75129},
 			expr: &choiceExpr{
-				pos: position{line: 2108, col: 21, offset: 78275},
+				pos: position{line: 2084, col: 21, offset: 75149},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 2108, col: 21, offset: 78275},
+						pos: position{line: 2084, col: 21, offset: 75149},
 						run: (*parser).callonSpecialCharacter2,
 						expr: &ruleRefExpr{
-							pos:  position{line: 2108, col: 21, offset: 78275},
+							pos:  position{line: 2084, col: 21, offset: 75149},
 							name: "InternalCrossReference",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2111, col: 9, offset: 78438},
+						pos: position{line: 2087, col: 9, offset: 75312},
 						run: (*parser).callonSpecialCharacter4,
 						expr: &choiceExpr{
-							pos: position{line: 2111, col: 10, offset: 78439},
+							pos: position{line: 2087, col: 10, offset: 75313},
 							alternatives: []interface{}{
 								&litMatcher{
-									pos:        position{line: 2111, col: 10, offset: 78439},
+									pos:        position{line: 2087, col: 10, offset: 75313},
 									val:        "<",
 									ignoreCase: false,
 									want:       "\"<\"",
 								},
 								&litMatcher{
-									pos:        position{line: 2111, col: 16, offset: 78445},
+									pos:        position{line: 2087, col: 16, offset: 75319},
 									val:        ">",
 									ignoreCase: false,
 									want:       "\">\"",
 								},
 								&litMatcher{
-									pos:        position{line: 2111, col: 22, offset: 78451},
+									pos:        position{line: 2087, col: 22, offset: 75325},
 									val:        "&",
 									ignoreCase: false,
 									want:       "\"&\"",
@@ -15306,9 +13602,9 @@ var g = &grammar{
 		},
 		{
 			name: "Alphanum",
-			pos:  position{line: 2118, col: 1, offset: 78629},
+			pos:  position{line: 2094, col: 1, offset: 75503},
 			expr: &charClassMatcher{
-				pos:        position{line: 2118, col: 13, offset: 78641},
+				pos:        position{line: 2094, col: 13, offset: 75515},
 				val:        "[\\pL0-9]",
 				ranges:     []rune{'0', '9'},
 				classes:    []*unicode.RangeTable{rangeTable("L")},
@@ -15318,42 +13614,42 @@ var g = &grammar{
 		},
 		{
 			name: "Parenthesis",
-			pos:  position{line: 2120, col: 1, offset: 78651},
+			pos:  position{line: 2096, col: 1, offset: 75525},
 			expr: &choiceExpr{
-				pos: position{line: 2120, col: 16, offset: 78666},
+				pos: position{line: 2096, col: 16, offset: 75540},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 2120, col: 16, offset: 78666},
+						pos:        position{line: 2096, col: 16, offset: 75540},
 						val:        "(",
 						ignoreCase: false,
 						want:       "\"(\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2120, col: 22, offset: 78672},
+						pos:        position{line: 2096, col: 22, offset: 75546},
 						val:        ")",
 						ignoreCase: false,
 						want:       "\")\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2120, col: 28, offset: 78678},
+						pos:        position{line: 2096, col: 28, offset: 75552},
 						val:        "[",
 						ignoreCase: false,
 						want:       "\"[\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2120, col: 34, offset: 78684},
+						pos:        position{line: 2096, col: 34, offset: 75558},
 						val:        "]",
 						ignoreCase: false,
 						want:       "\"]\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2120, col: 40, offset: 78690},
+						pos:        position{line: 2096, col: 40, offset: 75564},
 						val:        "{",
 						ignoreCase: false,
 						want:       "\"{\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2120, col: 46, offset: 78696},
+						pos:        position{line: 2096, col: 46, offset: 75570},
 						val:        "}",
 						ignoreCase: false,
 						want:       "\"}\"",
@@ -15363,14 +13659,14 @@ var g = &grammar{
 		},
 		{
 			name: "Alphanums",
-			pos:  position{line: 2122, col: 1, offset: 78702},
+			pos:  position{line: 2098, col: 1, offset: 75576},
 			expr: &actionExpr{
-				pos: position{line: 2122, col: 14, offset: 78715},
+				pos: position{line: 2098, col: 14, offset: 75589},
 				run: (*parser).callonAlphanums1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 2122, col: 14, offset: 78715},
+					pos: position{line: 2098, col: 14, offset: 75589},
 					expr: &charClassMatcher{
-						pos:        position{line: 2122, col: 14, offset: 78715},
+						pos:        position{line: 2098, col: 14, offset: 75589},
 						val:        "[\\pL0-9]",
 						ranges:     []rune{'0', '9'},
 						classes:    []*unicode.RangeTable{rangeTable("L")},
@@ -15382,20 +13678,20 @@ var g = &grammar{
 		},
 		{
 			name: "Word",
-			pos:  position{line: 2126, col: 1, offset: 78761},
+			pos:  position{line: 2102, col: 1, offset: 75635},
 			expr: &choiceExpr{
-				pos: position{line: 2130, col: 5, offset: 79088},
+				pos: position{line: 2106, col: 5, offset: 75962},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 2130, col: 5, offset: 79088},
+						pos: position{line: 2106, col: 5, offset: 75962},
 						run: (*parser).callonWord2,
 						expr: &seqExpr{
-							pos: position{line: 2130, col: 5, offset: 79088},
+							pos: position{line: 2106, col: 5, offset: 75962},
 							exprs: []interface{}{
 								&oneOrMoreExpr{
-									pos: position{line: 2130, col: 5, offset: 79088},
+									pos: position{line: 2106, col: 5, offset: 75962},
 									expr: &charClassMatcher{
-										pos:        position{line: 2130, col: 5, offset: 79088},
+										pos:        position{line: 2106, col: 5, offset: 75962},
 										val:        "[\\pL0-9]",
 										ranges:     []rune{'0', '9'},
 										classes:    []*unicode.RangeTable{rangeTable("L")},
@@ -15404,19 +13700,19 @@ var g = &grammar{
 									},
 								},
 								&andExpr{
-									pos: position{line: 2130, col: 15, offset: 79098},
+									pos: position{line: 2106, col: 15, offset: 75972},
 									expr: &choiceExpr{
-										pos: position{line: 2130, col: 17, offset: 79100},
+										pos: position{line: 2106, col: 17, offset: 75974},
 										alternatives: []interface{}{
 											&charClassMatcher{
-												pos:        position{line: 2130, col: 17, offset: 79100},
+												pos:        position{line: 2106, col: 17, offset: 75974},
 												val:        "[\\r\\n ,\\]]",
 												chars:      []rune{'\r', '\n', ' ', ',', ']'},
 												ignoreCase: false,
 												inverted:   false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2130, col: 30, offset: 79113},
+												pos:  position{line: 2106, col: 30, offset: 75987},
 												name: "EOF",
 											},
 										},
@@ -15426,15 +13722,15 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2132, col: 9, offset: 79183},
+						pos: position{line: 2108, col: 9, offset: 76057},
 						run: (*parser).callonWord10,
 						expr: &seqExpr{
-							pos: position{line: 2132, col: 9, offset: 79183},
+							pos: position{line: 2108, col: 9, offset: 76057},
 							exprs: []interface{}{
 								&oneOrMoreExpr{
-									pos: position{line: 2132, col: 9, offset: 79183},
+									pos: position{line: 2108, col: 9, offset: 76057},
 									expr: &charClassMatcher{
-										pos:        position{line: 2132, col: 9, offset: 79183},
+										pos:        position{line: 2108, col: 9, offset: 76057},
 										val:        "[\\pL0-9]",
 										ranges:     []rune{'0', '9'},
 										classes:    []*unicode.RangeTable{rangeTable("L")},
@@ -15443,21 +13739,21 @@ var g = &grammar{
 									},
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 2132, col: 19, offset: 79193},
+									pos: position{line: 2108, col: 19, offset: 76067},
 									expr: &seqExpr{
-										pos: position{line: 2132, col: 20, offset: 79194},
+										pos: position{line: 2108, col: 20, offset: 76068},
 										exprs: []interface{}{
 											&charClassMatcher{
-												pos:        position{line: 2132, col: 20, offset: 79194},
+												pos:        position{line: 2108, col: 20, offset: 76068},
 												val:        "[=*_`]",
 												chars:      []rune{'=', '*', '_', '`'},
 												ignoreCase: false,
 												inverted:   false,
 											},
 											&oneOrMoreExpr{
-												pos: position{line: 2132, col: 27, offset: 79201},
+												pos: position{line: 2108, col: 27, offset: 76075},
 												expr: &charClassMatcher{
-													pos:        position{line: 2132, col: 27, offset: 79201},
+													pos:        position{line: 2108, col: 27, offset: 76075},
 													val:        "[\\pL0-9]",
 													ranges:     []rune{'0', '9'},
 													classes:    []*unicode.RangeTable{rangeTable("L")},
@@ -15476,20 +13772,20 @@ var g = &grammar{
 		},
 		{
 			name: "InlineWord",
-			pos:  position{line: 2136, col: 1, offset: 79277},
+			pos:  position{line: 2112, col: 1, offset: 76162},
 			expr: &choiceExpr{
-				pos: position{line: 2137, col: 5, offset: 79358},
+				pos: position{line: 2113, col: 5, offset: 76243},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 2137, col: 5, offset: 79358},
+						pos: position{line: 2113, col: 5, offset: 76243},
 						run: (*parser).callonInlineWord2,
 						expr: &seqExpr{
-							pos: position{line: 2137, col: 5, offset: 79358},
+							pos: position{line: 2113, col: 5, offset: 76243},
 							exprs: []interface{}{
 								&oneOrMoreExpr{
-									pos: position{line: 2137, col: 5, offset: 79358},
+									pos: position{line: 2113, col: 5, offset: 76243},
 									expr: &charClassMatcher{
-										pos:        position{line: 2137, col: 5, offset: 79358},
+										pos:        position{line: 2113, col: 5, offset: 76243},
 										val:        "[\\pL0-9,?!;]",
 										chars:      []rune{',', '?', '!', ';'},
 										ranges:     []rune{'0', '9'},
@@ -15499,19 +13795,19 @@ var g = &grammar{
 									},
 								},
 								&andExpr{
-									pos: position{line: 2137, col: 19, offset: 79372},
+									pos: position{line: 2113, col: 19, offset: 76257},
 									expr: &choiceExpr{
-										pos: position{line: 2137, col: 21, offset: 79374},
+										pos: position{line: 2113, col: 21, offset: 76259},
 										alternatives: []interface{}{
 											&charClassMatcher{
-												pos:        position{line: 2137, col: 21, offset: 79374},
+												pos:        position{line: 2113, col: 21, offset: 76259},
 												val:        "[\\r\\n ]",
 												chars:      []rune{'\r', '\n', ' '},
 												ignoreCase: false,
 												inverted:   false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2137, col: 31, offset: 79384},
+												pos:  position{line: 2113, col: 31, offset: 76269},
 												name: "EOF",
 											},
 										},
@@ -15521,7 +13817,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2139, col: 9, offset: 79453},
+						pos:  position{line: 2115, col: 9, offset: 76338},
 						name: "Word",
 					},
 				},
@@ -15529,12 +13825,12 @@ var g = &grammar{
 		},
 		{
 			name: "AnyChar",
-			pos:  position{line: 2142, col: 1, offset: 79553},
+			pos:  position{line: 2118, col: 1, offset: 76438},
 			expr: &actionExpr{
-				pos: position{line: 2142, col: 12, offset: 79564},
+				pos: position{line: 2118, col: 12, offset: 76449},
 				run: (*parser).callonAnyChar1,
 				expr: &charClassMatcher{
-					pos:        position{line: 2142, col: 12, offset: 79564},
+					pos:        position{line: 2118, col: 12, offset: 76449},
 					val:        "[^\\r\\n]",
 					chars:      []rune{'\r', '\n'},
 					ignoreCase: false,
@@ -15544,24 +13840,24 @@ var g = &grammar{
 		},
 		{
 			name: "FileLocation",
-			pos:  position{line: 2146, col: 1, offset: 79629},
+			pos:  position{line: 2122, col: 1, offset: 76514},
 			expr: &actionExpr{
-				pos: position{line: 2146, col: 17, offset: 79645},
+				pos: position{line: 2122, col: 17, offset: 76530},
 				run: (*parser).callonFileLocation1,
 				expr: &labeledExpr{
-					pos:   position{line: 2146, col: 17, offset: 79645},
+					pos:   position{line: 2122, col: 17, offset: 76530},
 					label: "path",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 2146, col: 22, offset: 79650},
+						pos: position{line: 2122, col: 22, offset: 76535},
 						expr: &choiceExpr{
-							pos: position{line: 2146, col: 23, offset: 79651},
+							pos: position{line: 2122, col: 23, offset: 76536},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 2146, col: 23, offset: 79651},
+									pos:  position{line: 2122, col: 23, offset: 76536},
 									name: "Filename",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2146, col: 34, offset: 79662},
+									pos:  position{line: 2122, col: 34, offset: 76547},
 									name: "ElementPlaceHolder",
 								},
 							},
@@ -15572,38 +13868,38 @@ var g = &grammar{
 		},
 		{
 			name: "Location",
-			pos:  position{line: 2150, col: 1, offset: 79743},
+			pos:  position{line: 2126, col: 1, offset: 76628},
 			expr: &actionExpr{
-				pos: position{line: 2150, col: 13, offset: 79755},
+				pos: position{line: 2126, col: 13, offset: 76640},
 				run: (*parser).callonLocation1,
 				expr: &seqExpr{
-					pos: position{line: 2150, col: 13, offset: 79755},
+					pos: position{line: 2126, col: 13, offset: 76640},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 2150, col: 13, offset: 79755},
+							pos:   position{line: 2126, col: 13, offset: 76640},
 							label: "scheme",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2150, col: 20, offset: 79762},
+								pos: position{line: 2126, col: 20, offset: 76647},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2150, col: 21, offset: 79763},
+									pos:  position{line: 2126, col: 21, offset: 76648},
 									name: "Scheme",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2150, col: 30, offset: 79772},
+							pos:   position{line: 2126, col: 30, offset: 76657},
 							label: "path",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 2150, col: 35, offset: 79777},
+								pos: position{line: 2126, col: 35, offset: 76662},
 								expr: &choiceExpr{
-									pos: position{line: 2150, col: 36, offset: 79778},
+									pos: position{line: 2126, col: 36, offset: 76663},
 									alternatives: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 2150, col: 36, offset: 79778},
+											pos:  position{line: 2126, col: 36, offset: 76663},
 											name: "Filename",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2150, col: 47, offset: 79789},
+											pos:  position{line: 2126, col: 47, offset: 76674},
 											name: "ElementPlaceHolder",
 										},
 									},
@@ -15616,35 +13912,35 @@ var g = &grammar{
 		},
 		{
 			name: "LocationWithScheme",
-			pos:  position{line: 2154, col: 1, offset: 79874},
+			pos:  position{line: 2130, col: 1, offset: 76759},
 			expr: &actionExpr{
-				pos: position{line: 2154, col: 23, offset: 79896},
+				pos: position{line: 2130, col: 23, offset: 76781},
 				run: (*parser).callonLocationWithScheme1,
 				expr: &seqExpr{
-					pos: position{line: 2154, col: 23, offset: 79896},
+					pos: position{line: 2130, col: 23, offset: 76781},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 2154, col: 23, offset: 79896},
+							pos:   position{line: 2130, col: 23, offset: 76781},
 							label: "scheme",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2154, col: 31, offset: 79904},
+								pos:  position{line: 2130, col: 31, offset: 76789},
 								name: "Scheme",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2154, col: 39, offset: 79912},
+							pos:   position{line: 2130, col: 39, offset: 76797},
 							label: "path",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 2154, col: 44, offset: 79917},
+								pos: position{line: 2130, col: 44, offset: 76802},
 								expr: &choiceExpr{
-									pos: position{line: 2154, col: 45, offset: 79918},
+									pos: position{line: 2130, col: 45, offset: 76803},
 									alternatives: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 2154, col: 45, offset: 79918},
+											pos:  position{line: 2130, col: 45, offset: 76803},
 											name: "Filename",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2154, col: 56, offset: 79929},
+											pos:  position{line: 2130, col: 56, offset: 76814},
 											name: "ElementPlaceHolder",
 										},
 									},
@@ -15657,14 +13953,14 @@ var g = &grammar{
 		},
 		{
 			name: "Filename",
-			pos:  position{line: 2158, col: 1, offset: 80014},
+			pos:  position{line: 2134, col: 1, offset: 76899},
 			expr: &actionExpr{
-				pos: position{line: 2158, col: 13, offset: 80026},
+				pos: position{line: 2134, col: 13, offset: 76911},
 				run: (*parser).callonFilename1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 2158, col: 13, offset: 80026},
+					pos: position{line: 2134, col: 13, offset: 76911},
 					expr: &charClassMatcher{
-						pos:        position{line: 2158, col: 14, offset: 80027},
+						pos:        position{line: 2134, col: 14, offset: 76912},
 						val:        "[^\\r\\n[\\]\\uFFFD ]",
 						chars:      []rune{'\r', '\n', '[', ']', '�', ' '},
 						ignoreCase: false,
@@ -15675,36 +13971,36 @@ var g = &grammar{
 		},
 		{
 			name: "Scheme",
-			pos:  position{line: 2162, col: 1, offset: 80149},
+			pos:  position{line: 2138, col: 1, offset: 77034},
 			expr: &choiceExpr{
-				pos: position{line: 2162, col: 11, offset: 80159},
+				pos: position{line: 2138, col: 11, offset: 77044},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 2162, col: 11, offset: 80159},
+						pos:        position{line: 2138, col: 11, offset: 77044},
 						val:        "http://",
 						ignoreCase: false,
 						want:       "\"http://\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2162, col: 23, offset: 80171},
+						pos:        position{line: 2138, col: 23, offset: 77056},
 						val:        "https://",
 						ignoreCase: false,
 						want:       "\"https://\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2162, col: 36, offset: 80184},
+						pos:        position{line: 2138, col: 36, offset: 77069},
 						val:        "ftp://",
 						ignoreCase: false,
 						want:       "\"ftp://\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2162, col: 47, offset: 80195},
+						pos:        position{line: 2138, col: 47, offset: 77080},
 						val:        "irc://",
 						ignoreCase: false,
 						want:       "\"irc://\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2162, col: 58, offset: 80206},
+						pos:        position{line: 2138, col: 58, offset: 77091},
 						val:        "mailto:",
 						ignoreCase: false,
 						want:       "\"mailto:\"",
@@ -15714,14 +14010,14 @@ var g = &grammar{
 		},
 		{
 			name: "Id",
-			pos:  position{line: 2164, col: 1, offset: 80217},
+			pos:  position{line: 2140, col: 1, offset: 77102},
 			expr: &actionExpr{
-				pos: position{line: 2164, col: 7, offset: 80223},
+				pos: position{line: 2140, col: 7, offset: 77108},
 				run: (*parser).callonId1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 2164, col: 7, offset: 80223},
+					pos: position{line: 2140, col: 7, offset: 77108},
 					expr: &charClassMatcher{
-						pos:        position{line: 2164, col: 7, offset: 80223},
+						pos:        position{line: 2140, col: 7, offset: 77108},
 						val:        "[^[\\]<>,]",
 						chars:      []rune{'[', ']', '<', '>', ','},
 						ignoreCase: false,
@@ -15732,12 +14028,12 @@ var g = &grammar{
 		},
 		{
 			name: "Digit",
-			pos:  position{line: 2168, col: 1, offset: 80348},
+			pos:  position{line: 2144, col: 1, offset: 77233},
 			expr: &actionExpr{
-				pos: position{line: 2168, col: 10, offset: 80357},
+				pos: position{line: 2144, col: 10, offset: 77242},
 				run: (*parser).callonDigit1,
 				expr: &charClassMatcher{
-					pos:        position{line: 2168, col: 10, offset: 80357},
+					pos:        position{line: 2144, col: 10, offset: 77242},
 					val:        "[0-9]",
 					ranges:     []rune{'0', '9'},
 					ignoreCase: false,
@@ -15747,26 +14043,26 @@ var g = &grammar{
 		},
 		{
 			name: "Number",
-			pos:  position{line: 2172, col: 1, offset: 80399},
+			pos:  position{line: 2148, col: 1, offset: 77284},
 			expr: &actionExpr{
-				pos: position{line: 2172, col: 11, offset: 80409},
+				pos: position{line: 2148, col: 11, offset: 77294},
 				run: (*parser).callonNumber1,
 				expr: &seqExpr{
-					pos: position{line: 2172, col: 11, offset: 80409},
+					pos: position{line: 2148, col: 11, offset: 77294},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 2172, col: 11, offset: 80409},
+							pos: position{line: 2148, col: 11, offset: 77294},
 							expr: &litMatcher{
-								pos:        position{line: 2172, col: 11, offset: 80409},
+								pos:        position{line: 2148, col: 11, offset: 77294},
 								val:        "-",
 								ignoreCase: false,
 								want:       "\"-\"",
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 2172, col: 16, offset: 80414},
+							pos: position{line: 2148, col: 16, offset: 77299},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2172, col: 16, offset: 80414},
+								pos:  position{line: 2148, col: 16, offset: 77299},
 								name: "Digit",
 							},
 						},
@@ -15776,21 +14072,21 @@ var g = &grammar{
 		},
 		{
 			name: "Space",
-			pos:  position{line: 2176, col: 1, offset: 80466},
+			pos:  position{line: 2152, col: 1, offset: 77351},
 			expr: &choiceExpr{
-				pos: position{line: 2176, col: 10, offset: 80475},
+				pos: position{line: 2152, col: 10, offset: 77360},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 2176, col: 10, offset: 80475},
+						pos:        position{line: 2152, col: 10, offset: 77360},
 						val:        " ",
 						ignoreCase: false,
 						want:       "\" \"",
 					},
 					&actionExpr{
-						pos: position{line: 2176, col: 16, offset: 80481},
+						pos: position{line: 2152, col: 16, offset: 77366},
 						run: (*parser).callonSpace3,
 						expr: &litMatcher{
-							pos:        position{line: 2176, col: 16, offset: 80481},
+							pos:        position{line: 2152, col: 16, offset: 77366},
 							val:        "\t",
 							ignoreCase: false,
 							want:       "\"\\t\"",
@@ -15801,24 +14097,24 @@ var g = &grammar{
 		},
 		{
 			name: "Newline",
-			pos:  position{line: 2180, col: 1, offset: 80522},
+			pos:  position{line: 2156, col: 1, offset: 77407},
 			expr: &choiceExpr{
-				pos: position{line: 2180, col: 12, offset: 80533},
+				pos: position{line: 2156, col: 12, offset: 77418},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 2180, col: 12, offset: 80533},
+						pos:        position{line: 2156, col: 12, offset: 77418},
 						val:        "\r\n",
 						ignoreCase: false,
 						want:       "\"\\r\\n\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2180, col: 21, offset: 80542},
+						pos:        position{line: 2156, col: 21, offset: 77427},
 						val:        "\r",
 						ignoreCase: false,
 						want:       "\"\\r\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2180, col: 28, offset: 80549},
+						pos:        position{line: 2156, col: 28, offset: 77434},
 						val:        "\n",
 						ignoreCase: false,
 						want:       "\"\\n\"",
@@ -15828,26 +14124,26 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 2182, col: 1, offset: 80555},
+			pos:  position{line: 2158, col: 1, offset: 77440},
 			expr: &notExpr{
-				pos: position{line: 2182, col: 8, offset: 80562},
+				pos: position{line: 2158, col: 8, offset: 77447},
 				expr: &anyMatcher{
-					line: 2182, col: 9, offset: 80563,
+					line: 2158, col: 9, offset: 77448,
 				},
 			},
 		},
 		{
 			name: "EOL",
-			pos:  position{line: 2184, col: 1, offset: 80566},
+			pos:  position{line: 2160, col: 1, offset: 77451},
 			expr: &choiceExpr{
-				pos: position{line: 2184, col: 8, offset: 80573},
+				pos: position{line: 2160, col: 8, offset: 77458},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 2184, col: 8, offset: 80573},
+						pos:  position{line: 2160, col: 8, offset: 77458},
 						name: "Newline",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2184, col: 18, offset: 80583},
+						pos:  position{line: 2160, col: 18, offset: 77468},
 						name: "EOF",
 					},
 				},
@@ -16298,29 +14594,9 @@ func (p *parser) callonCounterSubStart21() (interface{}, error) {
 	return p.cur.onCounterSubStart21(stack["name"], stack["num"])
 }
 
-func (c *current) onElementAttribute1(attr interface{}) (interface{}, error) {
-	return attr, nil // avoid returning something like `[]interface{}{attr, EOL}`
-}
-
-func (p *parser) callonElementAttribute1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onElementAttribute1(stack["attr"])
-}
-
-func (c *current) onElementID1(id interface{}) (interface{}, error) {
-	return types.NewElementID(id)
-}
-
-func (p *parser) callonElementID1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onElementID1(stack["id"])
-}
-
 func (c *current) onInlineElementID1(id interface{}) (interface{}, error) {
 	// no EOL here since there can be multiple InlineElementID on the same line
-	return types.NewInlineElementID(id.(string))
+	return types.NewInlineIDAttribute(id.(string))
 }
 
 func (p *parser) callonInlineElementID1() (interface{}, error) {
@@ -16329,208 +14605,375 @@ func (p *parser) callonInlineElementID1() (interface{}, error) {
 	return p.cur.onInlineElementID1(stack["id"])
 }
 
-func (c *current) onElementTitle1(title interface{}) (interface{}, error) {
-	return types.NewElementTitle(title.([]interface{}))
+func (c *current) onStandaloneAttributeKey1(key interface{}) (interface{}, error) {
+	// value is not defined
+	return types.NewNamedAttribute(key.(string), nil)
 }
 
-func (p *parser) callonElementTitle1() (interface{}, error) {
+func (p *parser) callonStandaloneAttributeKey1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onElementTitle1(stack["title"])
+	return p.cur.onStandaloneAttributeKey1(stack["key"])
 }
 
-func (c *current) onElementTitleContent3() (interface{}, error) {
-	// `{`, `>` and `>` characters are not allowed as they are used for attribute substitutions and cross-references
+func (c *current) onBlockAttributes5(anchor interface{}) (interface{}, error) {
+	return anchor, nil
+
+}
+
+func (p *parser) callonBlockAttributes5() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onBlockAttributes5(stack["anchor"])
+}
+
+func (c *current) onBlockAttributes14(title interface{}) (interface{}, error) {
+	return title, nil
+
+}
+
+func (p *parser) callonBlockAttributes14() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onBlockAttributes14(stack["title"])
+}
+
+func (c *current) onBlockAttributes23(attributes interface{}) (interface{}, error) {
+	return attributes, nil
+
+}
+
+func (p *parser) callonBlockAttributes23() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onBlockAttributes23(stack["attributes"])
+}
+
+func (c *current) onBlockAttributes1(attributes interface{}) (interface{}, error) {
+	return types.NewAttributes(attributes.([]interface{})...)
+
+}
+
+func (p *parser) callonBlockAttributes1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onBlockAttributes1(stack["attributes"])
+}
+
+func (c *current) onInlineAttributes3() error {
+	return initPositionalIndex(c)
+
+}
+
+func (p *parser) callonInlineAttributes3() error {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onInlineAttributes3()
+}
+
+func (c *current) onInlineAttributes1(attributes interface{}) (interface{}, error) {
+	return types.NewAttributes(attributes.([]interface{})...)
+
+}
+
+func (p *parser) callonInlineAttributes1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onInlineAttributes1(stack["attributes"])
+}
+
+func (c *current) onStandaloneAttributes1(attributes interface{}) (interface{}, error) {
+
+	return attributes, nil
+}
+
+func (p *parser) callonStandaloneAttributes1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onStandaloneAttributes1(stack["attributes"])
+}
+
+func (c *current) onShortHandAnchor9() (interface{}, error) {
+	// spaces, commas and dots are allowed in this syntax
 	return types.NewStringElement(string(c.text))
 
 }
 
-func (p *parser) callonElementTitleContent3() (interface{}, error) {
+func (p *parser) callonShortHandAnchor9() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onElementTitleContent3()
+	return p.cur.onShortHandAnchor9()
 }
 
-func (c *current) onElementTitleContent9() (interface{}, error) {
+func (c *current) onShortHandAnchor14() (interface{}, error) {
 
 	return types.NewStringElement(string(c.text))
 
 }
 
-func (p *parser) callonElementTitleContent9() (interface{}, error) {
+func (p *parser) callonShortHandAnchor14() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onElementTitleContent9()
+	return p.cur.onShortHandAnchor14()
 }
 
-func (c *current) onElementShortHandAttributes1(attributes interface{}) (interface{}, error) {
-	return types.NewAttributeGroup(attributes.([]interface{})...)
+func (c *current) onShortHandAnchor5(elements interface{}) (interface{}, error) {
+	return types.Reduce(elements, strings.TrimSpace), nil
+
 }
 
-func (p *parser) callonElementShortHandAttributes1() (interface{}, error) {
+func (p *parser) callonShortHandAnchor5() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onElementShortHandAttributes1(stack["attributes"])
+	return p.cur.onShortHandAnchor5(stack["elements"])
 }
 
-func (c *current) onBlockAttributeList1(attributes interface{}) (interface{}, error) {
-	return types.NewAttributeGroup(attributes.([]interface{})...)
+func (c *current) onShortHandAnchor1(id interface{}) (interface{}, error) {
+	return types.NewIDAttribute(id)
+
 }
 
-func (p *parser) callonBlockAttributeList1() (interface{}, error) {
+func (p *parser) callonShortHandAnchor1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onBlockAttributeList1(stack["attributes"])
+	return p.cur.onShortHandAnchor1(stack["id"])
 }
 
-func (c *current) onBlockAttrStyle1(style interface{}) (interface{}, error) {
-	return types.NewElementStyle(style)
+func (c *current) onShortHandTitle12() (interface{}, error) {
+	return types.NewStringElement(string(c.text))
+
 }
 
-func (p *parser) callonBlockAttrStyle1() (interface{}, error) {
+func (p *parser) callonShortHandTitle12() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onBlockAttrStyle1(stack["style"])
+	return p.cur.onShortHandTitle12()
 }
 
-func (c *current) onBlockAttrPositional21(value interface{}) (interface{}, error) {
-	if value != nil {
-		return types.NewNamedAttribute(types.AttrPositional2, value)
+func (c *current) onShortHandTitle17() (interface{}, error) {
+
+	return types.NewStringElement(string(c.text))
+
+}
+
+func (p *parser) callonShortHandTitle17() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onShortHandTitle17()
+}
+
+func (c *current) onShortHandTitle5(elements interface{}) (interface{}, error) {
+	return types.Reduce(elements, strings.TrimSpace), nil
+
+}
+
+func (p *parser) callonShortHandTitle5() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onShortHandTitle5(stack["elements"])
+}
+
+func (c *current) onShortHandTitle1(title interface{}) (interface{}, error) {
+	return types.NewTitleAttribute(title)
+
+}
+
+func (p *parser) callonShortHandTitle1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onShortHandTitle1(stack["title"])
+}
+
+func (c *current) onLongHandAttributes3() error {
+	return initPositionalIndex(c)
+
+}
+
+func (p *parser) callonLongHandAttributes3() error {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onLongHandAttributes3()
+}
+
+func (c *current) onLongHandAttributes1(firstPositionalAttribute, otherAttributes interface{}) (interface{}, error) {
+	attributes := []interface{}{}
+	if firstPositionalAttribute != nil {
+		attributes = append(attributes, firstPositionalAttribute.([]interface{})...)
 	}
-	return nil, nil
+	attributes = append(attributes, otherAttributes.([]interface{})...)
+	return types.NewAttributes(attributes...)
+
 }
 
-func (p *parser) callonBlockAttrPositional21() (interface{}, error) {
+func (p *parser) callonLongHandAttributes1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onBlockAttrPositional21(stack["value"])
+	return p.cur.onLongHandAttributes1(stack["firstPositionalAttribute"], stack["otherAttributes"])
 }
 
-func (c *current) onBlockAttrPositional31(value interface{}) (interface{}, error) {
-	if value != nil {
-		return types.NewNamedAttribute(types.AttrPositional3, value)
+func (c *current) onFirstPositionalAttribute17(main, extras interface{}) (bool, error) {
+	// make sure there was a match
+	return main != nil || len(extras.([]interface{})) > 0, nil
+
+}
+
+func (p *parser) callonFirstPositionalAttribute17() (bool, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onFirstPositionalAttribute17(stack["main"], stack["extras"])
+}
+
+func (c *current) onFirstPositionalAttribute1(main, extras interface{}) (interface{}, error) {
+	attrs := []interface{}{}
+	if main != nil {
+		attrs = append(attrs, main)
 	}
-	return nil, nil
+	attrs = append(attrs, extras.([]interface{})...)
+	return attrs, nil
+
 }
 
-func (p *parser) callonBlockAttrPositional31() (interface{}, error) {
+func (p *parser) callonFirstPositionalAttribute1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onBlockAttrPositional31(stack["value"])
+	return p.cur.onFirstPositionalAttribute1(stack["main"], stack["extras"])
 }
 
-func (c *current) onLiteralBlockAttribute1() (interface{}, error) {
-	return types.NewLiteralBlockAttribute()
+func (c *current) onShortHandIDAttribute1(id interface{}) (interface{}, error) {
+	_, err := incrementPositionalIndex(c)
+	if err != nil {
+		return types.Attribute{}, err
+	}
+	return types.NewIDAttribute(id)
 }
 
-func (p *parser) callonLiteralBlockAttribute1() (interface{}, error) {
+func (p *parser) callonShortHandIDAttribute1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onLiteralBlockAttribute1()
+	return p.cur.onShortHandIDAttribute1(stack["id"])
 }
 
-func (c *current) onPassthroughBlockAttribute1() (interface{}, error) {
-	return types.NewPassthroughBlockAttribute()
+func (c *current) onShortHandAttribute1(value interface{}) (interface{}, error) {
+	i, err := incrementPositionalIndex(c)
+	if err != nil {
+		return types.Attribute{}, err
+	}
+	return types.NewPositionalAttribute(i, value)
 }
 
-func (p *parser) callonPassthroughBlockAttribute1() (interface{}, error) {
+func (p *parser) callonShortHandAttribute1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onPassthroughBlockAttribute1()
+	return p.cur.onShortHandAttribute1(stack["value"])
 }
 
-func (c *current) onExampleBlockAttribute1() (interface{}, error) {
-	return types.NewExampleBlockAttribute()
+func (c *current) onShortHandDotRoleAttribute1(role interface{}) (interface{}, error) {
+	return types.NewRoleAttribute(role)
 }
 
-func (p *parser) callonExampleBlockAttribute1() (interface{}, error) {
+func (p *parser) callonShortHandDotRoleAttribute1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onExampleBlockAttribute1()
+	return p.cur.onShortHandDotRoleAttribute1(stack["role"])
 }
 
-func (c *current) onListingBlockAttribute1() (interface{}, error) {
-	return types.NewListingBlockAttribute()
+func (c *current) onShortHandOptionAttribute1(option interface{}) (interface{}, error) {
+	return types.NewOptionAttribute(option)
 }
 
-func (p *parser) callonListingBlockAttribute1() (interface{}, error) {
+func (p *parser) callonShortHandOptionAttribute1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onListingBlockAttribute1()
+	return p.cur.onShortHandOptionAttribute1(stack["option"])
 }
 
-func (c *current) onAdmonitionMarkerAttribute1(k interface{}) (interface{}, error) {
-	return types.NewAdmonitionAttribute(k.(types.AdmonitionKind))
+func (c *current) onShortHandAttributeValue9() (interface{}, error) {
+	return types.NewStringElement(string(c.text))
+
 }
 
-func (p *parser) callonAdmonitionMarkerAttribute1() (interface{}, error) {
+func (p *parser) callonShortHandAttributeValue9() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onAdmonitionMarkerAttribute1(stack["k"])
+	return p.cur.onShortHandAttributeValue9()
 }
 
-func (c *current) onSourceAttributes6() (interface{}, error) {
-	return "nowrap", nil
+func (c *current) onShortHandAttributeValue14() (interface{}, error) {
+
+	return types.NewStringElement(string(c.text))
 
 }
 
-func (p *parser) callonSourceAttributes6() (interface{}, error) {
+func (p *parser) callonShortHandAttributeValue14() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onSourceAttributes6()
+	return p.cur.onShortHandAttributeValue14()
 }
 
-func (c *current) onSourceAttributes10(attr interface{}) (interface{}, error) {
-	return attr, nil
+func (c *current) onShortHandAttributeValue4(elements interface{}) (interface{}, error) {
+	return types.Reduce(elements, strings.TrimSpace), nil
+
 }
 
-func (p *parser) callonSourceAttributes10() (interface{}, error) {
+func (p *parser) callonShortHandAttributeValue4() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onSourceAttributes10(stack["attr"])
+	return p.cur.onShortHandAttributeValue4(stack["elements"])
 }
 
-func (c *current) onSourceAttributes18(attr interface{}) (interface{}, error) {
-	return attr, nil
+func (c *current) onPositionalAttribute2(value interface{}) (interface{}, error) {
+
+	i, err := incrementPositionalIndex(c)
+	if err != nil {
+		return types.Attribute{}, err
+	}
+	return types.NewPositionalAttribute(i, value)
+
 }
 
-func (p *parser) callonSourceAttributes18() (interface{}, error) {
+func (p *parser) callonPositionalAttribute2() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onSourceAttributes18(stack["attr"])
+	return p.cur.onPositionalAttribute2(stack["value"])
 }
 
-func (c *current) onSourceAttributes1(option, language, others interface{}) (interface{}, error) {
-	return types.NewSourceAttributes(language, option, others.([]interface{})...)
+func (c *current) onPositionalAttribute27(value interface{}) (bool, error) {
+	// here we can't rely on `c.text` if the content is empty
+	// (in which case, `c.text` contains the char sequence of the previous
+	// rule that matched)
+	v := types.Merge(value)
+	return len(v) > 0, nil
+
 }
 
-func (p *parser) callonSourceAttributes1() (interface{}, error) {
+func (p *parser) callonPositionalAttribute27() (bool, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onSourceAttributes1(stack["option"], stack["language"], stack["others"])
+	return p.cur.onPositionalAttribute27(stack["value"])
 }
 
-func (c *current) onAttributeGroup1(attributes interface{}) (interface{}, error) {
-	return types.NewAttributeGroup(attributes.([]interface{})...)
+func (c *current) onPositionalAttribute14(value interface{}) (interface{}, error) {
+
+	i, err := incrementPositionalIndex(c)
+	if err != nil {
+		return types.Attribute{}, err
+	}
+	return types.NewPositionalAttribute(i, nil)
+
 }
 
-func (p *parser) callonAttributeGroup1() (interface{}, error) {
+func (p *parser) callonPositionalAttribute14() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onAttributeGroup1(stack["attributes"])
-}
-
-func (c *current) onNamedAttributes1(attributes interface{}) (interface{}, error) {
-	return types.NewAttributeGroup(attributes.([]interface{})...)
-}
-
-func (p *parser) callonNamedAttributes1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onNamedAttributes1(stack["attributes"])
+	return p.cur.onPositionalAttribute14(stack["value"])
 }
 
 func (c *current) onNamedAttribute1(key, value interface{}) (interface{}, error) {
+	// TODO: include `,` or expect `]`
+	_, err := incrementPositionalIndex(c)
+	if err != nil {
+		return types.Attribute{}, err
+	}
 	return types.NewNamedAttribute(key.(string), value)
 }
 
@@ -16552,6 +14995,7 @@ func (p *parser) callonNamedAttributeKey1() (interface{}, error) {
 
 func (c *current) onAttributeValue1(value interface{}) (interface{}, error) {
 	return value, nil
+
 }
 
 func (p *parser) callonAttributeValue1() (interface{}, error) {
@@ -16561,7 +15005,7 @@ func (p *parser) callonAttributeValue1() (interface{}, error) {
 }
 
 func (c *current) onSingleQuotedAttributeValue7() (interface{}, error) {
-	// '=' and `,` signs are allowed within quotes
+	// = and , signs are allowed within ' quotes
 	return types.NewStringElement(string(c.text))
 
 }
@@ -16572,30 +15016,33 @@ func (p *parser) callonSingleQuotedAttributeValue7() (interface{}, error) {
 	return p.cur.onSingleQuotedAttributeValue7()
 }
 
-func (c *current) onSingleQuotedAttributeValue12() (interface{}, error) {
-	return `'`, nil
+func (c *current) onSingleQuotedAttributeValue13() (interface{}, error) {
+
+	return types.NewStringElement(`'`) // escaped quote
+
 }
 
-func (p *parser) callonSingleQuotedAttributeValue12() (interface{}, error) {
+func (p *parser) callonSingleQuotedAttributeValue13() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onSingleQuotedAttributeValue12()
+	return p.cur.onSingleQuotedAttributeValue13()
 }
 
-func (c *current) onSingleQuotedAttributeValue14() (interface{}, error) {
-	// `{` or `\`
+func (c *current) onSingleQuotedAttributeValue16() (interface{}, error) {
+
 	return types.NewStringElement(string(c.text))
 
 }
 
-func (p *parser) callonSingleQuotedAttributeValue14() (interface{}, error) {
+func (p *parser) callonSingleQuotedAttributeValue16() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onSingleQuotedAttributeValue14()
+	return p.cur.onSingleQuotedAttributeValue16()
 }
 
 func (c *current) onSingleQuotedAttributeValue1(elements interface{}) (interface{}, error) {
 	return types.Reduce(elements), nil
+
 }
 
 func (p *parser) callonSingleQuotedAttributeValue1() (interface{}, error) {
@@ -16605,7 +15052,7 @@ func (p *parser) callonSingleQuotedAttributeValue1() (interface{}, error) {
 }
 
 func (c *current) onDoubleQuotedAttributeValue7() (interface{}, error) {
-	// '=' and `,` signs are allowed within quotes
+	// = and , signs are allowed within " quotes
 	return types.NewStringElement(string(c.text))
 
 }
@@ -16616,32 +15063,33 @@ func (p *parser) callonDoubleQuotedAttributeValue7() (interface{}, error) {
 	return p.cur.onDoubleQuotedAttributeValue7()
 }
 
-func (c *current) onDoubleQuotedAttributeValue12() (interface{}, error) {
-	// escaped "
-	return types.NewStringElement(`"`) // escaped "
+func (c *current) onDoubleQuotedAttributeValue13() (interface{}, error) {
+
+	return types.NewStringElement(`"`) // escaped quote
 
 }
 
-func (p *parser) callonDoubleQuotedAttributeValue12() (interface{}, error) {
+func (p *parser) callonDoubleQuotedAttributeValue13() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onDoubleQuotedAttributeValue12()
+	return p.cur.onDoubleQuotedAttributeValue13()
 }
 
-func (c *current) onDoubleQuotedAttributeValue14() (interface{}, error) {
-	// `{` or `\`
+func (c *current) onDoubleQuotedAttributeValue16() (interface{}, error) {
+
 	return types.NewStringElement(string(c.text))
 
 }
 
-func (p *parser) callonDoubleQuotedAttributeValue14() (interface{}, error) {
+func (p *parser) callonDoubleQuotedAttributeValue16() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onDoubleQuotedAttributeValue14()
+	return p.cur.onDoubleQuotedAttributeValue16()
 }
 
 func (c *current) onDoubleQuotedAttributeValue1(elements interface{}) (interface{}, error) {
 	return types.Reduce(elements), nil
+
 }
 
 func (p *parser) callonDoubleQuotedAttributeValue1() (interface{}, error) {
@@ -16650,27 +15098,39 @@ func (p *parser) callonDoubleQuotedAttributeValue1() (interface{}, error) {
 	return p.cur.onDoubleQuotedAttributeValue1(stack["elements"])
 }
 
-func (c *current) onUnquotedAttributeValue5() (interface{}, error) {
+func (c *current) onUnquotedAttributeValue8() (interface{}, error) {
 	return types.NewStringElement(string(c.text))
 
 }
 
-func (p *parser) callonUnquotedAttributeValue5() (interface{}, error) {
+func (p *parser) callonUnquotedAttributeValue8() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onUnquotedAttributeValue5()
+	return p.cur.onUnquotedAttributeValue8()
 }
 
-func (c *current) onUnquotedAttributeValue10() (interface{}, error) {
+func (c *current) onUnquotedAttributeValue13() (interface{}, error) {
 
 	return types.NewStringElement(string(c.text))
 
 }
 
-func (p *parser) callonUnquotedAttributeValue10() (interface{}, error) {
+func (p *parser) callonUnquotedAttributeValue13() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onUnquotedAttributeValue10()
+	return p.cur.onUnquotedAttributeValue13()
+}
+
+func (c *current) onUnquotedAttributeValue15(elements interface{}) (bool, error) {
+	// empty string is not a valid value
+	return types.Reduce(elements, strings.TrimSpace) != "", nil
+
+}
+
+func (p *parser) callonUnquotedAttributeValue15() (bool, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onUnquotedAttributeValue15(stack["elements"])
 }
 
 func (c *current) onUnquotedAttributeValue1(elements interface{}) (interface{}, error) {
@@ -16682,151 +15142,6 @@ func (p *parser) callonUnquotedAttributeValue1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onUnquotedAttributeValue1(stack["elements"])
-}
-
-func (c *current) onStandaloneAttributeKey1(key interface{}) (interface{}, error) {
-	// value is not defined
-	return types.NewNamedAttribute(key.(string), nil)
-}
-
-func (p *parser) callonStandaloneAttributeKey1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onStandaloneAttributeKey1(stack["key"])
-}
-
-func (c *current) onQuoteAttributes1(author, title interface{}) (interface{}, error) {
-	return types.NewQuoteAttributes("quote", author, title)
-}
-
-func (p *parser) callonQuoteAttributes1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onQuoteAttributes1(stack["author"], stack["title"])
-}
-
-func (c *current) onVerseAttributes1(author, title interface{}) (interface{}, error) {
-	return types.NewQuoteAttributes("verse", author.(string), title.(string))
-}
-
-func (p *parser) callonVerseAttributes1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onVerseAttributes1(stack["author"], stack["title"])
-}
-
-func (c *current) onQuoteAttribute1() (interface{}, error) {
-	return string(c.text), nil
-}
-
-func (p *parser) callonQuoteAttribute1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onQuoteAttribute1()
-}
-
-func (c *current) onQuotedTextAttributes1(attributes interface{}) (interface{}, error) {
-	return types.NewAttributeGroup(attributes.([]interface{})...)
-}
-
-func (p *parser) callonQuotedTextAttributes1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onQuotedTextAttributes1(stack["attributes"])
-}
-
-func (c *current) onQuotedTextAttrRole1(role interface{}) (interface{}, error) {
-	return types.NewElementRole(role)
-}
-
-func (p *parser) callonQuotedTextAttrRole1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onQuotedTextAttrRole1(stack["role"])
-}
-
-func (c *current) onStandaloneAttributes1(attributes interface{}) (interface{}, error) {
-	// standalone attributes, i.e., with nothing afterwards
-	return types.NewAttributeGroup(attributes.([]interface{})...)
-}
-
-func (p *parser) callonStandaloneAttributes1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onStandaloneAttributes1(stack["attributes"])
-}
-
-func (c *current) onShortHandAttrOption1(option interface{}) (interface{}, error) {
-	return types.NewElementOption(option)
-}
-
-func (p *parser) callonShortHandAttrOption1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onShortHandAttrOption1(stack["option"])
-}
-
-func (c *current) onShortHandAttrID1(id interface{}) (interface{}, error) {
-	return types.NewElementID(id)
-}
-
-func (p *parser) callonShortHandAttrID1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onShortHandAttrID1(stack["id"])
-}
-
-func (c *current) onShortHandAttrRole1(role interface{}) (interface{}, error) {
-	return types.NewElementRole(role)
-}
-
-func (p *parser) callonShortHandAttrRole1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onShortHandAttrRole1(stack["role"])
-}
-
-func (c *current) onPositionalValue1(value interface{}) (interface{}, error) {
-	return types.Reduce(value, strings.TrimSpace), nil
-}
-
-func (p *parser) callonPositionalValue1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onPositionalValue1(stack["value"])
-}
-
-func (c *current) onShortHandValuePlain4() (interface{}, error) {
-	return types.NewStringElement(string(c.text))
-
-}
-
-func (p *parser) callonShortHandValuePlain4() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onShortHandValuePlain4()
-}
-
-func (c *current) onShortHandValuePlain12() (interface{}, error) {
-	return types.NewStringElement(string(c.text))
-
-}
-
-func (p *parser) callonShortHandValuePlain12() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onShortHandValuePlain12()
-}
-
-func (c *current) onShortHandValuePlain1(first, others interface{}) (interface{}, error) {
-	return append([]interface{}{first}, others.([]interface{})...), nil
-
-}
-
-func (p *parser) callonShortHandValuePlain1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onShortHandValuePlain1(stack["first"], stack["others"])
 }
 
 func (c *current) onSection7() (interface{}, error) {
@@ -16856,7 +15171,7 @@ func (p *parser) callonSection10() (bool, error) {
 }
 
 func (c *current) onSection1(attributes, level, title, id interface{}) (interface{}, error) {
-	return types.NewSection(level.(int), title.([]interface{}), id.([]interface{}), attributes.([]interface{}))
+	return types.NewSection(level.(int), title.([]interface{}), id.([]interface{}), attributes)
 }
 
 func (p *parser) callonSection1() (interface{}, error) {
@@ -16886,24 +15201,24 @@ func (p *parser) callonTitleElement1() (interface{}, error) {
 	return p.cur.onTitleElement1(stack["element"])
 }
 
-func (c *current) onUserMacroBlock1(name, value, attributes interface{}) (interface{}, error) {
-	return types.NewUserMacroBlock(name.(string), value.(string), attributes.(types.Attributes), string(c.text))
+func (c *current) onUserMacroBlock1(name, value, inlineAttributes interface{}) (interface{}, error) {
+	return types.NewUserMacroBlock(name.(string), value.(string), inlineAttributes, string(c.text))
 }
 
 func (p *parser) callonUserMacroBlock1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onUserMacroBlock1(stack["name"], stack["value"], stack["attributes"])
+	return p.cur.onUserMacroBlock1(stack["name"], stack["value"], stack["inlineAttributes"])
 }
 
-func (c *current) onInlineUserMacro1(name, value, attributes interface{}) (interface{}, error) {
-	return types.NewInlineUserMacro(name.(string), value.(string), attributes.(types.Attributes), string(c.text))
+func (c *current) onInlineUserMacro1(name, value, inlineAttributes interface{}) (interface{}, error) {
+	return types.NewInlineUserMacro(name.(string), value.(string), inlineAttributes, string(c.text))
 }
 
 func (p *parser) callonInlineUserMacro1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onInlineUserMacro1(stack["name"], stack["value"], stack["attributes"])
+	return p.cur.onInlineUserMacro1(stack["name"], stack["value"], stack["inlineAttributes"])
 }
 
 func (c *current) onUserMacroName1() (interface{}, error) {
@@ -16926,16 +15241,6 @@ func (p *parser) callonUserMacroValue1() (interface{}, error) {
 	return p.cur.onUserMacroValue1()
 }
 
-func (c *current) onUserMacroAttributes1(attributes interface{}) (interface{}, error) {
-	return types.NewAttributeGroup(attributes.([]interface{})...)
-}
-
-func (p *parser) callonUserMacroAttributes1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onUserMacroAttributes1(stack["attributes"])
-}
-
 func (c *current) onFileInclusion4(path, inlineAttributes interface{}) (interface{}, error) {
 
 	return types.NewFileInclusion(path.(types.Location), inlineAttributes.(types.Attributes), string(c.text))
@@ -16950,6 +15255,7 @@ func (p *parser) callonFileInclusion4() (interface{}, error) {
 
 func (c *current) onFileInclusion1(incl interface{}) (interface{}, error) {
 	return incl.(types.FileInclusion), nil
+
 }
 
 func (p *parser) callonFileInclusion1() (interface{}, error) {
@@ -16958,35 +15264,15 @@ func (p *parser) callonFileInclusion1() (interface{}, error) {
 	return p.cur.onFileInclusion1(stack["incl"])
 }
 
-func (c *current) onFileIncludeAttributes1(attributes interface{}) (interface{}, error) {
-	return types.NewAttributeGroup(attributes.([]interface{})...)
-}
-
-func (p *parser) callonFileIncludeAttributes1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onFileIncludeAttributes1(stack["attributes"])
-}
-
-func (c *current) onLineRangesAttribute1(lines interface{}) (interface{}, error) {
-
-	return types.NewLineRangesAttribute(lines)
-}
-
-func (p *parser) callonLineRangesAttribute1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onLineRangesAttribute1(stack["lines"])
-}
-
-func (c *current) onLineRangesAttributeValue1(value interface{}) (interface{}, error) {
+func (c *current) onLineRanges1(value interface{}) (interface{}, error) {
+	// must make sure that the whole content is parsed
 	return value, nil
 }
 
-func (p *parser) callonLineRangesAttributeValue1() (interface{}, error) {
+func (p *parser) callonLineRanges1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onLineRangesAttributeValue1(stack["value"])
+	return p.cur.onLineRanges1(stack["value"])
 }
 
 func (c *current) onMultipleLineRanges9(other interface{}) (interface{}, error) {
@@ -17011,28 +15297,6 @@ func (p *parser) callonMultipleLineRanges1() (interface{}, error) {
 	return p.cur.onMultipleLineRanges1(stack["first"], stack["others"])
 }
 
-func (c *current) onMultipleQuotedLineRanges10(other interface{}) (interface{}, error) {
-	return other, nil
-
-}
-
-func (p *parser) callonMultipleQuotedLineRanges10() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onMultipleQuotedLineRanges10(stack["other"])
-}
-
-func (c *current) onMultipleQuotedLineRanges1(first, others interface{}) (interface{}, error) {
-	return append([]interface{}{first}, others.([]interface{})...), nil
-
-}
-
-func (p *parser) callonMultipleQuotedLineRanges1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onMultipleQuotedLineRanges1(stack["first"], stack["others"])
-}
-
 func (c *current) onMultiLineRange1(start, end interface{}) (interface{}, error) {
 	// eg: lines=12..14
 	return types.NewLineRange(start.(int), end.(int))
@@ -17042,17 +15306,6 @@ func (p *parser) callonMultiLineRange1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onMultiLineRange1(stack["start"], stack["end"])
-}
-
-func (c *current) onMultiLineQuotedRange1(start, end interface{}) (interface{}, error) {
-	// eg: lines=12..14
-	return types.NewLineRange(start.(int), end.(int))
-}
-
-func (p *parser) callonMultiLineQuotedRange1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onMultiLineQuotedRange1(stack["start"], stack["end"])
 }
 
 func (c *current) onSingleLineRange1(singleline interface{}) (interface{}, error) {
@@ -17066,46 +15319,15 @@ func (p *parser) callonSingleLineRange1() (interface{}, error) {
 	return p.cur.onSingleLineRange1(stack["singleline"])
 }
 
-func (c *current) onSingleLineQuotedRange1(singleline interface{}) (interface{}, error) {
-	// eg: lines=12
-	return types.NewLineRange(singleline.(int), singleline.(int))
-}
-
-func (p *parser) callonSingleLineQuotedRange1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onSingleLineQuotedRange1(stack["singleline"])
-}
-
-func (c *current) onUndefinedLineRange1() (interface{}, error) {
-	return string(c.text), nil
-}
-
-func (p *parser) callonUndefinedLineRange1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onUndefinedLineRange1()
-}
-
-func (c *current) onTagRangesAttribute1(tags interface{}) (interface{}, error) {
-	//TODO: check if 'tags'/'tag' is allowed for both single and multiple values
-	return types.NewTagRangesAttribute(tags.([]interface{}))
-}
-
-func (p *parser) callonTagRangesAttribute1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onTagRangesAttribute1(stack["tags"])
-}
-
-func (c *current) onTagRangesAttributeValue1(value interface{}) (interface{}, error) {
+func (c *current) onTagRanges1(value interface{}) (interface{}, error) {
+	// must make sure that the whole content is parsed
 	return value, nil
 }
 
-func (p *parser) callonTagRangesAttributeValue1() (interface{}, error) {
+func (p *parser) callonTagRanges1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onTagRangesAttributeValue1(stack["value"])
+	return p.cur.onTagRanges1(stack["value"])
 }
 
 func (c *current) onMultipleTagRanges7(other interface{}) (interface{}, error) {
@@ -17311,7 +15533,7 @@ func (p *parser) callonContinuedListItemContent1() (interface{}, error) {
 }
 
 func (c *current) onOrderedListItem1(attributes, prefix, content interface{}) (interface{}, error) {
-	return types.NewOrderedListItem(prefix.(types.OrderedListItemPrefix), content.([]interface{}), attributes.([]interface{}))
+	return types.NewOrderedListItem(prefix.(types.OrderedListItemPrefix), content.([]interface{}), attributes)
 }
 
 func (p *parser) callonOrderedListItem1() (interface{}, error) {
@@ -17449,7 +15671,7 @@ func (p *parser) callonOrderedListItemContent1() (interface{}, error) {
 }
 
 func (c *current) onUnorderedListItem1(attributes, prefix, checkstyle, content interface{}) (interface{}, error) {
-	return types.NewUnorderedListItem(prefix.(types.UnorderedListItemPrefix), checkstyle, content.([]interface{}), attributes.([]interface{}))
+	return types.NewUnorderedListItem(prefix.(types.UnorderedListItemPrefix), checkstyle, content.([]interface{}), attributes)
 }
 
 func (p *parser) callonUnorderedListItem1() (interface{}, error) {
@@ -17580,7 +15802,7 @@ func (p *parser) callonUnorderedListItemContent1() (interface{}, error) {
 }
 
 func (c *current) onLabeledListItem1(attributes, term, separator, description interface{}) (interface{}, error) {
-	return types.NewLabeledListItem(len(separator.(string))-1, term.([]interface{}), description, attributes.([]interface{}))
+	return types.NewLabeledListItem(len(separator.(string))-1, term.([]interface{}), description, attributes)
 }
 
 func (p *parser) callonLabeledListItem1() (interface{}, error) {
@@ -17610,7 +15832,7 @@ func (p *parser) callonVerbatimLabeledListItemTerm1() (interface{}, error) {
 }
 
 func (c *current) onLabeledListItemTerm1(elements interface{}) (interface{}, error) {
-	// rule as an extra entrypoint
+
 	return types.NewInlineElements(elements.([]interface{}))
 }
 
@@ -17728,7 +15950,7 @@ func (p *parser) callonAdmonitionKind10() (interface{}, error) {
 
 func (c *current) onRawParagraph2(attributes, t, lines interface{}) (interface{}, error) {
 
-	return types.NewAdmonitionParagraph(lines.([]interface{}), t.(types.AdmonitionKind), attributes.([]interface{}))
+	return types.NewAdmonitionParagraph(lines.([]interface{}), t.(string), attributes)
 
 }
 
@@ -17739,7 +15961,7 @@ func (p *parser) callonRawParagraph2() (interface{}, error) {
 }
 
 func (c *current) onRawParagraph15(attributes, content interface{}) (interface{}, error) {
-	return types.NewMarkdownQuoteBlock(content.([]interface{}), attributes.([]interface{}))
+	return types.NewMarkdownQuoteBlock(content.([]interface{}), attributes)
 
 }
 
@@ -17751,7 +15973,7 @@ func (p *parser) callonRawParagraph15() (interface{}, error) {
 
 func (c *current) onRawParagraph28(attributes interface{}) (bool, error) {
 	// verify that one of the attributes is `kind:passthrough`
-	return types.HasAttributeWithValue(attributes, types.AttrBlockKind, types.Passthrough), nil
+	return types.HasAttributeWithValue(attributes, types.AttrPositional1, types.Passthrough), nil
 
 }
 
@@ -17763,7 +15985,7 @@ func (p *parser) callonRawParagraph28() (bool, error) {
 
 func (c *current) onRawParagraph23(attributes, content interface{}) (interface{}, error) {
 
-	return types.NewPassthroughBlock(content.([]interface{}), attributes.([]interface{}))
+	return types.NewPassthroughBlock(content.([]interface{}), attributes)
 
 }
 
@@ -17775,7 +15997,7 @@ func (p *parser) callonRawParagraph23() (interface{}, error) {
 
 func (c *current) onRawParagraph32(attributes, lines interface{}) (interface{}, error) {
 
-	return types.NewParagraph(lines.([]interface{}), attributes.([]interface{}))
+	return types.NewParagraph(lines.([]interface{}), attributes)
 
 }
 
@@ -17834,7 +16056,7 @@ func (p *parser) callonRawParagraphLineContent1() (interface{}, error) {
 }
 
 func (c *current) onSimpleRawParagraph6(attributes interface{}) (bool, error) {
-	return !types.HasAttributeWithValue(attributes, types.AttrBlockKind, types.Literal), nil
+	return !types.HasAttributeWithValue(attributes, types.AttrPositional1, types.Literal), nil
 
 }
 
@@ -17846,7 +16068,7 @@ func (p *parser) callonSimpleRawParagraph6() (bool, error) {
 
 func (c *current) onSimpleRawParagraph1(attributes, firstLine, otherLines interface{}) (interface{}, error) {
 
-	return types.NewParagraph(append([]interface{}{firstLine}, otherLines.([]interface{})...), attributes.([]interface{}))
+	return types.NewParagraph(append([]interface{}{firstLine}, otherLines.([]interface{})...), attributes)
 }
 
 func (p *parser) callonSimpleRawParagraph1() (interface{}, error) {
@@ -17878,7 +16100,7 @@ func (p *parser) callonFirstParagraphRawLine1() (interface{}, error) {
 
 func (c *current) onContinuedRawParagraph2(attributes, t, lines interface{}) (interface{}, error) {
 
-	return types.NewAdmonitionParagraph(lines.([]interface{}), t.(types.AdmonitionKind), attributes.([]interface{}))
+	return types.NewAdmonitionParagraph(lines.([]interface{}), t.(string), attributes)
 
 }
 
@@ -17890,7 +16112,7 @@ func (p *parser) callonContinuedRawParagraph2() (interface{}, error) {
 
 func (c *current) onContinuedRawParagraph12(attributes, lines interface{}) (interface{}, error) {
 
-	return types.NewParagraph(lines.([]interface{}), attributes.([]interface{}))
+	return types.NewParagraph(lines.([]interface{}), attributes)
 }
 
 func (p *parser) callonContinuedRawParagraph12() (interface{}, error) {
@@ -18703,6 +16925,30 @@ func (p *parser) callonExternalCrossReference1() (interface{}, error) {
 	return p.cur.onExternalCrossReference1(stack["url"], stack["inlineAttributes"])
 }
 
+func (c *current) onCrossReferenceLabel3() (interface{}, error) {
+	// `{`, `>` and `>` characters are not allowed as they are used for attribute substitutions and cross-references
+	return types.NewStringElement(string(c.text))
+
+}
+
+func (p *parser) callonCrossReferenceLabel3() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onCrossReferenceLabel3()
+}
+
+func (c *current) onCrossReferenceLabel9() (interface{}, error) {
+
+	return types.NewStringElement(string(c.text))
+
+}
+
+func (p *parser) callonCrossReferenceLabel9() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onCrossReferenceLabel9()
+}
+
 func (c *current) onRelativeLink1(url, inlineAttributes interface{}) (interface{}, error) {
 	return types.NewInlineLink(url.(types.Location), inlineAttributes.(types.Attributes))
 }
@@ -18723,110 +16969,27 @@ func (p *parser) callonExternalLink1() (interface{}, error) {
 	return p.cur.onExternalLink1(stack["url"], stack["inlineAttributes"])
 }
 
-func (c *current) onLinkAttributes1(firstAttr, otherAttrs interface{}) (interface{}, error) {
-	return types.NewInlineLinkAttributes(append(firstAttr.([]interface{}), otherAttrs.([]interface{})...))
+func (c *current) onImageBlock6(attributes interface{}) (bool, error) {
+	// AttrPositional1 must not be set
+	return types.HasNotAttribute(attributes, types.AttrPositional1), nil
+
 }
 
-func (p *parser) callonLinkAttributes1() (interface{}, error) {
+func (p *parser) callonImageBlock6() (bool, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onLinkAttributes1(stack["firstAttr"], stack["otherAttrs"])
-}
-
-func (c *current) onFirstLinkAttributeElement4(elements interface{}) (interface{}, error) {
-	return types.NewInlineElements(elements.([]interface{}))
-
-}
-
-func (p *parser) callonFirstLinkAttributeElement4() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onFirstLinkAttributeElement4(stack["elements"])
-}
-
-func (c *current) onFirstLinkAttributeElement20(elements interface{}) (interface{}, error) {
-	return types.NewInlineElements(elements.([]interface{}))
-
-}
-
-func (p *parser) callonFirstLinkAttributeElement20() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onFirstLinkAttributeElement20(stack["elements"])
-}
-
-func (c *current) onFirstLinkAttributeElement1(element interface{}) (interface{}, error) {
-	return element, nil
-}
-
-func (p *parser) callonFirstLinkAttributeElement1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onFirstLinkAttributeElement1(stack["element"])
-}
-
-func (c *current) onAttributeChar1() (interface{}, error) {
-	// excludes comma
-	return types.NewStringElement(string(c.text))
-}
-
-func (p *parser) callonAttributeChar1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onAttributeChar1()
-}
-
-func (c *current) onQuotedAttributeChar1() (interface{}, error) {
-	// does not exclude comma
-	return types.NewStringElement(string(c.text))
-}
-
-func (p *parser) callonQuotedAttributeChar1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onQuotedAttributeChar1()
-}
-
-func (c *current) onUnquotedAttributeChar1() (interface{}, error) {
-	// excludes comma
-	return types.NewStringElement(string(c.text))
-}
-
-func (p *parser) callonUnquotedAttributeChar1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onUnquotedAttributeChar1()
+	return p.cur.onImageBlock6(stack["attributes"])
 }
 
 func (c *current) onImageBlock1(attributes, path, inlineAttributes interface{}) (interface{}, error) {
 	// 'imagesdir' attribute is added after applying the attribute substitutions on the image location
-	return types.NewImageBlock(path.(types.Location), inlineAttributes.(types.Attributes), attributes.([]interface{}))
+	return types.NewImageBlock(path.(types.Location), inlineAttributes.(types.Attributes), attributes)
 }
 
 func (p *parser) callonImageBlock1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onImageBlock1(stack["attributes"], stack["path"], stack["inlineAttributes"])
-}
-
-func (c *current) onImageBlockAttributes2(attribute interface{}) (interface{}, error) {
-	return attribute, nil
-}
-
-func (p *parser) callonImageBlockAttributes2() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onImageBlockAttributes2(stack["attribute"])
-}
-
-func (c *current) onImageAttrList1(alt, shortHands, width, height, others interface{}) (interface{}, error) {
-	return types.NewAttributeGroup(alt, width, height, others)
-}
-
-func (p *parser) callonImageAttrList1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onImageAttrList1(stack["alt"], stack["shortHands"], stack["width"], stack["height"], stack["others"])
 }
 
 func (c *current) onInlineImage1(path, inlineAttributes interface{}) (interface{}, error) {
@@ -18837,46 +17000,6 @@ func (p *parser) callonInlineImage1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onInlineImage1(stack["path"], stack["inlineAttributes"])
-}
-
-func (c *current) onInlineImageAttributes1(alt, width, height, others interface{}) (interface{}, error) {
-	return types.NewAttributeGroup(alt, width, height, others)
-}
-
-func (p *parser) callonInlineImageAttributes1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onInlineImageAttributes1(stack["alt"], stack["width"], stack["height"], stack["others"])
-}
-
-func (c *current) onImageAlt1(value interface{}) (interface{}, error) {
-	return types.NewInlineAttribute(types.AttrImageAlt, value)
-}
-
-func (p *parser) callonImageAlt1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onImageAlt1(stack["value"])
-}
-
-func (c *current) onImageWidth1(value interface{}) (interface{}, error) {
-	return types.NewInlineAttribute(types.AttrWidth, value)
-}
-
-func (p *parser) callonImageWidth1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onImageWidth1(stack["value"])
-}
-
-func (c *current) onImageHeight1(value interface{}) (interface{}, error) {
-	return types.NewInlineAttribute(types.AttrImageHeight, value)
-}
-
-func (p *parser) callonImageHeight1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onImageHeight1(stack["value"])
 }
 
 func (c *current) onInlineIcon5() (interface{}, error) {
@@ -18890,34 +17013,13 @@ func (p *parser) callonInlineIcon5() (interface{}, error) {
 }
 
 func (c *current) onInlineIcon1(icon, attributes interface{}) (interface{}, error) {
-	return types.NewIcon(icon.(string), attributes.(types.Attributes))
+	return types.NewIcon(icon.(string), attributes)
 }
 
 func (p *parser) callonInlineIcon1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onInlineIcon1(stack["icon"], stack["attributes"])
-}
-
-func (c *current) onIconAttributes1(size, others interface{}) (interface{}, error) {
-	// TODO: use ellipsis on `nv`?
-	return types.NewAttributeGroup(size, others)
-}
-
-func (p *parser) callonIconAttributes1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onIconAttributes1(stack["size"], stack["others"])
-}
-
-func (c *current) onIconSize1(value interface{}) (interface{}, error) {
-	return types.NewInlineAttribute(types.AttrIconSize, value)
-}
-
-func (p *parser) callonIconSize1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onIconSize1(stack["value"])
 }
 
 func (c *current) onInlineFootnote2(content interface{}) (interface{}, error) {
@@ -19022,7 +17124,7 @@ func (p *parser) callonDelimitedBlock1() (interface{}, error) {
 }
 
 func (c *current) onExampleBlock1(attributes, blocks interface{}) (interface{}, error) {
-	return types.NewExampleBlock(blocks.([]interface{}), attributes.([]interface{}))
+	return types.NewExampleBlock(blocks.([]interface{}), attributes)
 }
 
 func (p *parser) callonExampleBlock1() (interface{}, error) {
@@ -19043,9 +17145,9 @@ func (p *parser) callonExampleBlockRawContent2() (interface{}, error) {
 }
 
 func (c *current) onQuoteBlock6(attributes interface{}) (bool, error) {
-	// AttrBlockKind may be missing or must be equal to `quote`
-	if types.HasNotAttribute(attributes, types.AttrBlockKind) ||
-		types.HasAttributeWithValue(attributes, types.AttrBlockKind, types.Quote) {
+	// AttrPositional1 may be missing or must be equal to `quote`
+	if types.HasNotAttribute(attributes, types.AttrPositional1) ||
+		types.HasAttributeWithValue(attributes, types.AttrPositional1, types.Quote) {
 		return true, nil
 	}
 	return false, nil
@@ -19059,7 +17161,7 @@ func (p *parser) callonQuoteBlock6() (bool, error) {
 }
 
 func (c *current) onQuoteBlock1(attributes, content interface{}) (interface{}, error) {
-	return types.NewQuoteBlock(content.([]interface{}), attributes.([]interface{}))
+	return types.NewQuoteBlock(content.([]interface{}), attributes)
 
 }
 
@@ -19081,7 +17183,7 @@ func (p *parser) callonQuoteBlockRawContent2() (interface{}, error) {
 }
 
 func (c *current) onSidebarBlock1(attributes, content interface{}) (interface{}, error) {
-	return types.NewSidebarBlock(content.([]interface{}), attributes.([]interface{}))
+	return types.NewSidebarBlock(content.([]interface{}), attributes)
 }
 
 func (p *parser) callonSidebarBlock1() (interface{}, error) {
@@ -19102,7 +17204,7 @@ func (p *parser) callonSidebarBlockRawContent2() (interface{}, error) {
 }
 
 func (c *current) onFencedBlock1(attributes, content interface{}) (interface{}, error) {
-	return types.NewFencedBlock(content.([]interface{}), attributes.([]interface{}))
+	return types.NewFencedBlock(content.([]interface{}), attributes)
 }
 
 func (p *parser) callonFencedBlock1() (interface{}, error) {
@@ -19123,7 +17225,7 @@ func (p *parser) callonFencedBlockRawContent2() (interface{}, error) {
 }
 
 func (c *current) onListingBlock1(attributes, content interface{}) (interface{}, error) {
-	return types.NewListingBlock(content.([]interface{}), attributes.([]interface{}))
+	return types.NewListingBlock(content.([]interface{}), attributes)
 }
 
 func (p *parser) callonListingBlock1() (interface{}, error) {
@@ -19144,8 +17246,8 @@ func (p *parser) callonListingBlockRawContent2() (interface{}, error) {
 }
 
 func (c *current) onVerseBlock6(attributes interface{}) (bool, error) {
-	// AttrBlockKind must be equal to `verse`
-	return types.HasAttributeWithValue(attributes, types.AttrBlockKind, types.Verse), nil
+	// AttrPositional1 must be equal to `verse`
+	return types.HasAttributeWithValue(attributes, types.AttrPositional1, types.Verse), nil
 
 }
 
@@ -19156,7 +17258,7 @@ func (p *parser) callonVerseBlock6() (bool, error) {
 }
 
 func (c *current) onVerseBlock1(attributes, content interface{}) (interface{}, error) {
-	return types.NewVerseBlock(content.([]interface{}), attributes.([]interface{}))
+	return types.NewVerseBlock(content.([]interface{}), attributes)
 
 }
 
@@ -19178,7 +17280,7 @@ func (p *parser) callonVerseBlockRawContent2() (interface{}, error) {
 }
 
 func (c *current) onPassthroughBlock1(attributes, content interface{}) (interface{}, error) {
-	return types.NewPassthroughBlock(content.([]interface{}), attributes.([]interface{}))
+	return types.NewPassthroughBlock(content.([]interface{}), attributes)
 }
 
 func (p *parser) callonPassthroughBlock1() (interface{}, error) {
@@ -19314,7 +17416,7 @@ func (p *parser) callonNoneSubs5() (interface{}, error) {
 
 func (c *current) onTable1(attributes, header, lines interface{}) (interface{}, error) {
 	// end delimiter or end of file
-	return types.NewTable(header, lines.([]interface{}), attributes.([]interface{}))
+	return types.NewTable(header, lines.([]interface{}), attributes)
 
 }
 
@@ -19355,7 +17457,7 @@ func (p *parser) callonTableCell1() (interface{}, error) {
 }
 
 func (c *current) onParagraphWithHeadingSpaces1(attributes, lines interface{}) (interface{}, error) {
-	return types.NewLiteralBlock(types.LiteralBlockWithSpacesOnFirstLine, lines.([]interface{}), attributes.([]interface{}))
+	return types.NewLiteralBlock(types.LiteralBlockWithSpacesOnFirstLine, lines.([]interface{}), attributes)
 }
 
 func (p *parser) callonParagraphWithHeadingSpaces1() (interface{}, error) {
@@ -19398,7 +17500,7 @@ func (p *parser) callonParagraphWithHeadingSpacesLine1() (interface{}, error) {
 }
 
 func (c *current) onParagraphWithLiteralBlockDelimiter1(attributes, lines interface{}) (interface{}, error) {
-	return types.NewLiteralBlock(types.LiteralBlockWithDelimiter, lines.([]interface{}), attributes.([]interface{}))
+	return types.NewLiteralBlock(types.LiteralBlockWithDelimiter, lines.([]interface{}), attributes)
 }
 
 func (p *parser) callonParagraphWithLiteralBlockDelimiter1() (interface{}, error) {
@@ -19440,7 +17542,7 @@ func (p *parser) callonParagraphWithLiteralBlockDelimiterLine1() (interface{}, e
 }
 
 func (c *current) onParagraphWithLiteralAttribute6(attributes interface{}) (bool, error) {
-	return types.HasAttributeWithValue(attributes, types.AttrBlockKind, types.Literal), nil
+	return types.HasAttributeWithValue(attributes, types.AttrPositional1, types.Literal), nil
 
 }
 
@@ -19451,7 +17553,7 @@ func (p *parser) callonParagraphWithLiteralAttribute6() (bool, error) {
 }
 
 func (c *current) onParagraphWithLiteralAttribute1(attributes, lines interface{}) (interface{}, error) {
-	return types.NewLiteralBlock(types.LiteralBlockWithAttribute, lines.([]interface{}), attributes.([]interface{}))
+	return types.NewLiteralBlock(types.LiteralBlockWithAttribute, lines.([]interface{}), attributes)
 
 }
 
@@ -19678,7 +17780,7 @@ func (p *parser) callonWord2() (interface{}, error) {
 }
 
 func (c *current) onWord10() (interface{}, error) {
-
+	// allow `
 	return types.NewStringElement(string(c.text))
 
 }
@@ -19883,6 +17985,16 @@ func GlobalStore(key string, value interface{}) Option {
 	}
 }
 
+// InitState creates an Option to set a key to a certain value in
+// the global "state" store.
+func InitState(key string, value interface{}) Option {
+	return func(p *parser) Option {
+		old := p.cur.state[key]
+		p.cur.state[key] = value
+		return InitState(key, old)
+	}
+}
+
 // ParseFile parses the file identified by filename.
 func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
 	f, err := os.Open(filename)
@@ -19934,6 +18046,11 @@ type savepoint struct {
 type current struct {
 	pos  position // start position of the match
 	text []byte   // raw text of the match
+
+	// state is a store for arbitrary key,value pairs that the user wants to be
+	// tied to the backtracking of the parser.
+	// This is always rolled back if a parsing rule fails.
+	state storeDict
 
 	// globalStore is a general store for the user to store arbitrary key-value
 	// pairs that they need to manage and that they do not want tied to the
@@ -20007,6 +18124,11 @@ type oneOrMoreExpr expr
 type ruleRefExpr struct {
 	pos  position
 	name string
+}
+
+type stateCodeExpr struct {
+	pos position
+	run func(*parser) error
 }
 
 type andCodeExpr struct {
@@ -20112,6 +18234,7 @@ func newParser(filename string, b []byte, opts ...Option) *parser {
 		pt:       savepoint{position: position{line: 1}},
 		recover:  true,
 		cur: current{
+			state:       make(storeDict),
 			globalStore: make(storeDict),
 		},
 		maxFailPos:      position{col: 1, line: 1},
@@ -20334,6 +18457,49 @@ func (p *parser) restore(pt savepoint) {
 	p.pt = pt
 }
 
+// Cloner is implemented by any value that has a Clone method, which returns a
+// copy of the value. This is mainly used for types which are not passed by
+// value (e.g map, slice, chan) or structs that contain such types.
+//
+// This is used in conjunction with the global state feature to create proper
+// copies of the state to allow the parser to properly restore the state in
+// the case of backtracking.
+type Cloner interface {
+	Clone() interface{}
+}
+
+var statePool = &sync.Pool{
+	New: func() interface{} { return make(storeDict) },
+}
+
+func (sd storeDict) Discard() {
+	for k := range sd {
+		delete(sd, k)
+	}
+	statePool.Put(sd)
+}
+
+// clone and return parser current state.
+func (p *parser) cloneState() storeDict {
+
+	state := statePool.Get().(storeDict)
+	for k, v := range p.cur.state {
+		if c, ok := v.(Cloner); ok {
+			state[k] = c.Clone()
+		} else {
+			state[k] = v
+		}
+	}
+	return state
+}
+
+// restore parser current state to the state storeDict.
+// every restoreState should applied only one time for every cloned state
+func (p *parser) restoreState(state storeDict) {
+	p.cur.state.Discard()
+	p.cur.state = state
+}
+
 // get the slice of bytes from the savepoint start to the current position.
 func (p *parser) sliceFrom(start savepoint) []byte {
 	return p.data[start.position.offset:p.pt.position.offset]
@@ -20467,6 +18633,8 @@ func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
 		val, ok = p.parseRuleRefExpr(expr)
 	case *seqExpr:
 		val, ok = p.parseSeqExpr(expr)
+	case *stateCodeExpr:
+		val, ok = p.parseStateCodeExpr(expr)
 	case *throwExpr:
 		val, ok = p.parseThrowExpr(expr)
 	case *zeroOrMoreExpr:
@@ -20485,10 +18653,12 @@ func (p *parser) parseActionExpr(act *actionExpr) (interface{}, bool) {
 	if ok {
 		p.cur.pos = start.position
 		p.cur.text = p.sliceFrom(start)
+		state := p.cloneState()
 		actVal, err := act.run(p)
 		if err != nil {
 			p.addErrAt(err, start.position, []string{})
 		}
+		p.restoreState(state)
 
 		val = actVal
 	}
@@ -20496,20 +18666,24 @@ func (p *parser) parseActionExpr(act *actionExpr) (interface{}, bool) {
 }
 
 func (p *parser) parseAndCodeExpr(and *andCodeExpr) (interface{}, bool) {
+	state := p.cloneState()
 
 	ok, err := and.run(p)
 	if err != nil {
 		p.addErr(err)
 	}
+	p.restoreState(state)
 
 	return nil, ok
 }
 
 func (p *parser) parseAndExpr(and *andExpr) (interface{}, bool) {
 	pt := p.pt
+	state := p.cloneState()
 	p.pushV()
 	_, ok := p.parseExpr(and.expr)
 	p.popV()
+	p.restoreState(state)
 	p.restore(pt)
 
 	return nil, ok
@@ -20594,12 +18768,15 @@ func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 		// dummy assignment to prevent compile error if optimized
 		_ = altI
 
+		state := p.cloneState()
+
 		p.pushV()
 		val, ok := p.parseExpr(alt)
 		p.popV()
 		if ok {
 			return val, ok
 		}
+		p.restoreState(state)
 	}
 	return nil, false
 }
@@ -20634,21 +18811,26 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 }
 
 func (p *parser) parseNotCodeExpr(not *notCodeExpr) (interface{}, bool) {
+	state := p.cloneState()
+
 	ok, err := not.run(p)
 	if err != nil {
 		p.addErr(err)
 	}
+	p.restoreState(state)
 
 	return nil, !ok
 }
 
 func (p *parser) parseNotExpr(not *notExpr) (interface{}, bool) {
 	pt := p.pt
+	state := p.cloneState()
 	p.pushV()
 	p.maxFailInvertExpected = !p.maxFailInvertExpected
 	_, ok := p.parseExpr(not.expr)
 	p.maxFailInvertExpected = !p.maxFailInvertExpected
 	p.popV()
+	p.restoreState(state)
 	p.restore(pt)
 
 	return nil, !ok
@@ -20698,15 +18880,25 @@ func (p *parser) parseSeqExpr(seq *seqExpr) (interface{}, bool) {
 	vals := make([]interface{}, 0, len(seq.exprs))
 
 	pt := p.pt
+	state := p.cloneState()
 	for _, expr := range seq.exprs {
 		val, ok := p.parseExpr(expr)
 		if !ok {
+			p.restoreState(state)
 			p.restore(pt)
 			return nil, false
 		}
 		vals = append(vals, val)
 	}
 	return vals, true
+}
+
+func (p *parser) parseStateCodeExpr(state *stateCodeExpr) (interface{}, bool) {
+	err := state.run(p)
+	if err != nil {
+		p.addErr(err)
+	}
+	return nil, true
 }
 
 func (p *parser) parseThrowExpr(expr *throwExpr) (interface{}, bool) {

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -1332,32 +1332,32 @@ var g = &grammar{
 		},
 		{
 			name: "CounterSub",
-			pos:  position{line: 205, col: 1, offset: 6493},
+			pos:  position{line: 206, col: 1, offset: 6542},
 			expr: &choiceExpr{
-				pos: position{line: 205, col: 15, offset: 6507},
+				pos: position{line: 206, col: 15, offset: 6556},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 205, col: 15, offset: 6507},
+						pos:  position{line: 206, col: 15, offset: 6556},
 						name: "CounterSub1",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 205, col: 29, offset: 6521},
+						pos:  position{line: 206, col: 29, offset: 6570},
 						name: "CounterSub2",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 205, col: 43, offset: 6535},
+						pos:  position{line: 206, col: 43, offset: 6584},
 						name: "CounterSubAlpha",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 205, col: 61, offset: 6553},
+						pos:  position{line: 206, col: 61, offset: 6602},
 						name: "CounterSubAlpha2",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 205, col: 80, offset: 6572},
+						pos:  position{line: 206, col: 80, offset: 6621},
 						name: "CounterSubStart",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 205, col: 98, offset: 6590},
+						pos:  position{line: 206, col: 98, offset: 6639},
 						name: "CounterSubStart2",
 					},
 				},
@@ -1365,29 +1365,29 @@ var g = &grammar{
 		},
 		{
 			name: "CounterSub1",
-			pos:  position{line: 207, col: 1, offset: 6608},
+			pos:  position{line: 208, col: 1, offset: 6657},
 			expr: &actionExpr{
-				pos: position{line: 207, col: 16, offset: 6623},
+				pos: position{line: 208, col: 16, offset: 6672},
 				run: (*parser).callonCounterSub11,
 				expr: &seqExpr{
-					pos: position{line: 207, col: 16, offset: 6623},
+					pos: position{line: 208, col: 16, offset: 6672},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 207, col: 16, offset: 6623},
+							pos:        position{line: 208, col: 16, offset: 6672},
 							val:        "{counter:",
 							ignoreCase: false,
 							want:       "\"{counter:\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 207, col: 28, offset: 6635},
+							pos:   position{line: 208, col: 28, offset: 6684},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 207, col: 33, offset: 6640},
+								pos:  position{line: 208, col: 33, offset: 6689},
 								name: "AttributeName",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 207, col: 47, offset: 6654},
+							pos:        position{line: 208, col: 47, offset: 6703},
 							val:        "}",
 							ignoreCase: false,
 							want:       "\"}\"",
@@ -1398,29 +1398,29 @@ var g = &grammar{
 		},
 		{
 			name: "CounterSub2",
-			pos:  position{line: 211, col: 1, offset: 6730},
+			pos:  position{line: 212, col: 1, offset: 6779},
 			expr: &actionExpr{
-				pos: position{line: 211, col: 16, offset: 6745},
+				pos: position{line: 212, col: 16, offset: 6794},
 				run: (*parser).callonCounterSub21,
 				expr: &seqExpr{
-					pos: position{line: 211, col: 16, offset: 6745},
+					pos: position{line: 212, col: 16, offset: 6794},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 211, col: 16, offset: 6745},
+							pos:        position{line: 212, col: 16, offset: 6794},
 							val:        "{counter2:",
 							ignoreCase: false,
 							want:       "\"{counter2:\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 211, col: 29, offset: 6758},
+							pos:   position{line: 212, col: 29, offset: 6807},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 211, col: 34, offset: 6763},
+								pos:  position{line: 212, col: 34, offset: 6812},
 								name: "AttributeName",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 211, col: 48, offset: 6777},
+							pos:        position{line: 212, col: 48, offset: 6826},
 							val:        "}",
 							ignoreCase: false,
 							want:       "\"}\"",
@@ -1431,38 +1431,38 @@ var g = &grammar{
 		},
 		{
 			name: "CounterSubAlpha",
-			pos:  position{line: 215, col: 1, offset: 6852},
+			pos:  position{line: 216, col: 1, offset: 6901},
 			expr: &actionExpr{
-				pos: position{line: 215, col: 20, offset: 6871},
+				pos: position{line: 216, col: 20, offset: 6920},
 				run: (*parser).callonCounterSubAlpha1,
 				expr: &seqExpr{
-					pos: position{line: 215, col: 20, offset: 6871},
+					pos: position{line: 216, col: 20, offset: 6920},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 215, col: 20, offset: 6871},
+							pos:        position{line: 216, col: 20, offset: 6920},
 							val:        "{counter:",
 							ignoreCase: false,
 							want:       "\"{counter:\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 215, col: 32, offset: 6883},
+							pos:   position{line: 216, col: 32, offset: 6932},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 215, col: 37, offset: 6888},
+								pos:  position{line: 216, col: 37, offset: 6937},
 								name: "AttributeName",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 215, col: 51, offset: 6902},
+							pos:        position{line: 216, col: 51, offset: 6951},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 215, col: 55, offset: 6906},
+							pos:   position{line: 216, col: 55, offset: 6955},
 							label: "start",
 							expr: &charClassMatcher{
-								pos:        position{line: 215, col: 61, offset: 6912},
+								pos:        position{line: 216, col: 61, offset: 6961},
 								val:        "[A-Za-z]",
 								ranges:     []rune{'A', 'Z', 'a', 'z'},
 								ignoreCase: false,
@@ -1470,7 +1470,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 215, col: 70, offset: 6921},
+							pos:        position{line: 216, col: 70, offset: 6970},
 							val:        "}",
 							ignoreCase: false,
 							want:       "\"}\"",
@@ -1481,38 +1481,38 @@ var g = &grammar{
 		},
 		{
 			name: "CounterSubAlpha2",
-			pos:  position{line: 219, col: 1, offset: 6999},
+			pos:  position{line: 220, col: 1, offset: 7048},
 			expr: &actionExpr{
-				pos: position{line: 219, col: 21, offset: 7019},
+				pos: position{line: 220, col: 21, offset: 7068},
 				run: (*parser).callonCounterSubAlpha21,
 				expr: &seqExpr{
-					pos: position{line: 219, col: 21, offset: 7019},
+					pos: position{line: 220, col: 21, offset: 7068},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 219, col: 21, offset: 7019},
+							pos:        position{line: 220, col: 21, offset: 7068},
 							val:        "{counter2:",
 							ignoreCase: false,
 							want:       "\"{counter2:\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 219, col: 34, offset: 7032},
+							pos:   position{line: 220, col: 34, offset: 7081},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 219, col: 39, offset: 7037},
+								pos:  position{line: 220, col: 39, offset: 7086},
 								name: "AttributeName",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 219, col: 53, offset: 7051},
+							pos:        position{line: 220, col: 53, offset: 7100},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 219, col: 57, offset: 7055},
+							pos:   position{line: 220, col: 57, offset: 7104},
 							label: "start",
 							expr: &charClassMatcher{
-								pos:        position{line: 219, col: 63, offset: 7061},
+								pos:        position{line: 220, col: 63, offset: 7110},
 								val:        "[A-Za-z]",
 								ranges:     []rune{'A', 'Z', 'a', 'z'},
 								ignoreCase: false,
@@ -1520,7 +1520,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 219, col: 72, offset: 7070},
+							pos:        position{line: 220, col: 72, offset: 7119},
 							val:        "}",
 							ignoreCase: false,
 							want:       "\"}\"",
@@ -1531,43 +1531,43 @@ var g = &grammar{
 		},
 		{
 			name: "CounterSubStart",
-			pos:  position{line: 223, col: 1, offset: 7147},
+			pos:  position{line: 224, col: 1, offset: 7196},
 			expr: &actionExpr{
-				pos: position{line: 223, col: 20, offset: 7166},
+				pos: position{line: 224, col: 20, offset: 7215},
 				run: (*parser).callonCounterSubStart1,
 				expr: &seqExpr{
-					pos: position{line: 223, col: 20, offset: 7166},
+					pos: position{line: 224, col: 20, offset: 7215},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 223, col: 20, offset: 7166},
+							pos:        position{line: 224, col: 20, offset: 7215},
 							val:        "{counter:",
 							ignoreCase: false,
 							want:       "\"{counter:\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 223, col: 32, offset: 7178},
+							pos:   position{line: 224, col: 32, offset: 7227},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 223, col: 37, offset: 7183},
+								pos:  position{line: 224, col: 37, offset: 7232},
 								name: "AttributeName",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 223, col: 51, offset: 7197},
+							pos:        position{line: 224, col: 51, offset: 7246},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 223, col: 55, offset: 7201},
+							pos:   position{line: 224, col: 55, offset: 7250},
 							label: "num",
 							expr: &actionExpr{
-								pos: position{line: 223, col: 60, offset: 7206},
+								pos: position{line: 224, col: 60, offset: 7255},
 								run: (*parser).callonCounterSubStart8,
 								expr: &oneOrMoreExpr{
-									pos: position{line: 223, col: 60, offset: 7206},
+									pos: position{line: 224, col: 60, offset: 7255},
 									expr: &charClassMatcher{
-										pos:        position{line: 223, col: 60, offset: 7206},
+										pos:        position{line: 224, col: 60, offset: 7255},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -1577,7 +1577,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 223, col: 108, offset: 7254},
+							pos:        position{line: 224, col: 108, offset: 7303},
 							val:        "}",
 							ignoreCase: false,
 							want:       "\"}\"",
@@ -1588,43 +1588,43 @@ var g = &grammar{
 		},
 		{
 			name: "CounterSubStart2",
-			pos:  position{line: 227, col: 1, offset: 7336},
+			pos:  position{line: 228, col: 1, offset: 7385},
 			expr: &actionExpr{
-				pos: position{line: 227, col: 21, offset: 7356},
+				pos: position{line: 228, col: 21, offset: 7405},
 				run: (*parser).callonCounterSubStart21,
 				expr: &seqExpr{
-					pos: position{line: 227, col: 21, offset: 7356},
+					pos: position{line: 228, col: 21, offset: 7405},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 227, col: 21, offset: 7356},
+							pos:        position{line: 228, col: 21, offset: 7405},
 							val:        "{counter2:",
 							ignoreCase: false,
 							want:       "\"{counter2:\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 227, col: 34, offset: 7369},
+							pos:   position{line: 228, col: 34, offset: 7418},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 227, col: 39, offset: 7374},
+								pos:  position{line: 228, col: 39, offset: 7423},
 								name: "AttributeName",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 227, col: 53, offset: 7388},
+							pos:        position{line: 228, col: 53, offset: 7437},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 227, col: 57, offset: 7392},
+							pos:   position{line: 228, col: 57, offset: 7441},
 							label: "num",
 							expr: &actionExpr{
-								pos: position{line: 227, col: 62, offset: 7397},
+								pos: position{line: 228, col: 62, offset: 7446},
 								run: (*parser).callonCounterSubStart28,
 								expr: &oneOrMoreExpr{
-									pos: position{line: 227, col: 62, offset: 7397},
+									pos: position{line: 228, col: 62, offset: 7446},
 									expr: &charClassMatcher{
-										pos:        position{line: 227, col: 62, offset: 7397},
+										pos:        position{line: 228, col: 62, offset: 7446},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -1634,7 +1634,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 227, col: 110, offset: 7445},
+							pos:        position{line: 228, col: 110, offset: 7494},
 							val:        "}",
 							ignoreCase: false,
 							want:       "\"}\"",
@@ -1645,37 +1645,37 @@ var g = &grammar{
 		},
 		{
 			name: "InlineElementID",
-			pos:  position{line: 231, col: 1, offset: 7526},
+			pos:  position{line: 232, col: 1, offset: 7575},
 			expr: &actionExpr{
-				pos: position{line: 231, col: 20, offset: 7545},
+				pos: position{line: 232, col: 20, offset: 7594},
 				run: (*parser).callonInlineElementID1,
 				expr: &seqExpr{
-					pos: position{line: 231, col: 20, offset: 7545},
+					pos: position{line: 232, col: 20, offset: 7594},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 231, col: 20, offset: 7545},
+							pos:        position{line: 232, col: 20, offset: 7594},
 							val:        "[[",
 							ignoreCase: false,
 							want:       "\"[[\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 231, col: 25, offset: 7550},
+							pos:   position{line: 232, col: 25, offset: 7599},
 							label: "id",
 							expr: &ruleRefExpr{
-								pos:  position{line: 231, col: 29, offset: 7554},
+								pos:  position{line: 232, col: 29, offset: 7603},
 								name: "Id",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 231, col: 33, offset: 7558},
+							pos:        position{line: 232, col: 33, offset: 7607},
 							val:        "]]",
 							ignoreCase: false,
 							want:       "\"]]\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 231, col: 38, offset: 7563},
+							pos: position{line: 232, col: 38, offset: 7612},
 							expr: &ruleRefExpr{
-								pos:  position{line: 231, col: 38, offset: 7563},
+								pos:  position{line: 232, col: 38, offset: 7612},
 								name: "Space",
 							},
 						},
@@ -1685,63 +1685,63 @@ var g = &grammar{
 		},
 		{
 			name: "StandaloneAttributeKey",
-			pos:  position{line: 235, col: 1, offset: 7702},
+			pos:  position{line: 236, col: 1, offset: 7751},
 			expr: &actionExpr{
-				pos: position{line: 235, col: 27, offset: 7728},
+				pos: position{line: 236, col: 27, offset: 7777},
 				run: (*parser).callonStandaloneAttributeKey1,
 				expr: &seqExpr{
-					pos: position{line: 235, col: 27, offset: 7728},
+					pos: position{line: 236, col: 27, offset: 7777},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 235, col: 27, offset: 7728},
+							pos: position{line: 236, col: 27, offset: 7777},
 							expr: &litMatcher{
-								pos:        position{line: 235, col: 28, offset: 7729},
+								pos:        position{line: 236, col: 28, offset: 7778},
 								val:        "quote",
 								ignoreCase: false,
 								want:       "\"quote\"",
 							},
 						},
 						&notExpr{
-							pos: position{line: 235, col: 36, offset: 7737},
+							pos: position{line: 236, col: 36, offset: 7786},
 							expr: &litMatcher{
-								pos:        position{line: 235, col: 37, offset: 7738},
+								pos:        position{line: 236, col: 37, offset: 7787},
 								val:        "verse",
 								ignoreCase: false,
 								want:       "\"verse\"",
 							},
 						},
 						&notExpr{
-							pos: position{line: 235, col: 45, offset: 7746},
+							pos: position{line: 236, col: 45, offset: 7795},
 							expr: &litMatcher{
-								pos:        position{line: 235, col: 46, offset: 7747},
+								pos:        position{line: 236, col: 46, offset: 7796},
 								val:        "literal",
 								ignoreCase: false,
 								want:       "\"literal\"",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 235, col: 56, offset: 7757},
+							pos:   position{line: 236, col: 56, offset: 7806},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 235, col: 61, offset: 7762},
+								pos:  position{line: 236, col: 61, offset: 7811},
 								name: "NamedAttributeKey",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 235, col: 80, offset: 7781},
+							pos: position{line: 236, col: 80, offset: 7830},
 							expr: &seqExpr{
-								pos: position{line: 235, col: 81, offset: 7782},
+								pos: position{line: 236, col: 81, offset: 7831},
 								exprs: []interface{}{
 									&litMatcher{
-										pos:        position{line: 235, col: 81, offset: 7782},
+										pos:        position{line: 236, col: 81, offset: 7831},
 										val:        ",",
 										ignoreCase: false,
 										want:       "\",\"",
 									},
 									&zeroOrMoreExpr{
-										pos: position{line: 235, col: 85, offset: 7786},
+										pos: position{line: 236, col: 85, offset: 7835},
 										expr: &ruleRefExpr{
-											pos:  position{line: 235, col: 85, offset: 7786},
+											pos:  position{line: 236, col: 85, offset: 7835},
 											name: "Space",
 										},
 									},
@@ -1754,46 +1754,46 @@ var g = &grammar{
 		},
 		{
 			name: "BlockAttributes",
-			pos:  position{line: 242, col: 1, offset: 7996},
+			pos:  position{line: 243, col: 1, offset: 8045},
 			expr: &actionExpr{
-				pos: position{line: 243, col: 5, offset: 8020},
+				pos: position{line: 244, col: 5, offset: 8069},
 				run: (*parser).callonBlockAttributes1,
 				expr: &labeledExpr{
-					pos:   position{line: 243, col: 5, offset: 8020},
+					pos:   position{line: 244, col: 5, offset: 8069},
 					label: "attributes",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 243, col: 16, offset: 8031},
+						pos: position{line: 244, col: 16, offset: 8080},
 						expr: &choiceExpr{
-							pos: position{line: 245, col: 9, offset: 8098},
+							pos: position{line: 246, col: 9, offset: 8147},
 							alternatives: []interface{}{
 								&actionExpr{
-									pos: position{line: 245, col: 10, offset: 8099},
+									pos: position{line: 246, col: 10, offset: 8148},
 									run: (*parser).callonBlockAttributes5,
 									expr: &seqExpr{
-										pos: position{line: 245, col: 10, offset: 8099},
+										pos: position{line: 246, col: 10, offset: 8148},
 										exprs: []interface{}{
 											&labeledExpr{
-												pos:   position{line: 245, col: 10, offset: 8099},
+												pos:   position{line: 246, col: 10, offset: 8148},
 												label: "anchor",
 												expr: &ruleRefExpr{
-													pos:  position{line: 245, col: 18, offset: 8107},
+													pos:  position{line: 246, col: 18, offset: 8156},
 													name: "ShortHandAnchor",
 												},
 											},
 											&oneOrMoreExpr{
-												pos: position{line: 245, col: 35, offset: 8124},
+												pos: position{line: 246, col: 35, offset: 8173},
 												expr: &seqExpr{
-													pos: position{line: 245, col: 36, offset: 8125},
+													pos: position{line: 246, col: 36, offset: 8174},
 													exprs: []interface{}{
 														&zeroOrMoreExpr{
-															pos: position{line: 245, col: 36, offset: 8125},
+															pos: position{line: 246, col: 36, offset: 8174},
 															expr: &ruleRefExpr{
-																pos:  position{line: 245, col: 36, offset: 8125},
+																pos:  position{line: 246, col: 36, offset: 8174},
 																name: "Space",
 															},
 														},
 														&ruleRefExpr{
-															pos:  position{line: 245, col: 43, offset: 8132},
+															pos:  position{line: 246, col: 43, offset: 8181},
 															name: "Newline",
 														},
 													},
@@ -1803,33 +1803,33 @@ var g = &grammar{
 									},
 								},
 								&actionExpr{
-									pos: position{line: 249, col: 12, offset: 8252},
+									pos: position{line: 250, col: 12, offset: 8301},
 									run: (*parser).callonBlockAttributes14,
 									expr: &seqExpr{
-										pos: position{line: 249, col: 12, offset: 8252},
+										pos: position{line: 250, col: 12, offset: 8301},
 										exprs: []interface{}{
 											&labeledExpr{
-												pos:   position{line: 249, col: 12, offset: 8252},
+												pos:   position{line: 250, col: 12, offset: 8301},
 												label: "title",
 												expr: &ruleRefExpr{
-													pos:  position{line: 249, col: 19, offset: 8259},
+													pos:  position{line: 250, col: 19, offset: 8308},
 													name: "ShortHandTitle",
 												},
 											},
 											&oneOrMoreExpr{
-												pos: position{line: 249, col: 35, offset: 8275},
+												pos: position{line: 250, col: 35, offset: 8324},
 												expr: &seqExpr{
-													pos: position{line: 249, col: 36, offset: 8276},
+													pos: position{line: 250, col: 36, offset: 8325},
 													exprs: []interface{}{
 														&zeroOrMoreExpr{
-															pos: position{line: 249, col: 36, offset: 8276},
+															pos: position{line: 250, col: 36, offset: 8325},
 															expr: &ruleRefExpr{
-																pos:  position{line: 249, col: 36, offset: 8276},
+																pos:  position{line: 250, col: 36, offset: 8325},
 																name: "Space",
 															},
 														},
 														&ruleRefExpr{
-															pos:  position{line: 249, col: 43, offset: 8283},
+															pos:  position{line: 250, col: 43, offset: 8332},
 															name: "Newline",
 														},
 													},
@@ -1839,33 +1839,33 @@ var g = &grammar{
 									},
 								},
 								&actionExpr{
-									pos: position{line: 253, col: 12, offset: 8373},
+									pos: position{line: 254, col: 12, offset: 8422},
 									run: (*parser).callonBlockAttributes23,
 									expr: &seqExpr{
-										pos: position{line: 253, col: 12, offset: 8373},
+										pos: position{line: 254, col: 12, offset: 8422},
 										exprs: []interface{}{
 											&labeledExpr{
-												pos:   position{line: 253, col: 12, offset: 8373},
+												pos:   position{line: 254, col: 12, offset: 8422},
 												label: "attributes",
 												expr: &ruleRefExpr{
-													pos:  position{line: 253, col: 24, offset: 8385},
+													pos:  position{line: 254, col: 24, offset: 8434},
 													name: "LongHandAttributes",
 												},
 											},
 											&oneOrMoreExpr{
-												pos: position{line: 253, col: 44, offset: 8405},
+												pos: position{line: 254, col: 44, offset: 8454},
 												expr: &seqExpr{
-													pos: position{line: 253, col: 45, offset: 8406},
+													pos: position{line: 254, col: 45, offset: 8455},
 													exprs: []interface{}{
 														&zeroOrMoreExpr{
-															pos: position{line: 253, col: 45, offset: 8406},
+															pos: position{line: 254, col: 45, offset: 8455},
 															expr: &ruleRefExpr{
-																pos:  position{line: 253, col: 45, offset: 8406},
+																pos:  position{line: 254, col: 45, offset: 8455},
 																name: "Space",
 															},
 														},
 														&ruleRefExpr{
-															pos:  position{line: 253, col: 52, offset: 8413},
+															pos:  position{line: 254, col: 52, offset: 8462},
 															name: "Newline",
 														},
 													},
@@ -1882,37 +1882,37 @@ var g = &grammar{
 		},
 		{
 			name: "InlineAttributes",
-			pos:  position{line: 260, col: 1, offset: 8553},
+			pos:  position{line: 261, col: 1, offset: 8602},
 			expr: &actionExpr{
-				pos: position{line: 261, col: 5, offset: 8577},
+				pos: position{line: 262, col: 5, offset: 8626},
 				run: (*parser).callonInlineAttributes1,
 				expr: &seqExpr{
-					pos: position{line: 261, col: 5, offset: 8577},
+					pos: position{line: 262, col: 5, offset: 8626},
 					exprs: []interface{}{
 						&stateCodeExpr{
-							pos: position{line: 261, col: 5, offset: 8577},
+							pos: position{line: 262, col: 5, offset: 8626},
 							run: (*parser).callonInlineAttributes3,
 						},
 						&litMatcher{
-							pos:        position{line: 264, col: 5, offset: 8628},
+							pos:        position{line: 265, col: 5, offset: 8677},
 							val:        "[",
 							ignoreCase: false,
 							want:       "\"[\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 265, col: 5, offset: 8636},
+							pos:   position{line: 266, col: 5, offset: 8685},
 							label: "attributes",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 265, col: 16, offset: 8647},
+								pos: position{line: 266, col: 16, offset: 8696},
 								expr: &choiceExpr{
-									pos: position{line: 265, col: 17, offset: 8648},
+									pos: position{line: 266, col: 17, offset: 8697},
 									alternatives: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 265, col: 17, offset: 8648},
+											pos:  position{line: 266, col: 17, offset: 8697},
 											name: "PositionalAttribute",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 265, col: 37, offset: 8668},
+											pos:  position{line: 266, col: 37, offset: 8717},
 											name: "NamedAttribute",
 										},
 									},
@@ -1920,7 +1920,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 266, col: 5, offset: 8689},
+							pos:        position{line: 267, col: 5, offset: 8738},
 							val:        "]",
 							ignoreCase: false,
 							want:       "\"]\"",
@@ -1931,25 +1931,25 @@ var g = &grammar{
 		},
 		{
 			name: "StandaloneAttributes",
-			pos:  position{line: 271, col: 1, offset: 8823},
+			pos:  position{line: 272, col: 1, offset: 8872},
 			expr: &actionExpr{
-				pos: position{line: 271, col: 25, offset: 8847},
+				pos: position{line: 272, col: 25, offset: 8896},
 				run: (*parser).callonStandaloneAttributes1,
 				expr: &seqExpr{
-					pos: position{line: 271, col: 25, offset: 8847},
+					pos: position{line: 272, col: 25, offset: 8896},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 271, col: 25, offset: 8847},
+							pos:   position{line: 272, col: 25, offset: 8896},
 							label: "attributes",
 							expr: &ruleRefExpr{
-								pos:  position{line: 271, col: 37, offset: 8859},
+								pos:  position{line: 272, col: 37, offset: 8908},
 								name: "BlockAttributes",
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 271, col: 54, offset: 8876},
+							pos: position{line: 272, col: 54, offset: 8925},
 							expr: &ruleRefExpr{
-								pos:  position{line: 271, col: 54, offset: 8876},
+								pos:  position{line: 272, col: 54, offset: 8925},
 								name: "BlankLine",
 							},
 						},
@@ -1959,40 +1959,40 @@ var g = &grammar{
 		},
 		{
 			name: "ShortHandAnchor",
-			pos:  position{line: 276, col: 1, offset: 8969},
+			pos:  position{line: 277, col: 1, offset: 9018},
 			expr: &actionExpr{
-				pos: position{line: 277, col: 4, offset: 8991},
+				pos: position{line: 278, col: 4, offset: 9040},
 				run: (*parser).callonShortHandAnchor1,
 				expr: &seqExpr{
-					pos: position{line: 277, col: 4, offset: 8991},
+					pos: position{line: 278, col: 4, offset: 9040},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 277, col: 4, offset: 8991},
+							pos:        position{line: 278, col: 4, offset: 9040},
 							val:        "[[",
 							ignoreCase: false,
 							want:       "\"[[\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 278, col: 5, offset: 9001},
+							pos:   position{line: 279, col: 5, offset: 9050},
 							label: "id",
 							expr: &actionExpr{
-								pos: position{line: 279, col: 9, offset: 9014},
+								pos: position{line: 280, col: 9, offset: 9063},
 								run: (*parser).callonShortHandAnchor5,
 								expr: &labeledExpr{
-									pos:   position{line: 279, col: 9, offset: 9014},
+									pos:   position{line: 280, col: 9, offset: 9063},
 									label: "elements",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 279, col: 18, offset: 9023},
+										pos: position{line: 280, col: 18, offset: 9072},
 										expr: &choiceExpr{
-											pos: position{line: 280, col: 13, offset: 9037},
+											pos: position{line: 281, col: 13, offset: 9086},
 											alternatives: []interface{}{
 												&actionExpr{
-													pos: position{line: 280, col: 14, offset: 9038},
+													pos: position{line: 281, col: 14, offset: 9087},
 													run: (*parser).callonShortHandAnchor9,
 													expr: &oneOrMoreExpr{
-														pos: position{line: 280, col: 14, offset: 9038},
+														pos: position{line: 281, col: 14, offset: 9087},
 														expr: &charClassMatcher{
-															pos:        position{line: 280, col: 14, offset: 9038},
+															pos:        position{line: 281, col: 14, offset: 9087},
 															val:        "[^=\\r\\n\\uFFFD{\\]]",
 															chars:      []rune{'=', '\r', '\n', '�', '{', ']'},
 															ignoreCase: false,
@@ -2001,18 +2001,18 @@ var g = &grammar{
 													},
 												},
 												&ruleRefExpr{
-													pos:  position{line: 283, col: 13, offset: 9205},
+													pos:  position{line: 284, col: 13, offset: 9254},
 													name: "ElementPlaceHolder",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 284, col: 13, offset: 9238},
+													pos:  position{line: 285, col: 13, offset: 9287},
 													name: "AttrSub",
 												},
 												&actionExpr{
-													pos: position{line: 285, col: 14, offset: 9261},
+													pos: position{line: 286, col: 14, offset: 9310},
 													run: (*parser).callonShortHandAnchor14,
 													expr: &litMatcher{
-														pos:        position{line: 285, col: 14, offset: 9261},
+														pos:        position{line: 286, col: 14, offset: 9310},
 														val:        "{",
 														ignoreCase: false,
 														want:       "\"{\"",
@@ -2025,7 +2025,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 291, col: 5, offset: 9447},
+							pos:        position{line: 292, col: 5, offset: 9496},
 							val:        "]]",
 							ignoreCase: false,
 							want:       "\"]]\"",
@@ -2036,32 +2036,32 @@ var g = &grammar{
 		},
 		{
 			name: "ShortHandTitle",
-			pos:  position{line: 296, col: 1, offset: 9548},
+			pos:  position{line: 297, col: 1, offset: 9597},
 			expr: &actionExpr{
-				pos: position{line: 296, col: 19, offset: 9566},
+				pos: position{line: 297, col: 19, offset: 9615},
 				run: (*parser).callonShortHandTitle1,
 				expr: &seqExpr{
-					pos: position{line: 296, col: 19, offset: 9566},
+					pos: position{line: 297, col: 19, offset: 9615},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 296, col: 19, offset: 9566},
+							pos:        position{line: 297, col: 19, offset: 9615},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 296, col: 23, offset: 9570},
+							pos:   position{line: 297, col: 23, offset: 9619},
 							label: "title",
 							expr: &actionExpr{
-								pos: position{line: 297, col: 5, offset: 9582},
+								pos: position{line: 298, col: 5, offset: 9631},
 								run: (*parser).callonShortHandTitle5,
 								expr: &seqExpr{
-									pos: position{line: 297, col: 5, offset: 9582},
+									pos: position{line: 298, col: 5, offset: 9631},
 									exprs: []interface{}{
 										&notExpr{
-											pos: position{line: 297, col: 5, offset: 9582},
+											pos: position{line: 298, col: 5, offset: 9631},
 											expr: &charClassMatcher{
-												pos:        position{line: 297, col: 6, offset: 9583},
+												pos:        position{line: 298, col: 6, offset: 9632},
 												val:        "[. ]",
 												chars:      []rune{'.', ' '},
 												ignoreCase: false,
@@ -2069,20 +2069,20 @@ var g = &grammar{
 											},
 										},
 										&labeledExpr{
-											pos:   position{line: 298, col: 5, offset: 9695},
+											pos:   position{line: 299, col: 5, offset: 9744},
 											label: "elements",
 											expr: &oneOrMoreExpr{
-												pos: position{line: 298, col: 14, offset: 9704},
+												pos: position{line: 299, col: 14, offset: 9753},
 												expr: &choiceExpr{
-													pos: position{line: 299, col: 9, offset: 9714},
+													pos: position{line: 300, col: 9, offset: 9763},
 													alternatives: []interface{}{
 														&actionExpr{
-															pos: position{line: 299, col: 10, offset: 9715},
+															pos: position{line: 300, col: 10, offset: 9764},
 															run: (*parser).callonShortHandTitle12,
 															expr: &oneOrMoreExpr{
-																pos: position{line: 299, col: 10, offset: 9715},
+																pos: position{line: 300, col: 10, offset: 9764},
 																expr: &charClassMatcher{
-																	pos:        position{line: 299, col: 10, offset: 9715},
+																	pos:        position{line: 300, col: 10, offset: 9764},
 																	val:        "[^\\r\\n\\uFFFD{]",
 																	chars:      []rune{'\r', '\n', '�', '{'},
 																	ignoreCase: false,
@@ -2091,18 +2091,18 @@ var g = &grammar{
 															},
 														},
 														&ruleRefExpr{
-															pos:  position{line: 302, col: 9, offset: 9813},
+															pos:  position{line: 303, col: 9, offset: 9862},
 															name: "ElementPlaceHolder",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 303, col: 9, offset: 9842},
+															pos:  position{line: 304, col: 9, offset: 9891},
 															name: "AttrSub",
 														},
 														&actionExpr{
-															pos: position{line: 304, col: 10, offset: 9861},
+															pos: position{line: 305, col: 10, offset: 9910},
 															run: (*parser).callonShortHandTitle17,
 															expr: &litMatcher{
-																pos:        position{line: 304, col: 10, offset: 9861},
+																pos:        position{line: 305, col: 10, offset: 9910},
 																val:        "{",
 																ignoreCase: false,
 																want:       "\"{\"",
@@ -2122,48 +2122,48 @@ var g = &grammar{
 		},
 		{
 			name: "LongHandAttributes",
-			pos:  position{line: 315, col: 1, offset: 10261},
+			pos:  position{line: 316, col: 1, offset: 10310},
 			expr: &actionExpr{
-				pos: position{line: 316, col: 5, offset: 10287},
+				pos: position{line: 317, col: 5, offset: 10336},
 				run: (*parser).callonLongHandAttributes1,
 				expr: &seqExpr{
-					pos: position{line: 316, col: 5, offset: 10287},
+					pos: position{line: 317, col: 5, offset: 10336},
 					exprs: []interface{}{
 						&stateCodeExpr{
-							pos: position{line: 316, col: 5, offset: 10287},
+							pos: position{line: 317, col: 5, offset: 10336},
 							run: (*parser).callonLongHandAttributes3,
 						},
 						&litMatcher{
-							pos:        position{line: 319, col: 5, offset: 10338},
+							pos:        position{line: 320, col: 5, offset: 10387},
 							val:        "[",
 							ignoreCase: false,
 							want:       "\"[\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 321, col: 5, offset: 10404},
+							pos:   position{line: 322, col: 5, offset: 10453},
 							label: "firstPositionalAttribute",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 321, col: 30, offset: 10429},
+								pos: position{line: 322, col: 30, offset: 10478},
 								expr: &ruleRefExpr{
-									pos:  position{line: 321, col: 31, offset: 10430},
+									pos:  position{line: 322, col: 31, offset: 10479},
 									name: "FirstPositionalAttribute",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 322, col: 5, offset: 10461},
+							pos:   position{line: 323, col: 5, offset: 10510},
 							label: "otherAttributes",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 322, col: 21, offset: 10477},
+								pos: position{line: 323, col: 21, offset: 10526},
 								expr: &choiceExpr{
-									pos: position{line: 322, col: 22, offset: 10478},
+									pos: position{line: 323, col: 22, offset: 10527},
 									alternatives: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 322, col: 22, offset: 10478},
+											pos:  position{line: 323, col: 22, offset: 10527},
 											name: "PositionalAttribute",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 322, col: 44, offset: 10500},
+											pos:  position{line: 323, col: 44, offset: 10549},
 											name: "NamedAttribute",
 										},
 									},
@@ -2171,7 +2171,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 323, col: 5, offset: 10521},
+							pos:        position{line: 324, col: 5, offset: 10570},
 							val:        "]",
 							ignoreCase: false,
 							want:       "\"]\"",
@@ -2182,42 +2182,42 @@ var g = &grammar{
 		},
 		{
 			name: "FirstPositionalAttribute",
-			pos:  position{line: 334, col: 1, offset: 10978},
+			pos:  position{line: 335, col: 1, offset: 11027},
 			expr: &actionExpr{
-				pos: position{line: 335, col: 5, offset: 11011},
+				pos: position{line: 336, col: 5, offset: 11060},
 				run: (*parser).callonFirstPositionalAttribute1,
 				expr: &seqExpr{
-					pos: position{line: 335, col: 5, offset: 11011},
+					pos: position{line: 336, col: 5, offset: 11060},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 335, col: 5, offset: 11011},
+							pos:   position{line: 336, col: 5, offset: 11060},
 							label: "main",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 335, col: 10, offset: 11016},
+								pos: position{line: 336, col: 10, offset: 11065},
 								expr: &ruleRefExpr{
-									pos:  position{line: 336, col: 9, offset: 11026},
+									pos:  position{line: 337, col: 9, offset: 11075},
 									name: "ShortHandAttribute",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 338, col: 5, offset: 11056},
+							pos:   position{line: 339, col: 5, offset: 11105},
 							label: "extras",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 338, col: 12, offset: 11063},
+								pos: position{line: 339, col: 12, offset: 11112},
 								expr: &choiceExpr{
-									pos: position{line: 339, col: 9, offset: 11074},
+									pos: position{line: 340, col: 9, offset: 11123},
 									alternatives: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 339, col: 9, offset: 11074},
+											pos:  position{line: 340, col: 9, offset: 11123},
 											name: "ShortHandIDAttribute",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 340, col: 11, offset: 11106},
+											pos:  position{line: 341, col: 11, offset: 11155},
 											name: "ShortHandOptionAttribute",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 341, col: 11, offset: 11141},
+											pos:  position{line: 342, col: 11, offset: 11190},
 											name: "ShortHandDotRoleAttribute",
 										},
 									},
@@ -2225,20 +2225,20 @@ var g = &grammar{
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 342, col: 8, offset: 11174},
+							pos: position{line: 343, col: 8, offset: 11223},
 							expr: &seqExpr{
-								pos: position{line: 342, col: 9, offset: 11175},
+								pos: position{line: 343, col: 9, offset: 11224},
 								exprs: []interface{}{
 									&litMatcher{
-										pos:        position{line: 342, col: 9, offset: 11175},
+										pos:        position{line: 343, col: 9, offset: 11224},
 										val:        ",",
 										ignoreCase: false,
 										want:       "\",\"",
 									},
 									&zeroOrMoreExpr{
-										pos: position{line: 342, col: 13, offset: 11179},
+										pos: position{line: 343, col: 13, offset: 11228},
 										expr: &ruleRefExpr{
-											pos:  position{line: 342, col: 13, offset: 11179},
+											pos:  position{line: 343, col: 13, offset: 11228},
 											name: "Space",
 										},
 									},
@@ -2246,7 +2246,7 @@ var g = &grammar{
 							},
 						},
 						&andCodeExpr{
-							pos: position{line: 343, col: 5, offset: 11193},
+							pos: position{line: 344, col: 5, offset: 11242},
 							run: (*parser).callonFirstPositionalAttribute17,
 						},
 					},
@@ -2255,24 +2255,24 @@ var g = &grammar{
 		},
 		{
 			name: "ShortHandIDAttribute",
-			pos:  position{line: 357, col: 1, offset: 11550},
+			pos:  position{line: 358, col: 1, offset: 11599},
 			expr: &actionExpr{
-				pos: position{line: 357, col: 25, offset: 11574},
+				pos: position{line: 358, col: 25, offset: 11623},
 				run: (*parser).callonShortHandIDAttribute1,
 				expr: &seqExpr{
-					pos: position{line: 357, col: 25, offset: 11574},
+					pos: position{line: 358, col: 25, offset: 11623},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 357, col: 25, offset: 11574},
+							pos:        position{line: 358, col: 25, offset: 11623},
 							val:        "#",
 							ignoreCase: false,
 							want:       "\"#\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 357, col: 29, offset: 11578},
+							pos:   position{line: 358, col: 29, offset: 11627},
 							label: "id",
 							expr: &ruleRefExpr{
-								pos:  position{line: 357, col: 33, offset: 11582},
+								pos:  position{line: 358, col: 33, offset: 11631},
 								name: "ShortHandAttributeValue",
 							},
 						},
@@ -2282,15 +2282,15 @@ var g = &grammar{
 		},
 		{
 			name: "ShortHandAttribute",
-			pos:  position{line: 365, col: 1, offset: 11745},
+			pos:  position{line: 366, col: 1, offset: 11794},
 			expr: &actionExpr{
-				pos: position{line: 365, col: 23, offset: 11767},
+				pos: position{line: 366, col: 23, offset: 11816},
 				run: (*parser).callonShortHandAttribute1,
 				expr: &labeledExpr{
-					pos:   position{line: 365, col: 23, offset: 11767},
+					pos:   position{line: 366, col: 23, offset: 11816},
 					label: "value",
 					expr: &ruleRefExpr{
-						pos:  position{line: 365, col: 30, offset: 11774},
+						pos:  position{line: 366, col: 30, offset: 11823},
 						name: "ShortHandAttributeValue",
 					},
 				},
@@ -2298,24 +2298,24 @@ var g = &grammar{
 		},
 		{
 			name: "ShortHandDotRoleAttribute",
-			pos:  position{line: 374, col: 1, offset: 11992},
+			pos:  position{line: 375, col: 1, offset: 12041},
 			expr: &actionExpr{
-				pos: position{line: 374, col: 30, offset: 12021},
+				pos: position{line: 375, col: 30, offset: 12070},
 				run: (*parser).callonShortHandDotRoleAttribute1,
 				expr: &seqExpr{
-					pos: position{line: 374, col: 30, offset: 12021},
+					pos: position{line: 375, col: 30, offset: 12070},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 374, col: 30, offset: 12021},
+							pos:        position{line: 375, col: 30, offset: 12070},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 374, col: 34, offset: 12025},
+							pos:   position{line: 375, col: 34, offset: 12074},
 							label: "role",
 							expr: &ruleRefExpr{
-								pos:  position{line: 374, col: 40, offset: 12031},
+								pos:  position{line: 375, col: 40, offset: 12080},
 								name: "ShortHandAttributeValue",
 							},
 						},
@@ -2325,24 +2325,24 @@ var g = &grammar{
 		},
 		{
 			name: "ShortHandOptionAttribute",
-			pos:  position{line: 379, col: 1, offset: 12145},
+			pos:  position{line: 380, col: 1, offset: 12194},
 			expr: &actionExpr{
-				pos: position{line: 379, col: 29, offset: 12173},
+				pos: position{line: 380, col: 29, offset: 12222},
 				run: (*parser).callonShortHandOptionAttribute1,
 				expr: &seqExpr{
-					pos: position{line: 379, col: 29, offset: 12173},
+					pos: position{line: 380, col: 29, offset: 12222},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 379, col: 29, offset: 12173},
+							pos:        position{line: 380, col: 29, offset: 12222},
 							val:        "%",
 							ignoreCase: false,
 							want:       "\"%\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 379, col: 33, offset: 12177},
+							pos:   position{line: 380, col: 33, offset: 12226},
 							label: "option",
 							expr: &ruleRefExpr{
-								pos:  position{line: 379, col: 41, offset: 12185},
+								pos:  position{line: 380, col: 41, offset: 12234},
 								name: "ShortHandAttributeValue",
 							},
 						},
@@ -2352,39 +2352,39 @@ var g = &grammar{
 		},
 		{
 			name: "ShortHandAttributeValue",
-			pos:  position{line: 384, col: 1, offset: 12290},
+			pos:  position{line: 385, col: 1, offset: 12339},
 			expr: &choiceExpr{
-				pos: position{line: 385, col: 5, offset: 12322},
+				pos: position{line: 386, col: 5, offset: 12371},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 385, col: 5, offset: 12322},
+						pos:  position{line: 386, col: 5, offset: 12371},
 						name: "SingleQuotedAttributeValue",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 386, col: 7, offset: 12356},
+						pos:  position{line: 387, col: 7, offset: 12405},
 						name: "DoubleQuotedAttributeValue",
 					},
 					&actionExpr{
-						pos: position{line: 387, col: 7, offset: 12390},
+						pos: position{line: 388, col: 7, offset: 12439},
 						run: (*parser).callonShortHandAttributeValue4,
 						expr: &seqExpr{
-							pos: position{line: 387, col: 7, offset: 12390},
+							pos: position{line: 388, col: 7, offset: 12439},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 387, col: 7, offset: 12390},
+									pos:   position{line: 388, col: 7, offset: 12439},
 									label: "elements",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 387, col: 16, offset: 12399},
+										pos: position{line: 388, col: 16, offset: 12448},
 										expr: &choiceExpr{
-											pos: position{line: 390, col: 5, offset: 12569},
+											pos: position{line: 391, col: 5, offset: 12618},
 											alternatives: []interface{}{
 												&actionExpr{
-													pos: position{line: 390, col: 6, offset: 12570},
+													pos: position{line: 391, col: 6, offset: 12619},
 													run: (*parser).callonShortHandAttributeValue9,
 													expr: &oneOrMoreExpr{
-														pos: position{line: 390, col: 6, offset: 12570},
+														pos: position{line: 391, col: 6, offset: 12619},
 														expr: &charClassMatcher{
-															pos:        position{line: 390, col: 6, offset: 12570},
+															pos:        position{line: 391, col: 6, offset: 12619},
 															val:        "[^,=.%# \\r\\n\\uFFFD{\\]]",
 															chars:      []rune{',', '=', '.', '%', '#', ' ', '\r', '\n', '�', '{', ']'},
 															ignoreCase: false,
@@ -2393,18 +2393,18 @@ var g = &grammar{
 													},
 												},
 												&ruleRefExpr{
-													pos:  position{line: 393, col: 5, offset: 12664},
+													pos:  position{line: 394, col: 5, offset: 12713},
 													name: "ElementPlaceHolder",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 394, col: 5, offset: 12689},
+													pos:  position{line: 395, col: 5, offset: 12738},
 													name: "AttrSub",
 												},
 												&actionExpr{
-													pos: position{line: 395, col: 6, offset: 12704},
+													pos: position{line: 396, col: 6, offset: 12753},
 													run: (*parser).callonShortHandAttributeValue14,
 													expr: &litMatcher{
-														pos:        position{line: 395, col: 6, offset: 12704},
+														pos:        position{line: 396, col: 6, offset: 12753},
 														val:        "{",
 														ignoreCase: false,
 														want:       "\"{\"",
@@ -2415,9 +2415,9 @@ var g = &grammar{
 									},
 								},
 								&andExpr{
-									pos: position{line: 397, col: 10, offset: 12774},
+									pos: position{line: 398, col: 10, offset: 12823},
 									expr: &charClassMatcher{
-										pos:        position{line: 397, col: 11, offset: 12775},
+										pos:        position{line: 398, col: 11, offset: 12824},
 										val:        "[^=]",
 										chars:      []rune{'='},
 										ignoreCase: false,
@@ -2432,42 +2432,42 @@ var g = &grammar{
 		},
 		{
 			name: "PositionalAttribute",
-			pos:  position{line: 401, col: 1, offset: 12851},
+			pos:  position{line: 402, col: 1, offset: 12900},
 			expr: &choiceExpr{
-				pos: position{line: 401, col: 24, offset: 12874},
+				pos: position{line: 402, col: 24, offset: 12923},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 402, col: 5, offset: 12880},
+						pos: position{line: 403, col: 5, offset: 12929},
 						run: (*parser).callonPositionalAttribute2,
 						expr: &seqExpr{
-							pos: position{line: 402, col: 5, offset: 12880},
+							pos: position{line: 403, col: 5, offset: 12929},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 402, col: 5, offset: 12880},
+									pos:   position{line: 403, col: 5, offset: 12929},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 402, col: 12, offset: 12887},
+										pos:  position{line: 403, col: 12, offset: 12936},
 										name: "AttributeValue",
 									},
 								},
 								&choiceExpr{
-									pos: position{line: 402, col: 29, offset: 12904},
+									pos: position{line: 403, col: 29, offset: 12953},
 									alternatives: []interface{}{
 										&zeroOrOneExpr{
-											pos: position{line: 402, col: 29, offset: 12904},
+											pos: position{line: 403, col: 29, offset: 12953},
 											expr: &seqExpr{
-												pos: position{line: 402, col: 30, offset: 12905},
+												pos: position{line: 403, col: 30, offset: 12954},
 												exprs: []interface{}{
 													&litMatcher{
-														pos:        position{line: 402, col: 30, offset: 12905},
+														pos:        position{line: 403, col: 30, offset: 12954},
 														val:        ",",
 														ignoreCase: false,
 														want:       "\",\"",
 													},
 													&zeroOrMoreExpr{
-														pos: position{line: 402, col: 34, offset: 12909},
+														pos: position{line: 403, col: 34, offset: 12958},
 														expr: &ruleRefExpr{
-															pos:  position{line: 402, col: 34, offset: 12909},
+															pos:  position{line: 403, col: 34, offset: 12958},
 															name: "Space",
 														},
 													},
@@ -2475,9 +2475,9 @@ var g = &grammar{
 											},
 										},
 										&andExpr{
-											pos: position{line: 402, col: 45, offset: 12920},
+											pos: position{line: 403, col: 45, offset: 12969},
 											expr: &litMatcher{
-												pos:        position{line: 402, col: 46, offset: 12921},
+												pos:        position{line: 403, col: 46, offset: 12970},
 												val:        "]",
 												ignoreCase: false,
 												want:       "\"]\"",
@@ -2489,49 +2489,49 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 411, col: 6, offset: 13172},
+						pos: position{line: 412, col: 6, offset: 13221},
 						run: (*parser).callonPositionalAttribute14,
 						expr: &seqExpr{
-							pos: position{line: 411, col: 6, offset: 13172},
+							pos: position{line: 412, col: 6, offset: 13221},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 411, col: 6, offset: 13172},
+									pos:   position{line: 412, col: 6, offset: 13221},
 									label: "value",
 									expr: &seqExpr{
-										pos: position{line: 411, col: 13, offset: 13179},
+										pos: position{line: 412, col: 13, offset: 13228},
 										exprs: []interface{}{
 											&zeroOrMoreExpr{
-												pos: position{line: 411, col: 13, offset: 13179},
+												pos: position{line: 412, col: 13, offset: 13228},
 												expr: &ruleRefExpr{
-													pos:  position{line: 411, col: 13, offset: 13179},
+													pos:  position{line: 412, col: 13, offset: 13228},
 													name: "Space",
 												},
 											},
 											&choiceExpr{
-												pos: position{line: 411, col: 21, offset: 13187},
+												pos: position{line: 412, col: 21, offset: 13236},
 												alternatives: []interface{}{
 													&seqExpr{
-														pos: position{line: 411, col: 22, offset: 13188},
+														pos: position{line: 412, col: 22, offset: 13237},
 														exprs: []interface{}{
 															&litMatcher{
-																pos:        position{line: 411, col: 22, offset: 13188},
+																pos:        position{line: 412, col: 22, offset: 13237},
 																val:        ",",
 																ignoreCase: false,
 																want:       "\",\"",
 															},
 															&zeroOrMoreExpr{
-																pos: position{line: 411, col: 26, offset: 13192},
+																pos: position{line: 412, col: 26, offset: 13241},
 																expr: &ruleRefExpr{
-																	pos:  position{line: 411, col: 26, offset: 13192},
+																	pos:  position{line: 412, col: 26, offset: 13241},
 																	name: "Space",
 																},
 															},
 														},
 													},
 													&andExpr{
-														pos: position{line: 411, col: 36, offset: 13202},
+														pos: position{line: 412, col: 36, offset: 13251},
 														expr: &litMatcher{
-															pos:        position{line: 411, col: 37, offset: 13203},
+															pos:        position{line: 412, col: 37, offset: 13252},
 															val:        "]",
 															ignoreCase: false,
 															want:       "\"]\"",
@@ -2543,7 +2543,7 @@ var g = &grammar{
 									},
 								},
 								&andCodeExpr{
-									pos: position{line: 412, col: 5, offset: 13213},
+									pos: position{line: 413, col: 5, offset: 13262},
 									run: (*parser).callonPositionalAttribute27,
 								},
 							},
@@ -2554,57 +2554,57 @@ var g = &grammar{
 		},
 		{
 			name: "NamedAttribute",
-			pos:  position{line: 427, col: 1, offset: 13648},
+			pos:  position{line: 428, col: 1, offset: 13697},
 			expr: &actionExpr{
-				pos: position{line: 427, col: 19, offset: 13666},
+				pos: position{line: 428, col: 19, offset: 13715},
 				run: (*parser).callonNamedAttribute1,
 				expr: &seqExpr{
-					pos: position{line: 427, col: 19, offset: 13666},
+					pos: position{line: 428, col: 19, offset: 13715},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 427, col: 19, offset: 13666},
+							pos:   position{line: 428, col: 19, offset: 13715},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 427, col: 24, offset: 13671},
+								pos:  position{line: 428, col: 24, offset: 13720},
 								name: "NamedAttributeKey",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 427, col: 43, offset: 13690},
+							pos:        position{line: 428, col: 43, offset: 13739},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 427, col: 47, offset: 13694},
+							pos: position{line: 428, col: 47, offset: 13743},
 							expr: &ruleRefExpr{
-								pos:  position{line: 427, col: 47, offset: 13694},
+								pos:  position{line: 428, col: 47, offset: 13743},
 								name: "Space",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 427, col: 54, offset: 13701},
+							pos:   position{line: 428, col: 54, offset: 13750},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 427, col: 61, offset: 13708},
+								pos:  position{line: 428, col: 61, offset: 13757},
 								name: "AttributeValue",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 427, col: 77, offset: 13724},
+							pos: position{line: 428, col: 77, offset: 13773},
 							expr: &seqExpr{
-								pos: position{line: 427, col: 78, offset: 13725},
+								pos: position{line: 428, col: 78, offset: 13774},
 								exprs: []interface{}{
 									&litMatcher{
-										pos:        position{line: 427, col: 78, offset: 13725},
+										pos:        position{line: 428, col: 78, offset: 13774},
 										val:        ",",
 										ignoreCase: false,
 										want:       "\",\"",
 									},
 									&zeroOrMoreExpr{
-										pos: position{line: 427, col: 82, offset: 13729},
+										pos: position{line: 428, col: 82, offset: 13778},
 										expr: &ruleRefExpr{
-											pos:  position{line: 427, col: 82, offset: 13729},
+											pos:  position{line: 428, col: 82, offset: 13778},
 											name: "Space",
 										},
 									},
@@ -2617,24 +2617,24 @@ var g = &grammar{
 		},
 		{
 			name: "NamedAttributeKey",
-			pos:  position{line: 436, col: 1, offset: 14042},
+			pos:  position{line: 437, col: 1, offset: 14091},
 			expr: &actionExpr{
-				pos: position{line: 436, col: 22, offset: 14063},
+				pos: position{line: 437, col: 22, offset: 14112},
 				run: (*parser).callonNamedAttributeKey1,
 				expr: &seqExpr{
-					pos: position{line: 436, col: 22, offset: 14063},
+					pos: position{line: 437, col: 22, offset: 14112},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 436, col: 22, offset: 14063},
+							pos: position{line: 437, col: 22, offset: 14112},
 							expr: &ruleRefExpr{
-								pos:  position{line: 436, col: 23, offset: 14064},
+								pos:  position{line: 437, col: 23, offset: 14113},
 								name: "Space",
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 436, col: 29, offset: 14070},
+							pos: position{line: 437, col: 29, offset: 14119},
 							expr: &charClassMatcher{
-								pos:        position{line: 436, col: 29, offset: 14070},
+								pos:        position{line: 437, col: 29, offset: 14119},
 								val:        "[^\\r\\n=,\\]]",
 								chars:      []rune{'\r', '\n', '=', ',', ']'},
 								ignoreCase: false,
@@ -2642,9 +2642,9 @@ var g = &grammar{
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 436, col: 42, offset: 14083},
+							pos: position{line: 437, col: 42, offset: 14132},
 							expr: &ruleRefExpr{
-								pos:  position{line: 436, col: 42, offset: 14083},
+								pos:  position{line: 437, col: 42, offset: 14132},
 								name: "Space",
 							},
 						},
@@ -2654,50 +2654,50 @@ var g = &grammar{
 		},
 		{
 			name: "AttributeValue",
-			pos:  position{line: 440, col: 1, offset: 14145},
+			pos:  position{line: 441, col: 1, offset: 14194},
 			expr: &actionExpr{
-				pos: position{line: 441, col: 5, offset: 14168},
+				pos: position{line: 442, col: 5, offset: 14217},
 				run: (*parser).callonAttributeValue1,
 				expr: &seqExpr{
-					pos: position{line: 441, col: 5, offset: 14168},
+					pos: position{line: 442, col: 5, offset: 14217},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 441, col: 5, offset: 14168},
+							pos:   position{line: 442, col: 5, offset: 14217},
 							label: "value",
 							expr: &choiceExpr{
-								pos: position{line: 442, col: 9, offset: 14184},
+								pos: position{line: 443, col: 9, offset: 14233},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 442, col: 9, offset: 14184},
+										pos:  position{line: 443, col: 9, offset: 14233},
 										name: "SingleQuotedAttributeValue",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 443, col: 11, offset: 14222},
+										pos:  position{line: 444, col: 11, offset: 14271},
 										name: "DoubleQuotedAttributeValue",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 444, col: 11, offset: 14260},
+										pos:  position{line: 445, col: 11, offset: 14309},
 										name: "UnquotedAttributeValue",
 									},
 								},
 							},
 						},
 						&andExpr{
-							pos: position{line: 446, col: 5, offset: 14294},
+							pos: position{line: 447, col: 5, offset: 14343},
 							expr: &notExpr{
-								pos: position{line: 446, col: 7, offset: 14296},
+								pos: position{line: 447, col: 7, offset: 14345},
 								expr: &seqExpr{
-									pos: position{line: 446, col: 9, offset: 14298},
+									pos: position{line: 447, col: 9, offset: 14347},
 									exprs: []interface{}{
 										&zeroOrMoreExpr{
-											pos: position{line: 446, col: 9, offset: 14298},
+											pos: position{line: 447, col: 9, offset: 14347},
 											expr: &ruleRefExpr{
-												pos:  position{line: 446, col: 9, offset: 14298},
+												pos:  position{line: 447, col: 9, offset: 14347},
 												name: "Space",
 											},
 										},
 										&litMatcher{
-											pos:        position{line: 446, col: 16, offset: 14305},
+											pos:        position{line: 447, col: 16, offset: 14354},
 											val:        "=",
 											ignoreCase: false,
 											want:       "\"=\"",
@@ -2712,34 +2712,34 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedAttributeValue",
-			pos:  position{line: 450, col: 1, offset: 14346},
+			pos:  position{line: 451, col: 1, offset: 14395},
 			expr: &actionExpr{
-				pos: position{line: 451, col: 5, offset: 14381},
+				pos: position{line: 452, col: 5, offset: 14430},
 				run: (*parser).callonSingleQuotedAttributeValue1,
 				expr: &seqExpr{
-					pos: position{line: 451, col: 5, offset: 14381},
+					pos: position{line: 452, col: 5, offset: 14430},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 451, col: 5, offset: 14381},
+							pos:        position{line: 452, col: 5, offset: 14430},
 							val:        "'",
 							ignoreCase: false,
 							want:       "\"'\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 452, col: 5, offset: 14390},
+							pos:   position{line: 453, col: 5, offset: 14439},
 							label: "elements",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 452, col: 14, offset: 14399},
+								pos: position{line: 453, col: 14, offset: 14448},
 								expr: &choiceExpr{
-									pos: position{line: 453, col: 9, offset: 14409},
+									pos: position{line: 454, col: 9, offset: 14458},
 									alternatives: []interface{}{
 										&actionExpr{
-											pos: position{line: 453, col: 10, offset: 14410},
+											pos: position{line: 454, col: 10, offset: 14459},
 											run: (*parser).callonSingleQuotedAttributeValue7,
 											expr: &oneOrMoreExpr{
-												pos: position{line: 453, col: 10, offset: 14410},
+												pos: position{line: 454, col: 10, offset: 14459},
 												expr: &charClassMatcher{
-													pos:        position{line: 453, col: 10, offset: 14410},
+													pos:        position{line: 454, col: 10, offset: 14459},
 													val:        "[^'\\r\\n\\uFFFD\\\\{]",
 													chars:      []rune{'\'', '\r', '\n', '�', '\\', '{'},
 													ignoreCase: false,
@@ -2748,37 +2748,37 @@ var g = &grammar{
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 456, col: 11, offset: 14556},
+											pos:  position{line: 457, col: 11, offset: 14605},
 											name: "ElementPlaceHolder",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 457, col: 11, offset: 14585},
+											pos:  position{line: 458, col: 11, offset: 14634},
 											name: "AttrSub",
 										},
 										&choiceExpr{
-											pos: position{line: 458, col: 12, offset: 14604},
+											pos: position{line: 459, col: 12, offset: 14653},
 											alternatives: []interface{}{
 												&actionExpr{
-													pos: position{line: 458, col: 12, offset: 14604},
+													pos: position{line: 459, col: 12, offset: 14653},
 													run: (*parser).callonSingleQuotedAttributeValue13,
 													expr: &litMatcher{
-														pos:        position{line: 458, col: 12, offset: 14604},
+														pos:        position{line: 459, col: 12, offset: 14653},
 														val:        "\\'",
 														ignoreCase: false,
 														want:       "\"\\\\'\"",
 													},
 												},
 												&litMatcher{
-													pos:        position{line: 461, col: 11, offset: 14696},
+													pos:        position{line: 462, col: 11, offset: 14745},
 													val:        "{",
 													ignoreCase: false,
 													want:       "\"{\"",
 												},
 												&actionExpr{
-													pos: position{line: 461, col: 17, offset: 14702},
+													pos: position{line: 462, col: 17, offset: 14751},
 													run: (*parser).callonSingleQuotedAttributeValue16,
 													expr: &litMatcher{
-														pos:        position{line: 461, col: 17, offset: 14702},
+														pos:        position{line: 462, col: 17, offset: 14751},
 														val:        "\\",
 														ignoreCase: false,
 														want:       "\"\\\\\"",
@@ -2791,7 +2791,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 465, col: 5, offset: 14791},
+							pos:        position{line: 466, col: 5, offset: 14840},
 							val:        "'",
 							ignoreCase: false,
 							want:       "\"'\"",
@@ -2802,34 +2802,34 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedAttributeValue",
-			pos:  position{line: 469, col: 1, offset: 14847},
+			pos:  position{line: 470, col: 1, offset: 14896},
 			expr: &actionExpr{
-				pos: position{line: 470, col: 5, offset: 14882},
+				pos: position{line: 471, col: 5, offset: 14931},
 				run: (*parser).callonDoubleQuotedAttributeValue1,
 				expr: &seqExpr{
-					pos: position{line: 470, col: 5, offset: 14882},
+					pos: position{line: 471, col: 5, offset: 14931},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 470, col: 5, offset: 14882},
+							pos:        position{line: 471, col: 5, offset: 14931},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 471, col: 5, offset: 14892},
+							pos:   position{line: 472, col: 5, offset: 14941},
 							label: "elements",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 471, col: 14, offset: 14901},
+								pos: position{line: 472, col: 14, offset: 14950},
 								expr: &choiceExpr{
-									pos: position{line: 472, col: 9, offset: 14911},
+									pos: position{line: 473, col: 9, offset: 14960},
 									alternatives: []interface{}{
 										&actionExpr{
-											pos: position{line: 472, col: 10, offset: 14912},
+											pos: position{line: 473, col: 10, offset: 14961},
 											run: (*parser).callonDoubleQuotedAttributeValue7,
 											expr: &oneOrMoreExpr{
-												pos: position{line: 472, col: 10, offset: 14912},
+												pos: position{line: 473, col: 10, offset: 14961},
 												expr: &charClassMatcher{
-													pos:        position{line: 472, col: 10, offset: 14912},
+													pos:        position{line: 473, col: 10, offset: 14961},
 													val:        "[^\\r\\n\\uFFFD\"\\\\{]",
 													chars:      []rune{'\r', '\n', '�', '"', '\\', '{'},
 													ignoreCase: false,
@@ -2838,37 +2838,37 @@ var g = &grammar{
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 475, col: 11, offset: 15058},
+											pos:  position{line: 476, col: 11, offset: 15107},
 											name: "ElementPlaceHolder",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 476, col: 11, offset: 15087},
+											pos:  position{line: 477, col: 11, offset: 15136},
 											name: "AttrSub",
 										},
 										&choiceExpr{
-											pos: position{line: 477, col: 12, offset: 15106},
+											pos: position{line: 478, col: 12, offset: 15155},
 											alternatives: []interface{}{
 												&actionExpr{
-													pos: position{line: 477, col: 12, offset: 15106},
+													pos: position{line: 478, col: 12, offset: 15155},
 													run: (*parser).callonDoubleQuotedAttributeValue13,
 													expr: &litMatcher{
-														pos:        position{line: 477, col: 12, offset: 15106},
+														pos:        position{line: 478, col: 12, offset: 15155},
 														val:        "\\\"",
 														ignoreCase: false,
 														want:       "\"\\\\\\\"\"",
 													},
 												},
 												&litMatcher{
-													pos:        position{line: 480, col: 11, offset: 15198},
+													pos:        position{line: 481, col: 11, offset: 15247},
 													val:        "{",
 													ignoreCase: false,
 													want:       "\"{\"",
 												},
 												&actionExpr{
-													pos: position{line: 480, col: 17, offset: 15204},
+													pos: position{line: 481, col: 17, offset: 15253},
 													run: (*parser).callonDoubleQuotedAttributeValue16,
 													expr: &litMatcher{
-														pos:        position{line: 480, col: 17, offset: 15204},
+														pos:        position{line: 481, col: 17, offset: 15253},
 														val:        "\\",
 														ignoreCase: false,
 														want:       "\"\\\\\"",
@@ -2881,7 +2881,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 484, col: 5, offset: 15293},
+							pos:        position{line: 485, col: 5, offset: 15342},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -2892,35 +2892,35 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedAttributeValue",
-			pos:  position{line: 489, col: 1, offset: 15428},
+			pos:  position{line: 490, col: 1, offset: 15477},
 			expr: &actionExpr{
-				pos: position{line: 490, col: 5, offset: 15459},
+				pos: position{line: 491, col: 5, offset: 15508},
 				run: (*parser).callonUnquotedAttributeValue1,
 				expr: &seqExpr{
-					pos: position{line: 490, col: 5, offset: 15459},
+					pos: position{line: 491, col: 5, offset: 15508},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 490, col: 5, offset: 15459},
+							pos: position{line: 491, col: 5, offset: 15508},
 							expr: &ruleRefExpr{
-								pos:  position{line: 490, col: 6, offset: 15460},
+								pos:  position{line: 491, col: 6, offset: 15509},
 								name: "Space",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 491, col: 5, offset: 15470},
+							pos:   position{line: 492, col: 5, offset: 15519},
 							label: "elements",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 491, col: 14, offset: 15479},
+								pos: position{line: 492, col: 14, offset: 15528},
 								expr: &choiceExpr{
-									pos: position{line: 492, col: 9, offset: 15489},
+									pos: position{line: 493, col: 9, offset: 15538},
 									alternatives: []interface{}{
 										&actionExpr{
-											pos: position{line: 492, col: 10, offset: 15490},
+											pos: position{line: 493, col: 10, offset: 15539},
 											run: (*parser).callonUnquotedAttributeValue8,
 											expr: &oneOrMoreExpr{
-												pos: position{line: 492, col: 10, offset: 15490},
+												pos: position{line: 493, col: 10, offset: 15539},
 												expr: &charClassMatcher{
-													pos:        position{line: 492, col: 10, offset: 15490},
+													pos:        position{line: 493, col: 10, offset: 15539},
 													val:        "[^,=\\r\\n\\uFFFD{\\]]",
 													chars:      []rune{',', '=', '\r', '\n', '�', '{', ']'},
 													ignoreCase: false,
@@ -2929,18 +2929,18 @@ var g = &grammar{
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 495, col: 11, offset: 15592},
+											pos:  position{line: 496, col: 11, offset: 15641},
 											name: "ElementPlaceHolder",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 496, col: 11, offset: 15621},
+											pos:  position{line: 497, col: 11, offset: 15670},
 											name: "AttrSub",
 										},
 										&actionExpr{
-											pos: position{line: 497, col: 12, offset: 15640},
+											pos: position{line: 498, col: 12, offset: 15689},
 											run: (*parser).callonUnquotedAttributeValue13,
 											expr: &litMatcher{
-												pos:        position{line: 497, col: 12, offset: 15640},
+												pos:        position{line: 498, col: 12, offset: 15689},
 												val:        "{",
 												ignoreCase: false,
 												want:       "\"{\"",
@@ -2951,7 +2951,7 @@ var g = &grammar{
 							},
 						},
 						&andCodeExpr{
-							pos: position{line: 501, col: 5, offset: 15728},
+							pos: position{line: 502, col: 5, offset: 15777},
 							run: (*parser).callonUnquotedAttributeValue15,
 						},
 					},
@@ -2960,34 +2960,34 @@ var g = &grammar{
 		},
 		{
 			name: "Section",
-			pos:  position{line: 512, col: 1, offset: 16029},
+			pos:  position{line: 513, col: 1, offset: 16078},
 			expr: &actionExpr{
-				pos: position{line: 512, col: 12, offset: 16040},
+				pos: position{line: 513, col: 12, offset: 16089},
 				run: (*parser).callonSection1,
 				expr: &seqExpr{
-					pos: position{line: 512, col: 12, offset: 16040},
+					pos: position{line: 513, col: 12, offset: 16089},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 512, col: 12, offset: 16040},
+							pos:   position{line: 513, col: 12, offset: 16089},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 512, col: 23, offset: 16051},
+								pos: position{line: 513, col: 23, offset: 16100},
 								expr: &ruleRefExpr{
-									pos:  position{line: 512, col: 24, offset: 16052},
+									pos:  position{line: 513, col: 24, offset: 16101},
 									name: "BlockAttributes",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 513, col: 5, offset: 16074},
+							pos:   position{line: 514, col: 5, offset: 16123},
 							label: "level",
 							expr: &actionExpr{
-								pos: position{line: 513, col: 12, offset: 16081},
+								pos: position{line: 514, col: 12, offset: 16130},
 								run: (*parser).callonSection7,
 								expr: &oneOrMoreExpr{
-									pos: position{line: 513, col: 12, offset: 16081},
+									pos: position{line: 514, col: 12, offset: 16130},
 									expr: &litMatcher{
-										pos:        position{line: 513, col: 13, offset: 16082},
+										pos:        position{line: 514, col: 13, offset: 16131},
 										val:        "=",
 										ignoreCase: false,
 										want:       "\"=\"",
@@ -2996,37 +2996,37 @@ var g = &grammar{
 							},
 						},
 						&andCodeExpr{
-							pos: position{line: 517, col: 5, offset: 16173},
+							pos: position{line: 518, col: 5, offset: 16222},
 							run: (*parser).callonSection10,
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 521, col: 5, offset: 16325},
+							pos: position{line: 522, col: 5, offset: 16374},
 							expr: &ruleRefExpr{
-								pos:  position{line: 521, col: 5, offset: 16325},
+								pos:  position{line: 522, col: 5, offset: 16374},
 								name: "Space",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 521, col: 12, offset: 16332},
+							pos:   position{line: 522, col: 12, offset: 16381},
 							label: "title",
 							expr: &ruleRefExpr{
-								pos:  position{line: 521, col: 19, offset: 16339},
+								pos:  position{line: 522, col: 19, offset: 16388},
 								name: "TitleElements",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 521, col: 34, offset: 16354},
+							pos:   position{line: 522, col: 34, offset: 16403},
 							label: "id",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 521, col: 38, offset: 16358},
+								pos: position{line: 522, col: 38, offset: 16407},
 								expr: &ruleRefExpr{
-									pos:  position{line: 521, col: 38, offset: 16358},
+									pos:  position{line: 522, col: 38, offset: 16407},
 									name: "InlineElementID",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 521, col: 56, offset: 16376},
+							pos:  position{line: 522, col: 56, offset: 16425},
 							name: "EOL",
 						},
 					},
@@ -3035,34 +3035,34 @@ var g = &grammar{
 		},
 		{
 			name: "TitleElements",
-			pos:  position{line: 525, col: 1, offset: 16482},
+			pos:  position{line: 526, col: 1, offset: 16531},
 			expr: &actionExpr{
-				pos: position{line: 525, col: 18, offset: 16499},
+				pos: position{line: 526, col: 18, offset: 16548},
 				run: (*parser).callonTitleElements1,
 				expr: &labeledExpr{
-					pos:   position{line: 525, col: 18, offset: 16499},
+					pos:   position{line: 526, col: 18, offset: 16548},
 					label: "elements",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 525, col: 27, offset: 16508},
+						pos: position{line: 526, col: 27, offset: 16557},
 						expr: &seqExpr{
-							pos: position{line: 525, col: 28, offset: 16509},
+							pos: position{line: 526, col: 28, offset: 16558},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 525, col: 28, offset: 16509},
+									pos: position{line: 526, col: 28, offset: 16558},
 									expr: &ruleRefExpr{
-										pos:  position{line: 525, col: 29, offset: 16510},
+										pos:  position{line: 526, col: 29, offset: 16559},
 										name: "Newline",
 									},
 								},
 								&notExpr{
-									pos: position{line: 525, col: 37, offset: 16518},
+									pos: position{line: 526, col: 37, offset: 16567},
 									expr: &ruleRefExpr{
-										pos:  position{line: 525, col: 38, offset: 16519},
+										pos:  position{line: 526, col: 38, offset: 16568},
 										name: "InlineElementID",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 525, col: 54, offset: 16535},
+									pos:  position{line: 526, col: 54, offset: 16584},
 									name: "TitleElement",
 								},
 							},
@@ -3073,37 +3073,37 @@ var g = &grammar{
 		},
 		{
 			name: "TitleElement",
-			pos:  position{line: 529, col: 1, offset: 16656},
+			pos:  position{line: 530, col: 1, offset: 16705},
 			expr: &actionExpr{
-				pos: position{line: 529, col: 17, offset: 16672},
+				pos: position{line: 530, col: 17, offset: 16721},
 				run: (*parser).callonTitleElement1,
 				expr: &labeledExpr{
-					pos:   position{line: 529, col: 17, offset: 16672},
+					pos:   position{line: 530, col: 17, offset: 16721},
 					label: "element",
 					expr: &choiceExpr{
-						pos: position{line: 529, col: 26, offset: 16681},
+						pos: position{line: 530, col: 26, offset: 16730},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 529, col: 26, offset: 16681},
+								pos:  position{line: 530, col: 26, offset: 16730},
 								name: "Word",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 530, col: 11, offset: 16696},
+								pos:  position{line: 531, col: 11, offset: 16745},
 								name: "LineBreak",
 							},
 							&oneOrMoreExpr{
-								pos: position{line: 531, col: 11, offset: 16741},
+								pos: position{line: 532, col: 11, offset: 16790},
 								expr: &ruleRefExpr{
-									pos:  position{line: 531, col: 11, offset: 16741},
+									pos:  position{line: 532, col: 11, offset: 16790},
 									name: "Space",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 532, col: 11, offset: 16759},
+								pos:  position{line: 533, col: 11, offset: 16808},
 								name: "ElementPlaceHolder",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 533, col: 11, offset: 16788},
+								pos:  position{line: 534, col: 11, offset: 16837},
 								name: "AnyChar",
 							},
 						},
@@ -3113,18 +3113,18 @@ var g = &grammar{
 		},
 		{
 			name: "TableOfContentsPlaceHolder",
-			pos:  position{line: 540, col: 1, offset: 16939},
+			pos:  position{line: 541, col: 1, offset: 16988},
 			expr: &seqExpr{
-				pos: position{line: 540, col: 31, offset: 16969},
+				pos: position{line: 541, col: 31, offset: 17018},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 540, col: 31, offset: 16969},
+						pos:        position{line: 541, col: 31, offset: 17018},
 						val:        "toc::[]",
 						ignoreCase: false,
 						want:       "\"toc::[]\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 540, col: 41, offset: 16979},
+						pos:  position{line: 541, col: 41, offset: 17028},
 						name: "EOL",
 					},
 				},
@@ -3132,40 +3132,40 @@ var g = &grammar{
 		},
 		{
 			name: "UserMacroBlock",
-			pos:  position{line: 545, col: 1, offset: 17090},
+			pos:  position{line: 546, col: 1, offset: 17139},
 			expr: &actionExpr{
-				pos: position{line: 545, col: 19, offset: 17108},
+				pos: position{line: 546, col: 19, offset: 17157},
 				run: (*parser).callonUserMacroBlock1,
 				expr: &seqExpr{
-					pos: position{line: 545, col: 19, offset: 17108},
+					pos: position{line: 546, col: 19, offset: 17157},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 545, col: 19, offset: 17108},
+							pos:   position{line: 546, col: 19, offset: 17157},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 545, col: 25, offset: 17114},
+								pos:  position{line: 546, col: 25, offset: 17163},
 								name: "UserMacroName",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 545, col: 40, offset: 17129},
+							pos:        position{line: 546, col: 40, offset: 17178},
 							val:        "::",
 							ignoreCase: false,
 							want:       "\"::\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 545, col: 45, offset: 17134},
+							pos:   position{line: 546, col: 45, offset: 17183},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 545, col: 52, offset: 17141},
+								pos:  position{line: 546, col: 52, offset: 17190},
 								name: "UserMacroValue",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 545, col: 68, offset: 17157},
+							pos:   position{line: 546, col: 68, offset: 17206},
 							label: "inlineAttributes",
 							expr: &ruleRefExpr{
-								pos:  position{line: 545, col: 86, offset: 17175},
+								pos:  position{line: 546, col: 86, offset: 17224},
 								name: "InlineAttributes",
 							},
 						},
@@ -3175,40 +3175,40 @@ var g = &grammar{
 		},
 		{
 			name: "InlineUserMacro",
-			pos:  position{line: 549, col: 1, offset: 17298},
+			pos:  position{line: 550, col: 1, offset: 17347},
 			expr: &actionExpr{
-				pos: position{line: 549, col: 20, offset: 17317},
+				pos: position{line: 550, col: 20, offset: 17366},
 				run: (*parser).callonInlineUserMacro1,
 				expr: &seqExpr{
-					pos: position{line: 549, col: 20, offset: 17317},
+					pos: position{line: 550, col: 20, offset: 17366},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 549, col: 20, offset: 17317},
+							pos:   position{line: 550, col: 20, offset: 17366},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 549, col: 26, offset: 17323},
+								pos:  position{line: 550, col: 26, offset: 17372},
 								name: "UserMacroName",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 549, col: 41, offset: 17338},
+							pos:        position{line: 550, col: 41, offset: 17387},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 549, col: 45, offset: 17342},
+							pos:   position{line: 550, col: 45, offset: 17391},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 549, col: 52, offset: 17349},
+								pos:  position{line: 550, col: 52, offset: 17398},
 								name: "UserMacroValue",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 549, col: 68, offset: 17365},
+							pos:   position{line: 550, col: 68, offset: 17414},
 							label: "inlineAttributes",
 							expr: &ruleRefExpr{
-								pos:  position{line: 549, col: 86, offset: 17383},
+								pos:  position{line: 550, col: 86, offset: 17432},
 								name: "InlineAttributes",
 							},
 						},
@@ -3218,26 +3218,26 @@ var g = &grammar{
 		},
 		{
 			name: "UserMacroName",
-			pos:  position{line: 553, col: 1, offset: 17507},
+			pos:  position{line: 554, col: 1, offset: 17556},
 			expr: &actionExpr{
-				pos: position{line: 553, col: 18, offset: 17524},
+				pos: position{line: 554, col: 18, offset: 17573},
 				run: (*parser).callonUserMacroName1,
 				expr: &seqExpr{
-					pos: position{line: 553, col: 18, offset: 17524},
+					pos: position{line: 554, col: 18, offset: 17573},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 553, col: 18, offset: 17524},
+							pos: position{line: 554, col: 18, offset: 17573},
 							expr: &litMatcher{
-								pos:        position{line: 553, col: 19, offset: 17525},
+								pos:        position{line: 554, col: 19, offset: 17574},
 								val:        "include",
 								ignoreCase: false,
 								want:       "\"include\"",
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 553, col: 30, offset: 17536},
+							pos: position{line: 554, col: 30, offset: 17585},
 							expr: &charClassMatcher{
-								pos:        position{line: 553, col: 30, offset: 17536},
+								pos:        position{line: 554, col: 30, offset: 17585},
 								val:        "[\\pL0-9_-]",
 								chars:      []rune{'_', '-'},
 								ranges:     []rune{'0', '9'},
@@ -3252,14 +3252,14 @@ var g = &grammar{
 		},
 		{
 			name: "UserMacroValue",
-			pos:  position{line: 557, col: 1, offset: 17585},
+			pos:  position{line: 558, col: 1, offset: 17634},
 			expr: &actionExpr{
-				pos: position{line: 557, col: 19, offset: 17603},
+				pos: position{line: 558, col: 19, offset: 17652},
 				run: (*parser).callonUserMacroValue1,
 				expr: &zeroOrMoreExpr{
-					pos: position{line: 557, col: 19, offset: 17603},
+					pos: position{line: 558, col: 19, offset: 17652},
 					expr: &charClassMatcher{
-						pos:        position{line: 557, col: 19, offset: 17603},
+						pos:        position{line: 558, col: 19, offset: 17652},
 						val:        "[^:[ \\r\\n]",
 						chars:      []rune{':', '[', ' ', '\r', '\n'},
 						ignoreCase: false,
@@ -3270,41 +3270,41 @@ var g = &grammar{
 		},
 		{
 			name: "FileInclusion",
-			pos:  position{line: 564, col: 1, offset: 17762},
+			pos:  position{line: 565, col: 1, offset: 17811},
 			expr: &actionExpr{
-				pos: position{line: 565, col: 5, offset: 17784},
+				pos: position{line: 566, col: 5, offset: 17833},
 				run: (*parser).callonFileInclusion1,
 				expr: &seqExpr{
-					pos: position{line: 565, col: 5, offset: 17784},
+					pos: position{line: 566, col: 5, offset: 17833},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 565, col: 5, offset: 17784},
+							pos:   position{line: 566, col: 5, offset: 17833},
 							label: "incl",
 							expr: &actionExpr{
-								pos: position{line: 566, col: 9, offset: 17799},
+								pos: position{line: 567, col: 9, offset: 17848},
 								run: (*parser).callonFileInclusion4,
 								expr: &seqExpr{
-									pos: position{line: 566, col: 9, offset: 17799},
+									pos: position{line: 567, col: 9, offset: 17848},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 566, col: 9, offset: 17799},
+											pos:        position{line: 567, col: 9, offset: 17848},
 											val:        "include::",
 											ignoreCase: false,
 											want:       "\"include::\"",
 										},
 										&labeledExpr{
-											pos:   position{line: 567, col: 9, offset: 17820},
+											pos:   position{line: 568, col: 9, offset: 17869},
 											label: "path",
 											expr: &ruleRefExpr{
-												pos:  position{line: 567, col: 15, offset: 17826},
+												pos:  position{line: 568, col: 15, offset: 17875},
 												name: "FileLocation",
 											},
 										},
 										&labeledExpr{
-											pos:   position{line: 568, col: 9, offset: 17849},
+											pos:   position{line: 569, col: 9, offset: 17898},
 											label: "inlineAttributes",
 											expr: &ruleRefExpr{
-												pos:  position{line: 568, col: 27, offset: 17867},
+												pos:  position{line: 569, col: 27, offset: 17916},
 												name: "InlineAttributes",
 											},
 										},
@@ -3313,14 +3313,14 @@ var g = &grammar{
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 572, col: 5, offset: 18027},
+							pos: position{line: 573, col: 5, offset: 18076},
 							expr: &ruleRefExpr{
-								pos:  position{line: 572, col: 5, offset: 18027},
+								pos:  position{line: 573, col: 5, offset: 18076},
 								name: "Space",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 572, col: 12, offset: 18034},
+							pos:  position{line: 573, col: 12, offset: 18083},
 							name: "EOL",
 						},
 					},
@@ -3329,44 +3329,44 @@ var g = &grammar{
 		},
 		{
 			name: "FileIncludeAttributes",
-			pos:  position{line: 576, col: 1, offset: 18094},
+			pos:  position{line: 577, col: 1, offset: 18143},
 			expr: &ruleRefExpr{
-				pos:  position{line: 576, col: 26, offset: 18119},
+				pos:  position{line: 577, col: 26, offset: 18168},
 				name: "LongHandAttributes",
 			},
 		},
 		{
 			name: "LineRanges",
-			pos:  position{line: 579, col: 1, offset: 18159},
+			pos:  position{line: 580, col: 1, offset: 18208},
 			expr: &actionExpr{
-				pos: position{line: 579, col: 15, offset: 18173},
+				pos: position{line: 580, col: 15, offset: 18222},
 				run: (*parser).callonLineRanges1,
 				expr: &seqExpr{
-					pos: position{line: 579, col: 15, offset: 18173},
+					pos: position{line: 580, col: 15, offset: 18222},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 579, col: 15, offset: 18173},
+							pos:   position{line: 580, col: 15, offset: 18222},
 							label: "value",
 							expr: &choiceExpr{
-								pos: position{line: 579, col: 22, offset: 18180},
+								pos: position{line: 580, col: 22, offset: 18229},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 579, col: 22, offset: 18180},
+										pos:  position{line: 580, col: 22, offset: 18229},
 										name: "MultipleLineRanges",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 580, col: 11, offset: 18210},
+										pos:  position{line: 581, col: 11, offset: 18259},
 										name: "MultiLineRange",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 581, col: 11, offset: 18236},
+										pos:  position{line: 582, col: 11, offset: 18285},
 										name: "SingleLineRange",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 582, col: 11, offset: 18263},
+							pos:  position{line: 583, col: 11, offset: 18312},
 							name: "EOF",
 						},
 					},
@@ -3375,52 +3375,52 @@ var g = &grammar{
 		},
 		{
 			name: "MultipleLineRanges",
-			pos:  position{line: 586, col: 1, offset: 18345},
+			pos:  position{line: 587, col: 1, offset: 18394},
 			expr: &actionExpr{
-				pos: position{line: 586, col: 23, offset: 18367},
+				pos: position{line: 587, col: 23, offset: 18416},
 				run: (*parser).callonMultipleLineRanges1,
 				expr: &seqExpr{
-					pos: position{line: 586, col: 23, offset: 18367},
+					pos: position{line: 587, col: 23, offset: 18416},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 586, col: 23, offset: 18367},
+							pos:   position{line: 587, col: 23, offset: 18416},
 							label: "first",
 							expr: &choiceExpr{
-								pos: position{line: 586, col: 30, offset: 18374},
+								pos: position{line: 587, col: 30, offset: 18423},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 586, col: 30, offset: 18374},
+										pos:  position{line: 587, col: 30, offset: 18423},
 										name: "MultiLineRange",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 586, col: 47, offset: 18391},
+										pos:  position{line: 587, col: 47, offset: 18440},
 										name: "SingleLineRange",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 587, col: 5, offset: 18413},
+							pos:   position{line: 588, col: 5, offset: 18462},
 							label: "others",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 587, col: 12, offset: 18420},
+								pos: position{line: 588, col: 12, offset: 18469},
 								expr: &actionExpr{
-									pos: position{line: 588, col: 9, offset: 18430},
+									pos: position{line: 589, col: 9, offset: 18479},
 									run: (*parser).callonMultipleLineRanges9,
 									expr: &seqExpr{
-										pos: position{line: 588, col: 9, offset: 18430},
+										pos: position{line: 589, col: 9, offset: 18479},
 										exprs: []interface{}{
 											&choiceExpr{
-												pos: position{line: 588, col: 10, offset: 18431},
+												pos: position{line: 589, col: 10, offset: 18480},
 												alternatives: []interface{}{
 													&litMatcher{
-														pos:        position{line: 588, col: 10, offset: 18431},
+														pos:        position{line: 589, col: 10, offset: 18480},
 														val:        ",",
 														ignoreCase: false,
 														want:       "\",\"",
 													},
 													&litMatcher{
-														pos:        position{line: 588, col: 16, offset: 18437},
+														pos:        position{line: 589, col: 16, offset: 18486},
 														val:        ";",
 														ignoreCase: false,
 														want:       "\";\"",
@@ -3428,17 +3428,17 @@ var g = &grammar{
 												},
 											},
 											&labeledExpr{
-												pos:   position{line: 589, col: 9, offset: 18548},
+												pos:   position{line: 590, col: 9, offset: 18597},
 												label: "other",
 												expr: &choiceExpr{
-													pos: position{line: 589, col: 16, offset: 18555},
+													pos: position{line: 590, col: 16, offset: 18604},
 													alternatives: []interface{}{
 														&ruleRefExpr{
-															pos:  position{line: 589, col: 16, offset: 18555},
+															pos:  position{line: 590, col: 16, offset: 18604},
 															name: "MultiLineRange",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 589, col: 33, offset: 18572},
+															pos:  position{line: 590, col: 33, offset: 18621},
 															name: "SingleLineRange",
 														},
 													},
@@ -3455,32 +3455,32 @@ var g = &grammar{
 		},
 		{
 			name: "MultiLineRange",
-			pos:  position{line: 595, col: 1, offset: 18714},
+			pos:  position{line: 596, col: 1, offset: 18763},
 			expr: &actionExpr{
-				pos: position{line: 595, col: 19, offset: 18732},
+				pos: position{line: 596, col: 19, offset: 18781},
 				run: (*parser).callonMultiLineRange1,
 				expr: &seqExpr{
-					pos: position{line: 595, col: 19, offset: 18732},
+					pos: position{line: 596, col: 19, offset: 18781},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 595, col: 19, offset: 18732},
+							pos:   position{line: 596, col: 19, offset: 18781},
 							label: "start",
 							expr: &ruleRefExpr{
-								pos:  position{line: 595, col: 26, offset: 18739},
+								pos:  position{line: 596, col: 26, offset: 18788},
 								name: "Number",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 595, col: 34, offset: 18747},
+							pos:        position{line: 596, col: 34, offset: 18796},
 							val:        "..",
 							ignoreCase: false,
 							want:       "\"..\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 595, col: 39, offset: 18752},
+							pos:   position{line: 596, col: 39, offset: 18801},
 							label: "end",
 							expr: &ruleRefExpr{
-								pos:  position{line: 595, col: 44, offset: 18757},
+								pos:  position{line: 596, col: 44, offset: 18806},
 								name: "Number",
 							},
 						},
@@ -3490,15 +3490,15 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineRange",
-			pos:  position{line: 599, col: 1, offset: 18845},
+			pos:  position{line: 600, col: 1, offset: 18894},
 			expr: &actionExpr{
-				pos: position{line: 599, col: 20, offset: 18864},
+				pos: position{line: 600, col: 20, offset: 18913},
 				run: (*parser).callonSingleLineRange1,
 				expr: &labeledExpr{
-					pos:   position{line: 599, col: 20, offset: 18864},
+					pos:   position{line: 600, col: 20, offset: 18913},
 					label: "singleline",
 					expr: &ruleRefExpr{
-						pos:  position{line: 599, col: 32, offset: 18876},
+						pos:  position{line: 600, col: 32, offset: 18925},
 						name: "Number",
 					},
 				},
@@ -3506,23 +3506,23 @@ var g = &grammar{
 		},
 		{
 			name: "TagRanges",
-			pos:  position{line: 604, col: 1, offset: 18991},
+			pos:  position{line: 605, col: 1, offset: 19040},
 			expr: &actionExpr{
-				pos: position{line: 604, col: 14, offset: 19004},
+				pos: position{line: 605, col: 14, offset: 19053},
 				run: (*parser).callonTagRanges1,
 				expr: &seqExpr{
-					pos: position{line: 604, col: 14, offset: 19004},
+					pos: position{line: 605, col: 14, offset: 19053},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 604, col: 14, offset: 19004},
+							pos:   position{line: 605, col: 14, offset: 19053},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 604, col: 21, offset: 19011},
+								pos:  position{line: 605, col: 21, offset: 19060},
 								name: "MultipleTagRanges",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 604, col: 40, offset: 19030},
+							pos:  position{line: 605, col: 40, offset: 19079},
 							name: "EOF",
 						},
 					},
@@ -3531,43 +3531,43 @@ var g = &grammar{
 		},
 		{
 			name: "MultipleTagRanges",
-			pos:  position{line: 608, col: 1, offset: 19112},
+			pos:  position{line: 609, col: 1, offset: 19161},
 			expr: &actionExpr{
-				pos: position{line: 608, col: 22, offset: 19133},
+				pos: position{line: 609, col: 22, offset: 19182},
 				run: (*parser).callonMultipleTagRanges1,
 				expr: &seqExpr{
-					pos: position{line: 608, col: 22, offset: 19133},
+					pos: position{line: 609, col: 22, offset: 19182},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 608, col: 22, offset: 19133},
+							pos:   position{line: 609, col: 22, offset: 19182},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 608, col: 29, offset: 19140},
+								pos:  position{line: 609, col: 29, offset: 19189},
 								name: "TagRange",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 609, col: 5, offset: 19154},
+							pos:   position{line: 610, col: 5, offset: 19203},
 							label: "others",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 609, col: 12, offset: 19161},
+								pos: position{line: 610, col: 12, offset: 19210},
 								expr: &actionExpr{
-									pos: position{line: 610, col: 9, offset: 19171},
+									pos: position{line: 611, col: 9, offset: 19220},
 									run: (*parser).callonMultipleTagRanges7,
 									expr: &seqExpr{
-										pos: position{line: 610, col: 9, offset: 19171},
+										pos: position{line: 611, col: 9, offset: 19220},
 										exprs: []interface{}{
 											&choiceExpr{
-												pos: position{line: 610, col: 10, offset: 19172},
+												pos: position{line: 611, col: 10, offset: 19221},
 												alternatives: []interface{}{
 													&litMatcher{
-														pos:        position{line: 610, col: 10, offset: 19172},
+														pos:        position{line: 611, col: 10, offset: 19221},
 														val:        ",",
 														ignoreCase: false,
 														want:       "\",\"",
 													},
 													&litMatcher{
-														pos:        position{line: 610, col: 16, offset: 19178},
+														pos:        position{line: 611, col: 16, offset: 19227},
 														val:        ";",
 														ignoreCase: false,
 														want:       "\";\"",
@@ -3575,10 +3575,10 @@ var g = &grammar{
 												},
 											},
 											&labeledExpr{
-												pos:   position{line: 611, col: 9, offset: 19289},
+												pos:   position{line: 612, col: 9, offset: 19338},
 												label: "other",
 												expr: &ruleRefExpr{
-													pos:  position{line: 611, col: 16, offset: 19296},
+													pos:  position{line: 612, col: 16, offset: 19345},
 													name: "TagRange",
 												},
 											},
@@ -3593,25 +3593,25 @@ var g = &grammar{
 		},
 		{
 			name: "TagRange",
-			pos:  position{line: 617, col: 1, offset: 19431},
+			pos:  position{line: 618, col: 1, offset: 19480},
 			expr: &choiceExpr{
-				pos: position{line: 617, col: 13, offset: 19443},
+				pos: position{line: 618, col: 13, offset: 19492},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 617, col: 13, offset: 19443},
+						pos: position{line: 618, col: 13, offset: 19492},
 						run: (*parser).callonTagRange2,
 						expr: &labeledExpr{
-							pos:   position{line: 617, col: 13, offset: 19443},
+							pos:   position{line: 618, col: 13, offset: 19492},
 							label: "tag",
 							expr: &choiceExpr{
-								pos: position{line: 617, col: 18, offset: 19448},
+								pos: position{line: 618, col: 18, offset: 19497},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 617, col: 18, offset: 19448},
+										pos:  position{line: 618, col: 18, offset: 19497},
 										name: "Alphanums",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 617, col: 30, offset: 19460},
+										pos:  position{line: 618, col: 30, offset: 19509},
 										name: "TagWildcard",
 									},
 								},
@@ -3619,29 +3619,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 619, col: 5, offset: 19528},
+						pos: position{line: 620, col: 5, offset: 19577},
 						run: (*parser).callonTagRange7,
 						expr: &seqExpr{
-							pos: position{line: 619, col: 5, offset: 19528},
+							pos: position{line: 620, col: 5, offset: 19577},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 619, col: 5, offset: 19528},
+									pos:        position{line: 620, col: 5, offset: 19577},
 									val:        "!",
 									ignoreCase: false,
 									want:       "\"!\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 619, col: 9, offset: 19532},
+									pos:   position{line: 620, col: 9, offset: 19581},
 									label: "tag",
 									expr: &choiceExpr{
-										pos: position{line: 619, col: 14, offset: 19537},
+										pos: position{line: 620, col: 14, offset: 19586},
 										alternatives: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 619, col: 14, offset: 19537},
+												pos:  position{line: 620, col: 14, offset: 19586},
 												name: "Alphanums",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 619, col: 26, offset: 19549},
+												pos:  position{line: 620, col: 26, offset: 19598},
 												name: "TagWildcard",
 											},
 										},
@@ -3655,23 +3655,23 @@ var g = &grammar{
 		},
 		{
 			name: "TagWildcard",
-			pos:  position{line: 623, col: 1, offset: 19617},
+			pos:  position{line: 624, col: 1, offset: 19666},
 			expr: &actionExpr{
-				pos: position{line: 623, col: 16, offset: 19632},
+				pos: position{line: 624, col: 16, offset: 19681},
 				run: (*parser).callonTagWildcard1,
 				expr: &seqExpr{
-					pos: position{line: 623, col: 16, offset: 19632},
+					pos: position{line: 624, col: 16, offset: 19681},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 623, col: 16, offset: 19632},
+							pos:   position{line: 624, col: 16, offset: 19681},
 							label: "stars",
 							expr: &actionExpr{
-								pos: position{line: 623, col: 23, offset: 19639},
+								pos: position{line: 624, col: 23, offset: 19688},
 								run: (*parser).callonTagWildcard4,
 								expr: &oneOrMoreExpr{
-									pos: position{line: 623, col: 23, offset: 19639},
+									pos: position{line: 624, col: 23, offset: 19688},
 									expr: &litMatcher{
-										pos:        position{line: 623, col: 24, offset: 19640},
+										pos:        position{line: 624, col: 24, offset: 19689},
 										val:        "*",
 										ignoreCase: false,
 										want:       "\"*\"",
@@ -3680,7 +3680,7 @@ var g = &grammar{
 							},
 						},
 						&andCodeExpr{
-							pos: position{line: 626, col: 5, offset: 19694},
+							pos: position{line: 627, col: 5, offset: 19743},
 							run: (*parser).callonTagWildcard7,
 						},
 					},
@@ -3689,34 +3689,34 @@ var g = &grammar{
 		},
 		{
 			name: "IncludedFileLine",
-			pos:  position{line: 636, col: 1, offset: 19988},
+			pos:  position{line: 637, col: 1, offset: 20037},
 			expr: &actionExpr{
-				pos: position{line: 636, col: 21, offset: 20008},
+				pos: position{line: 637, col: 21, offset: 20057},
 				run: (*parser).callonIncludedFileLine1,
 				expr: &seqExpr{
-					pos: position{line: 636, col: 21, offset: 20008},
+					pos: position{line: 637, col: 21, offset: 20057},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 636, col: 21, offset: 20008},
+							pos:   position{line: 637, col: 21, offset: 20057},
 							label: "content",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 636, col: 29, offset: 20016},
+								pos: position{line: 637, col: 29, offset: 20065},
 								expr: &choiceExpr{
-									pos: position{line: 636, col: 30, offset: 20017},
+									pos: position{line: 637, col: 30, offset: 20066},
 									alternatives: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 636, col: 30, offset: 20017},
+											pos:  position{line: 637, col: 30, offset: 20066},
 											name: "IncludedFileStartTag",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 636, col: 53, offset: 20040},
+											pos:  position{line: 637, col: 53, offset: 20089},
 											name: "IncludedFileEndTag",
 										},
 										&actionExpr{
-											pos: position{line: 636, col: 74, offset: 20061},
+											pos: position{line: 637, col: 74, offset: 20110},
 											run: (*parser).callonIncludedFileLine8,
 											expr: &anyMatcher{
-												line: 636, col: 74, offset: 20061,
+												line: 637, col: 74, offset: 20110,
 											},
 										},
 									},
@@ -3724,7 +3724,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 636, col: 107, offset: 20094},
+							pos:  position{line: 637, col: 107, offset: 20143},
 							name: "EOL",
 						},
 					},
@@ -3733,33 +3733,33 @@ var g = &grammar{
 		},
 		{
 			name: "IncludedFileStartTag",
-			pos:  position{line: 640, col: 1, offset: 20165},
+			pos:  position{line: 641, col: 1, offset: 20214},
 			expr: &actionExpr{
-				pos: position{line: 640, col: 25, offset: 20189},
+				pos: position{line: 641, col: 25, offset: 20238},
 				run: (*parser).callonIncludedFileStartTag1,
 				expr: &seqExpr{
-					pos: position{line: 640, col: 25, offset: 20189},
+					pos: position{line: 641, col: 25, offset: 20238},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 640, col: 25, offset: 20189},
+							pos:        position{line: 641, col: 25, offset: 20238},
 							val:        "tag::",
 							ignoreCase: false,
 							want:       "\"tag::\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 640, col: 33, offset: 20197},
+							pos:   position{line: 641, col: 33, offset: 20246},
 							label: "tag",
 							expr: &actionExpr{
-								pos: position{line: 640, col: 38, offset: 20202},
+								pos: position{line: 641, col: 38, offset: 20251},
 								run: (*parser).callonIncludedFileStartTag5,
 								expr: &ruleRefExpr{
-									pos:  position{line: 640, col: 38, offset: 20202},
+									pos:  position{line: 641, col: 38, offset: 20251},
 									name: "Alphanums",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 640, col: 78, offset: 20242},
+							pos:        position{line: 641, col: 78, offset: 20291},
 							val:        "[]",
 							ignoreCase: false,
 							want:       "\"[]\"",
@@ -3770,33 +3770,33 @@ var g = &grammar{
 		},
 		{
 			name: "IncludedFileEndTag",
-			pos:  position{line: 644, col: 1, offset: 20307},
+			pos:  position{line: 645, col: 1, offset: 20356},
 			expr: &actionExpr{
-				pos: position{line: 644, col: 23, offset: 20329},
+				pos: position{line: 645, col: 23, offset: 20378},
 				run: (*parser).callonIncludedFileEndTag1,
 				expr: &seqExpr{
-					pos: position{line: 644, col: 23, offset: 20329},
+					pos: position{line: 645, col: 23, offset: 20378},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 644, col: 23, offset: 20329},
+							pos:        position{line: 645, col: 23, offset: 20378},
 							val:        "end::",
 							ignoreCase: false,
 							want:       "\"end::\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 644, col: 31, offset: 20337},
+							pos:   position{line: 645, col: 31, offset: 20386},
 							label: "tag",
 							expr: &actionExpr{
-								pos: position{line: 644, col: 36, offset: 20342},
+								pos: position{line: 645, col: 36, offset: 20391},
 								run: (*parser).callonIncludedFileEndTag5,
 								expr: &ruleRefExpr{
-									pos:  position{line: 644, col: 36, offset: 20342},
+									pos:  position{line: 645, col: 36, offset: 20391},
 									name: "Alphanums",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 644, col: 76, offset: 20382},
+							pos:        position{line: 645, col: 76, offset: 20431},
 							val:        "[]",
 							ignoreCase: false,
 							want:       "\"[]\"",
@@ -3807,32 +3807,32 @@ var g = &grammar{
 		},
 		{
 			name: "ListParagraph",
-			pos:  position{line: 651, col: 1, offset: 20546},
+			pos:  position{line: 652, col: 1, offset: 20595},
 			expr: &choiceExpr{
-				pos: position{line: 651, col: 18, offset: 20563},
+				pos: position{line: 652, col: 18, offset: 20612},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 651, col: 18, offset: 20563},
+						pos: position{line: 652, col: 18, offset: 20612},
 						run: (*parser).callonListParagraph2,
 						expr: &labeledExpr{
-							pos:   position{line: 651, col: 18, offset: 20563},
+							pos:   position{line: 652, col: 18, offset: 20612},
 							label: "comment",
 							expr: &ruleRefExpr{
-								pos:  position{line: 651, col: 27, offset: 20572},
+								pos:  position{line: 652, col: 27, offset: 20621},
 								name: "SingleLineComment",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 653, col: 9, offset: 20629},
+						pos: position{line: 654, col: 9, offset: 20678},
 						run: (*parser).callonListParagraph5,
 						expr: &labeledExpr{
-							pos:   position{line: 653, col: 9, offset: 20629},
+							pos:   position{line: 654, col: 9, offset: 20678},
 							label: "lines",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 653, col: 15, offset: 20635},
+								pos: position{line: 654, col: 15, offset: 20684},
 								expr: &ruleRefExpr{
-									pos:  position{line: 653, col: 16, offset: 20636},
+									pos:  position{line: 654, col: 16, offset: 20685},
 									name: "ListParagraphLine",
 								},
 							},
@@ -3843,106 +3843,106 @@ var g = &grammar{
 		},
 		{
 			name: "ListParagraphLine",
-			pos:  position{line: 657, col: 1, offset: 20728},
+			pos:  position{line: 658, col: 1, offset: 20777},
 			expr: &actionExpr{
-				pos: position{line: 657, col: 22, offset: 20749},
+				pos: position{line: 658, col: 22, offset: 20798},
 				run: (*parser).callonListParagraphLine1,
 				expr: &seqExpr{
-					pos: position{line: 657, col: 22, offset: 20749},
+					pos: position{line: 658, col: 22, offset: 20798},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 657, col: 22, offset: 20749},
+							pos: position{line: 658, col: 22, offset: 20798},
 							expr: &ruleRefExpr{
-								pos:  position{line: 657, col: 23, offset: 20750},
+								pos:  position{line: 658, col: 23, offset: 20799},
 								name: "EOF",
 							},
 						},
 						&notExpr{
-							pos: position{line: 658, col: 5, offset: 20758},
+							pos: position{line: 659, col: 5, offset: 20807},
 							expr: &ruleRefExpr{
-								pos:  position{line: 658, col: 6, offset: 20759},
+								pos:  position{line: 659, col: 6, offset: 20808},
 								name: "BlankLine",
 							},
 						},
 						&notExpr{
-							pos: position{line: 659, col: 5, offset: 20773},
+							pos: position{line: 660, col: 5, offset: 20822},
 							expr: &ruleRefExpr{
-								pos:  position{line: 659, col: 6, offset: 20774},
+								pos:  position{line: 660, col: 6, offset: 20823},
 								name: "SingleLineComment",
 							},
 						},
 						&notExpr{
-							pos: position{line: 660, col: 5, offset: 20796},
+							pos: position{line: 661, col: 5, offset: 20845},
 							expr: &ruleRefExpr{
-								pos:  position{line: 660, col: 6, offset: 20797},
+								pos:  position{line: 661, col: 6, offset: 20846},
 								name: "OrderedListItemPrefix",
 							},
 						},
 						&notExpr{
-							pos: position{line: 661, col: 5, offset: 20823},
+							pos: position{line: 662, col: 5, offset: 20872},
 							expr: &ruleRefExpr{
-								pos:  position{line: 661, col: 6, offset: 20824},
+								pos:  position{line: 662, col: 6, offset: 20873},
 								name: "UnorderedListItemPrefix",
 							},
 						},
 						&notExpr{
-							pos: position{line: 662, col: 5, offset: 20852},
+							pos: position{line: 663, col: 5, offset: 20901},
 							expr: &ruleRefExpr{
-								pos:  position{line: 662, col: 6, offset: 20853},
+								pos:  position{line: 663, col: 6, offset: 20902},
 								name: "CalloutListItemPrefix",
 							},
 						},
 						&notExpr{
-							pos: position{line: 663, col: 5, offset: 20879},
+							pos: position{line: 664, col: 5, offset: 20928},
 							expr: &ruleRefExpr{
-								pos:  position{line: 663, col: 6, offset: 20880},
+								pos:  position{line: 664, col: 6, offset: 20929},
 								name: "ListItemContinuation",
 							},
 						},
 						&notExpr{
-							pos: position{line: 664, col: 5, offset: 20905},
+							pos: position{line: 665, col: 5, offset: 20954},
 							expr: &ruleRefExpr{
-								pos:  position{line: 664, col: 6, offset: 20906},
+								pos:  position{line: 665, col: 6, offset: 20955},
 								name: "BlockAttributes",
 							},
 						},
 						&notExpr{
-							pos: position{line: 665, col: 5, offset: 20926},
+							pos: position{line: 666, col: 5, offset: 20975},
 							expr: &ruleRefExpr{
-								pos:  position{line: 665, col: 6, offset: 20927},
+								pos:  position{line: 666, col: 6, offset: 20976},
 								name: "BlockDelimiter",
 							},
 						},
 						&notExpr{
-							pos: position{line: 666, col: 5, offset: 20946},
+							pos: position{line: 667, col: 5, offset: 20995},
 							expr: &ruleRefExpr{
-								pos:  position{line: 666, col: 6, offset: 20947},
+								pos:  position{line: 667, col: 6, offset: 20996},
 								name: "LabeledListItemPrefix",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 667, col: 5, offset: 20974},
+							pos:   position{line: 668, col: 5, offset: 21023},
 							label: "line",
 							expr: &actionExpr{
-								pos: position{line: 667, col: 11, offset: 20980},
+								pos: position{line: 668, col: 11, offset: 21029},
 								run: (*parser).callonListParagraphLine24,
 								expr: &seqExpr{
-									pos: position{line: 667, col: 11, offset: 20980},
+									pos: position{line: 668, col: 11, offset: 21029},
 									exprs: []interface{}{
 										&zeroOrMoreExpr{
-											pos: position{line: 667, col: 11, offset: 20980},
+											pos: position{line: 668, col: 11, offset: 21029},
 											expr: &ruleRefExpr{
-												pos:  position{line: 667, col: 11, offset: 20980},
+												pos:  position{line: 668, col: 11, offset: 21029},
 												name: "Space",
 											},
 										},
 										&labeledExpr{
-											pos:   position{line: 667, col: 18, offset: 20987},
+											pos:   position{line: 668, col: 18, offset: 21036},
 											label: "elements",
 											expr: &oneOrMoreExpr{
-												pos: position{line: 667, col: 27, offset: 20996},
+												pos: position{line: 668, col: 27, offset: 21045},
 												expr: &ruleRefExpr{
-													pos:  position{line: 667, col: 28, offset: 20997},
+													pos:  position{line: 668, col: 28, offset: 21046},
 													name: "InlineElement",
 												},
 											},
@@ -3952,7 +3952,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 669, col: 12, offset: 21096},
+							pos:  position{line: 670, col: 12, offset: 21145},
 							name: "EOL",
 						},
 					},
@@ -3961,25 +3961,25 @@ var g = &grammar{
 		},
 		{
 			name: "ListItemContinuation",
-			pos:  position{line: 673, col: 1, offset: 21135},
+			pos:  position{line: 674, col: 1, offset: 21184},
 			expr: &seqExpr{
-				pos: position{line: 673, col: 25, offset: 21159},
+				pos: position{line: 674, col: 25, offset: 21208},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 673, col: 25, offset: 21159},
+						pos:        position{line: 674, col: 25, offset: 21208},
 						val:        "+",
 						ignoreCase: false,
 						want:       "\"+\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 673, col: 29, offset: 21163},
+						pos: position{line: 674, col: 29, offset: 21212},
 						expr: &ruleRefExpr{
-							pos:  position{line: 673, col: 29, offset: 21163},
+							pos:  position{line: 674, col: 29, offset: 21212},
 							name: "Space",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 673, col: 36, offset: 21170},
+						pos:  position{line: 674, col: 36, offset: 21219},
 						name: "Newline",
 					},
 				},
@@ -3987,22 +3987,22 @@ var g = &grammar{
 		},
 		{
 			name: "ContinuedListItemElement",
-			pos:  position{line: 675, col: 1, offset: 21242},
+			pos:  position{line: 676, col: 1, offset: 21291},
 			expr: &actionExpr{
-				pos: position{line: 675, col: 29, offset: 21270},
+				pos: position{line: 676, col: 29, offset: 21319},
 				run: (*parser).callonContinuedListItemElement1,
 				expr: &seqExpr{
-					pos: position{line: 675, col: 29, offset: 21270},
+					pos: position{line: 676, col: 29, offset: 21319},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 675, col: 29, offset: 21270},
+							pos:  position{line: 676, col: 29, offset: 21319},
 							name: "ListItemContinuation",
 						},
 						&labeledExpr{
-							pos:   position{line: 675, col: 50, offset: 21291},
+							pos:   position{line: 676, col: 50, offset: 21340},
 							label: "element",
 							expr: &ruleRefExpr{
-								pos:  position{line: 675, col: 58, offset: 21299},
+								pos:  position{line: 676, col: 58, offset: 21348},
 								name: "ContinuedListItemContent",
 							},
 						},
@@ -4012,84 +4012,84 @@ var g = &grammar{
 		},
 		{
 			name: "ContinuedListItemContent",
-			pos:  position{line: 679, col: 1, offset: 21405},
+			pos:  position{line: 680, col: 1, offset: 21454},
 			expr: &actionExpr{
-				pos: position{line: 679, col: 29, offset: 21433},
+				pos: position{line: 680, col: 29, offset: 21482},
 				run: (*parser).callonContinuedListItemContent1,
 				expr: &seqExpr{
-					pos: position{line: 679, col: 29, offset: 21433},
+					pos: position{line: 680, col: 29, offset: 21482},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 679, col: 29, offset: 21433},
+							pos: position{line: 680, col: 29, offset: 21482},
 							expr: &ruleRefExpr{
-								pos:  position{line: 679, col: 30, offset: 21434},
+								pos:  position{line: 680, col: 30, offset: 21483},
 								name: "EOF",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 680, col: 5, offset: 21443},
+							pos:   position{line: 681, col: 5, offset: 21492},
 							label: "content",
 							expr: &choiceExpr{
-								pos: position{line: 680, col: 14, offset: 21452},
+								pos: position{line: 681, col: 14, offset: 21501},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 680, col: 14, offset: 21452},
+										pos:  position{line: 681, col: 14, offset: 21501},
 										name: "DelimitedBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 681, col: 11, offset: 21477},
+										pos:  position{line: 682, col: 11, offset: 21526},
 										name: "SingleLineComment",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 682, col: 11, offset: 21505},
+										pos:  position{line: 683, col: 11, offset: 21554},
 										name: "Table",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 683, col: 11, offset: 21521},
+										pos:  position{line: 684, col: 11, offset: 21570},
 										name: "ImageBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 684, col: 11, offset: 21542},
+										pos:  position{line: 685, col: 11, offset: 21591},
 										name: "ThematicBreak",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 685, col: 11, offset: 21566},
+										pos:  position{line: 686, col: 11, offset: 21615},
 										name: "OrderedListItem",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 686, col: 11, offset: 21593},
+										pos:  position{line: 687, col: 11, offset: 21642},
 										name: "UnorderedListItem",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 687, col: 11, offset: 21622},
+										pos:  position{line: 688, col: 11, offset: 21671},
 										name: "LabeledListItem",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 688, col: 11, offset: 21649},
+										pos:  position{line: 689, col: 11, offset: 21698},
 										name: "BlankLine",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 689, col: 11, offset: 21700},
+										pos:  position{line: 690, col: 11, offset: 21749},
 										name: "LiteralBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 690, col: 11, offset: 21724},
+										pos:  position{line: 691, col: 11, offset: 21773},
 										name: "AttributeDeclaration",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 691, col: 11, offset: 21756},
+										pos:  position{line: 692, col: 11, offset: 21805},
 										name: "AttributeReset",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 692, col: 11, offset: 21782},
+										pos:  position{line: 693, col: 11, offset: 21831},
 										name: "TableOfContentsPlaceHolder",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 693, col: 11, offset: 21819},
+										pos:  position{line: 694, col: 11, offset: 21868},
 										name: "UserMacroBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 694, col: 11, offset: 21844},
+										pos:  position{line: 695, col: 11, offset: 21893},
 										name: "ContinuedRawParagraph",
 									},
 								},
@@ -4101,37 +4101,37 @@ var g = &grammar{
 		},
 		{
 			name: "OrderedListItem",
-			pos:  position{line: 701, col: 1, offset: 22010},
+			pos:  position{line: 702, col: 1, offset: 22059},
 			expr: &actionExpr{
-				pos: position{line: 701, col: 20, offset: 22029},
+				pos: position{line: 702, col: 20, offset: 22078},
 				run: (*parser).callonOrderedListItem1,
 				expr: &seqExpr{
-					pos: position{line: 701, col: 20, offset: 22029},
+					pos: position{line: 702, col: 20, offset: 22078},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 701, col: 20, offset: 22029},
+							pos:   position{line: 702, col: 20, offset: 22078},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 701, col: 31, offset: 22040},
+								pos: position{line: 702, col: 31, offset: 22089},
 								expr: &ruleRefExpr{
-									pos:  position{line: 701, col: 32, offset: 22041},
+									pos:  position{line: 702, col: 32, offset: 22090},
 									name: "BlockAttributes",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 701, col: 50, offset: 22059},
+							pos:   position{line: 702, col: 50, offset: 22108},
 							label: "prefix",
 							expr: &ruleRefExpr{
-								pos:  position{line: 701, col: 58, offset: 22067},
+								pos:  position{line: 702, col: 58, offset: 22116},
 								name: "OrderedListItemPrefix",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 701, col: 81, offset: 22090},
+							pos:   position{line: 702, col: 81, offset: 22139},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 701, col: 90, offset: 22099},
+								pos:  position{line: 702, col: 90, offset: 22148},
 								name: "OrderedListItemContent",
 							},
 						},
@@ -4141,42 +4141,42 @@ var g = &grammar{
 		},
 		{
 			name: "OrderedListItemPrefix",
-			pos:  position{line: 705, col: 1, offset: 22239},
+			pos:  position{line: 706, col: 1, offset: 22288},
 			expr: &actionExpr{
-				pos: position{line: 706, col: 5, offset: 22269},
+				pos: position{line: 707, col: 5, offset: 22318},
 				run: (*parser).callonOrderedListItemPrefix1,
 				expr: &seqExpr{
-					pos: position{line: 706, col: 5, offset: 22269},
+					pos: position{line: 707, col: 5, offset: 22318},
 					exprs: []interface{}{
 						&zeroOrMoreExpr{
-							pos: position{line: 706, col: 5, offset: 22269},
+							pos: position{line: 707, col: 5, offset: 22318},
 							expr: &ruleRefExpr{
-								pos:  position{line: 706, col: 5, offset: 22269},
+								pos:  position{line: 707, col: 5, offset: 22318},
 								name: "Space",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 706, col: 12, offset: 22276},
+							pos:   position{line: 707, col: 12, offset: 22325},
 							label: "prefix",
 							expr: &choiceExpr{
-								pos: position{line: 708, col: 9, offset: 22339},
+								pos: position{line: 709, col: 9, offset: 22388},
 								alternatives: []interface{}{
 									&actionExpr{
-										pos: position{line: 708, col: 9, offset: 22339},
+										pos: position{line: 709, col: 9, offset: 22388},
 										run: (*parser).callonOrderedListItemPrefix7,
 										expr: &seqExpr{
-											pos: position{line: 708, col: 9, offset: 22339},
+											pos: position{line: 709, col: 9, offset: 22388},
 											exprs: []interface{}{
 												&labeledExpr{
-													pos:   position{line: 708, col: 9, offset: 22339},
+													pos:   position{line: 709, col: 9, offset: 22388},
 													label: "depth",
 													expr: &actionExpr{
-														pos: position{line: 708, col: 16, offset: 22346},
+														pos: position{line: 709, col: 16, offset: 22395},
 														run: (*parser).callonOrderedListItemPrefix10,
 														expr: &oneOrMoreExpr{
-															pos: position{line: 708, col: 16, offset: 22346},
+															pos: position{line: 709, col: 16, offset: 22395},
 															expr: &litMatcher{
-																pos:        position{line: 708, col: 17, offset: 22347},
+																pos:        position{line: 709, col: 17, offset: 22396},
 																val:        ".",
 																ignoreCase: false,
 																want:       "\".\"",
@@ -4185,22 +4185,22 @@ var g = &grammar{
 													},
 												},
 												&andCodeExpr{
-													pos: position{line: 712, col: 9, offset: 22447},
+													pos: position{line: 713, col: 9, offset: 22496},
 													run: (*parser).callonOrderedListItemPrefix13,
 												},
 											},
 										},
 									},
 									&actionExpr{
-										pos: position{line: 731, col: 11, offset: 23164},
+										pos: position{line: 732, col: 11, offset: 23213},
 										run: (*parser).callonOrderedListItemPrefix14,
 										expr: &seqExpr{
-											pos: position{line: 731, col: 11, offset: 23164},
+											pos: position{line: 732, col: 11, offset: 23213},
 											exprs: []interface{}{
 												&oneOrMoreExpr{
-													pos: position{line: 731, col: 11, offset: 23164},
+													pos: position{line: 732, col: 11, offset: 23213},
 													expr: &charClassMatcher{
-														pos:        position{line: 731, col: 12, offset: 23165},
+														pos:        position{line: 732, col: 12, offset: 23214},
 														val:        "[0-9]",
 														ranges:     []rune{'0', '9'},
 														ignoreCase: false,
@@ -4208,7 +4208,7 @@ var g = &grammar{
 													},
 												},
 												&litMatcher{
-													pos:        position{line: 731, col: 20, offset: 23173},
+													pos:        position{line: 732, col: 20, offset: 23222},
 													val:        ".",
 													ignoreCase: false,
 													want:       "\".\"",
@@ -4217,20 +4217,20 @@ var g = &grammar{
 										},
 									},
 									&actionExpr{
-										pos: position{line: 733, col: 13, offset: 23284},
+										pos: position{line: 734, col: 13, offset: 23333},
 										run: (*parser).callonOrderedListItemPrefix19,
 										expr: &seqExpr{
-											pos: position{line: 733, col: 13, offset: 23284},
+											pos: position{line: 734, col: 13, offset: 23333},
 											exprs: []interface{}{
 												&charClassMatcher{
-													pos:        position{line: 733, col: 14, offset: 23285},
+													pos:        position{line: 734, col: 14, offset: 23334},
 													val:        "[a-z]",
 													ranges:     []rune{'a', 'z'},
 													ignoreCase: false,
 													inverted:   false,
 												},
 												&litMatcher{
-													pos:        position{line: 733, col: 21, offset: 23292},
+													pos:        position{line: 734, col: 21, offset: 23341},
 													val:        ".",
 													ignoreCase: false,
 													want:       "\".\"",
@@ -4239,20 +4239,20 @@ var g = &grammar{
 										},
 									},
 									&actionExpr{
-										pos: position{line: 735, col: 13, offset: 23406},
+										pos: position{line: 736, col: 13, offset: 23455},
 										run: (*parser).callonOrderedListItemPrefix23,
 										expr: &seqExpr{
-											pos: position{line: 735, col: 13, offset: 23406},
+											pos: position{line: 736, col: 13, offset: 23455},
 											exprs: []interface{}{
 												&charClassMatcher{
-													pos:        position{line: 735, col: 14, offset: 23407},
+													pos:        position{line: 736, col: 14, offset: 23456},
 													val:        "[A-Z]",
 													ranges:     []rune{'A', 'Z'},
 													ignoreCase: false,
 													inverted:   false,
 												},
 												&litMatcher{
-													pos:        position{line: 735, col: 21, offset: 23414},
+													pos:        position{line: 736, col: 21, offset: 23463},
 													val:        ".",
 													ignoreCase: false,
 													want:       "\".\"",
@@ -4261,15 +4261,15 @@ var g = &grammar{
 										},
 									},
 									&actionExpr{
-										pos: position{line: 737, col: 13, offset: 23528},
+										pos: position{line: 738, col: 13, offset: 23577},
 										run: (*parser).callonOrderedListItemPrefix27,
 										expr: &seqExpr{
-											pos: position{line: 737, col: 13, offset: 23528},
+											pos: position{line: 738, col: 13, offset: 23577},
 											exprs: []interface{}{
 												&oneOrMoreExpr{
-													pos: position{line: 737, col: 13, offset: 23528},
+													pos: position{line: 738, col: 13, offset: 23577},
 													expr: &charClassMatcher{
-														pos:        position{line: 737, col: 14, offset: 23529},
+														pos:        position{line: 738, col: 14, offset: 23578},
 														val:        "[ivxdlcm]",
 														chars:      []rune{'i', 'v', 'x', 'd', 'l', 'c', 'm'},
 														ignoreCase: false,
@@ -4277,7 +4277,7 @@ var g = &grammar{
 													},
 												},
 												&litMatcher{
-													pos:        position{line: 737, col: 26, offset: 23541},
+													pos:        position{line: 738, col: 26, offset: 23590},
 													val:        ")",
 													ignoreCase: false,
 													want:       "\")\"",
@@ -4286,15 +4286,15 @@ var g = &grammar{
 										},
 									},
 									&actionExpr{
-										pos: position{line: 739, col: 13, offset: 23655},
+										pos: position{line: 740, col: 13, offset: 23704},
 										run: (*parser).callonOrderedListItemPrefix32,
 										expr: &seqExpr{
-											pos: position{line: 739, col: 13, offset: 23655},
+											pos: position{line: 740, col: 13, offset: 23704},
 											exprs: []interface{}{
 												&oneOrMoreExpr{
-													pos: position{line: 739, col: 13, offset: 23655},
+													pos: position{line: 740, col: 13, offset: 23704},
 													expr: &charClassMatcher{
-														pos:        position{line: 739, col: 14, offset: 23656},
+														pos:        position{line: 740, col: 14, offset: 23705},
 														val:        "[IVXDLCM]",
 														chars:      []rune{'I', 'V', 'X', 'D', 'L', 'C', 'M'},
 														ignoreCase: false,
@@ -4302,7 +4302,7 @@ var g = &grammar{
 													},
 												},
 												&litMatcher{
-													pos:        position{line: 739, col: 26, offset: 23668},
+													pos:        position{line: 740, col: 26, offset: 23717},
 													val:        ")",
 													ignoreCase: false,
 													want:       "\")\"",
@@ -4314,9 +4314,9 @@ var g = &grammar{
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 741, col: 12, offset: 23781},
+							pos: position{line: 742, col: 12, offset: 23830},
 							expr: &ruleRefExpr{
-								pos:  position{line: 741, col: 12, offset: 23781},
+								pos:  position{line: 742, col: 12, offset: 23830},
 								name: "Space",
 							},
 						},
@@ -4326,17 +4326,17 @@ var g = &grammar{
 		},
 		{
 			name: "OrderedListItemContent",
-			pos:  position{line: 745, col: 1, offset: 23816},
+			pos:  position{line: 746, col: 1, offset: 23865},
 			expr: &actionExpr{
-				pos: position{line: 745, col: 27, offset: 23842},
+				pos: position{line: 746, col: 27, offset: 23891},
 				run: (*parser).callonOrderedListItemContent1,
 				expr: &labeledExpr{
-					pos:   position{line: 745, col: 27, offset: 23842},
+					pos:   position{line: 746, col: 27, offset: 23891},
 					label: "elements",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 745, col: 37, offset: 23852},
+						pos: position{line: 746, col: 37, offset: 23901},
 						expr: &ruleRefExpr{
-							pos:  position{line: 745, col: 37, offset: 23852},
+							pos:  position{line: 746, col: 37, offset: 23901},
 							name: "ListParagraph",
 						},
 					},
@@ -4345,48 +4345,48 @@ var g = &grammar{
 		},
 		{
 			name: "UnorderedListItem",
-			pos:  position{line: 752, col: 1, offset: 24052},
+			pos:  position{line: 753, col: 1, offset: 24101},
 			expr: &actionExpr{
-				pos: position{line: 752, col: 22, offset: 24073},
+				pos: position{line: 753, col: 22, offset: 24122},
 				run: (*parser).callonUnorderedListItem1,
 				expr: &seqExpr{
-					pos: position{line: 752, col: 22, offset: 24073},
+					pos: position{line: 753, col: 22, offset: 24122},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 752, col: 22, offset: 24073},
+							pos:   position{line: 753, col: 22, offset: 24122},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 752, col: 33, offset: 24084},
+								pos: position{line: 753, col: 33, offset: 24133},
 								expr: &ruleRefExpr{
-									pos:  position{line: 752, col: 34, offset: 24085},
+									pos:  position{line: 753, col: 34, offset: 24134},
 									name: "BlockAttributes",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 752, col: 52, offset: 24103},
+							pos:   position{line: 753, col: 52, offset: 24152},
 							label: "prefix",
 							expr: &ruleRefExpr{
-								pos:  position{line: 752, col: 60, offset: 24111},
+								pos:  position{line: 753, col: 60, offset: 24160},
 								name: "UnorderedListItemPrefix",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 752, col: 85, offset: 24136},
+							pos:   position{line: 753, col: 85, offset: 24185},
 							label: "checkstyle",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 752, col: 96, offset: 24147},
+								pos: position{line: 753, col: 96, offset: 24196},
 								expr: &ruleRefExpr{
-									pos:  position{line: 752, col: 97, offset: 24148},
+									pos:  position{line: 753, col: 97, offset: 24197},
 									name: "UnorderedListItemCheckStyle",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 752, col: 127, offset: 24178},
+							pos:   position{line: 753, col: 127, offset: 24227},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 752, col: 136, offset: 24187},
+								pos:  position{line: 753, col: 136, offset: 24236},
 								name: "UnorderedListItemContent",
 							},
 						},
@@ -4396,42 +4396,42 @@ var g = &grammar{
 		},
 		{
 			name: "UnorderedListItemPrefix",
-			pos:  position{line: 756, col: 1, offset: 24345},
+			pos:  position{line: 757, col: 1, offset: 24394},
 			expr: &actionExpr{
-				pos: position{line: 757, col: 5, offset: 24377},
+				pos: position{line: 758, col: 5, offset: 24426},
 				run: (*parser).callonUnorderedListItemPrefix1,
 				expr: &seqExpr{
-					pos: position{line: 757, col: 5, offset: 24377},
+					pos: position{line: 758, col: 5, offset: 24426},
 					exprs: []interface{}{
 						&zeroOrMoreExpr{
-							pos: position{line: 757, col: 5, offset: 24377},
+							pos: position{line: 758, col: 5, offset: 24426},
 							expr: &ruleRefExpr{
-								pos:  position{line: 757, col: 5, offset: 24377},
+								pos:  position{line: 758, col: 5, offset: 24426},
 								name: "Space",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 757, col: 12, offset: 24384},
+							pos:   position{line: 758, col: 12, offset: 24433},
 							label: "prefix",
 							expr: &choiceExpr{
-								pos: position{line: 757, col: 20, offset: 24392},
+								pos: position{line: 758, col: 20, offset: 24441},
 								alternatives: []interface{}{
 									&actionExpr{
-										pos: position{line: 759, col: 9, offset: 24449},
+										pos: position{line: 760, col: 9, offset: 24498},
 										run: (*parser).callonUnorderedListItemPrefix7,
 										expr: &seqExpr{
-											pos: position{line: 759, col: 9, offset: 24449},
+											pos: position{line: 760, col: 9, offset: 24498},
 											exprs: []interface{}{
 												&labeledExpr{
-													pos:   position{line: 759, col: 9, offset: 24449},
+													pos:   position{line: 760, col: 9, offset: 24498},
 													label: "depth",
 													expr: &actionExpr{
-														pos: position{line: 759, col: 16, offset: 24456},
+														pos: position{line: 760, col: 16, offset: 24505},
 														run: (*parser).callonUnorderedListItemPrefix10,
 														expr: &oneOrMoreExpr{
-															pos: position{line: 759, col: 16, offset: 24456},
+															pos: position{line: 760, col: 16, offset: 24505},
 															expr: &litMatcher{
-																pos:        position{line: 759, col: 17, offset: 24457},
+																pos:        position{line: 760, col: 17, offset: 24506},
 																val:        "*",
 																ignoreCase: false,
 																want:       "\"*\"",
@@ -4440,20 +4440,20 @@ var g = &grammar{
 													},
 												},
 												&andCodeExpr{
-													pos: position{line: 763, col: 9, offset: 24557},
+													pos: position{line: 764, col: 9, offset: 24606},
 													run: (*parser).callonUnorderedListItemPrefix13,
 												},
 											},
 										},
 									},
 									&labeledExpr{
-										pos:   position{line: 780, col: 14, offset: 25264},
+										pos:   position{line: 781, col: 14, offset: 25313},
 										label: "depth",
 										expr: &actionExpr{
-											pos: position{line: 780, col: 21, offset: 25271},
+											pos: position{line: 781, col: 21, offset: 25320},
 											run: (*parser).callonUnorderedListItemPrefix15,
 											expr: &litMatcher{
-												pos:        position{line: 780, col: 22, offset: 25272},
+												pos:        position{line: 781, col: 22, offset: 25321},
 												val:        "-",
 												ignoreCase: false,
 												want:       "\"-\"",
@@ -4464,9 +4464,9 @@ var g = &grammar{
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 782, col: 13, offset: 25358},
+							pos: position{line: 783, col: 13, offset: 25407},
 							expr: &ruleRefExpr{
-								pos:  position{line: 782, col: 13, offset: 25358},
+								pos:  position{line: 783, col: 13, offset: 25407},
 								name: "Space",
 							},
 						},
@@ -4476,53 +4476,53 @@ var g = &grammar{
 		},
 		{
 			name: "UnorderedListItemCheckStyle",
-			pos:  position{line: 786, col: 1, offset: 25394},
+			pos:  position{line: 787, col: 1, offset: 25443},
 			expr: &actionExpr{
-				pos: position{line: 786, col: 32, offset: 25425},
+				pos: position{line: 787, col: 32, offset: 25474},
 				run: (*parser).callonUnorderedListItemCheckStyle1,
 				expr: &seqExpr{
-					pos: position{line: 786, col: 32, offset: 25425},
+					pos: position{line: 787, col: 32, offset: 25474},
 					exprs: []interface{}{
 						&andExpr{
-							pos: position{line: 786, col: 32, offset: 25425},
+							pos: position{line: 787, col: 32, offset: 25474},
 							expr: &litMatcher{
-								pos:        position{line: 786, col: 33, offset: 25426},
+								pos:        position{line: 787, col: 33, offset: 25475},
 								val:        "[",
 								ignoreCase: false,
 								want:       "\"[\"",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 786, col: 37, offset: 25430},
+							pos:   position{line: 787, col: 37, offset: 25479},
 							label: "style",
 							expr: &choiceExpr{
-								pos: position{line: 787, col: 7, offset: 25444},
+								pos: position{line: 788, col: 7, offset: 25493},
 								alternatives: []interface{}{
 									&actionExpr{
-										pos: position{line: 787, col: 7, offset: 25444},
+										pos: position{line: 788, col: 7, offset: 25493},
 										run: (*parser).callonUnorderedListItemCheckStyle7,
 										expr: &litMatcher{
-											pos:        position{line: 787, col: 7, offset: 25444},
+											pos:        position{line: 788, col: 7, offset: 25493},
 											val:        "[ ]",
 											ignoreCase: false,
 											want:       "\"[ ]\"",
 										},
 									},
 									&actionExpr{
-										pos: position{line: 788, col: 7, offset: 25489},
+										pos: position{line: 789, col: 7, offset: 25538},
 										run: (*parser).callonUnorderedListItemCheckStyle9,
 										expr: &litMatcher{
-											pos:        position{line: 788, col: 7, offset: 25489},
+											pos:        position{line: 789, col: 7, offset: 25538},
 											val:        "[*]",
 											ignoreCase: false,
 											want:       "\"[*]\"",
 										},
 									},
 									&actionExpr{
-										pos: position{line: 789, col: 7, offset: 25532},
+										pos: position{line: 790, col: 7, offset: 25581},
 										run: (*parser).callonUnorderedListItemCheckStyle11,
 										expr: &litMatcher{
-											pos:        position{line: 789, col: 7, offset: 25532},
+											pos:        position{line: 790, col: 7, offset: 25581},
 											val:        "[x]",
 											ignoreCase: false,
 											want:       "\"[x]\"",
@@ -4532,9 +4532,9 @@ var g = &grammar{
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 790, col: 7, offset: 25574},
+							pos: position{line: 791, col: 7, offset: 25623},
 							expr: &ruleRefExpr{
-								pos:  position{line: 790, col: 7, offset: 25574},
+								pos:  position{line: 791, col: 7, offset: 25623},
 								name: "Space",
 							},
 						},
@@ -4544,17 +4544,17 @@ var g = &grammar{
 		},
 		{
 			name: "UnorderedListItemContent",
-			pos:  position{line: 794, col: 1, offset: 25616},
+			pos:  position{line: 795, col: 1, offset: 25665},
 			expr: &actionExpr{
-				pos: position{line: 794, col: 29, offset: 25644},
+				pos: position{line: 795, col: 29, offset: 25693},
 				run: (*parser).callonUnorderedListItemContent1,
 				expr: &labeledExpr{
-					pos:   position{line: 794, col: 29, offset: 25644},
+					pos:   position{line: 795, col: 29, offset: 25693},
 					label: "elements",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 794, col: 39, offset: 25654},
+						pos: position{line: 795, col: 39, offset: 25703},
 						expr: &ruleRefExpr{
-							pos:  position{line: 794, col: 39, offset: 25654},
+							pos:  position{line: 795, col: 39, offset: 25703},
 							name: "ListParagraph",
 						},
 					},
@@ -4563,47 +4563,47 @@ var g = &grammar{
 		},
 		{
 			name: "LabeledListItem",
-			pos:  position{line: 801, col: 1, offset: 25970},
+			pos:  position{line: 802, col: 1, offset: 26019},
 			expr: &actionExpr{
-				pos: position{line: 801, col: 20, offset: 25989},
+				pos: position{line: 802, col: 20, offset: 26038},
 				run: (*parser).callonLabeledListItem1,
 				expr: &seqExpr{
-					pos: position{line: 801, col: 20, offset: 25989},
+					pos: position{line: 802, col: 20, offset: 26038},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 801, col: 20, offset: 25989},
+							pos:   position{line: 802, col: 20, offset: 26038},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 801, col: 31, offset: 26000},
+								pos: position{line: 802, col: 31, offset: 26049},
 								expr: &ruleRefExpr{
-									pos:  position{line: 801, col: 32, offset: 26001},
+									pos:  position{line: 802, col: 32, offset: 26050},
 									name: "BlockAttributes",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 801, col: 50, offset: 26019},
+							pos:   position{line: 802, col: 50, offset: 26068},
 							label: "term",
 							expr: &ruleRefExpr{
-								pos:  position{line: 801, col: 56, offset: 26025},
+								pos:  position{line: 802, col: 56, offset: 26074},
 								name: "VerbatimLabeledListItemTerm",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 801, col: 85, offset: 26054},
+							pos:   position{line: 802, col: 85, offset: 26103},
 							label: "separator",
 							expr: &ruleRefExpr{
-								pos:  position{line: 801, col: 96, offset: 26065},
+								pos:  position{line: 802, col: 96, offset: 26114},
 								name: "LabeledListItemSeparator",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 801, col: 122, offset: 26091},
+							pos:   position{line: 802, col: 122, offset: 26140},
 							label: "description",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 801, col: 134, offset: 26103},
+								pos: position{line: 802, col: 134, offset: 26152},
 								expr: &ruleRefExpr{
-									pos:  position{line: 801, col: 135, offset: 26104},
+									pos:  position{line: 802, col: 135, offset: 26153},
 									name: "LabeledListItemDescription",
 								},
 							},
@@ -4614,16 +4614,16 @@ var g = &grammar{
 		},
 		{
 			name: "LabeledListItemPrefix",
-			pos:  position{line: 805, col: 1, offset: 26250},
+			pos:  position{line: 806, col: 1, offset: 26299},
 			expr: &seqExpr{
-				pos: position{line: 805, col: 26, offset: 26275},
+				pos: position{line: 806, col: 26, offset: 26324},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 805, col: 26, offset: 26275},
+						pos:  position{line: 806, col: 26, offset: 26324},
 						name: "VerbatimLabeledListItemTerm",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 805, col: 54, offset: 26303},
+						pos:  position{line: 806, col: 54, offset: 26352},
 						name: "LabeledListItemSeparator",
 					},
 				},
@@ -4631,14 +4631,14 @@ var g = &grammar{
 		},
 		{
 			name: "VerbatimLabeledListItemChars",
-			pos:  position{line: 807, col: 1, offset: 26329},
+			pos:  position{line: 808, col: 1, offset: 26378},
 			expr: &choiceExpr{
-				pos: position{line: 807, col: 33, offset: 26361},
+				pos: position{line: 808, col: 33, offset: 26410},
 				alternatives: []interface{}{
 					&oneOrMoreExpr{
-						pos: position{line: 807, col: 33, offset: 26361},
+						pos: position{line: 808, col: 33, offset: 26410},
 						expr: &charClassMatcher{
-							pos:        position{line: 807, col: 33, offset: 26361},
+							pos:        position{line: 808, col: 33, offset: 26410},
 							val:        "[^:\\r\\n]",
 							chars:      []rune{':', '\r', '\n'},
 							ignoreCase: false,
@@ -4646,18 +4646,18 @@ var g = &grammar{
 						},
 					},
 					&seqExpr{
-						pos: position{line: 807, col: 45, offset: 26373},
+						pos: position{line: 808, col: 45, offset: 26422},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 807, col: 45, offset: 26373},
+								pos:        position{line: 808, col: 45, offset: 26422},
 								val:        ":",
 								ignoreCase: false,
 								want:       "\":\"",
 							},
 							&notExpr{
-								pos: position{line: 807, col: 49, offset: 26377},
+								pos: position{line: 808, col: 49, offset: 26426},
 								expr: &litMatcher{
-									pos:        position{line: 807, col: 50, offset: 26378},
+									pos:        position{line: 808, col: 50, offset: 26427},
 									val:        ":",
 									ignoreCase: false,
 									want:       "\":\"",
@@ -4670,20 +4670,20 @@ var g = &grammar{
 		},
 		{
 			name: "VerbatimLabeledListItemTerm",
-			pos:  position{line: 808, col: 1, offset: 26382},
+			pos:  position{line: 809, col: 1, offset: 26431},
 			expr: &actionExpr{
-				pos: position{line: 808, col: 32, offset: 26413},
+				pos: position{line: 809, col: 32, offset: 26462},
 				run: (*parser).callonVerbatimLabeledListItemTerm1,
 				expr: &labeledExpr{
-					pos:   position{line: 808, col: 32, offset: 26413},
+					pos:   position{line: 809, col: 32, offset: 26462},
 					label: "content",
 					expr: &actionExpr{
-						pos: position{line: 808, col: 42, offset: 26423},
+						pos: position{line: 809, col: 42, offset: 26472},
 						run: (*parser).callonVerbatimLabeledListItemTerm3,
 						expr: &oneOrMoreExpr{
-							pos: position{line: 808, col: 42, offset: 26423},
+							pos: position{line: 809, col: 42, offset: 26472},
 							expr: &ruleRefExpr{
-								pos:  position{line: 808, col: 42, offset: 26423},
+								pos:  position{line: 809, col: 42, offset: 26472},
 								name: "VerbatimLabeledListItemChars",
 							},
 						},
@@ -4693,36 +4693,36 @@ var g = &grammar{
 		},
 		{
 			name: "LabeledListItemTerm",
-			pos:  position{line: 815, col: 1, offset: 26598},
+			pos:  position{line: 816, col: 1, offset: 26647},
 			expr: &actionExpr{
-				pos: position{line: 815, col: 24, offset: 26621},
+				pos: position{line: 816, col: 24, offset: 26670},
 				run: (*parser).callonLabeledListItemTerm1,
 				expr: &labeledExpr{
-					pos:   position{line: 815, col: 24, offset: 26621},
+					pos:   position{line: 816, col: 24, offset: 26670},
 					label: "elements",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 815, col: 33, offset: 26630},
+						pos: position{line: 816, col: 33, offset: 26679},
 						expr: &seqExpr{
-							pos: position{line: 815, col: 34, offset: 26631},
+							pos: position{line: 816, col: 34, offset: 26680},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 815, col: 34, offset: 26631},
+									pos: position{line: 816, col: 34, offset: 26680},
 									expr: &ruleRefExpr{
-										pos:  position{line: 815, col: 35, offset: 26632},
+										pos:  position{line: 816, col: 35, offset: 26681},
 										name: "Newline",
 									},
 								},
 								&notExpr{
-									pos: position{line: 815, col: 43, offset: 26640},
+									pos: position{line: 816, col: 43, offset: 26689},
 									expr: &litMatcher{
-										pos:        position{line: 815, col: 44, offset: 26641},
+										pos:        position{line: 816, col: 44, offset: 26690},
 										val:        "::",
 										ignoreCase: false,
 										want:       "\"::\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 815, col: 49, offset: 26646},
+									pos:  position{line: 816, col: 49, offset: 26695},
 									name: "LabeledListItemTermElement",
 								},
 							},
@@ -4733,85 +4733,85 @@ var g = &grammar{
 		},
 		{
 			name: "LabeledListItemTermElement",
-			pos:  position{line: 819, col: 1, offset: 26743},
+			pos:  position{line: 820, col: 1, offset: 26792},
 			expr: &actionExpr{
-				pos: position{line: 819, col: 31, offset: 26773},
+				pos: position{line: 820, col: 31, offset: 26822},
 				run: (*parser).callonLabeledListItemTermElement1,
 				expr: &labeledExpr{
-					pos:   position{line: 819, col: 31, offset: 26773},
+					pos:   position{line: 820, col: 31, offset: 26822},
 					label: "element",
 					expr: &choiceExpr{
-						pos: position{line: 819, col: 40, offset: 26782},
+						pos: position{line: 820, col: 40, offset: 26831},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 819, col: 40, offset: 26782},
+								pos:  position{line: 820, col: 40, offset: 26831},
 								name: "Word",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 820, col: 11, offset: 26797},
+								pos:  position{line: 821, col: 11, offset: 26846},
 								name: "LineBreak",
 							},
 							&oneOrMoreExpr{
-								pos: position{line: 821, col: 11, offset: 26846},
+								pos: position{line: 822, col: 11, offset: 26895},
 								expr: &ruleRefExpr{
-									pos:  position{line: 821, col: 11, offset: 26846},
+									pos:  position{line: 822, col: 11, offset: 26895},
 									name: "Space",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 822, col: 11, offset: 26864},
+								pos:  position{line: 823, col: 11, offset: 26913},
 								name: "CrossReference",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 823, col: 11, offset: 26889},
+								pos:  position{line: 824, col: 11, offset: 26938},
 								name: "ConcealedIndexTerm",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 824, col: 11, offset: 26918},
+								pos:  position{line: 825, col: 11, offset: 26967},
 								name: "IndexTerm",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 825, col: 11, offset: 26938},
+								pos:  position{line: 826, col: 11, offset: 26987},
 								name: "InlinePassthrough",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 826, col: 11, offset: 27027},
+								pos:  position{line: 827, col: 11, offset: 27076},
 								name: "InlineIcon",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 827, col: 11, offset: 27048},
+								pos:  position{line: 828, col: 11, offset: 27097},
 								name: "InlineImage",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 828, col: 11, offset: 27071},
+								pos:  position{line: 829, col: 11, offset: 27120},
 								name: "Link",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 829, col: 11, offset: 27086},
+								pos:  position{line: 830, col: 11, offset: 27135},
 								name: "InlineFootnote",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 830, col: 11, offset: 27111},
+								pos:  position{line: 831, col: 11, offset: 27160},
 								name: "QuotedString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 831, col: 11, offset: 27134},
+								pos:  position{line: 832, col: 11, offset: 27183},
 								name: "QuotedText",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 832, col: 11, offset: 27155},
+								pos:  position{line: 833, col: 11, offset: 27204},
 								name: "SpecialCharacter",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 833, col: 11, offset: 27182},
+								pos:  position{line: 834, col: 11, offset: 27231},
 								name: "Symbol",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 834, col: 11, offset: 27199},
+								pos:  position{line: 835, col: 11, offset: 27248},
 								name: "AttributeSubstitution",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 835, col: 11, offset: 27231},
+								pos:  position{line: 836, col: 11, offset: 27280},
 								name: "AnyChar",
 							},
 						},
@@ -4821,23 +4821,23 @@ var g = &grammar{
 		},
 		{
 			name: "LabeledListItemSeparator",
-			pos:  position{line: 839, col: 1, offset: 27270},
+			pos:  position{line: 840, col: 1, offset: 27319},
 			expr: &actionExpr{
-				pos: position{line: 840, col: 5, offset: 27303},
+				pos: position{line: 841, col: 5, offset: 27352},
 				run: (*parser).callonLabeledListItemSeparator1,
 				expr: &seqExpr{
-					pos: position{line: 840, col: 5, offset: 27303},
+					pos: position{line: 841, col: 5, offset: 27352},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 840, col: 5, offset: 27303},
+							pos:   position{line: 841, col: 5, offset: 27352},
 							label: "separator",
 							expr: &actionExpr{
-								pos: position{line: 840, col: 16, offset: 27314},
+								pos: position{line: 841, col: 16, offset: 27363},
 								run: (*parser).callonLabeledListItemSeparator4,
 								expr: &oneOrMoreExpr{
-									pos: position{line: 840, col: 16, offset: 27314},
+									pos: position{line: 841, col: 16, offset: 27363},
 									expr: &litMatcher{
-										pos:        position{line: 840, col: 17, offset: 27315},
+										pos:        position{line: 841, col: 17, offset: 27364},
 										val:        ":",
 										ignoreCase: false,
 										want:       "\":\"",
@@ -4846,30 +4846,30 @@ var g = &grammar{
 							},
 						},
 						&andCodeExpr{
-							pos: position{line: 843, col: 5, offset: 27373},
+							pos: position{line: 844, col: 5, offset: 27422},
 							run: (*parser).callonLabeledListItemSeparator7,
 						},
 						&choiceExpr{
-							pos: position{line: 847, col: 6, offset: 27549},
+							pos: position{line: 848, col: 6, offset: 27598},
 							alternatives: []interface{}{
 								&oneOrMoreExpr{
-									pos: position{line: 847, col: 6, offset: 27549},
+									pos: position{line: 848, col: 6, offset: 27598},
 									expr: &choiceExpr{
-										pos: position{line: 847, col: 7, offset: 27550},
+										pos: position{line: 848, col: 7, offset: 27599},
 										alternatives: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 847, col: 7, offset: 27550},
+												pos:  position{line: 848, col: 7, offset: 27599},
 												name: "Space",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 847, col: 15, offset: 27558},
+												pos:  position{line: 848, col: 15, offset: 27607},
 												name: "Newline",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 847, col: 27, offset: 27570},
+									pos:  position{line: 848, col: 27, offset: 27619},
 									name: "EOL",
 								},
 							},
@@ -4880,17 +4880,17 @@ var g = &grammar{
 		},
 		{
 			name: "LabeledListItemDescription",
-			pos:  position{line: 851, col: 1, offset: 27610},
+			pos:  position{line: 852, col: 1, offset: 27659},
 			expr: &actionExpr{
-				pos: position{line: 851, col: 31, offset: 27640},
+				pos: position{line: 852, col: 31, offset: 27689},
 				run: (*parser).callonLabeledListItemDescription1,
 				expr: &labeledExpr{
-					pos:   position{line: 851, col: 31, offset: 27640},
+					pos:   position{line: 852, col: 31, offset: 27689},
 					label: "elements",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 851, col: 40, offset: 27649},
+						pos: position{line: 852, col: 40, offset: 27698},
 						expr: &ruleRefExpr{
-							pos:  position{line: 851, col: 41, offset: 27650},
+							pos:  position{line: 852, col: 41, offset: 27699},
 							name: "ListParagraph",
 						},
 					},
@@ -4899,55 +4899,55 @@ var g = &grammar{
 		},
 		{
 			name: "AdmonitionKind",
-			pos:  position{line: 858, col: 1, offset: 27841},
+			pos:  position{line: 859, col: 1, offset: 27890},
 			expr: &choiceExpr{
-				pos: position{line: 858, col: 19, offset: 27859},
+				pos: position{line: 859, col: 19, offset: 27908},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 858, col: 19, offset: 27859},
+						pos: position{line: 859, col: 19, offset: 27908},
 						run: (*parser).callonAdmonitionKind2,
 						expr: &litMatcher{
-							pos:        position{line: 858, col: 19, offset: 27859},
+							pos:        position{line: 859, col: 19, offset: 27908},
 							val:        "TIP",
 							ignoreCase: false,
 							want:       "\"TIP\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 860, col: 5, offset: 27897},
+						pos: position{line: 861, col: 5, offset: 27946},
 						run: (*parser).callonAdmonitionKind4,
 						expr: &litMatcher{
-							pos:        position{line: 860, col: 5, offset: 27897},
+							pos:        position{line: 861, col: 5, offset: 27946},
 							val:        "NOTE",
 							ignoreCase: false,
 							want:       "\"NOTE\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 862, col: 5, offset: 27937},
+						pos: position{line: 863, col: 5, offset: 27986},
 						run: (*parser).callonAdmonitionKind6,
 						expr: &litMatcher{
-							pos:        position{line: 862, col: 5, offset: 27937},
+							pos:        position{line: 863, col: 5, offset: 27986},
 							val:        "IMPORTANT",
 							ignoreCase: false,
 							want:       "\"IMPORTANT\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 864, col: 5, offset: 27987},
+						pos: position{line: 865, col: 5, offset: 28036},
 						run: (*parser).callonAdmonitionKind8,
 						expr: &litMatcher{
-							pos:        position{line: 864, col: 5, offset: 27987},
+							pos:        position{line: 865, col: 5, offset: 28036},
 							val:        "WARNING",
 							ignoreCase: false,
 							want:       "\"WARNING\"",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 866, col: 5, offset: 28033},
+						pos: position{line: 867, col: 5, offset: 28082},
 						run: (*parser).callonAdmonitionKind10,
 						expr: &litMatcher{
-							pos:        position{line: 866, col: 5, offset: 28033},
+							pos:        position{line: 867, col: 5, offset: 28082},
 							val:        "CAUTION",
 							ignoreCase: false,
 							want:       "\"CAUTION\"",
@@ -4958,55 +4958,55 @@ var g = &grammar{
 		},
 		{
 			name: "RawParagraph",
-			pos:  position{line: 878, col: 1, offset: 28413},
+			pos:  position{line: 879, col: 1, offset: 28462},
 			expr: &choiceExpr{
-				pos: position{line: 880, col: 6, offset: 28464},
+				pos: position{line: 881, col: 6, offset: 28513},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 880, col: 6, offset: 28464},
+						pos: position{line: 881, col: 6, offset: 28513},
 						run: (*parser).callonRawParagraph2,
 						expr: &seqExpr{
-							pos: position{line: 880, col: 6, offset: 28464},
+							pos: position{line: 881, col: 6, offset: 28513},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 880, col: 6, offset: 28464},
+									pos:   position{line: 881, col: 6, offset: 28513},
 									label: "attributes",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 880, col: 17, offset: 28475},
+										pos: position{line: 881, col: 17, offset: 28524},
 										expr: &ruleRefExpr{
-											pos:  position{line: 880, col: 18, offset: 28476},
+											pos:  position{line: 881, col: 18, offset: 28525},
 											name: "BlockAttributes",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 880, col: 36, offset: 28494},
+									pos:   position{line: 881, col: 36, offset: 28543},
 									label: "t",
 									expr: &ruleRefExpr{
-										pos:  position{line: 880, col: 39, offset: 28497},
+										pos:  position{line: 881, col: 39, offset: 28546},
 										name: "AdmonitionKind",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 880, col: 55, offset: 28513},
+									pos:        position{line: 881, col: 55, offset: 28562},
 									val:        ": ",
 									ignoreCase: false,
 									want:       "\": \"",
 								},
 								&labeledExpr{
-									pos:   position{line: 880, col: 60, offset: 28518},
+									pos:   position{line: 881, col: 60, offset: 28567},
 									label: "lines",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 880, col: 66, offset: 28524},
+										pos: position{line: 881, col: 66, offset: 28573},
 										expr: &choiceExpr{
-											pos: position{line: 880, col: 67, offset: 28525},
+											pos: position{line: 881, col: 67, offset: 28574},
 											alternatives: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 880, col: 67, offset: 28525},
+													pos:  position{line: 881, col: 67, offset: 28574},
 													name: "SingleLineComment",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 880, col: 87, offset: 28545},
+													pos:  position{line: 881, col: 87, offset: 28594},
 													name: "RawParagraphLine",
 												},
 											},
@@ -5017,33 +5017,33 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 885, col: 5, offset: 28766},
+						pos: position{line: 886, col: 5, offset: 28815},
 						run: (*parser).callonRawParagraph15,
 						expr: &seqExpr{
-							pos: position{line: 885, col: 5, offset: 28766},
+							pos: position{line: 886, col: 5, offset: 28815},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 885, col: 5, offset: 28766},
+									pos:   position{line: 886, col: 5, offset: 28815},
 									label: "attributes",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 885, col: 16, offset: 28777},
+										pos: position{line: 886, col: 16, offset: 28826},
 										expr: &ruleRefExpr{
-											pos:  position{line: 885, col: 17, offset: 28778},
+											pos:  position{line: 886, col: 17, offset: 28827},
 											name: "BlockAttributes",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 885, col: 35, offset: 28796},
+									pos:        position{line: 886, col: 35, offset: 28845},
 									val:        "> ",
 									ignoreCase: false,
 									want:       "\"> \"",
 								},
 								&labeledExpr{
-									pos:   position{line: 885, col: 40, offset: 28801},
+									pos:   position{line: 886, col: 40, offset: 28850},
 									label: "content",
 									expr: &ruleRefExpr{
-										pos:  position{line: 885, col: 49, offset: 28810},
+										pos:  position{line: 886, col: 49, offset: 28859},
 										name: "MarkdownQuoteBlockRawContent",
 									},
 								},
@@ -5051,33 +5051,33 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 889, col: 5, offset: 28983},
+						pos: position{line: 890, col: 5, offset: 29032},
 						run: (*parser).callonRawParagraph23,
 						expr: &seqExpr{
-							pos: position{line: 889, col: 5, offset: 28983},
+							pos: position{line: 890, col: 5, offset: 29032},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 889, col: 5, offset: 28983},
+									pos:   position{line: 890, col: 5, offset: 29032},
 									label: "attributes",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 889, col: 16, offset: 28994},
+										pos: position{line: 890, col: 16, offset: 29043},
 										expr: &ruleRefExpr{
-											pos:  position{line: 889, col: 17, offset: 28995},
+											pos:  position{line: 890, col: 17, offset: 29044},
 											name: "BlockAttributes",
 										},
 									},
 								},
 								&andCodeExpr{
-									pos: position{line: 889, col: 35, offset: 29013},
+									pos: position{line: 890, col: 35, offset: 29062},
 									run: (*parser).callonRawParagraph28,
 								},
 								&labeledExpr{
-									pos:   position{line: 892, col: 7, offset: 29191},
+									pos:   position{line: 893, col: 7, offset: 29240},
 									label: "content",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 892, col: 15, offset: 29199},
+										pos: position{line: 893, col: 15, offset: 29248},
 										expr: &ruleRefExpr{
-											pos:  position{line: 892, col: 16, offset: 29200},
+											pos:  position{line: 893, col: 16, offset: 29249},
 											name: "RawParagraphLine",
 										},
 									},
@@ -5086,36 +5086,36 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 896, col: 5, offset: 29366},
+						pos: position{line: 897, col: 5, offset: 29415},
 						run: (*parser).callonRawParagraph32,
 						expr: &seqExpr{
-							pos: position{line: 896, col: 5, offset: 29366},
+							pos: position{line: 897, col: 5, offset: 29415},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 896, col: 5, offset: 29366},
+									pos:   position{line: 897, col: 5, offset: 29415},
 									label: "attributes",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 896, col: 16, offset: 29377},
+										pos: position{line: 897, col: 16, offset: 29426},
 										expr: &ruleRefExpr{
-											pos:  position{line: 896, col: 17, offset: 29378},
+											pos:  position{line: 897, col: 17, offset: 29427},
 											name: "BlockAttributes",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 896, col: 35, offset: 29396},
+									pos:   position{line: 897, col: 35, offset: 29445},
 									label: "lines",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 896, col: 41, offset: 29402},
+										pos: position{line: 897, col: 41, offset: 29451},
 										expr: &choiceExpr{
-											pos: position{line: 896, col: 42, offset: 29403},
+											pos: position{line: 897, col: 42, offset: 29452},
 											alternatives: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 896, col: 42, offset: 29403},
+													pos:  position{line: 897, col: 42, offset: 29452},
 													name: "SingleLineComment",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 896, col: 62, offset: 29423},
+													pos:  position{line: 897, col: 62, offset: 29472},
 													name: "RawParagraphLine",
 												},
 											},
@@ -5130,36 +5130,36 @@ var g = &grammar{
 		},
 		{
 			name: "MarkdownQuoteBlockRawContent",
-			pos:  position{line: 900, col: 1, offset: 29521},
+			pos:  position{line: 901, col: 1, offset: 29570},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 900, col: 33, offset: 29553},
+				pos: position{line: 901, col: 33, offset: 29602},
 				expr: &actionExpr{
-					pos: position{line: 900, col: 34, offset: 29554},
+					pos: position{line: 901, col: 34, offset: 29603},
 					run: (*parser).callonMarkdownQuoteBlockRawContent2,
 					expr: &seqExpr{
-						pos: position{line: 900, col: 34, offset: 29554},
+						pos: position{line: 901, col: 34, offset: 29603},
 						exprs: []interface{}{
 							&notExpr{
-								pos: position{line: 900, col: 34, offset: 29554},
+								pos: position{line: 901, col: 34, offset: 29603},
 								expr: &ruleRefExpr{
-									pos:  position{line: 900, col: 35, offset: 29555},
+									pos:  position{line: 901, col: 35, offset: 29604},
 									name: "BlankLine",
 								},
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 900, col: 45, offset: 29565},
+								pos: position{line: 901, col: 45, offset: 29614},
 								expr: &litMatcher{
-									pos:        position{line: 900, col: 45, offset: 29565},
+									pos:        position{line: 901, col: 45, offset: 29614},
 									val:        "> ",
 									ignoreCase: false,
 									want:       "\"> \"",
 								},
 							},
 							&labeledExpr{
-								pos:   position{line: 900, col: 51, offset: 29571},
+								pos:   position{line: 901, col: 51, offset: 29620},
 								label: "content",
 								expr: &ruleRefExpr{
-									pos:  position{line: 900, col: 60, offset: 29580},
+									pos:  position{line: 901, col: 60, offset: 29629},
 									name: "RawLine",
 								},
 							},
@@ -5170,34 +5170,34 @@ var g = &grammar{
 		},
 		{
 			name: "RawParagraphLine",
-			pos:  position{line: 904, col: 1, offset: 29621},
+			pos:  position{line: 905, col: 1, offset: 29670},
 			expr: &actionExpr{
-				pos: position{line: 904, col: 21, offset: 29641},
+				pos: position{line: 905, col: 21, offset: 29690},
 				run: (*parser).callonRawParagraphLine1,
 				expr: &seqExpr{
-					pos: position{line: 904, col: 21, offset: 29641},
+					pos: position{line: 905, col: 21, offset: 29690},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 904, col: 21, offset: 29641},
+							pos: position{line: 905, col: 21, offset: 29690},
 							expr: &ruleRefExpr{
-								pos:  position{line: 904, col: 22, offset: 29642},
+								pos:  position{line: 905, col: 22, offset: 29691},
 								name: "BlockDelimiter",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 905, col: 5, offset: 29662},
+							pos:   position{line: 906, col: 5, offset: 29711},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 905, col: 14, offset: 29671},
+								pos:  position{line: 906, col: 14, offset: 29720},
 								name: "RawParagraphLineContent",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 905, col: 39, offset: 29696},
+							pos:  position{line: 906, col: 39, offset: 29745},
 							name: "EOL",
 						},
 						&andCodeExpr{
-							pos: position{line: 905, col: 43, offset: 29700},
+							pos: position{line: 906, col: 43, offset: 29749},
 							run: (*parser).callonRawParagraphLine8,
 						},
 					},
@@ -5206,14 +5206,14 @@ var g = &grammar{
 		},
 		{
 			name: "RawParagraphLineContent",
-			pos:  position{line: 915, col: 1, offset: 29935},
+			pos:  position{line: 916, col: 1, offset: 29984},
 			expr: &actionExpr{
-				pos: position{line: 915, col: 28, offset: 29962},
+				pos: position{line: 916, col: 28, offset: 30011},
 				run: (*parser).callonRawParagraphLineContent1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 915, col: 28, offset: 29962},
+					pos: position{line: 916, col: 28, offset: 30011},
 					expr: &charClassMatcher{
-						pos:        position{line: 915, col: 28, offset: 29962},
+						pos:        position{line: 916, col: 28, offset: 30011},
 						val:        "[^\\r\\n]",
 						chars:      []rune{'\r', '\n'},
 						ignoreCase: false,
@@ -5224,50 +5224,50 @@ var g = &grammar{
 		},
 		{
 			name: "SimpleRawParagraph",
-			pos:  position{line: 920, col: 1, offset: 30079},
+			pos:  position{line: 921, col: 1, offset: 30128},
 			expr: &actionExpr{
-				pos: position{line: 920, col: 23, offset: 30101},
+				pos: position{line: 921, col: 23, offset: 30150},
 				run: (*parser).callonSimpleRawParagraph1,
 				expr: &seqExpr{
-					pos: position{line: 920, col: 23, offset: 30101},
+					pos: position{line: 921, col: 23, offset: 30150},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 920, col: 23, offset: 30101},
+							pos:   position{line: 921, col: 23, offset: 30150},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 920, col: 34, offset: 30112},
+								pos: position{line: 921, col: 34, offset: 30161},
 								expr: &ruleRefExpr{
-									pos:  position{line: 920, col: 35, offset: 30113},
+									pos:  position{line: 921, col: 35, offset: 30162},
 									name: "BlockAttributes",
 								},
 							},
 						},
 						&andCodeExpr{
-							pos: position{line: 921, col: 5, offset: 30136},
+							pos: position{line: 922, col: 5, offset: 30185},
 							run: (*parser).callonSimpleRawParagraph6,
 						},
 						&labeledExpr{
-							pos:   position{line: 924, col: 5, offset: 30248},
+							pos:   position{line: 925, col: 5, offset: 30297},
 							label: "firstLine",
 							expr: &ruleRefExpr{
-								pos:  position{line: 924, col: 16, offset: 30259},
+								pos:  position{line: 925, col: 16, offset: 30308},
 								name: "FirstParagraphRawLine",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 925, col: 5, offset: 30285},
+							pos:   position{line: 926, col: 5, offset: 30334},
 							label: "otherLines",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 925, col: 16, offset: 30296},
+								pos: position{line: 926, col: 16, offset: 30345},
 								expr: &choiceExpr{
-									pos: position{line: 925, col: 17, offset: 30297},
+									pos: position{line: 926, col: 17, offset: 30346},
 									alternatives: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 925, col: 17, offset: 30297},
+											pos:  position{line: 926, col: 17, offset: 30346},
 											name: "SingleLineComment",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 925, col: 37, offset: 30317},
+											pos:  position{line: 926, col: 37, offset: 30366},
 											name: "RawParagraphLine",
 										},
 									},
@@ -5280,34 +5280,34 @@ var g = &grammar{
 		},
 		{
 			name: "FirstParagraphRawLine",
-			pos:  position{line: 929, col: 1, offset: 30449},
+			pos:  position{line: 930, col: 1, offset: 30498},
 			expr: &actionExpr{
-				pos: position{line: 930, col: 5, offset: 30479},
+				pos: position{line: 931, col: 5, offset: 30528},
 				run: (*parser).callonFirstParagraphRawLine1,
 				expr: &seqExpr{
-					pos: position{line: 930, col: 5, offset: 30479},
+					pos: position{line: 931, col: 5, offset: 30528},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 930, col: 5, offset: 30479},
+							pos:   position{line: 931, col: 5, offset: 30528},
 							label: "content",
 							expr: &actionExpr{
-								pos: position{line: 930, col: 14, offset: 30488},
+								pos: position{line: 931, col: 14, offset: 30537},
 								run: (*parser).callonFirstParagraphRawLine4,
 								expr: &seqExpr{
-									pos: position{line: 930, col: 14, offset: 30488},
+									pos: position{line: 931, col: 14, offset: 30537},
 									exprs: []interface{}{
 										&labeledExpr{
-											pos:   position{line: 930, col: 14, offset: 30488},
+											pos:   position{line: 931, col: 14, offset: 30537},
 											label: "elements",
 											expr: &ruleRefExpr{
-												pos:  position{line: 930, col: 23, offset: 30497},
+												pos:  position{line: 931, col: 23, offset: 30546},
 												name: "Word",
 											},
 										},
 										&zeroOrMoreExpr{
-											pos: position{line: 930, col: 28, offset: 30502},
+											pos: position{line: 931, col: 28, offset: 30551},
 											expr: &charClassMatcher{
-												pos:        position{line: 930, col: 28, offset: 30502},
+												pos:        position{line: 931, col: 28, offset: 30551},
 												val:        "[^\\r\\n]",
 												chars:      []rune{'\r', '\n'},
 												ignoreCase: false,
@@ -5319,7 +5319,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 930, col: 68, offset: 30542},
+							pos:  position{line: 931, col: 68, offset: 30591},
 							name: "EOL",
 						},
 					},
@@ -5328,46 +5328,46 @@ var g = &grammar{
 		},
 		{
 			name: "ContinuedRawParagraph",
-			pos:  position{line: 941, col: 1, offset: 30794},
+			pos:  position{line: 942, col: 1, offset: 30843},
 			expr: &choiceExpr{
-				pos: position{line: 943, col: 5, offset: 30853},
+				pos: position{line: 944, col: 5, offset: 30902},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 943, col: 5, offset: 30853},
+						pos: position{line: 944, col: 5, offset: 30902},
 						run: (*parser).callonContinuedRawParagraph2,
 						expr: &seqExpr{
-							pos: position{line: 943, col: 5, offset: 30853},
+							pos: position{line: 944, col: 5, offset: 30902},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 943, col: 5, offset: 30853},
+									pos:   position{line: 944, col: 5, offset: 30902},
 									label: "attributes",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 943, col: 16, offset: 30864},
+										pos: position{line: 944, col: 16, offset: 30913},
 										expr: &ruleRefExpr{
-											pos:  position{line: 943, col: 17, offset: 30865},
+											pos:  position{line: 944, col: 17, offset: 30914},
 											name: "BlockAttributes",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 943, col: 35, offset: 30883},
+									pos:   position{line: 944, col: 35, offset: 30932},
 									label: "t",
 									expr: &ruleRefExpr{
-										pos:  position{line: 943, col: 38, offset: 30886},
+										pos:  position{line: 944, col: 38, offset: 30935},
 										name: "AdmonitionKind",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 943, col: 54, offset: 30902},
+									pos:        position{line: 944, col: 54, offset: 30951},
 									val:        ": ",
 									ignoreCase: false,
 									want:       "\": \"",
 								},
 								&labeledExpr{
-									pos:   position{line: 943, col: 59, offset: 30907},
+									pos:   position{line: 944, col: 59, offset: 30956},
 									label: "lines",
 									expr: &ruleRefExpr{
-										pos:  position{line: 943, col: 66, offset: 30914},
+										pos:  position{line: 944, col: 66, offset: 30963},
 										name: "ContinuedRawParagraphLines",
 									},
 								},
@@ -5375,27 +5375,27 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 947, col: 5, offset: 31103},
+						pos: position{line: 948, col: 5, offset: 31152},
 						run: (*parser).callonContinuedRawParagraph12,
 						expr: &seqExpr{
-							pos: position{line: 947, col: 5, offset: 31103},
+							pos: position{line: 948, col: 5, offset: 31152},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 947, col: 5, offset: 31103},
+									pos:   position{line: 948, col: 5, offset: 31152},
 									label: "attributes",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 947, col: 16, offset: 31114},
+										pos: position{line: 948, col: 16, offset: 31163},
 										expr: &ruleRefExpr{
-											pos:  position{line: 947, col: 17, offset: 31115},
+											pos:  position{line: 948, col: 17, offset: 31164},
 											name: "BlockAttributes",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 947, col: 35, offset: 31133},
+									pos:   position{line: 948, col: 35, offset: 31182},
 									label: "lines",
 									expr: &ruleRefExpr{
-										pos:  position{line: 947, col: 42, offset: 31140},
+										pos:  position{line: 948, col: 42, offset: 31189},
 										name: "ContinuedRawParagraphLines",
 									},
 								},
@@ -5407,51 +5407,51 @@ var g = &grammar{
 		},
 		{
 			name: "ContinuedRawParagraphLines",
-			pos:  position{line: 951, col: 1, offset: 31244},
+			pos:  position{line: 952, col: 1, offset: 31293},
 			expr: &actionExpr{
-				pos: position{line: 951, col: 31, offset: 31274},
+				pos: position{line: 952, col: 31, offset: 31323},
 				run: (*parser).callonContinuedRawParagraphLines1,
 				expr: &seqExpr{
-					pos: position{line: 951, col: 31, offset: 31274},
+					pos: position{line: 952, col: 31, offset: 31323},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 951, col: 31, offset: 31274},
+							pos:   position{line: 952, col: 31, offset: 31323},
 							label: "firstLine",
 							expr: &ruleRefExpr{
-								pos:  position{line: 951, col: 42, offset: 31285},
+								pos:  position{line: 952, col: 42, offset: 31334},
 								name: "FirstParagraphRawLine",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 951, col: 65, offset: 31308},
+							pos:   position{line: 952, col: 65, offset: 31357},
 							label: "otherLines",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 951, col: 76, offset: 31319},
+								pos: position{line: 952, col: 76, offset: 31368},
 								expr: &actionExpr{
-									pos: position{line: 951, col: 77, offset: 31320},
+									pos: position{line: 952, col: 77, offset: 31369},
 									run: (*parser).callonContinuedRawParagraphLines7,
 									expr: &seqExpr{
-										pos: position{line: 951, col: 77, offset: 31320},
+										pos: position{line: 952, col: 77, offset: 31369},
 										exprs: []interface{}{
 											&notExpr{
-												pos: position{line: 951, col: 77, offset: 31320},
+												pos: position{line: 952, col: 77, offset: 31369},
 												expr: &ruleRefExpr{
-													pos:  position{line: 951, col: 78, offset: 31321},
+													pos:  position{line: 952, col: 78, offset: 31370},
 													name: "ListItemContinuation",
 												},
 											},
 											&labeledExpr{
-												pos:   position{line: 951, col: 99, offset: 31342},
+												pos:   position{line: 952, col: 99, offset: 31391},
 												label: "line",
 												expr: &choiceExpr{
-													pos: position{line: 951, col: 105, offset: 31348},
+													pos: position{line: 952, col: 105, offset: 31397},
 													alternatives: []interface{}{
 														&ruleRefExpr{
-															pos:  position{line: 951, col: 105, offset: 31348},
+															pos:  position{line: 952, col: 105, offset: 31397},
 															name: "SingleLineComment",
 														},
 														&ruleRefExpr{
-															pos:  position{line: 951, col: 125, offset: 31368},
+															pos:  position{line: 952, col: 125, offset: 31417},
 															name: "RawParagraphLine",
 														},
 													},
@@ -5468,57 +5468,57 @@ var g = &grammar{
 		},
 		{
 			name: "InlineElements",
-			pos:  position{line: 959, col: 1, offset: 31610},
+			pos:  position{line: 960, col: 1, offset: 31659},
 			expr: &actionExpr{
-				pos: position{line: 959, col: 19, offset: 31628},
+				pos: position{line: 960, col: 19, offset: 31677},
 				run: (*parser).callonInlineElements1,
 				expr: &seqExpr{
-					pos: position{line: 959, col: 19, offset: 31628},
+					pos: position{line: 960, col: 19, offset: 31677},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 959, col: 19, offset: 31628},
+							pos: position{line: 960, col: 19, offset: 31677},
 							expr: &ruleRefExpr{
-								pos:  position{line: 959, col: 20, offset: 31629},
+								pos:  position{line: 960, col: 20, offset: 31678},
 								name: "BlankLine",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 960, col: 5, offset: 31643},
+							pos:   position{line: 961, col: 5, offset: 31692},
 							label: "elements",
 							expr: &choiceExpr{
-								pos: position{line: 960, col: 15, offset: 31653},
+								pos: position{line: 961, col: 15, offset: 31702},
 								alternatives: []interface{}{
 									&actionExpr{
-										pos: position{line: 960, col: 15, offset: 31653},
+										pos: position{line: 961, col: 15, offset: 31702},
 										run: (*parser).callonInlineElements7,
 										expr: &labeledExpr{
-											pos:   position{line: 960, col: 15, offset: 31653},
+											pos:   position{line: 961, col: 15, offset: 31702},
 											label: "comment",
 											expr: &ruleRefExpr{
-												pos:  position{line: 960, col: 24, offset: 31662},
+												pos:  position{line: 961, col: 24, offset: 31711},
 												name: "SingleLineComment",
 											},
 										},
 									},
 									&actionExpr{
-										pos: position{line: 962, col: 9, offset: 31754},
+										pos: position{line: 963, col: 9, offset: 31803},
 										run: (*parser).callonInlineElements10,
 										expr: &seqExpr{
-											pos: position{line: 962, col: 9, offset: 31754},
+											pos: position{line: 963, col: 9, offset: 31803},
 											exprs: []interface{}{
 												&labeledExpr{
-													pos:   position{line: 962, col: 9, offset: 31754},
+													pos:   position{line: 963, col: 9, offset: 31803},
 													label: "elements",
 													expr: &oneOrMoreExpr{
-														pos: position{line: 962, col: 18, offset: 31763},
+														pos: position{line: 963, col: 18, offset: 31812},
 														expr: &ruleRefExpr{
-															pos:  position{line: 962, col: 19, offset: 31764},
+															pos:  position{line: 963, col: 19, offset: 31813},
 															name: "InlineElement",
 														},
 													},
 												},
 												&ruleRefExpr{
-													pos:  position{line: 962, col: 35, offset: 31780},
+													pos:  position{line: 963, col: 35, offset: 31829},
 													name: "EOL",
 												},
 											},
@@ -5533,110 +5533,110 @@ var g = &grammar{
 		},
 		{
 			name: "InlineElement",
-			pos:  position{line: 968, col: 1, offset: 31897},
+			pos:  position{line: 969, col: 1, offset: 31946},
 			expr: &actionExpr{
-				pos: position{line: 969, col: 5, offset: 31920},
+				pos: position{line: 970, col: 5, offset: 31969},
 				run: (*parser).callonInlineElement1,
 				expr: &labeledExpr{
-					pos:   position{line: 969, col: 5, offset: 31920},
+					pos:   position{line: 970, col: 5, offset: 31969},
 					label: "element",
 					expr: &choiceExpr{
-						pos: position{line: 969, col: 14, offset: 31929},
+						pos: position{line: 970, col: 14, offset: 31978},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 969, col: 14, offset: 31929},
+								pos:  position{line: 970, col: 14, offset: 31978},
 								name: "InlineWord",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 970, col: 11, offset: 31990},
+								pos:  position{line: 971, col: 11, offset: 32039},
 								name: "LineBreak",
 							},
 							&oneOrMoreExpr{
-								pos: position{line: 971, col: 11, offset: 32035},
+								pos: position{line: 972, col: 11, offset: 32084},
 								expr: &ruleRefExpr{
-									pos:  position{line: 971, col: 11, offset: 32035},
+									pos:  position{line: 972, col: 11, offset: 32084},
 									name: "Space",
 								},
 							},
 							&seqExpr{
-								pos: position{line: 972, col: 11, offset: 32053},
+								pos: position{line: 973, col: 11, offset: 32102},
 								exprs: []interface{}{
 									&notExpr{
-										pos: position{line: 972, col: 11, offset: 32053},
+										pos: position{line: 973, col: 11, offset: 32102},
 										expr: &ruleRefExpr{
-											pos:  position{line: 972, col: 12, offset: 32054},
+											pos:  position{line: 973, col: 12, offset: 32103},
 											name: "EOL",
 										},
 									},
 									&choiceExpr{
-										pos: position{line: 973, col: 13, offset: 32072},
+										pos: position{line: 974, col: 13, offset: 32121},
 										alternatives: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 973, col: 13, offset: 32072},
+												pos:  position{line: 974, col: 13, offset: 32121},
 												name: "QuotedString",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 974, col: 15, offset: 32099},
+												pos:  position{line: 975, col: 15, offset: 32148},
 												name: "QuotedText",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 975, col: 15, offset: 32124},
+												pos:  position{line: 976, col: 15, offset: 32173},
 												name: "InlineIcon",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 976, col: 15, offset: 32149},
+												pos:  position{line: 977, col: 15, offset: 32198},
 												name: "InlineImage",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 977, col: 15, offset: 32176},
+												pos:  position{line: 978, col: 15, offset: 32225},
 												name: "Link",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 978, col: 15, offset: 32196},
+												pos:  position{line: 979, col: 15, offset: 32245},
 												name: "InlinePassthrough",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 979, col: 15, offset: 32289},
+												pos:  position{line: 980, col: 15, offset: 32338},
 												name: "InlineFootnote",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 980, col: 15, offset: 32319},
+												pos:  position{line: 981, col: 15, offset: 32368},
 												name: "CrossReference",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 981, col: 15, offset: 32387},
+												pos:  position{line: 982, col: 15, offset: 32436},
 												name: "SpecialCharacter",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 982, col: 15, offset: 32418},
+												pos:  position{line: 983, col: 15, offset: 32467},
 												name: "Symbol",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 983, col: 15, offset: 32439},
+												pos:  position{line: 984, col: 15, offset: 32488},
 												name: "InlineUserMacro",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 984, col: 15, offset: 32470},
+												pos:  position{line: 985, col: 15, offset: 32519},
 												name: "AttributeSubstitution",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 985, col: 15, offset: 32507},
+												pos:  position{line: 986, col: 15, offset: 32556},
 												name: "InlineElementID",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 986, col: 15, offset: 32537},
+												pos:  position{line: 987, col: 15, offset: 32586},
 												name: "ConcealedIndexTerm",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 987, col: 15, offset: 32570},
+												pos:  position{line: 988, col: 15, offset: 32619},
 												name: "IndexTerm",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 988, col: 15, offset: 32594},
+												pos:  position{line: 989, col: 15, offset: 32643},
 												name: "ElementPlaceHolder",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 989, col: 15, offset: 32627},
+												pos:  position{line: 990, col: 15, offset: 32676},
 												name: "AnyChar",
 											},
 										},
@@ -5650,34 +5650,34 @@ var g = &grammar{
 		},
 		{
 			name: "LineBreak",
-			pos:  position{line: 996, col: 1, offset: 32850},
+			pos:  position{line: 997, col: 1, offset: 32899},
 			expr: &actionExpr{
-				pos: position{line: 996, col: 14, offset: 32863},
+				pos: position{line: 997, col: 14, offset: 32912},
 				run: (*parser).callonLineBreak1,
 				expr: &seqExpr{
-					pos: position{line: 996, col: 14, offset: 32863},
+					pos: position{line: 997, col: 14, offset: 32912},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 996, col: 14, offset: 32863},
+							pos:  position{line: 997, col: 14, offset: 32912},
 							name: "Space",
 						},
 						&litMatcher{
-							pos:        position{line: 996, col: 20, offset: 32869},
+							pos:        position{line: 997, col: 20, offset: 32918},
 							val:        "+",
 							ignoreCase: false,
 							want:       "\"+\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 996, col: 24, offset: 32873},
+							pos: position{line: 997, col: 24, offset: 32922},
 							expr: &ruleRefExpr{
-								pos:  position{line: 996, col: 24, offset: 32873},
+								pos:  position{line: 997, col: 24, offset: 32922},
 								name: "Space",
 							},
 						},
 						&andExpr{
-							pos: position{line: 996, col: 31, offset: 32880},
+							pos: position{line: 997, col: 31, offset: 32929},
 							expr: &ruleRefExpr{
-								pos:  position{line: 996, col: 32, offset: 32881},
+								pos:  position{line: 997, col: 32, offset: 32930},
 								name: "EOL",
 							},
 						},
@@ -5687,20 +5687,20 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedText",
-			pos:  position{line: 1003, col: 1, offset: 33165},
+			pos:  position{line: 1004, col: 1, offset: 33214},
 			expr: &choiceExpr{
-				pos: position{line: 1003, col: 15, offset: 33179},
+				pos: position{line: 1004, col: 15, offset: 33228},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1003, col: 15, offset: 33179},
+						pos:  position{line: 1004, col: 15, offset: 33228},
 						name: "UnconstrainedQuotedText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1003, col: 41, offset: 33205},
+						pos:  position{line: 1004, col: 41, offset: 33254},
 						name: "ConstrainedQuotedText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1003, col: 65, offset: 33229},
+						pos:  position{line: 1004, col: 65, offset: 33278},
 						name: "EscapedQuotedText",
 					},
 				},
@@ -5708,23 +5708,23 @@ var g = &grammar{
 		},
 		{
 			name: "ConstrainedQuotedTextMarker",
-			pos:  position{line: 1005, col: 1, offset: 33248},
+			pos:  position{line: 1006, col: 1, offset: 33297},
 			expr: &choiceExpr{
-				pos: position{line: 1005, col: 32, offset: 33279},
+				pos: position{line: 1006, col: 32, offset: 33328},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 1005, col: 32, offset: 33279},
+						pos: position{line: 1006, col: 32, offset: 33328},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 1005, col: 32, offset: 33279},
+								pos:        position{line: 1006, col: 32, offset: 33328},
 								val:        "*",
 								ignoreCase: false,
 								want:       "\"*\"",
 							},
 							&notExpr{
-								pos: position{line: 1005, col: 36, offset: 33283},
+								pos: position{line: 1006, col: 36, offset: 33332},
 								expr: &litMatcher{
-									pos:        position{line: 1005, col: 37, offset: 33284},
+									pos:        position{line: 1006, col: 37, offset: 33333},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
@@ -5733,18 +5733,18 @@ var g = &grammar{
 						},
 					},
 					&seqExpr{
-						pos: position{line: 1005, col: 43, offset: 33290},
+						pos: position{line: 1006, col: 43, offset: 33339},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 1005, col: 43, offset: 33290},
+								pos:        position{line: 1006, col: 43, offset: 33339},
 								val:        "_",
 								ignoreCase: false,
 								want:       "\"_\"",
 							},
 							&notExpr{
-								pos: position{line: 1005, col: 47, offset: 33294},
+								pos: position{line: 1006, col: 47, offset: 33343},
 								expr: &litMatcher{
-									pos:        position{line: 1005, col: 48, offset: 33295},
+									pos:        position{line: 1006, col: 48, offset: 33344},
 									val:        "_",
 									ignoreCase: false,
 									want:       "\"_\"",
@@ -5753,18 +5753,18 @@ var g = &grammar{
 						},
 					},
 					&seqExpr{
-						pos: position{line: 1005, col: 54, offset: 33301},
+						pos: position{line: 1006, col: 54, offset: 33350},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 1005, col: 54, offset: 33301},
+								pos:        position{line: 1006, col: 54, offset: 33350},
 								val:        "#",
 								ignoreCase: false,
 								want:       "\"#\"",
 							},
 							&notExpr{
-								pos: position{line: 1005, col: 58, offset: 33305},
+								pos: position{line: 1006, col: 58, offset: 33354},
 								expr: &litMatcher{
-									pos:        position{line: 1005, col: 59, offset: 33306},
+									pos:        position{line: 1006, col: 59, offset: 33355},
 									val:        "#",
 									ignoreCase: false,
 									want:       "\"#\"",
@@ -5773,18 +5773,18 @@ var g = &grammar{
 						},
 					},
 					&seqExpr{
-						pos: position{line: 1005, col: 65, offset: 33312},
+						pos: position{line: 1006, col: 65, offset: 33361},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 1005, col: 65, offset: 33312},
+								pos:        position{line: 1006, col: 65, offset: 33361},
 								val:        "`",
 								ignoreCase: false,
 								want:       "\"`\"",
 							},
 							&notExpr{
-								pos: position{line: 1005, col: 69, offset: 33316},
+								pos: position{line: 1006, col: 69, offset: 33365},
 								expr: &litMatcher{
-									pos:        position{line: 1005, col: 70, offset: 33317},
+									pos:        position{line: 1006, col: 70, offset: 33366},
 									val:        "`",
 									ignoreCase: false,
 									want:       "\"`\"",
@@ -5797,42 +5797,42 @@ var g = &grammar{
 		},
 		{
 			name: "UnconstrainedQuotedTextPrefix",
-			pos:  position{line: 1007, col: 1, offset: 33322},
+			pos:  position{line: 1008, col: 1, offset: 33371},
 			expr: &choiceExpr{
-				pos: position{line: 1007, col: 34, offset: 33355},
+				pos: position{line: 1008, col: 34, offset: 33404},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1007, col: 34, offset: 33355},
+						pos:        position{line: 1008, col: 34, offset: 33404},
 						val:        "**",
 						ignoreCase: false,
 						want:       "\"**\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1007, col: 41, offset: 33362},
+						pos:        position{line: 1008, col: 41, offset: 33411},
 						val:        "__",
 						ignoreCase: false,
 						want:       "\"__\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1007, col: 48, offset: 33369},
+						pos:        position{line: 1008, col: 48, offset: 33418},
 						val:        "``",
 						ignoreCase: false,
 						want:       "\"``\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1007, col: 55, offset: 33376},
+						pos:        position{line: 1008, col: 55, offset: 33425},
 						val:        "##",
 						ignoreCase: false,
 						want:       "\"##\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1007, col: 62, offset: 33383},
+						pos:        position{line: 1008, col: 62, offset: 33432},
 						val:        "^",
 						ignoreCase: false,
 						want:       "\"^\"",
 					},
 					&litMatcher{
-						pos:        position{line: 1007, col: 68, offset: 33389},
+						pos:        position{line: 1008, col: 68, offset: 33438},
 						val:        "~",
 						ignoreCase: false,
 						want:       "\"~\"",
@@ -5842,42 +5842,42 @@ var g = &grammar{
 		},
 		{
 			name: "ConstrainedQuotedText",
-			pos:  position{line: 1009, col: 1, offset: 33394},
+			pos:  position{line: 1010, col: 1, offset: 33443},
 			expr: &actionExpr{
-				pos: position{line: 1009, col: 26, offset: 33419},
+				pos: position{line: 1010, col: 26, offset: 33468},
 				run: (*parser).callonConstrainedQuotedText1,
 				expr: &labeledExpr{
-					pos:   position{line: 1009, col: 26, offset: 33419},
+					pos:   position{line: 1010, col: 26, offset: 33468},
 					label: "text",
 					expr: &choiceExpr{
-						pos: position{line: 1009, col: 32, offset: 33425},
+						pos: position{line: 1010, col: 32, offset: 33474},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 1009, col: 32, offset: 33425},
+								pos:  position{line: 1010, col: 32, offset: 33474},
 								name: "SingleQuoteBoldText",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1010, col: 15, offset: 33460},
+								pos:  position{line: 1011, col: 15, offset: 33509},
 								name: "SingleQuoteItalicText",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1011, col: 15, offset: 33496},
+								pos:  position{line: 1012, col: 15, offset: 33545},
 								name: "SingleQuoteMarkedText",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1012, col: 15, offset: 33532},
+								pos:  position{line: 1013, col: 15, offset: 33581},
 								name: "SingleQuoteMonospaceText",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1013, col: 15, offset: 33572},
+								pos:  position{line: 1014, col: 15, offset: 33621},
 								name: "SubscriptText",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1014, col: 15, offset: 33601},
+								pos:  position{line: 1015, col: 15, offset: 33650},
 								name: "SuperscriptText",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1015, col: 15, offset: 33632},
+								pos:  position{line: 1016, col: 15, offset: 33681},
 								name: "SubscriptOrSuperscriptPrefix",
 							},
 						},
@@ -5887,24 +5887,24 @@ var g = &grammar{
 		},
 		{
 			name: "UnconstrainedQuotedText",
-			pos:  position{line: 1019, col: 1, offset: 33786},
+			pos:  position{line: 1020, col: 1, offset: 33835},
 			expr: &choiceExpr{
-				pos: position{line: 1019, col: 28, offset: 33813},
+				pos: position{line: 1020, col: 28, offset: 33862},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1019, col: 28, offset: 33813},
+						pos:  position{line: 1020, col: 28, offset: 33862},
 						name: "DoubleQuoteBoldText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1020, col: 15, offset: 33847},
+						pos:  position{line: 1021, col: 15, offset: 33896},
 						name: "DoubleQuoteItalicText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1021, col: 15, offset: 33883},
+						pos:  position{line: 1022, col: 15, offset: 33932},
 						name: "DoubleQuoteMarkedText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1022, col: 15, offset: 33919},
+						pos:  position{line: 1023, col: 15, offset: 33968},
 						name: "DoubleQuoteMonospaceText",
 					},
 				},
@@ -5912,32 +5912,32 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedQuotedText",
-			pos:  position{line: 1024, col: 1, offset: 33945},
+			pos:  position{line: 1025, col: 1, offset: 33994},
 			expr: &choiceExpr{
-				pos: position{line: 1024, col: 22, offset: 33966},
+				pos: position{line: 1025, col: 22, offset: 34015},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1024, col: 22, offset: 33966},
+						pos:  position{line: 1025, col: 22, offset: 34015},
 						name: "EscapedBoldText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1025, col: 15, offset: 33997},
+						pos:  position{line: 1026, col: 15, offset: 34046},
 						name: "EscapedItalicText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1026, col: 15, offset: 34029},
+						pos:  position{line: 1027, col: 15, offset: 34078},
 						name: "EscapedMarkedText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1027, col: 15, offset: 34061},
+						pos:  position{line: 1028, col: 15, offset: 34110},
 						name: "EscapedMonospaceText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1028, col: 15, offset: 34097},
+						pos:  position{line: 1029, col: 15, offset: 34146},
 						name: "EscapedSubscriptText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1029, col: 15, offset: 34133},
+						pos:  position{line: 1030, col: 15, offset: 34182},
 						name: "EscapedSuperscriptText",
 					},
 				},
@@ -5945,21 +5945,21 @@ var g = &grammar{
 		},
 		{
 			name: "SubscriptOrSuperscriptPrefix",
-			pos:  position{line: 1031, col: 1, offset: 34157},
+			pos:  position{line: 1032, col: 1, offset: 34206},
 			expr: &choiceExpr{
-				pos: position{line: 1031, col: 33, offset: 34189},
+				pos: position{line: 1032, col: 33, offset: 34238},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1031, col: 33, offset: 34189},
+						pos:        position{line: 1032, col: 33, offset: 34238},
 						val:        "^",
 						ignoreCase: false,
 						want:       "\"^\"",
 					},
 					&actionExpr{
-						pos: position{line: 1031, col: 39, offset: 34195},
+						pos: position{line: 1032, col: 39, offset: 34244},
 						run: (*parser).callonSubscriptOrSuperscriptPrefix3,
 						expr: &litMatcher{
-							pos:        position{line: 1031, col: 39, offset: 34195},
+							pos:        position{line: 1032, col: 39, offset: 34244},
 							val:        "~",
 							ignoreCase: false,
 							want:       "\"~\"",
@@ -5970,14 +5970,14 @@ var g = &grammar{
 		},
 		{
 			name: "OneOrMoreBackslashes",
-			pos:  position{line: 1035, col: 1, offset: 34328},
+			pos:  position{line: 1036, col: 1, offset: 34377},
 			expr: &actionExpr{
-				pos: position{line: 1035, col: 25, offset: 34352},
+				pos: position{line: 1036, col: 25, offset: 34401},
 				run: (*parser).callonOneOrMoreBackslashes1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1035, col: 25, offset: 34352},
+					pos: position{line: 1036, col: 25, offset: 34401},
 					expr: &litMatcher{
-						pos:        position{line: 1035, col: 25, offset: 34352},
+						pos:        position{line: 1036, col: 25, offset: 34401},
 						val:        "\\",
 						ignoreCase: false,
 						want:       "\"\\\\\"",
@@ -5987,23 +5987,23 @@ var g = &grammar{
 		},
 		{
 			name: "TwoOrMoreBackslashes",
-			pos:  position{line: 1039, col: 1, offset: 34393},
+			pos:  position{line: 1040, col: 1, offset: 34442},
 			expr: &actionExpr{
-				pos: position{line: 1039, col: 25, offset: 34417},
+				pos: position{line: 1040, col: 25, offset: 34466},
 				run: (*parser).callonTwoOrMoreBackslashes1,
 				expr: &seqExpr{
-					pos: position{line: 1039, col: 25, offset: 34417},
+					pos: position{line: 1040, col: 25, offset: 34466},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1039, col: 25, offset: 34417},
+							pos:        position{line: 1040, col: 25, offset: 34466},
 							val:        "\\\\",
 							ignoreCase: false,
 							want:       "\"\\\\\\\\\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1039, col: 30, offset: 34422},
+							pos: position{line: 1040, col: 30, offset: 34471},
 							expr: &litMatcher{
-								pos:        position{line: 1039, col: 30, offset: 34422},
+								pos:        position{line: 1040, col: 30, offset: 34471},
 								val:        "\\",
 								ignoreCase: false,
 								want:       "\"\\\\\"",
@@ -6015,16 +6015,16 @@ var g = &grammar{
 		},
 		{
 			name: "BoldText",
-			pos:  position{line: 1047, col: 1, offset: 34519},
+			pos:  position{line: 1048, col: 1, offset: 34568},
 			expr: &choiceExpr{
-				pos: position{line: 1047, col: 13, offset: 34531},
+				pos: position{line: 1048, col: 13, offset: 34580},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1047, col: 13, offset: 34531},
+						pos:  position{line: 1048, col: 13, offset: 34580},
 						name: "DoubleQuoteBoldText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1047, col: 35, offset: 34553},
+						pos:  position{line: 1048, col: 35, offset: 34602},
 						name: "SingleQuoteBoldText",
 					},
 				},
@@ -6032,40 +6032,40 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteBoldText",
-			pos:  position{line: 1049, col: 1, offset: 34620},
+			pos:  position{line: 1050, col: 1, offset: 34669},
 			expr: &actionExpr{
-				pos: position{line: 1049, col: 24, offset: 34643},
+				pos: position{line: 1050, col: 24, offset: 34692},
 				run: (*parser).callonDoubleQuoteBoldText1,
 				expr: &seqExpr{
-					pos: position{line: 1049, col: 24, offset: 34643},
+					pos: position{line: 1050, col: 24, offset: 34692},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1049, col: 24, offset: 34643},
+							pos:   position{line: 1050, col: 24, offset: 34692},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1049, col: 35, offset: 34654},
+								pos: position{line: 1050, col: 35, offset: 34703},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1049, col: 36, offset: 34655},
+									pos:  position{line: 1050, col: 36, offset: 34704},
 									name: "LongHandAttributes",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1049, col: 57, offset: 34676},
+							pos:        position{line: 1050, col: 57, offset: 34725},
 							val:        "**",
 							ignoreCase: false,
 							want:       "\"**\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1049, col: 62, offset: 34681},
+							pos:   position{line: 1050, col: 62, offset: 34730},
 							label: "elements",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1049, col: 72, offset: 34691},
+								pos:  position{line: 1050, col: 72, offset: 34740},
 								name: "DoubleQuoteBoldTextElements",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1049, col: 101, offset: 34720},
+							pos:        position{line: 1050, col: 101, offset: 34769},
 							val:        "**",
 							ignoreCase: false,
 							want:       "\"**\"",
@@ -6076,97 +6076,97 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteBoldTextElements",
-			pos:  position{line: 1053, col: 1, offset: 34812},
+			pos:  position{line: 1054, col: 1, offset: 34861},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1053, col: 32, offset: 34843},
+				pos: position{line: 1054, col: 32, offset: 34892},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1053, col: 32, offset: 34843},
+					pos:  position{line: 1054, col: 32, offset: 34892},
 					name: "DoubleQuoteBoldTextElement",
 				},
 			},
 		},
 		{
 			name: "DoubleQuoteBoldTextElement",
-			pos:  position{line: 1055, col: 1, offset: 34874},
+			pos:  position{line: 1056, col: 1, offset: 34923},
 			expr: &actionExpr{
-				pos: position{line: 1055, col: 31, offset: 34904},
+				pos: position{line: 1056, col: 31, offset: 34953},
 				run: (*parser).callonDoubleQuoteBoldTextElement1,
 				expr: &seqExpr{
-					pos: position{line: 1055, col: 31, offset: 34904},
+					pos: position{line: 1056, col: 31, offset: 34953},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1055, col: 31, offset: 34904},
+							pos: position{line: 1056, col: 31, offset: 34953},
 							expr: &litMatcher{
-								pos:        position{line: 1055, col: 33, offset: 34906},
+								pos:        position{line: 1056, col: 33, offset: 34955},
 								val:        "**",
 								ignoreCase: false,
 								want:       "\"**\"",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1055, col: 39, offset: 34912},
+							pos:   position{line: 1056, col: 39, offset: 34961},
 							label: "element",
 							expr: &choiceExpr{
-								pos: position{line: 1055, col: 48, offset: 34921},
+								pos: position{line: 1056, col: 48, offset: 34970},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1055, col: 48, offset: 34921},
+										pos:  position{line: 1056, col: 48, offset: 34970},
 										name: "Word",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1056, col: 11, offset: 34936},
+										pos:  position{line: 1057, col: 11, offset: 34985},
 										name: "Space",
 									},
 									&seqExpr{
-										pos: position{line: 1057, col: 11, offset: 34985},
+										pos: position{line: 1058, col: 11, offset: 35034},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1057, col: 11, offset: 34985},
+												pos:  position{line: 1058, col: 11, offset: 35034},
 												name: "Newline",
 											},
 											&notExpr{
-												pos: position{line: 1057, col: 19, offset: 34993},
+												pos: position{line: 1058, col: 19, offset: 35042},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1057, col: 20, offset: 34994},
+													pos:  position{line: 1058, col: 20, offset: 35043},
 													name: "Newline",
 												},
 											},
 										},
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1058, col: 11, offset: 35012},
+										pos:  position{line: 1059, col: 11, offset: 35061},
 										name: "SingleQuoteBoldText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1059, col: 11, offset: 35042},
+										pos:  position{line: 1060, col: 11, offset: 35091},
 										name: "QuotedString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1060, col: 11, offset: 35065},
+										pos:  position{line: 1061, col: 11, offset: 35114},
 										name: "ItalicText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1061, col: 11, offset: 35086},
+										pos:  position{line: 1062, col: 11, offset: 35135},
 										name: "MarkedText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1062, col: 11, offset: 35107},
+										pos:  position{line: 1063, col: 11, offset: 35156},
 										name: "MonospaceText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1063, col: 11, offset: 35131},
+										pos:  position{line: 1064, col: 11, offset: 35180},
 										name: "SubscriptText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1064, col: 11, offset: 35155},
+										pos:  position{line: 1065, col: 11, offset: 35204},
 										name: "SuperscriptText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1065, col: 11, offset: 35181},
+										pos:  position{line: 1066, col: 11, offset: 35230},
 										name: "ElementPlaceHolder",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1066, col: 11, offset: 35210},
+										pos:  position{line: 1067, col: 11, offset: 35259},
 										name: "DoubleQuoteBoldTextFallbackCharacter",
 									},
 								},
@@ -6178,31 +6178,31 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteBoldTextFallbackCharacter",
-			pos:  position{line: 1070, col: 1, offset: 35277},
+			pos:  position{line: 1071, col: 1, offset: 35326},
 			expr: &choiceExpr{
-				pos: position{line: 1071, col: 5, offset: 35321},
+				pos: position{line: 1072, col: 5, offset: 35370},
 				alternatives: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 1071, col: 5, offset: 35321},
+						pos:        position{line: 1072, col: 5, offset: 35370},
 						val:        "[^\\r\\n*]",
 						chars:      []rune{'\r', '\n', '*'},
 						ignoreCase: false,
 						inverted:   true,
 					},
 					&actionExpr{
-						pos: position{line: 1072, col: 7, offset: 35418},
+						pos: position{line: 1073, col: 7, offset: 35467},
 						run: (*parser).callonDoubleQuoteBoldTextFallbackCharacter3,
 						expr: &seqExpr{
-							pos: position{line: 1072, col: 7, offset: 35418},
+							pos: position{line: 1073, col: 7, offset: 35467},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1072, col: 7, offset: 35418},
+									pos:        position{line: 1073, col: 7, offset: 35467},
 									val:        "**",
 									ignoreCase: false,
 									want:       "\"**\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1072, col: 12, offset: 35423},
+									pos:  position{line: 1073, col: 12, offset: 35472},
 									name: "Alphanums",
 								},
 							},
@@ -6213,40 +6213,40 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteBoldText",
-			pos:  position{line: 1076, col: 1, offset: 35586},
+			pos:  position{line: 1077, col: 1, offset: 35635},
 			expr: &choiceExpr{
-				pos: position{line: 1076, col: 24, offset: 35609},
+				pos: position{line: 1077, col: 24, offset: 35658},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1076, col: 24, offset: 35609},
+						pos: position{line: 1077, col: 24, offset: 35658},
 						run: (*parser).callonSingleQuoteBoldText2,
 						expr: &seqExpr{
-							pos: position{line: 1076, col: 24, offset: 35609},
+							pos: position{line: 1077, col: 24, offset: 35658},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1076, col: 24, offset: 35609},
+									pos:   position{line: 1077, col: 24, offset: 35658},
 									label: "attributes",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1076, col: 35, offset: 35620},
+										pos: position{line: 1077, col: 35, offset: 35669},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1076, col: 36, offset: 35621},
+											pos:  position{line: 1077, col: 36, offset: 35670},
 											name: "LongHandAttributes",
 										},
 									},
 								},
 								&seqExpr{
-									pos: position{line: 1076, col: 59, offset: 35644},
+									pos: position{line: 1077, col: 59, offset: 35693},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 1076, col: 59, offset: 35644},
+											pos:        position{line: 1077, col: 59, offset: 35693},
 											val:        "*",
 											ignoreCase: false,
 											want:       "\"*\"",
 										},
 										&notExpr{
-											pos: position{line: 1076, col: 63, offset: 35648},
+											pos: position{line: 1077, col: 63, offset: 35697},
 											expr: &litMatcher{
-												pos:        position{line: 1076, col: 64, offset: 35649},
+												pos:        position{line: 1077, col: 64, offset: 35698},
 												val:        "*",
 												ignoreCase: false,
 												want:       "\"*\"",
@@ -6255,25 +6255,25 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1076, col: 69, offset: 35654},
+									pos:   position{line: 1077, col: 69, offset: 35703},
 									label: "elements",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1076, col: 79, offset: 35664},
+										pos:  position{line: 1077, col: 79, offset: 35713},
 										name: "SingleQuoteBoldTextElements",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1076, col: 108, offset: 35693},
+									pos:        position{line: 1077, col: 108, offset: 35742},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
 								},
 								&andExpr{
-									pos: position{line: 1076, col: 112, offset: 35697},
+									pos: position{line: 1077, col: 112, offset: 35746},
 									expr: &notExpr{
-										pos: position{line: 1076, col: 114, offset: 35699},
+										pos: position{line: 1077, col: 114, offset: 35748},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1076, col: 115, offset: 35700},
+											pos:  position{line: 1077, col: 115, offset: 35749},
 											name: "Alphanum",
 										},
 									},
@@ -6282,49 +6282,49 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1078, col: 5, offset: 35899},
+						pos: position{line: 1079, col: 5, offset: 35948},
 						run: (*parser).callonSingleQuoteBoldText17,
 						expr: &seqExpr{
-							pos: position{line: 1078, col: 5, offset: 35899},
+							pos: position{line: 1079, col: 5, offset: 35948},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1078, col: 5, offset: 35899},
+									pos:   position{line: 1079, col: 5, offset: 35948},
 									label: "attributes",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1078, col: 16, offset: 35910},
+										pos: position{line: 1079, col: 16, offset: 35959},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1078, col: 17, offset: 35911},
+											pos:  position{line: 1079, col: 17, offset: 35960},
 											name: "LongHandAttributes",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1078, col: 38, offset: 35932},
+									pos:        position{line: 1079, col: 38, offset: 35981},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1078, col: 42, offset: 35936},
+									pos:   position{line: 1079, col: 42, offset: 35985},
 									label: "elements",
 									expr: &seqExpr{
-										pos: position{line: 1078, col: 52, offset: 35946},
+										pos: position{line: 1079, col: 52, offset: 35995},
 										exprs: []interface{}{
 											&litMatcher{
-												pos:        position{line: 1078, col: 52, offset: 35946},
+												pos:        position{line: 1079, col: 52, offset: 35995},
 												val:        "*",
 												ignoreCase: false,
 												want:       "\"*\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1078, col: 56, offset: 35950},
+												pos:  position{line: 1079, col: 56, offset: 35999},
 												name: "SingleQuoteBoldTextElements",
 											},
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1078, col: 85, offset: 35979},
+									pos:        position{line: 1079, col: 85, offset: 36028},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
@@ -6337,21 +6337,21 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteBoldTextElements",
-			pos:  position{line: 1082, col: 1, offset: 36190},
+			pos:  position{line: 1083, col: 1, offset: 36239},
 			expr: &seqExpr{
-				pos: position{line: 1082, col: 32, offset: 36221},
+				pos: position{line: 1083, col: 32, offset: 36270},
 				exprs: []interface{}{
 					&notExpr{
-						pos: position{line: 1082, col: 32, offset: 36221},
+						pos: position{line: 1083, col: 32, offset: 36270},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1082, col: 33, offset: 36222},
+							pos:  position{line: 1083, col: 33, offset: 36271},
 							name: "Space",
 						},
 					},
 					&oneOrMoreExpr{
-						pos: position{line: 1082, col: 39, offset: 36228},
+						pos: position{line: 1083, col: 39, offset: 36277},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1082, col: 39, offset: 36228},
+							pos:  position{line: 1083, col: 39, offset: 36277},
 							name: "SingleQuoteBoldTextElement",
 						},
 					},
@@ -6360,63 +6360,63 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteBoldTextElement",
-			pos:  position{line: 1084, col: 1, offset: 36257},
+			pos:  position{line: 1085, col: 1, offset: 36306},
 			expr: &choiceExpr{
-				pos: position{line: 1084, col: 31, offset: 36287},
+				pos: position{line: 1085, col: 31, offset: 36336},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1084, col: 31, offset: 36287},
+						pos:  position{line: 1085, col: 31, offset: 36336},
 						name: "Word",
 					},
 					&seqExpr{
-						pos: position{line: 1085, col: 11, offset: 36302},
+						pos: position{line: 1086, col: 11, offset: 36351},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 1085, col: 11, offset: 36302},
+								pos:  position{line: 1086, col: 11, offset: 36351},
 								name: "Newline",
 							},
 							&notExpr{
-								pos: position{line: 1085, col: 19, offset: 36310},
+								pos: position{line: 1086, col: 19, offset: 36359},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1085, col: 20, offset: 36311},
+									pos:  position{line: 1086, col: 20, offset: 36360},
 									name: "Newline",
 								},
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1086, col: 11, offset: 36329},
+						pos:  position{line: 1087, col: 11, offset: 36378},
 						name: "DoubleQuoteBoldText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1087, col: 11, offset: 36359},
+						pos:  position{line: 1088, col: 11, offset: 36408},
 						name: "QuotedString",
 					},
 					&seqExpr{
-						pos: position{line: 1088, col: 11, offset: 36382},
+						pos: position{line: 1089, col: 11, offset: 36431},
 						exprs: []interface{}{
 							&oneOrMoreExpr{
-								pos: position{line: 1088, col: 11, offset: 36382},
+								pos: position{line: 1089, col: 11, offset: 36431},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1088, col: 11, offset: 36382},
+									pos:  position{line: 1089, col: 11, offset: 36431},
 									name: "Space",
 								},
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 1088, col: 18, offset: 36389},
+								pos: position{line: 1089, col: 18, offset: 36438},
 								expr: &seqExpr{
-									pos: position{line: 1088, col: 19, offset: 36390},
+									pos: position{line: 1089, col: 19, offset: 36439},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 1088, col: 19, offset: 36390},
+											pos:        position{line: 1089, col: 19, offset: 36439},
 											val:        "*",
 											ignoreCase: false,
 											want:       "\"*\"",
 										},
 										&notExpr{
-											pos: position{line: 1088, col: 23, offset: 36394},
+											pos: position{line: 1089, col: 23, offset: 36443},
 											expr: &litMatcher{
-												pos:        position{line: 1088, col: 24, offset: 36395},
+												pos:        position{line: 1089, col: 24, offset: 36444},
 												val:        "*",
 												ignoreCase: false,
 												want:       "\"*\"",
@@ -6428,31 +6428,31 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1089, col: 11, offset: 36411},
+						pos:  position{line: 1090, col: 11, offset: 36460},
 						name: "ItalicText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1090, col: 11, offset: 36432},
+						pos:  position{line: 1091, col: 11, offset: 36481},
 						name: "MarkedText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1091, col: 11, offset: 36453},
+						pos:  position{line: 1092, col: 11, offset: 36502},
 						name: "MonospaceText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1092, col: 11, offset: 36477},
+						pos:  position{line: 1093, col: 11, offset: 36526},
 						name: "SubscriptText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1093, col: 11, offset: 36501},
+						pos:  position{line: 1094, col: 11, offset: 36550},
 						name: "SuperscriptText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1094, col: 11, offset: 36527},
+						pos:  position{line: 1095, col: 11, offset: 36576},
 						name: "ElementPlaceHolder",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1095, col: 11, offset: 36556},
+						pos:  position{line: 1096, col: 11, offset: 36605},
 						name: "SingleQuoteBoldTextFallbackCharacter",
 					},
 				},
@@ -6460,31 +6460,31 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteBoldTextFallbackCharacter",
-			pos:  position{line: 1097, col: 1, offset: 36594},
+			pos:  position{line: 1098, col: 1, offset: 36643},
 			expr: &choiceExpr{
-				pos: position{line: 1098, col: 5, offset: 36638},
+				pos: position{line: 1099, col: 5, offset: 36687},
 				alternatives: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 1098, col: 5, offset: 36638},
+						pos:        position{line: 1099, col: 5, offset: 36687},
 						val:        "[^\\r\\n*]",
 						chars:      []rune{'\r', '\n', '*'},
 						ignoreCase: false,
 						inverted:   true,
 					},
 					&actionExpr{
-						pos: position{line: 1099, col: 7, offset: 36735},
+						pos: position{line: 1100, col: 7, offset: 36784},
 						run: (*parser).callonSingleQuoteBoldTextFallbackCharacter3,
 						expr: &seqExpr{
-							pos: position{line: 1099, col: 7, offset: 36735},
+							pos: position{line: 1100, col: 7, offset: 36784},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1099, col: 7, offset: 36735},
+									pos:        position{line: 1100, col: 7, offset: 36784},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1099, col: 11, offset: 36739},
+									pos:  position{line: 1100, col: 11, offset: 36788},
 									name: "Alphanums",
 								},
 							},
@@ -6495,40 +6495,40 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedBoldText",
-			pos:  position{line: 1103, col: 1, offset: 36902},
+			pos:  position{line: 1104, col: 1, offset: 36951},
 			expr: &choiceExpr{
-				pos: position{line: 1104, col: 5, offset: 36926},
+				pos: position{line: 1105, col: 5, offset: 36975},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1104, col: 5, offset: 36926},
+						pos: position{line: 1105, col: 5, offset: 36975},
 						run: (*parser).callonEscapedBoldText2,
 						expr: &seqExpr{
-							pos: position{line: 1104, col: 5, offset: 36926},
+							pos: position{line: 1105, col: 5, offset: 36975},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1104, col: 5, offset: 36926},
+									pos:   position{line: 1105, col: 5, offset: 36975},
 									label: "backslashes",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1104, col: 18, offset: 36939},
+										pos:  position{line: 1105, col: 18, offset: 36988},
 										name: "TwoOrMoreBackslashes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1104, col: 40, offset: 36961},
+									pos:        position{line: 1105, col: 40, offset: 37010},
 									val:        "**",
 									ignoreCase: false,
 									want:       "\"**\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1104, col: 45, offset: 36966},
+									pos:   position{line: 1105, col: 45, offset: 37015},
 									label: "elements",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1104, col: 55, offset: 36976},
+										pos:  position{line: 1105, col: 55, offset: 37025},
 										name: "DoubleQuoteBoldTextElements",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1104, col: 84, offset: 37005},
+									pos:        position{line: 1105, col: 84, offset: 37054},
 									val:        "**",
 									ignoreCase: false,
 									want:       "\"**\"",
@@ -6537,35 +6537,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1106, col: 9, offset: 37162},
+						pos: position{line: 1107, col: 9, offset: 37211},
 						run: (*parser).callonEscapedBoldText10,
 						expr: &seqExpr{
-							pos: position{line: 1106, col: 9, offset: 37162},
+							pos: position{line: 1107, col: 9, offset: 37211},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1106, col: 9, offset: 37162},
+									pos:   position{line: 1107, col: 9, offset: 37211},
 									label: "backslashes",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1106, col: 22, offset: 37175},
+										pos:  position{line: 1107, col: 22, offset: 37224},
 										name: "OneOrMoreBackslashes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1106, col: 44, offset: 37197},
+									pos:        position{line: 1107, col: 44, offset: 37246},
 									val:        "**",
 									ignoreCase: false,
 									want:       "\"**\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1106, col: 49, offset: 37202},
+									pos:   position{line: 1107, col: 49, offset: 37251},
 									label: "elements",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1106, col: 59, offset: 37212},
+										pos:  position{line: 1107, col: 59, offset: 37261},
 										name: "SingleQuoteBoldTextElements",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1106, col: 88, offset: 37241},
+									pos:        position{line: 1107, col: 88, offset: 37290},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
@@ -6574,35 +6574,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1109, col: 9, offset: 37441},
+						pos: position{line: 1110, col: 9, offset: 37490},
 						run: (*parser).callonEscapedBoldText18,
 						expr: &seqExpr{
-							pos: position{line: 1109, col: 9, offset: 37441},
+							pos: position{line: 1110, col: 9, offset: 37490},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1109, col: 9, offset: 37441},
+									pos:   position{line: 1110, col: 9, offset: 37490},
 									label: "backslashes",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1109, col: 22, offset: 37454},
+										pos:  position{line: 1110, col: 22, offset: 37503},
 										name: "OneOrMoreBackslashes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1109, col: 44, offset: 37476},
+									pos:        position{line: 1110, col: 44, offset: 37525},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1109, col: 48, offset: 37480},
+									pos:   position{line: 1110, col: 48, offset: 37529},
 									label: "elements",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1109, col: 58, offset: 37490},
+										pos:  position{line: 1110, col: 58, offset: 37539},
 										name: "SingleQuoteBoldTextElements",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1109, col: 87, offset: 37519},
+									pos:        position{line: 1110, col: 87, offset: 37568},
 									val:        "*",
 									ignoreCase: false,
 									want:       "\"*\"",
@@ -6615,16 +6615,16 @@ var g = &grammar{
 		},
 		{
 			name: "ItalicText",
-			pos:  position{line: 1117, col: 1, offset: 37727},
+			pos:  position{line: 1118, col: 1, offset: 37776},
 			expr: &choiceExpr{
-				pos: position{line: 1117, col: 15, offset: 37741},
+				pos: position{line: 1118, col: 15, offset: 37790},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1117, col: 15, offset: 37741},
+						pos:  position{line: 1118, col: 15, offset: 37790},
 						name: "DoubleQuoteItalicText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1117, col: 39, offset: 37765},
+						pos:  position{line: 1118, col: 39, offset: 37814},
 						name: "SingleQuoteItalicText",
 					},
 				},
@@ -6632,40 +6632,40 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteItalicText",
-			pos:  position{line: 1119, col: 1, offset: 37788},
+			pos:  position{line: 1120, col: 1, offset: 37837},
 			expr: &actionExpr{
-				pos: position{line: 1119, col: 26, offset: 37813},
+				pos: position{line: 1120, col: 26, offset: 37862},
 				run: (*parser).callonDoubleQuoteItalicText1,
 				expr: &seqExpr{
-					pos: position{line: 1119, col: 26, offset: 37813},
+					pos: position{line: 1120, col: 26, offset: 37862},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1119, col: 26, offset: 37813},
+							pos:   position{line: 1120, col: 26, offset: 37862},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1119, col: 37, offset: 37824},
+								pos: position{line: 1120, col: 37, offset: 37873},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1119, col: 38, offset: 37825},
+									pos:  position{line: 1120, col: 38, offset: 37874},
 									name: "LongHandAttributes",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1119, col: 59, offset: 37846},
+							pos:        position{line: 1120, col: 59, offset: 37895},
 							val:        "__",
 							ignoreCase: false,
 							want:       "\"__\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1119, col: 64, offset: 37851},
+							pos:   position{line: 1120, col: 64, offset: 37900},
 							label: "elements",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1119, col: 74, offset: 37861},
+								pos:  position{line: 1120, col: 74, offset: 37910},
 								name: "DoubleQuoteItalicTextElements",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1119, col: 105, offset: 37892},
+							pos:        position{line: 1120, col: 105, offset: 37941},
 							val:        "__",
 							ignoreCase: false,
 							want:       "\"__\"",
@@ -6676,97 +6676,97 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteItalicTextElements",
-			pos:  position{line: 1123, col: 1, offset: 38031},
+			pos:  position{line: 1124, col: 1, offset: 38080},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1123, col: 34, offset: 38064},
+				pos: position{line: 1124, col: 34, offset: 38113},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1123, col: 34, offset: 38064},
+					pos:  position{line: 1124, col: 34, offset: 38113},
 					name: "DoubleQuoteItalicTextElement",
 				},
 			},
 		},
 		{
 			name: "DoubleQuoteItalicTextElement",
-			pos:  position{line: 1125, col: 1, offset: 38096},
+			pos:  position{line: 1126, col: 1, offset: 38145},
 			expr: &actionExpr{
-				pos: position{line: 1125, col: 33, offset: 38128},
+				pos: position{line: 1126, col: 33, offset: 38177},
 				run: (*parser).callonDoubleQuoteItalicTextElement1,
 				expr: &seqExpr{
-					pos: position{line: 1125, col: 33, offset: 38128},
+					pos: position{line: 1126, col: 33, offset: 38177},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1125, col: 33, offset: 38128},
+							pos: position{line: 1126, col: 33, offset: 38177},
 							expr: &litMatcher{
-								pos:        position{line: 1125, col: 35, offset: 38130},
+								pos:        position{line: 1126, col: 35, offset: 38179},
 								val:        "__",
 								ignoreCase: false,
 								want:       "\"__\"",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1125, col: 41, offset: 38136},
+							pos:   position{line: 1126, col: 41, offset: 38185},
 							label: "element",
 							expr: &choiceExpr{
-								pos: position{line: 1125, col: 50, offset: 38145},
+								pos: position{line: 1126, col: 50, offset: 38194},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1125, col: 50, offset: 38145},
+										pos:  position{line: 1126, col: 50, offset: 38194},
 										name: "Word",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1126, col: 11, offset: 38160},
+										pos:  position{line: 1127, col: 11, offset: 38209},
 										name: "Space",
 									},
 									&seqExpr{
-										pos: position{line: 1127, col: 11, offset: 38209},
+										pos: position{line: 1128, col: 11, offset: 38258},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1127, col: 11, offset: 38209},
+												pos:  position{line: 1128, col: 11, offset: 38258},
 												name: "Newline",
 											},
 											&notExpr{
-												pos: position{line: 1127, col: 19, offset: 38217},
+												pos: position{line: 1128, col: 19, offset: 38266},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1127, col: 20, offset: 38218},
+													pos:  position{line: 1128, col: 20, offset: 38267},
 													name: "Newline",
 												},
 											},
 										},
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1128, col: 11, offset: 38236},
+										pos:  position{line: 1129, col: 11, offset: 38285},
 										name: "SingleQuoteItalicText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1129, col: 11, offset: 38268},
+										pos:  position{line: 1130, col: 11, offset: 38317},
 										name: "QuotedString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1130, col: 11, offset: 38291},
+										pos:  position{line: 1131, col: 11, offset: 38340},
 										name: "BoldText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1131, col: 11, offset: 38310},
+										pos:  position{line: 1132, col: 11, offset: 38359},
 										name: "MarkedText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1132, col: 11, offset: 38331},
+										pos:  position{line: 1133, col: 11, offset: 38380},
 										name: "MonospaceText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1133, col: 11, offset: 38355},
+										pos:  position{line: 1134, col: 11, offset: 38404},
 										name: "SubscriptText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1134, col: 11, offset: 38379},
+										pos:  position{line: 1135, col: 11, offset: 38428},
 										name: "SuperscriptText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1135, col: 11, offset: 38405},
+										pos:  position{line: 1136, col: 11, offset: 38454},
 										name: "ElementPlaceHolder",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1136, col: 11, offset: 38434},
+										pos:  position{line: 1137, col: 11, offset: 38483},
 										name: "DoubleQuoteItalicTextFallbackCharacter",
 									},
 								},
@@ -6778,31 +6778,31 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteItalicTextFallbackCharacter",
-			pos:  position{line: 1140, col: 1, offset: 38503},
+			pos:  position{line: 1141, col: 1, offset: 38552},
 			expr: &choiceExpr{
-				pos: position{line: 1141, col: 5, offset: 38549},
+				pos: position{line: 1142, col: 5, offset: 38598},
 				alternatives: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 1141, col: 5, offset: 38549},
+						pos:        position{line: 1142, col: 5, offset: 38598},
 						val:        "[^\\r\\n_]",
 						chars:      []rune{'\r', '\n', '_'},
 						ignoreCase: false,
 						inverted:   true,
 					},
 					&actionExpr{
-						pos: position{line: 1142, col: 7, offset: 38648},
+						pos: position{line: 1143, col: 7, offset: 38697},
 						run: (*parser).callonDoubleQuoteItalicTextFallbackCharacter3,
 						expr: &seqExpr{
-							pos: position{line: 1142, col: 7, offset: 38648},
+							pos: position{line: 1143, col: 7, offset: 38697},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1142, col: 7, offset: 38648},
+									pos:        position{line: 1143, col: 7, offset: 38697},
 									val:        "__",
 									ignoreCase: false,
 									want:       "\"__\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1142, col: 12, offset: 38653},
+									pos:  position{line: 1143, col: 12, offset: 38702},
 									name: "Alphanums",
 								},
 							},
@@ -6813,40 +6813,40 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteItalicText",
-			pos:  position{line: 1146, col: 1, offset: 38818},
+			pos:  position{line: 1147, col: 1, offset: 38867},
 			expr: &choiceExpr{
-				pos: position{line: 1146, col: 26, offset: 38843},
+				pos: position{line: 1147, col: 26, offset: 38892},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1146, col: 26, offset: 38843},
+						pos: position{line: 1147, col: 26, offset: 38892},
 						run: (*parser).callonSingleQuoteItalicText2,
 						expr: &seqExpr{
-							pos: position{line: 1146, col: 26, offset: 38843},
+							pos: position{line: 1147, col: 26, offset: 38892},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1146, col: 26, offset: 38843},
+									pos:   position{line: 1147, col: 26, offset: 38892},
 									label: "attributes",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1146, col: 37, offset: 38854},
+										pos: position{line: 1147, col: 37, offset: 38903},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1146, col: 38, offset: 38855},
+											pos:  position{line: 1147, col: 38, offset: 38904},
 											name: "LongHandAttributes",
 										},
 									},
 								},
 								&seqExpr{
-									pos: position{line: 1146, col: 60, offset: 38877},
+									pos: position{line: 1147, col: 60, offset: 38926},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 1146, col: 60, offset: 38877},
+											pos:        position{line: 1147, col: 60, offset: 38926},
 											val:        "_",
 											ignoreCase: false,
 											want:       "\"_\"",
 										},
 										&notExpr{
-											pos: position{line: 1146, col: 64, offset: 38881},
+											pos: position{line: 1147, col: 64, offset: 38930},
 											expr: &litMatcher{
-												pos:        position{line: 1146, col: 65, offset: 38882},
+												pos:        position{line: 1147, col: 65, offset: 38931},
 												val:        "_",
 												ignoreCase: false,
 												want:       "\"_\"",
@@ -6855,15 +6855,15 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1146, col: 70, offset: 38887},
+									pos:   position{line: 1147, col: 70, offset: 38936},
 									label: "elements",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1146, col: 80, offset: 38897},
+										pos:  position{line: 1147, col: 80, offset: 38946},
 										name: "SingleQuoteItalicTextElements",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1146, col: 111, offset: 38928},
+									pos:        position{line: 1147, col: 111, offset: 38977},
 									val:        "_",
 									ignoreCase: false,
 									want:       "\"_\"",
@@ -6872,49 +6872,49 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1148, col: 5, offset: 39123},
+						pos: position{line: 1149, col: 5, offset: 39172},
 						run: (*parser).callonSingleQuoteItalicText14,
 						expr: &seqExpr{
-							pos: position{line: 1148, col: 5, offset: 39123},
+							pos: position{line: 1149, col: 5, offset: 39172},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1148, col: 5, offset: 39123},
+									pos:   position{line: 1149, col: 5, offset: 39172},
 									label: "attributes",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1148, col: 16, offset: 39134},
+										pos: position{line: 1149, col: 16, offset: 39183},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1148, col: 17, offset: 39135},
+											pos:  position{line: 1149, col: 17, offset: 39184},
 											name: "LongHandAttributes",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1148, col: 38, offset: 39156},
+									pos:        position{line: 1149, col: 38, offset: 39205},
 									val:        "_",
 									ignoreCase: false,
 									want:       "\"_\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1148, col: 42, offset: 39160},
+									pos:   position{line: 1149, col: 42, offset: 39209},
 									label: "elements",
 									expr: &seqExpr{
-										pos: position{line: 1148, col: 52, offset: 39170},
+										pos: position{line: 1149, col: 52, offset: 39219},
 										exprs: []interface{}{
 											&litMatcher{
-												pos:        position{line: 1148, col: 52, offset: 39170},
+												pos:        position{line: 1149, col: 52, offset: 39219},
 												val:        "_",
 												ignoreCase: false,
 												want:       "\"_\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1148, col: 56, offset: 39174},
+												pos:  position{line: 1149, col: 56, offset: 39223},
 												name: "SingleQuoteItalicTextElements",
 											},
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1148, col: 87, offset: 39205},
+									pos:        position{line: 1149, col: 87, offset: 39254},
 									val:        "_",
 									ignoreCase: false,
 									want:       "\"_\"",
@@ -6927,21 +6927,21 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteItalicTextElements",
-			pos:  position{line: 1152, col: 1, offset: 39420},
+			pos:  position{line: 1153, col: 1, offset: 39469},
 			expr: &seqExpr{
-				pos: position{line: 1152, col: 34, offset: 39453},
+				pos: position{line: 1153, col: 34, offset: 39502},
 				exprs: []interface{}{
 					&notExpr{
-						pos: position{line: 1152, col: 34, offset: 39453},
+						pos: position{line: 1153, col: 34, offset: 39502},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1152, col: 35, offset: 39454},
+							pos:  position{line: 1153, col: 35, offset: 39503},
 							name: "Space",
 						},
 					},
 					&oneOrMoreExpr{
-						pos: position{line: 1152, col: 41, offset: 39460},
+						pos: position{line: 1153, col: 41, offset: 39509},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1152, col: 41, offset: 39460},
+							pos:  position{line: 1153, col: 41, offset: 39509},
 							name: "SingleQuoteItalicTextElement",
 						},
 					},
@@ -6950,63 +6950,63 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteItalicTextElement",
-			pos:  position{line: 1154, col: 1, offset: 39491},
+			pos:  position{line: 1155, col: 1, offset: 39540},
 			expr: &choiceExpr{
-				pos: position{line: 1154, col: 33, offset: 39523},
+				pos: position{line: 1155, col: 33, offset: 39572},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1154, col: 33, offset: 39523},
+						pos:  position{line: 1155, col: 33, offset: 39572},
 						name: "Word",
 					},
 					&seqExpr{
-						pos: position{line: 1155, col: 11, offset: 39538},
+						pos: position{line: 1156, col: 11, offset: 39587},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 1155, col: 11, offset: 39538},
+								pos:  position{line: 1156, col: 11, offset: 39587},
 								name: "Newline",
 							},
 							&notExpr{
-								pos: position{line: 1155, col: 19, offset: 39546},
+								pos: position{line: 1156, col: 19, offset: 39595},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1155, col: 20, offset: 39547},
+									pos:  position{line: 1156, col: 20, offset: 39596},
 									name: "Newline",
 								},
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1156, col: 11, offset: 39565},
+						pos:  position{line: 1157, col: 11, offset: 39614},
 						name: "DoubleQuoteItalicText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1157, col: 11, offset: 39597},
+						pos:  position{line: 1158, col: 11, offset: 39646},
 						name: "QuotedString",
 					},
 					&seqExpr{
-						pos: position{line: 1158, col: 11, offset: 39620},
+						pos: position{line: 1159, col: 11, offset: 39669},
 						exprs: []interface{}{
 							&oneOrMoreExpr{
-								pos: position{line: 1158, col: 11, offset: 39620},
+								pos: position{line: 1159, col: 11, offset: 39669},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1158, col: 11, offset: 39620},
+									pos:  position{line: 1159, col: 11, offset: 39669},
 									name: "Space",
 								},
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 1158, col: 18, offset: 39627},
+								pos: position{line: 1159, col: 18, offset: 39676},
 								expr: &seqExpr{
-									pos: position{line: 1158, col: 19, offset: 39628},
+									pos: position{line: 1159, col: 19, offset: 39677},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 1158, col: 19, offset: 39628},
+											pos:        position{line: 1159, col: 19, offset: 39677},
 											val:        "_",
 											ignoreCase: false,
 											want:       "\"_\"",
 										},
 										&notExpr{
-											pos: position{line: 1158, col: 23, offset: 39632},
+											pos: position{line: 1159, col: 23, offset: 39681},
 											expr: &litMatcher{
-												pos:        position{line: 1158, col: 24, offset: 39633},
+												pos:        position{line: 1159, col: 24, offset: 39682},
 												val:        "_",
 												ignoreCase: false,
 												want:       "\"_\"",
@@ -7018,31 +7018,31 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1159, col: 11, offset: 39649},
+						pos:  position{line: 1160, col: 11, offset: 39698},
 						name: "BoldText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1160, col: 11, offset: 39668},
+						pos:  position{line: 1161, col: 11, offset: 39717},
 						name: "MarkedText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1161, col: 11, offset: 39689},
+						pos:  position{line: 1162, col: 11, offset: 39738},
 						name: "MonospaceText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1162, col: 11, offset: 39713},
+						pos:  position{line: 1163, col: 11, offset: 39762},
 						name: "SubscriptText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1163, col: 11, offset: 39737},
+						pos:  position{line: 1164, col: 11, offset: 39786},
 						name: "SuperscriptText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1164, col: 11, offset: 39763},
+						pos:  position{line: 1165, col: 11, offset: 39812},
 						name: "ElementPlaceHolder",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1165, col: 11, offset: 39792},
+						pos:  position{line: 1166, col: 11, offset: 39841},
 						name: "SingleQuoteItalicTextFallbackCharacter",
 					},
 				},
@@ -7050,31 +7050,31 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteItalicTextFallbackCharacter",
-			pos:  position{line: 1167, col: 1, offset: 39832},
+			pos:  position{line: 1168, col: 1, offset: 39881},
 			expr: &choiceExpr{
-				pos: position{line: 1168, col: 5, offset: 39878},
+				pos: position{line: 1169, col: 5, offset: 39927},
 				alternatives: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 1168, col: 5, offset: 39878},
+						pos:        position{line: 1169, col: 5, offset: 39927},
 						val:        "[^\\r\\n_]",
 						chars:      []rune{'\r', '\n', '_'},
 						ignoreCase: false,
 						inverted:   true,
 					},
 					&actionExpr{
-						pos: position{line: 1169, col: 7, offset: 39977},
+						pos: position{line: 1170, col: 7, offset: 40026},
 						run: (*parser).callonSingleQuoteItalicTextFallbackCharacter3,
 						expr: &seqExpr{
-							pos: position{line: 1169, col: 7, offset: 39977},
+							pos: position{line: 1170, col: 7, offset: 40026},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1169, col: 7, offset: 39977},
+									pos:        position{line: 1170, col: 7, offset: 40026},
 									val:        "_",
 									ignoreCase: false,
 									want:       "\"_\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1169, col: 11, offset: 39981},
+									pos:  position{line: 1170, col: 11, offset: 40030},
 									name: "Alphanums",
 								},
 							},
@@ -7085,40 +7085,40 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedItalicText",
-			pos:  position{line: 1173, col: 1, offset: 40147},
+			pos:  position{line: 1174, col: 1, offset: 40196},
 			expr: &choiceExpr{
-				pos: position{line: 1174, col: 5, offset: 40173},
+				pos: position{line: 1175, col: 5, offset: 40222},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1174, col: 5, offset: 40173},
+						pos: position{line: 1175, col: 5, offset: 40222},
 						run: (*parser).callonEscapedItalicText2,
 						expr: &seqExpr{
-							pos: position{line: 1174, col: 5, offset: 40173},
+							pos: position{line: 1175, col: 5, offset: 40222},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1174, col: 5, offset: 40173},
+									pos:   position{line: 1175, col: 5, offset: 40222},
 									label: "backslashes",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1174, col: 18, offset: 40186},
+										pos:  position{line: 1175, col: 18, offset: 40235},
 										name: "TwoOrMoreBackslashes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1174, col: 40, offset: 40208},
+									pos:        position{line: 1175, col: 40, offset: 40257},
 									val:        "__",
 									ignoreCase: false,
 									want:       "\"__\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1174, col: 45, offset: 40213},
+									pos:   position{line: 1175, col: 45, offset: 40262},
 									label: "elements",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1174, col: 55, offset: 40223},
+										pos:  position{line: 1175, col: 55, offset: 40272},
 										name: "DoubleQuoteItalicTextElements",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1174, col: 86, offset: 40254},
+									pos:        position{line: 1175, col: 86, offset: 40303},
 									val:        "__",
 									ignoreCase: false,
 									want:       "\"__\"",
@@ -7127,35 +7127,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1176, col: 9, offset: 40411},
+						pos: position{line: 1177, col: 9, offset: 40460},
 						run: (*parser).callonEscapedItalicText10,
 						expr: &seqExpr{
-							pos: position{line: 1176, col: 9, offset: 40411},
+							pos: position{line: 1177, col: 9, offset: 40460},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1176, col: 9, offset: 40411},
+									pos:   position{line: 1177, col: 9, offset: 40460},
 									label: "backslashes",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1176, col: 22, offset: 40424},
+										pos:  position{line: 1177, col: 22, offset: 40473},
 										name: "OneOrMoreBackslashes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1176, col: 44, offset: 40446},
+									pos:        position{line: 1177, col: 44, offset: 40495},
 									val:        "__",
 									ignoreCase: false,
 									want:       "\"__\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1176, col: 49, offset: 40451},
+									pos:   position{line: 1177, col: 49, offset: 40500},
 									label: "elements",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1176, col: 59, offset: 40461},
+										pos:  position{line: 1177, col: 59, offset: 40510},
 										name: "SingleQuoteItalicTextElements",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1176, col: 90, offset: 40492},
+									pos:        position{line: 1177, col: 90, offset: 40541},
 									val:        "_",
 									ignoreCase: false,
 									want:       "\"_\"",
@@ -7164,35 +7164,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1179, col: 9, offset: 40692},
+						pos: position{line: 1180, col: 9, offset: 40741},
 						run: (*parser).callonEscapedItalicText18,
 						expr: &seqExpr{
-							pos: position{line: 1179, col: 9, offset: 40692},
+							pos: position{line: 1180, col: 9, offset: 40741},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1179, col: 9, offset: 40692},
+									pos:   position{line: 1180, col: 9, offset: 40741},
 									label: "backslashes",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1179, col: 22, offset: 40705},
+										pos:  position{line: 1180, col: 22, offset: 40754},
 										name: "OneOrMoreBackslashes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1179, col: 44, offset: 40727},
+									pos:        position{line: 1180, col: 44, offset: 40776},
 									val:        "_",
 									ignoreCase: false,
 									want:       "\"_\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1179, col: 48, offset: 40731},
+									pos:   position{line: 1180, col: 48, offset: 40780},
 									label: "elements",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1179, col: 58, offset: 40741},
+										pos:  position{line: 1180, col: 58, offset: 40790},
 										name: "SingleQuoteItalicTextElements",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1179, col: 89, offset: 40772},
+									pos:        position{line: 1180, col: 89, offset: 40821},
 									val:        "_",
 									ignoreCase: false,
 									want:       "\"_\"",
@@ -7205,16 +7205,16 @@ var g = &grammar{
 		},
 		{
 			name: "MonospaceText",
-			pos:  position{line: 1186, col: 1, offset: 40982},
+			pos:  position{line: 1187, col: 1, offset: 41031},
 			expr: &choiceExpr{
-				pos: position{line: 1186, col: 18, offset: 40999},
+				pos: position{line: 1187, col: 18, offset: 41048},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1186, col: 18, offset: 40999},
+						pos:  position{line: 1187, col: 18, offset: 41048},
 						name: "DoubleQuoteMonospaceText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1186, col: 45, offset: 41026},
+						pos:  position{line: 1187, col: 45, offset: 41075},
 						name: "SingleQuoteMonospaceText",
 					},
 				},
@@ -7222,40 +7222,40 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteMonospaceText",
-			pos:  position{line: 1188, col: 1, offset: 41052},
+			pos:  position{line: 1189, col: 1, offset: 41101},
 			expr: &actionExpr{
-				pos: position{line: 1188, col: 29, offset: 41080},
+				pos: position{line: 1189, col: 29, offset: 41129},
 				run: (*parser).callonDoubleQuoteMonospaceText1,
 				expr: &seqExpr{
-					pos: position{line: 1188, col: 29, offset: 41080},
+					pos: position{line: 1189, col: 29, offset: 41129},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1188, col: 29, offset: 41080},
+							pos:   position{line: 1189, col: 29, offset: 41129},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1188, col: 40, offset: 41091},
+								pos: position{line: 1189, col: 40, offset: 41140},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1188, col: 41, offset: 41092},
+									pos:  position{line: 1189, col: 41, offset: 41141},
 									name: "LongHandAttributes",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1188, col: 62, offset: 41113},
+							pos:        position{line: 1189, col: 62, offset: 41162},
 							val:        "``",
 							ignoreCase: false,
 							want:       "\"``\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1188, col: 67, offset: 41118},
+							pos:   position{line: 1189, col: 67, offset: 41167},
 							label: "elements",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1188, col: 77, offset: 41128},
+								pos:  position{line: 1189, col: 77, offset: 41177},
 								name: "DoubleQuoteMonospaceTextElements",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1188, col: 111, offset: 41162},
+							pos:        position{line: 1189, col: 111, offset: 41211},
 							val:        "``",
 							ignoreCase: false,
 							want:       "\"``\"",
@@ -7266,105 +7266,105 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteMonospaceTextElements",
-			pos:  position{line: 1192, col: 1, offset: 41304},
+			pos:  position{line: 1193, col: 1, offset: 41353},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1192, col: 37, offset: 41340},
+				pos: position{line: 1193, col: 37, offset: 41389},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1192, col: 37, offset: 41340},
+					pos:  position{line: 1193, col: 37, offset: 41389},
 					name: "DoubleQuoteMonospaceTextElement",
 				},
 			},
 		},
 		{
 			name: "DoubleQuoteMonospaceTextElement",
-			pos:  position{line: 1194, col: 1, offset: 41407},
+			pos:  position{line: 1195, col: 1, offset: 41456},
 			expr: &actionExpr{
-				pos: position{line: 1194, col: 36, offset: 41442},
+				pos: position{line: 1195, col: 36, offset: 41491},
 				run: (*parser).callonDoubleQuoteMonospaceTextElement1,
 				expr: &seqExpr{
-					pos: position{line: 1194, col: 36, offset: 41442},
+					pos: position{line: 1195, col: 36, offset: 41491},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1194, col: 36, offset: 41442},
+							pos: position{line: 1195, col: 36, offset: 41491},
 							expr: &litMatcher{
-								pos:        position{line: 1194, col: 38, offset: 41444},
+								pos:        position{line: 1195, col: 38, offset: 41493},
 								val:        "``",
 								ignoreCase: false,
 								want:       "\"``\"",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1194, col: 44, offset: 41450},
+							pos:   position{line: 1195, col: 44, offset: 41499},
 							label: "element",
 							expr: &choiceExpr{
-								pos: position{line: 1194, col: 53, offset: 41459},
+								pos: position{line: 1195, col: 53, offset: 41508},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1194, col: 53, offset: 41459},
+										pos:  position{line: 1195, col: 53, offset: 41508},
 										name: "Word",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1195, col: 11, offset: 41474},
+										pos:  position{line: 1196, col: 11, offset: 41523},
 										name: "Space",
 									},
 									&seqExpr{
-										pos: position{line: 1196, col: 11, offset: 41523},
+										pos: position{line: 1197, col: 11, offset: 41572},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1196, col: 11, offset: 41523},
+												pos:  position{line: 1197, col: 11, offset: 41572},
 												name: "Newline",
 											},
 											&notExpr{
-												pos: position{line: 1196, col: 19, offset: 41531},
+												pos: position{line: 1197, col: 19, offset: 41580},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1196, col: 20, offset: 41532},
+													pos:  position{line: 1197, col: 20, offset: 41581},
 													name: "Newline",
 												},
 											},
 										},
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1197, col: 11, offset: 41550},
+										pos:  position{line: 1198, col: 11, offset: 41599},
 										name: "QuotedString",
 									},
 									&actionExpr{
-										pos: position{line: 1198, col: 11, offset: 41573},
+										pos: position{line: 1199, col: 11, offset: 41622},
 										run: (*parser).callonDoubleQuoteMonospaceTextElement14,
 										expr: &ruleRefExpr{
-											pos:  position{line: 1198, col: 11, offset: 41573},
+											pos:  position{line: 1199, col: 11, offset: 41622},
 											name: "Apostrophe",
 										},
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1202, col: 11, offset: 41757},
+										pos:  position{line: 1203, col: 11, offset: 41806},
 										name: "SingleQuoteMonospaceText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1203, col: 11, offset: 41792},
+										pos:  position{line: 1204, col: 11, offset: 41841},
 										name: "BoldText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1204, col: 11, offset: 41811},
+										pos:  position{line: 1205, col: 11, offset: 41860},
 										name: "ItalicText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1205, col: 11, offset: 41832},
+										pos:  position{line: 1206, col: 11, offset: 41881},
 										name: "MarkedText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1206, col: 11, offset: 41853},
+										pos:  position{line: 1207, col: 11, offset: 41902},
 										name: "SubscriptText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1207, col: 11, offset: 41877},
+										pos:  position{line: 1208, col: 11, offset: 41926},
 										name: "SuperscriptText",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1208, col: 11, offset: 41903},
+										pos:  position{line: 1209, col: 11, offset: 41952},
 										name: "ElementPlaceHolder",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1209, col: 11, offset: 41932},
+										pos:  position{line: 1210, col: 11, offset: 41981},
 										name: "DoubleQuoteMonospaceTextFallbackCharacter",
 									},
 								},
@@ -7376,31 +7376,31 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteMonospaceTextFallbackCharacter",
-			pos:  position{line: 1213, col: 1, offset: 42004},
+			pos:  position{line: 1214, col: 1, offset: 42053},
 			expr: &choiceExpr{
-				pos: position{line: 1214, col: 5, offset: 42053},
+				pos: position{line: 1215, col: 5, offset: 42102},
 				alternatives: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 1214, col: 5, offset: 42053},
+						pos:        position{line: 1215, col: 5, offset: 42102},
 						val:        "[^\\r\\n`]",
 						chars:      []rune{'\r', '\n', '`'},
 						ignoreCase: false,
 						inverted:   true,
 					},
 					&actionExpr{
-						pos: position{line: 1215, col: 7, offset: 42155},
+						pos: position{line: 1216, col: 7, offset: 42204},
 						run: (*parser).callonDoubleQuoteMonospaceTextFallbackCharacter3,
 						expr: &seqExpr{
-							pos: position{line: 1215, col: 7, offset: 42155},
+							pos: position{line: 1216, col: 7, offset: 42204},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1215, col: 7, offset: 42155},
+									pos:        position{line: 1216, col: 7, offset: 42204},
 									val:        "``",
 									ignoreCase: false,
 									want:       "\"``\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1215, col: 12, offset: 42160},
+									pos:  position{line: 1216, col: 12, offset: 42209},
 									name: "Alphanums",
 								},
 							},
@@ -7411,40 +7411,40 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteMonospaceText",
-			pos:  position{line: 1219, col: 1, offset: 42328},
+			pos:  position{line: 1220, col: 1, offset: 42377},
 			expr: &choiceExpr{
-				pos: position{line: 1219, col: 29, offset: 42356},
+				pos: position{line: 1220, col: 29, offset: 42405},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1219, col: 29, offset: 42356},
+						pos: position{line: 1220, col: 29, offset: 42405},
 						run: (*parser).callonSingleQuoteMonospaceText2,
 						expr: &seqExpr{
-							pos: position{line: 1219, col: 29, offset: 42356},
+							pos: position{line: 1220, col: 29, offset: 42405},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1219, col: 29, offset: 42356},
+									pos:   position{line: 1220, col: 29, offset: 42405},
 									label: "attributes",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1219, col: 40, offset: 42367},
+										pos: position{line: 1220, col: 40, offset: 42416},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1219, col: 41, offset: 42368},
+											pos:  position{line: 1220, col: 41, offset: 42417},
 											name: "LongHandAttributes",
 										},
 									},
 								},
 								&seqExpr{
-									pos: position{line: 1219, col: 63, offset: 42390},
+									pos: position{line: 1220, col: 63, offset: 42439},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 1219, col: 63, offset: 42390},
+											pos:        position{line: 1220, col: 63, offset: 42439},
 											val:        "`",
 											ignoreCase: false,
 											want:       "\"`\"",
 										},
 										&notExpr{
-											pos: position{line: 1219, col: 67, offset: 42394},
+											pos: position{line: 1220, col: 67, offset: 42443},
 											expr: &litMatcher{
-												pos:        position{line: 1219, col: 68, offset: 42395},
+												pos:        position{line: 1220, col: 68, offset: 42444},
 												val:        "`",
 												ignoreCase: false,
 												want:       "\"`\"",
@@ -7453,15 +7453,15 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1219, col: 73, offset: 42400},
+									pos:   position{line: 1220, col: 73, offset: 42449},
 									label: "elements",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1219, col: 83, offset: 42410},
+										pos:  position{line: 1220, col: 83, offset: 42459},
 										name: "SingleQuoteMonospaceTextElements",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1219, col: 117, offset: 42444},
+									pos:        position{line: 1220, col: 117, offset: 42493},
 									val:        "`",
 									ignoreCase: false,
 									want:       "\"`\"",
@@ -7470,49 +7470,49 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1221, col: 5, offset: 42642},
+						pos: position{line: 1222, col: 5, offset: 42691},
 						run: (*parser).callonSingleQuoteMonospaceText14,
 						expr: &seqExpr{
-							pos: position{line: 1221, col: 5, offset: 42642},
+							pos: position{line: 1222, col: 5, offset: 42691},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1221, col: 5, offset: 42642},
+									pos:   position{line: 1222, col: 5, offset: 42691},
 									label: "attributes",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1221, col: 16, offset: 42653},
+										pos: position{line: 1222, col: 16, offset: 42702},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1221, col: 17, offset: 42654},
+											pos:  position{line: 1222, col: 17, offset: 42703},
 											name: "LongHandAttributes",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1221, col: 38, offset: 42675},
+									pos:        position{line: 1222, col: 38, offset: 42724},
 									val:        "`",
 									ignoreCase: false,
 									want:       "\"`\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1221, col: 42, offset: 42679},
+									pos:   position{line: 1222, col: 42, offset: 42728},
 									label: "elements",
 									expr: &seqExpr{
-										pos: position{line: 1221, col: 52, offset: 42689},
+										pos: position{line: 1222, col: 52, offset: 42738},
 										exprs: []interface{}{
 											&litMatcher{
-												pos:        position{line: 1221, col: 52, offset: 42689},
+												pos:        position{line: 1222, col: 52, offset: 42738},
 												val:        "`",
 												ignoreCase: false,
 												want:       "\"`\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1221, col: 56, offset: 42693},
+												pos:  position{line: 1222, col: 56, offset: 42742},
 												name: "SingleQuoteMonospaceTextElements",
 											},
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1221, col: 90, offset: 42727},
+									pos:        position{line: 1222, col: 90, offset: 42776},
 									val:        "`",
 									ignoreCase: false,
 									want:       "\"`\"",
@@ -7525,21 +7525,21 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteMonospaceTextElements",
-			pos:  position{line: 1225, col: 1, offset: 42946},
+			pos:  position{line: 1226, col: 1, offset: 42995},
 			expr: &seqExpr{
-				pos: position{line: 1225, col: 37, offset: 42982},
+				pos: position{line: 1226, col: 37, offset: 43031},
 				exprs: []interface{}{
 					&notExpr{
-						pos: position{line: 1225, col: 37, offset: 42982},
+						pos: position{line: 1226, col: 37, offset: 43031},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1225, col: 38, offset: 42983},
+							pos:  position{line: 1226, col: 38, offset: 43032},
 							name: "Space",
 						},
 					},
 					&oneOrMoreExpr{
-						pos: position{line: 1225, col: 44, offset: 42989},
+						pos: position{line: 1226, col: 44, offset: 43038},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1225, col: 44, offset: 42989},
+							pos:  position{line: 1226, col: 44, offset: 43038},
 							name: "SingleQuoteMonospaceTextElement",
 						},
 					},
@@ -7548,63 +7548,63 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteMonospaceTextElement",
-			pos:  position{line: 1227, col: 1, offset: 43023},
+			pos:  position{line: 1228, col: 1, offset: 43072},
 			expr: &choiceExpr{
-				pos: position{line: 1227, col: 37, offset: 43059},
+				pos: position{line: 1228, col: 37, offset: 43108},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1227, col: 37, offset: 43059},
+						pos:  position{line: 1228, col: 37, offset: 43108},
 						name: "Word",
 					},
 					&seqExpr{
-						pos: position{line: 1228, col: 11, offset: 43074},
+						pos: position{line: 1229, col: 11, offset: 43123},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 1228, col: 11, offset: 43074},
+								pos:  position{line: 1229, col: 11, offset: 43123},
 								name: "Newline",
 							},
 							&notExpr{
-								pos: position{line: 1228, col: 19, offset: 43082},
+								pos: position{line: 1229, col: 19, offset: 43131},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1228, col: 20, offset: 43083},
+									pos:  position{line: 1229, col: 20, offset: 43132},
 									name: "Newline",
 								},
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1229, col: 11, offset: 43101},
+						pos:  position{line: 1230, col: 11, offset: 43150},
 						name: "DoubleQuoteMonospaceText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1230, col: 11, offset: 43136},
+						pos:  position{line: 1231, col: 11, offset: 43185},
 						name: "QuotedString",
 					},
 					&seqExpr{
-						pos: position{line: 1231, col: 11, offset: 43159},
+						pos: position{line: 1232, col: 11, offset: 43208},
 						exprs: []interface{}{
 							&oneOrMoreExpr{
-								pos: position{line: 1231, col: 11, offset: 43159},
+								pos: position{line: 1232, col: 11, offset: 43208},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1231, col: 11, offset: 43159},
+									pos:  position{line: 1232, col: 11, offset: 43208},
 									name: "Space",
 								},
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 1231, col: 18, offset: 43166},
+								pos: position{line: 1232, col: 18, offset: 43215},
 								expr: &seqExpr{
-									pos: position{line: 1231, col: 19, offset: 43167},
+									pos: position{line: 1232, col: 19, offset: 43216},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 1231, col: 19, offset: 43167},
+											pos:        position{line: 1232, col: 19, offset: 43216},
 											val:        "`",
 											ignoreCase: false,
 											want:       "\"`\"",
 										},
 										&notExpr{
-											pos: position{line: 1231, col: 23, offset: 43171},
+											pos: position{line: 1232, col: 23, offset: 43220},
 											expr: &litMatcher{
-												pos:        position{line: 1231, col: 24, offset: 43172},
+												pos:        position{line: 1232, col: 24, offset: 43221},
 												val:        "`",
 												ignoreCase: false,
 												want:       "\"`\"",
@@ -7616,39 +7616,39 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1232, col: 11, offset: 43300},
+						pos:  position{line: 1233, col: 11, offset: 43349},
 						name: "BoldText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1233, col: 11, offset: 43319},
+						pos:  position{line: 1234, col: 11, offset: 43368},
 						name: "ItalicText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1234, col: 11, offset: 43340},
+						pos:  position{line: 1235, col: 11, offset: 43389},
 						name: "MarkedText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1235, col: 11, offset: 43361},
+						pos:  position{line: 1236, col: 11, offset: 43410},
 						name: "SubscriptText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1236, col: 11, offset: 43385},
+						pos:  position{line: 1237, col: 11, offset: 43434},
 						name: "SuperscriptText",
 					},
 					&actionExpr{
-						pos: position{line: 1237, col: 11, offset: 43411},
+						pos: position{line: 1238, col: 11, offset: 43460},
 						run: (*parser).callonSingleQuoteMonospaceTextElement22,
 						expr: &ruleRefExpr{
-							pos:  position{line: 1237, col: 11, offset: 43411},
+							pos:  position{line: 1238, col: 11, offset: 43460},
 							name: "Apostrophe",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1241, col: 11, offset: 43552},
+						pos:  position{line: 1242, col: 11, offset: 43601},
 						name: "ElementPlaceHolder",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1242, col: 11, offset: 43581},
+						pos:  position{line: 1243, col: 11, offset: 43630},
 						name: "SingleQuoteMonospaceTextFallbackCharacter",
 					},
 				},
@@ -7656,31 +7656,31 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteMonospaceTextFallbackCharacter",
-			pos:  position{line: 1244, col: 1, offset: 43624},
+			pos:  position{line: 1245, col: 1, offset: 43673},
 			expr: &choiceExpr{
-				pos: position{line: 1245, col: 5, offset: 43673},
+				pos: position{line: 1246, col: 5, offset: 43722},
 				alternatives: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 1245, col: 5, offset: 43673},
+						pos:        position{line: 1246, col: 5, offset: 43722},
 						val:        "[^\\r\\n`]",
 						chars:      []rune{'\r', '\n', '`'},
 						ignoreCase: false,
 						inverted:   true,
 					},
 					&actionExpr{
-						pos: position{line: 1246, col: 7, offset: 43775},
+						pos: position{line: 1247, col: 7, offset: 43824},
 						run: (*parser).callonSingleQuoteMonospaceTextFallbackCharacter3,
 						expr: &seqExpr{
-							pos: position{line: 1246, col: 7, offset: 43775},
+							pos: position{line: 1247, col: 7, offset: 43824},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1246, col: 7, offset: 43775},
+									pos:        position{line: 1247, col: 7, offset: 43824},
 									val:        "`",
 									ignoreCase: false,
 									want:       "\"`\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1246, col: 11, offset: 43779},
+									pos:  position{line: 1247, col: 11, offset: 43828},
 									name: "Alphanums",
 								},
 							},
@@ -7691,40 +7691,40 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedMonospaceText",
-			pos:  position{line: 1250, col: 1, offset: 43948},
+			pos:  position{line: 1251, col: 1, offset: 43997},
 			expr: &choiceExpr{
-				pos: position{line: 1251, col: 5, offset: 43977},
+				pos: position{line: 1252, col: 5, offset: 44026},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1251, col: 5, offset: 43977},
+						pos: position{line: 1252, col: 5, offset: 44026},
 						run: (*parser).callonEscapedMonospaceText2,
 						expr: &seqExpr{
-							pos: position{line: 1251, col: 5, offset: 43977},
+							pos: position{line: 1252, col: 5, offset: 44026},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1251, col: 5, offset: 43977},
+									pos:   position{line: 1252, col: 5, offset: 44026},
 									label: "backslashes",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1251, col: 18, offset: 43990},
+										pos:  position{line: 1252, col: 18, offset: 44039},
 										name: "TwoOrMoreBackslashes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1251, col: 40, offset: 44012},
+									pos:        position{line: 1252, col: 40, offset: 44061},
 									val:        "``",
 									ignoreCase: false,
 									want:       "\"``\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1251, col: 45, offset: 44017},
+									pos:   position{line: 1252, col: 45, offset: 44066},
 									label: "elements",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1251, col: 55, offset: 44027},
+										pos:  position{line: 1252, col: 55, offset: 44076},
 										name: "DoubleQuoteMonospaceTextElements",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1251, col: 89, offset: 44061},
+									pos:        position{line: 1252, col: 89, offset: 44110},
 									val:        "``",
 									ignoreCase: false,
 									want:       "\"``\"",
@@ -7733,35 +7733,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1253, col: 9, offset: 44218},
+						pos: position{line: 1254, col: 9, offset: 44267},
 						run: (*parser).callonEscapedMonospaceText10,
 						expr: &seqExpr{
-							pos: position{line: 1253, col: 9, offset: 44218},
+							pos: position{line: 1254, col: 9, offset: 44267},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1253, col: 9, offset: 44218},
+									pos:   position{line: 1254, col: 9, offset: 44267},
 									label: "backslashes",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1253, col: 22, offset: 44231},
+										pos:  position{line: 1254, col: 22, offset: 44280},
 										name: "OneOrMoreBackslashes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1253, col: 44, offset: 44253},
+									pos:        position{line: 1254, col: 44, offset: 44302},
 									val:        "``",
 									ignoreCase: false,
 									want:       "\"``\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1253, col: 49, offset: 44258},
+									pos:   position{line: 1254, col: 49, offset: 44307},
 									label: "elements",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1253, col: 59, offset: 44268},
+										pos:  position{line: 1254, col: 59, offset: 44317},
 										name: "SingleQuoteMonospaceTextElements",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1253, col: 93, offset: 44302},
+									pos:        position{line: 1254, col: 93, offset: 44351},
 									val:        "`",
 									ignoreCase: false,
 									want:       "\"`\"",
@@ -7770,35 +7770,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1256, col: 9, offset: 44502},
+						pos: position{line: 1257, col: 9, offset: 44551},
 						run: (*parser).callonEscapedMonospaceText18,
 						expr: &seqExpr{
-							pos: position{line: 1256, col: 9, offset: 44502},
+							pos: position{line: 1257, col: 9, offset: 44551},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1256, col: 9, offset: 44502},
+									pos:   position{line: 1257, col: 9, offset: 44551},
 									label: "backslashes",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1256, col: 22, offset: 44515},
+										pos:  position{line: 1257, col: 22, offset: 44564},
 										name: "OneOrMoreBackslashes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1256, col: 44, offset: 44537},
+									pos:        position{line: 1257, col: 44, offset: 44586},
 									val:        "`",
 									ignoreCase: false,
 									want:       "\"`\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1256, col: 48, offset: 44541},
+									pos:   position{line: 1257, col: 48, offset: 44590},
 									label: "elements",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1256, col: 58, offset: 44551},
+										pos:  position{line: 1257, col: 58, offset: 44600},
 										name: "SingleQuoteMonospaceTextElements",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1256, col: 92, offset: 44585},
+									pos:        position{line: 1257, col: 92, offset: 44634},
 									val:        "`",
 									ignoreCase: false,
 									want:       "\"`\"",
@@ -7811,16 +7811,16 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedString",
-			pos:  position{line: 1264, col: 1, offset: 44910},
+			pos:  position{line: 1265, col: 1, offset: 44959},
 			expr: &choiceExpr{
-				pos: position{line: 1264, col: 17, offset: 44926},
+				pos: position{line: 1265, col: 17, offset: 44975},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1264, col: 17, offset: 44926},
+						pos:  position{line: 1265, col: 17, offset: 44975},
 						name: "SingleQuotedString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1264, col: 38, offset: 44947},
+						pos:  position{line: 1265, col: 38, offset: 44996},
 						name: "DoubleQuotedString",
 					},
 				},
@@ -7828,27 +7828,27 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedString",
-			pos:  position{line: 1266, col: 1, offset: 44967},
+			pos:  position{line: 1267, col: 1, offset: 45016},
 			expr: &actionExpr{
-				pos: position{line: 1266, col: 23, offset: 44989},
+				pos: position{line: 1267, col: 23, offset: 45038},
 				run: (*parser).callonSingleQuotedString1,
 				expr: &seqExpr{
-					pos: position{line: 1266, col: 23, offset: 44989},
+					pos: position{line: 1267, col: 23, offset: 45038},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1266, col: 23, offset: 44989},
+							pos:  position{line: 1267, col: 23, offset: 45038},
 							name: "SingleQuoteStringStart",
 						},
 						&labeledExpr{
-							pos:   position{line: 1266, col: 46, offset: 45012},
+							pos:   position{line: 1267, col: 46, offset: 45061},
 							label: "elements",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1266, col: 55, offset: 45021},
+								pos:  position{line: 1267, col: 55, offset: 45070},
 								name: "SingleQuotedStringElements",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1266, col: 82, offset: 45048},
+							pos:  position{line: 1267, col: 82, offset: 45097},
 							name: "SingleQuoteStringEnd",
 						},
 					},
@@ -7857,17 +7857,17 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedStringElements",
-			pos:  position{line: 1270, col: 1, offset: 45152},
+			pos:  position{line: 1271, col: 1, offset: 45201},
 			expr: &actionExpr{
-				pos: position{line: 1270, col: 31, offset: 45182},
+				pos: position{line: 1271, col: 31, offset: 45231},
 				run: (*parser).callonSingleQuotedStringElements1,
 				expr: &labeledExpr{
-					pos:   position{line: 1270, col: 31, offset: 45182},
+					pos:   position{line: 1271, col: 31, offset: 45231},
 					label: "elements",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 1270, col: 41, offset: 45192},
+						pos: position{line: 1271, col: 41, offset: 45241},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1270, col: 41, offset: 45192},
+							pos:  position{line: 1271, col: 41, offset: 45241},
 							name: "SingleQuotedStringElement",
 						},
 					},
@@ -7876,20 +7876,20 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteStringStart",
-			pos:  position{line: 1274, col: 1, offset: 45270},
+			pos:  position{line: 1275, col: 1, offset: 45319},
 			expr: &seqExpr{
-				pos: position{line: 1274, col: 27, offset: 45296},
+				pos: position{line: 1275, col: 27, offset: 45345},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1274, col: 27, offset: 45296},
+						pos:        position{line: 1275, col: 27, offset: 45345},
 						val:        "'`",
 						ignoreCase: false,
 						want:       "\"'`\"",
 					},
 					&notExpr{
-						pos: position{line: 1274, col: 32, offset: 45301},
+						pos: position{line: 1275, col: 32, offset: 45350},
 						expr: &charClassMatcher{
-							pos:        position{line: 1274, col: 33, offset: 45302},
+							pos:        position{line: 1275, col: 33, offset: 45351},
 							val:        "[ \\t\\r\\n]",
 							chars:      []rune{' ', '\t', '\r', '\n'},
 							ignoreCase: false,
@@ -7901,9 +7901,9 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteStringEnd",
-			pos:  position{line: 1276, col: 1, offset: 45313},
+			pos:  position{line: 1277, col: 1, offset: 45362},
 			expr: &litMatcher{
-				pos:        position{line: 1276, col: 25, offset: 45337},
+				pos:        position{line: 1277, col: 25, offset: 45386},
 				val:        "`'",
 				ignoreCase: false,
 				want:       "\"`'\"",
@@ -7911,113 +7911,113 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedStringElement",
-			pos:  position{line: 1279, col: 1, offset: 45425},
+			pos:  position{line: 1280, col: 1, offset: 45474},
 			expr: &actionExpr{
-				pos: position{line: 1279, col: 30, offset: 45454},
+				pos: position{line: 1280, col: 30, offset: 45503},
 				run: (*parser).callonSingleQuotedStringElement1,
 				expr: &labeledExpr{
-					pos:   position{line: 1279, col: 30, offset: 45454},
+					pos:   position{line: 1280, col: 30, offset: 45503},
 					label: "element",
 					expr: &choiceExpr{
-						pos: position{line: 1280, col: 9, offset: 45472},
+						pos: position{line: 1281, col: 9, offset: 45521},
 						alternatives: []interface{}{
 							&seqExpr{
-								pos: position{line: 1280, col: 9, offset: 45472},
+								pos: position{line: 1281, col: 9, offset: 45521},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1280, col: 9, offset: 45472},
+										pos:  position{line: 1281, col: 9, offset: 45521},
 										name: "LineBreak",
 									},
 									&notExpr{
-										pos: position{line: 1280, col: 19, offset: 45482},
+										pos: position{line: 1281, col: 19, offset: 45531},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1280, col: 20, offset: 45483},
+											pos:  position{line: 1281, col: 20, offset: 45532},
 											name: "SingleQuoteStringEnd",
 										},
 									},
 								},
 							},
 							&seqExpr{
-								pos: position{line: 1281, col: 11, offset: 45539},
+								pos: position{line: 1282, col: 11, offset: 45588},
 								exprs: []interface{}{
 									&oneOrMoreExpr{
-										pos: position{line: 1281, col: 11, offset: 45539},
+										pos: position{line: 1282, col: 11, offset: 45588},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1281, col: 11, offset: 45539},
+											pos:  position{line: 1282, col: 11, offset: 45588},
 											name: "Space",
 										},
 									},
 									&notExpr{
-										pos: position{line: 1281, col: 18, offset: 45546},
+										pos: position{line: 1282, col: 18, offset: 45595},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1281, col: 19, offset: 45547},
+											pos:  position{line: 1282, col: 19, offset: 45596},
 											name: "SingleQuoteStringEnd",
 										},
 									},
 								},
 							},
 							&seqExpr{
-								pos: position{line: 1282, col: 11, offset: 45578},
+								pos: position{line: 1283, col: 11, offset: 45627},
 								exprs: []interface{}{
 									&notExpr{
-										pos: position{line: 1282, col: 11, offset: 45578},
+										pos: position{line: 1283, col: 11, offset: 45627},
 										expr: &litMatcher{
-											pos:        position{line: 1282, col: 12, offset: 45579},
+											pos:        position{line: 1283, col: 12, offset: 45628},
 											val:        "`",
 											ignoreCase: false,
 											want:       "\"`\"",
 										},
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1282, col: 16, offset: 45583},
+										pos:  position{line: 1283, col: 16, offset: 45632},
 										name: "Symbol",
 									},
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1283, col: 11, offset: 45631},
+								pos:  position{line: 1284, col: 11, offset: 45680},
 								name: "BoldText",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1284, col: 11, offset: 45650},
+								pos:  position{line: 1285, col: 11, offset: 45699},
 								name: "ItalicText",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1285, col: 11, offset: 45671},
+								pos:  position{line: 1286, col: 11, offset: 45720},
 								name: "MarkedText",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1286, col: 11, offset: 45692},
+								pos:  position{line: 1287, col: 11, offset: 45741},
 								name: "SubscriptText",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1287, col: 11, offset: 45716},
+								pos:  position{line: 1288, col: 11, offset: 45765},
 								name: "SuperscriptText",
 							},
 							&seqExpr{
-								pos: position{line: 1288, col: 11, offset: 45742},
+								pos: position{line: 1289, col: 11, offset: 45791},
 								exprs: []interface{}{
 									&notExpr{
-										pos: position{line: 1288, col: 11, offset: 45742},
+										pos: position{line: 1289, col: 11, offset: 45791},
 										expr: &litMatcher{
-											pos:        position{line: 1288, col: 12, offset: 45743},
+											pos:        position{line: 1289, col: 12, offset: 45792},
 											val:        "`'",
 											ignoreCase: false,
 											want:       "\"`'\"",
 										},
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1288, col: 17, offset: 45748},
+										pos:  position{line: 1289, col: 17, offset: 45797},
 										name: "MonospaceText",
 									},
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1289, col: 11, offset: 45772},
+								pos:  position{line: 1290, col: 11, offset: 45821},
 								name: "DoubleQuotedString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1290, col: 11, offset: 45801},
+								pos:  position{line: 1291, col: 11, offset: 45850},
 								name: "SingleQuotedStringFallbackCharacter",
 							},
 						},
@@ -8027,33 +8027,33 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedStringFallbackCharacter",
-			pos:  position{line: 1294, col: 1, offset: 45867},
+			pos:  position{line: 1295, col: 1, offset: 45916},
 			expr: &choiceExpr{
-				pos: position{line: 1294, col: 41, offset: 45907},
+				pos: position{line: 1295, col: 41, offset: 45956},
 				alternatives: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 1294, col: 41, offset: 45907},
+						pos:        position{line: 1295, col: 41, offset: 45956},
 						val:        "[^\\r\\n\\t `]",
 						chars:      []rune{'\r', '\n', '\t', ' ', '`'},
 						ignoreCase: false,
 						inverted:   true,
 					},
 					&actionExpr{
-						pos: position{line: 1294, col: 55, offset: 45921},
+						pos: position{line: 1295, col: 55, offset: 45970},
 						run: (*parser).callonSingleQuotedStringFallbackCharacter3,
 						expr: &seqExpr{
-							pos: position{line: 1294, col: 55, offset: 45921},
+							pos: position{line: 1295, col: 55, offset: 45970},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1294, col: 55, offset: 45921},
+									pos:        position{line: 1295, col: 55, offset: 45970},
 									val:        "`",
 									ignoreCase: false,
 									want:       "\"`\"",
 								},
 								&notExpr{
-									pos: position{line: 1294, col: 59, offset: 45925},
+									pos: position{line: 1295, col: 59, offset: 45974},
 									expr: &litMatcher{
-										pos:        position{line: 1294, col: 60, offset: 45926},
+										pos:        position{line: 1295, col: 60, offset: 45975},
 										val:        "'",
 										ignoreCase: false,
 										want:       "\"'\"",
@@ -8067,27 +8067,27 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedString",
-			pos:  position{line: 1298, col: 1, offset: 45985},
+			pos:  position{line: 1299, col: 1, offset: 46034},
 			expr: &actionExpr{
-				pos: position{line: 1298, col: 23, offset: 46007},
+				pos: position{line: 1299, col: 23, offset: 46056},
 				run: (*parser).callonDoubleQuotedString1,
 				expr: &seqExpr{
-					pos: position{line: 1298, col: 23, offset: 46007},
+					pos: position{line: 1299, col: 23, offset: 46056},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1298, col: 23, offset: 46007},
+							pos:  position{line: 1299, col: 23, offset: 46056},
 							name: "DoubleQuoteStringStart",
 						},
 						&labeledExpr{
-							pos:   position{line: 1298, col: 46, offset: 46030},
+							pos:   position{line: 1299, col: 46, offset: 46079},
 							label: "elements",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1298, col: 55, offset: 46039},
+								pos:  position{line: 1299, col: 55, offset: 46088},
 								name: "DoubleQuotedStringElements",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1298, col: 82, offset: 46066},
+							pos:  position{line: 1299, col: 82, offset: 46115},
 							name: "DoubleQuoteStringEnd",
 						},
 					},
@@ -8096,17 +8096,17 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedStringElements",
-			pos:  position{line: 1302, col: 1, offset: 46170},
+			pos:  position{line: 1303, col: 1, offset: 46219},
 			expr: &actionExpr{
-				pos: position{line: 1302, col: 31, offset: 46200},
+				pos: position{line: 1303, col: 31, offset: 46249},
 				run: (*parser).callonDoubleQuotedStringElements1,
 				expr: &labeledExpr{
-					pos:   position{line: 1302, col: 31, offset: 46200},
+					pos:   position{line: 1303, col: 31, offset: 46249},
 					label: "elements",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 1302, col: 41, offset: 46210},
+						pos: position{line: 1303, col: 41, offset: 46259},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1302, col: 41, offset: 46210},
+							pos:  position{line: 1303, col: 41, offset: 46259},
 							name: "DoubleQuotedStringElement",
 						},
 					},
@@ -8115,95 +8115,95 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedStringElement",
-			pos:  position{line: 1307, col: 1, offset: 46370},
+			pos:  position{line: 1308, col: 1, offset: 46419},
 			expr: &actionExpr{
-				pos: position{line: 1307, col: 30, offset: 46399},
+				pos: position{line: 1308, col: 30, offset: 46448},
 				run: (*parser).callonDoubleQuotedStringElement1,
 				expr: &labeledExpr{
-					pos:   position{line: 1307, col: 30, offset: 46399},
+					pos:   position{line: 1308, col: 30, offset: 46448},
 					label: "element",
 					expr: &choiceExpr{
-						pos: position{line: 1308, col: 9, offset: 46417},
+						pos: position{line: 1309, col: 9, offset: 46466},
 						alternatives: []interface{}{
 							&seqExpr{
-								pos: position{line: 1308, col: 9, offset: 46417},
+								pos: position{line: 1309, col: 9, offset: 46466},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1308, col: 9, offset: 46417},
+										pos:  position{line: 1309, col: 9, offset: 46466},
 										name: "LineBreak",
 									},
 									&notExpr{
-										pos: position{line: 1308, col: 19, offset: 46427},
+										pos: position{line: 1309, col: 19, offset: 46476},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1308, col: 20, offset: 46428},
+											pos:  position{line: 1309, col: 20, offset: 46477},
 											name: "DoubleQuoteStringEnd",
 										},
 									},
 								},
 							},
 							&seqExpr{
-								pos: position{line: 1309, col: 11, offset: 46484},
+								pos: position{line: 1310, col: 11, offset: 46533},
 								exprs: []interface{}{
 									&oneOrMoreExpr{
-										pos: position{line: 1309, col: 11, offset: 46484},
+										pos: position{line: 1310, col: 11, offset: 46533},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1309, col: 11, offset: 46484},
+											pos:  position{line: 1310, col: 11, offset: 46533},
 											name: "Space",
 										},
 									},
 									&notExpr{
-										pos: position{line: 1309, col: 18, offset: 46491},
+										pos: position{line: 1310, col: 18, offset: 46540},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1309, col: 19, offset: 46492},
+											pos:  position{line: 1310, col: 19, offset: 46541},
 											name: "DoubleQuoteStringEnd",
 										},
 									},
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1310, col: 11, offset: 46523},
+								pos:  position{line: 1311, col: 11, offset: 46572},
 								name: "BoldText",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1311, col: 11, offset: 46542},
+								pos:  position{line: 1312, col: 11, offset: 46591},
 								name: "ItalicText",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1312, col: 11, offset: 46563},
+								pos:  position{line: 1313, col: 11, offset: 46612},
 								name: "MarkedText",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1313, col: 11, offset: 46584},
+								pos:  position{line: 1314, col: 11, offset: 46633},
 								name: "SubscriptText",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1314, col: 11, offset: 46608},
+								pos:  position{line: 1315, col: 11, offset: 46657},
 								name: "SuperscriptText",
 							},
 							&seqExpr{
-								pos: position{line: 1315, col: 11, offset: 46634},
+								pos: position{line: 1316, col: 11, offset: 46683},
 								exprs: []interface{}{
 									&notExpr{
-										pos: position{line: 1315, col: 11, offset: 46634},
+										pos: position{line: 1316, col: 11, offset: 46683},
 										expr: &litMatcher{
-											pos:        position{line: 1315, col: 12, offset: 46635},
+											pos:        position{line: 1316, col: 12, offset: 46684},
 											val:        "`\"",
 											ignoreCase: false,
 											want:       "\"`\\\"\"",
 										},
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1315, col: 18, offset: 46641},
+										pos:  position{line: 1316, col: 18, offset: 46690},
 										name: "MonospaceText",
 									},
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1316, col: 10, offset: 46664},
+								pos:  position{line: 1317, col: 10, offset: 46713},
 								name: "SingleQuotedString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1317, col: 11, offset: 46693},
+								pos:  position{line: 1318, col: 11, offset: 46742},
 								name: "DoubleQuotedStringFallbackCharacter",
 							},
 						},
@@ -8213,20 +8213,20 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteStringStart",
-			pos:  position{line: 1321, col: 1, offset: 46767},
+			pos:  position{line: 1322, col: 1, offset: 46816},
 			expr: &seqExpr{
-				pos: position{line: 1321, col: 27, offset: 46793},
+				pos: position{line: 1322, col: 27, offset: 46842},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1321, col: 27, offset: 46793},
+						pos:        position{line: 1322, col: 27, offset: 46842},
 						val:        "\"`",
 						ignoreCase: false,
 						want:       "\"\\\"`\"",
 					},
 					&notExpr{
-						pos: position{line: 1321, col: 33, offset: 46799},
+						pos: position{line: 1322, col: 33, offset: 46848},
 						expr: &charClassMatcher{
-							pos:        position{line: 1321, col: 34, offset: 46800},
+							pos:        position{line: 1322, col: 34, offset: 46849},
 							val:        "[ \\t\\r\\n]",
 							chars:      []rune{' ', '\t', '\r', '\n'},
 							ignoreCase: false,
@@ -8238,9 +8238,9 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteStringEnd",
-			pos:  position{line: 1323, col: 1, offset: 46811},
+			pos:  position{line: 1324, col: 1, offset: 46860},
 			expr: &litMatcher{
-				pos:        position{line: 1323, col: 25, offset: 46835},
+				pos:        position{line: 1324, col: 25, offset: 46884},
 				val:        "`\"",
 				ignoreCase: false,
 				want:       "\"`\\\"\"",
@@ -8248,33 +8248,33 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedStringFallbackCharacter",
-			pos:  position{line: 1325, col: 1, offset: 46842},
+			pos:  position{line: 1326, col: 1, offset: 46891},
 			expr: &actionExpr{
-				pos: position{line: 1325, col: 41, offset: 46882},
+				pos: position{line: 1326, col: 41, offset: 46931},
 				run: (*parser).callonDoubleQuotedStringFallbackCharacter1,
 				expr: &choiceExpr{
-					pos: position{line: 1325, col: 42, offset: 46883},
+					pos: position{line: 1326, col: 42, offset: 46932},
 					alternatives: []interface{}{
 						&charClassMatcher{
-							pos:        position{line: 1325, col: 42, offset: 46883},
+							pos:        position{line: 1326, col: 42, offset: 46932},
 							val:        "[^\\r\\n\\t `]",
 							chars:      []rune{'\r', '\n', '\t', ' ', '`'},
 							ignoreCase: false,
 							inverted:   true,
 						},
 						&seqExpr{
-							pos: position{line: 1325, col: 56, offset: 46897},
+							pos: position{line: 1326, col: 56, offset: 46946},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1325, col: 56, offset: 46897},
+									pos:        position{line: 1326, col: 56, offset: 46946},
 									val:        "`",
 									ignoreCase: false,
 									want:       "\"`\"",
 								},
 								&notExpr{
-									pos: position{line: 1325, col: 60, offset: 46901},
+									pos: position{line: 1326, col: 60, offset: 46950},
 									expr: &litMatcher{
-										pos:        position{line: 1325, col: 61, offset: 46902},
+										pos:        position{line: 1326, col: 61, offset: 46951},
 										val:        "\"",
 										ignoreCase: false,
 										want:       "\"\\\"\"",
@@ -8288,16 +8288,16 @@ var g = &grammar{
 		},
 		{
 			name: "MarkedText",
-			pos:  position{line: 1334, col: 1, offset: 47022},
+			pos:  position{line: 1335, col: 1, offset: 47071},
 			expr: &choiceExpr{
-				pos: position{line: 1334, col: 15, offset: 47036},
+				pos: position{line: 1335, col: 15, offset: 47085},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1334, col: 15, offset: 47036},
+						pos:  position{line: 1335, col: 15, offset: 47085},
 						name: "DoubleQuoteMarkedText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1334, col: 39, offset: 47060},
+						pos:  position{line: 1335, col: 39, offset: 47109},
 						name: "SingleQuoteMarkedText",
 					},
 				},
@@ -8305,40 +8305,40 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteMarkedText",
-			pos:  position{line: 1336, col: 1, offset: 47083},
+			pos:  position{line: 1337, col: 1, offset: 47132},
 			expr: &actionExpr{
-				pos: position{line: 1336, col: 26, offset: 47108},
+				pos: position{line: 1337, col: 26, offset: 47157},
 				run: (*parser).callonDoubleQuoteMarkedText1,
 				expr: &seqExpr{
-					pos: position{line: 1336, col: 26, offset: 47108},
+					pos: position{line: 1337, col: 26, offset: 47157},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1336, col: 26, offset: 47108},
+							pos:   position{line: 1337, col: 26, offset: 47157},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1336, col: 37, offset: 47119},
+								pos: position{line: 1337, col: 37, offset: 47168},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1336, col: 38, offset: 47120},
+									pos:  position{line: 1337, col: 38, offset: 47169},
 									name: "LongHandAttributes",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1336, col: 59, offset: 47141},
+							pos:        position{line: 1337, col: 59, offset: 47190},
 							val:        "##",
 							ignoreCase: false,
 							want:       "\"##\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1336, col: 64, offset: 47146},
+							pos:   position{line: 1337, col: 64, offset: 47195},
 							label: "elements",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1336, col: 74, offset: 47156},
+								pos:  position{line: 1337, col: 74, offset: 47205},
 								name: "DoubleQuoteMarkedTextElements",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1336, col: 105, offset: 47187},
+							pos:        position{line: 1337, col: 105, offset: 47236},
 							val:        "##",
 							ignoreCase: false,
 							want:       "\"##\"",
@@ -8349,37 +8349,37 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteMarkedTextElements",
-			pos:  position{line: 1340, col: 1, offset: 47326},
+			pos:  position{line: 1341, col: 1, offset: 47375},
 			expr: &seqExpr{
-				pos: position{line: 1340, col: 34, offset: 47359},
+				pos: position{line: 1341, col: 34, offset: 47408},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1340, col: 34, offset: 47359},
+						pos:  position{line: 1341, col: 34, offset: 47408},
 						name: "DoubleQuoteMarkedTextElement",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1340, col: 63, offset: 47388},
+						pos: position{line: 1341, col: 63, offset: 47437},
 						expr: &seqExpr{
-							pos: position{line: 1340, col: 64, offset: 47389},
+							pos: position{line: 1341, col: 64, offset: 47438},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1340, col: 64, offset: 47389},
+									pos: position{line: 1341, col: 64, offset: 47438},
 									expr: &litMatcher{
-										pos:        position{line: 1340, col: 66, offset: 47391},
+										pos:        position{line: 1341, col: 66, offset: 47440},
 										val:        "##",
 										ignoreCase: false,
 										want:       "\"##\"",
 									},
 								},
 								&choiceExpr{
-									pos: position{line: 1340, col: 73, offset: 47398},
+									pos: position{line: 1341, col: 73, offset: 47447},
 									alternatives: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 1340, col: 73, offset: 47398},
+											pos:  position{line: 1341, col: 73, offset: 47447},
 											name: "Space",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1340, col: 81, offset: 47406},
+											pos:  position{line: 1341, col: 81, offset: 47455},
 											name: "DoubleQuoteMarkedTextElement",
 										},
 									},
@@ -8392,64 +8392,64 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteMarkedTextElement",
-			pos:  position{line: 1342, col: 1, offset: 47473},
+			pos:  position{line: 1343, col: 1, offset: 47522},
 			expr: &choiceExpr{
-				pos: position{line: 1342, col: 33, offset: 47505},
+				pos: position{line: 1343, col: 33, offset: 47554},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1342, col: 33, offset: 47505},
+						pos:  position{line: 1343, col: 33, offset: 47554},
 						name: "Word",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1343, col: 11, offset: 47520},
+						pos:  position{line: 1344, col: 11, offset: 47569},
 						name: "SingleQuoteMarkedText",
 					},
 					&seqExpr{
-						pos: position{line: 1344, col: 11, offset: 47552},
+						pos: position{line: 1345, col: 11, offset: 47601},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 1344, col: 11, offset: 47552},
+								pos:  position{line: 1345, col: 11, offset: 47601},
 								name: "Newline",
 							},
 							&notExpr{
-								pos: position{line: 1344, col: 19, offset: 47560},
+								pos: position{line: 1345, col: 19, offset: 47609},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1344, col: 20, offset: 47561},
+									pos:  position{line: 1345, col: 20, offset: 47610},
 									name: "Newline",
 								},
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1345, col: 11, offset: 47579},
+						pos:  position{line: 1346, col: 11, offset: 47628},
 						name: "QuotedString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1346, col: 11, offset: 47602},
+						pos:  position{line: 1347, col: 11, offset: 47651},
 						name: "BoldText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1347, col: 11, offset: 47621},
+						pos:  position{line: 1348, col: 11, offset: 47670},
 						name: "ItalicText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1348, col: 11, offset: 47642},
+						pos:  position{line: 1349, col: 11, offset: 47691},
 						name: "MonospaceText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1349, col: 11, offset: 47666},
+						pos:  position{line: 1350, col: 11, offset: 47715},
 						name: "SubscriptText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1350, col: 11, offset: 47690},
+						pos:  position{line: 1351, col: 11, offset: 47739},
 						name: "SuperscriptText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1351, col: 11, offset: 47716},
+						pos:  position{line: 1352, col: 11, offset: 47765},
 						name: "ElementPlaceHolder",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1352, col: 11, offset: 47745},
+						pos:  position{line: 1353, col: 11, offset: 47794},
 						name: "DoubleQuoteMarkedTextFallbackCharacter",
 					},
 				},
@@ -8457,31 +8457,31 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuoteMarkedTextFallbackCharacter",
-			pos:  position{line: 1354, col: 1, offset: 47785},
+			pos:  position{line: 1355, col: 1, offset: 47834},
 			expr: &choiceExpr{
-				pos: position{line: 1355, col: 5, offset: 47831},
+				pos: position{line: 1356, col: 5, offset: 47880},
 				alternatives: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 1355, col: 5, offset: 47831},
+						pos:        position{line: 1356, col: 5, offset: 47880},
 						val:        "[^\\r\\n#]",
 						chars:      []rune{'\r', '\n', '#'},
 						ignoreCase: false,
 						inverted:   true,
 					},
 					&actionExpr{
-						pos: position{line: 1356, col: 7, offset: 47930},
+						pos: position{line: 1357, col: 7, offset: 47979},
 						run: (*parser).callonDoubleQuoteMarkedTextFallbackCharacter3,
 						expr: &seqExpr{
-							pos: position{line: 1356, col: 7, offset: 47930},
+							pos: position{line: 1357, col: 7, offset: 47979},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1356, col: 7, offset: 47930},
+									pos:        position{line: 1357, col: 7, offset: 47979},
 									val:        "##",
 									ignoreCase: false,
 									want:       "\"##\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1356, col: 12, offset: 47935},
+									pos:  position{line: 1357, col: 12, offset: 47984},
 									name: "Alphanums",
 								},
 							},
@@ -8492,40 +8492,40 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteMarkedText",
-			pos:  position{line: 1360, col: 1, offset: 48100},
+			pos:  position{line: 1361, col: 1, offset: 48149},
 			expr: &choiceExpr{
-				pos: position{line: 1360, col: 26, offset: 48125},
+				pos: position{line: 1361, col: 26, offset: 48174},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1360, col: 26, offset: 48125},
+						pos: position{line: 1361, col: 26, offset: 48174},
 						run: (*parser).callonSingleQuoteMarkedText2,
 						expr: &seqExpr{
-							pos: position{line: 1360, col: 26, offset: 48125},
+							pos: position{line: 1361, col: 26, offset: 48174},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1360, col: 26, offset: 48125},
+									pos:   position{line: 1361, col: 26, offset: 48174},
 									label: "attributes",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1360, col: 37, offset: 48136},
+										pos: position{line: 1361, col: 37, offset: 48185},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1360, col: 38, offset: 48137},
+											pos:  position{line: 1361, col: 38, offset: 48186},
 											name: "LongHandAttributes",
 										},
 									},
 								},
 								&seqExpr{
-									pos: position{line: 1360, col: 60, offset: 48159},
+									pos: position{line: 1361, col: 60, offset: 48208},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 1360, col: 60, offset: 48159},
+											pos:        position{line: 1361, col: 60, offset: 48208},
 											val:        "#",
 											ignoreCase: false,
 											want:       "\"#\"",
 										},
 										&notExpr{
-											pos: position{line: 1360, col: 64, offset: 48163},
+											pos: position{line: 1361, col: 64, offset: 48212},
 											expr: &litMatcher{
-												pos:        position{line: 1360, col: 65, offset: 48164},
+												pos:        position{line: 1361, col: 65, offset: 48213},
 												val:        "#",
 												ignoreCase: false,
 												want:       "\"#\"",
@@ -8534,15 +8534,15 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1360, col: 70, offset: 48169},
+									pos:   position{line: 1361, col: 70, offset: 48218},
 									label: "elements",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1360, col: 80, offset: 48179},
+										pos:  position{line: 1361, col: 80, offset: 48228},
 										name: "SingleQuoteMarkedTextElements",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1360, col: 111, offset: 48210},
+									pos:        position{line: 1361, col: 111, offset: 48259},
 									val:        "#",
 									ignoreCase: false,
 									want:       "\"#\"",
@@ -8551,49 +8551,49 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1362, col: 5, offset: 48405},
+						pos: position{line: 1363, col: 5, offset: 48454},
 						run: (*parser).callonSingleQuoteMarkedText14,
 						expr: &seqExpr{
-							pos: position{line: 1362, col: 5, offset: 48405},
+							pos: position{line: 1363, col: 5, offset: 48454},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1362, col: 5, offset: 48405},
+									pos:   position{line: 1363, col: 5, offset: 48454},
 									label: "attributes",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1362, col: 16, offset: 48416},
+										pos: position{line: 1363, col: 16, offset: 48465},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1362, col: 17, offset: 48417},
+											pos:  position{line: 1363, col: 17, offset: 48466},
 											name: "LongHandAttributes",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1362, col: 38, offset: 48438},
+									pos:        position{line: 1363, col: 38, offset: 48487},
 									val:        "#",
 									ignoreCase: false,
 									want:       "\"#\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1362, col: 42, offset: 48442},
+									pos:   position{line: 1363, col: 42, offset: 48491},
 									label: "elements",
 									expr: &seqExpr{
-										pos: position{line: 1362, col: 52, offset: 48452},
+										pos: position{line: 1363, col: 52, offset: 48501},
 										exprs: []interface{}{
 											&litMatcher{
-												pos:        position{line: 1362, col: 52, offset: 48452},
+												pos:        position{line: 1363, col: 52, offset: 48501},
 												val:        "#",
 												ignoreCase: false,
 												want:       "\"#\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1362, col: 56, offset: 48456},
+												pos:  position{line: 1363, col: 56, offset: 48505},
 												name: "SingleQuoteMarkedTextElements",
 											},
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1362, col: 87, offset: 48487},
+									pos:        position{line: 1363, col: 87, offset: 48536},
 									val:        "#",
 									ignoreCase: false,
 									want:       "\"#\"",
@@ -8606,21 +8606,21 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteMarkedTextElements",
-			pos:  position{line: 1366, col: 1, offset: 48701},
+			pos:  position{line: 1367, col: 1, offset: 48750},
 			expr: &seqExpr{
-				pos: position{line: 1366, col: 34, offset: 48734},
+				pos: position{line: 1367, col: 34, offset: 48783},
 				exprs: []interface{}{
 					&notExpr{
-						pos: position{line: 1366, col: 34, offset: 48734},
+						pos: position{line: 1367, col: 34, offset: 48783},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1366, col: 35, offset: 48735},
+							pos:  position{line: 1367, col: 35, offset: 48784},
 							name: "Space",
 						},
 					},
 					&oneOrMoreExpr{
-						pos: position{line: 1366, col: 41, offset: 48741},
+						pos: position{line: 1367, col: 41, offset: 48790},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1366, col: 41, offset: 48741},
+							pos:  position{line: 1367, col: 41, offset: 48790},
 							name: "SingleQuoteMarkedTextElement",
 						},
 					},
@@ -8629,63 +8629,63 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteMarkedTextElement",
-			pos:  position{line: 1368, col: 1, offset: 48772},
+			pos:  position{line: 1369, col: 1, offset: 48821},
 			expr: &choiceExpr{
-				pos: position{line: 1368, col: 33, offset: 48804},
+				pos: position{line: 1369, col: 33, offset: 48853},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1368, col: 33, offset: 48804},
+						pos:  position{line: 1369, col: 33, offset: 48853},
 						name: "Word",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1369, col: 11, offset: 48819},
+						pos:  position{line: 1370, col: 11, offset: 48868},
 						name: "DoubleQuoteMarkedText",
 					},
 					&seqExpr{
-						pos: position{line: 1370, col: 11, offset: 48851},
+						pos: position{line: 1371, col: 11, offset: 48900},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 1370, col: 11, offset: 48851},
+								pos:  position{line: 1371, col: 11, offset: 48900},
 								name: "Newline",
 							},
 							&notExpr{
-								pos: position{line: 1370, col: 19, offset: 48859},
+								pos: position{line: 1371, col: 19, offset: 48908},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1370, col: 20, offset: 48860},
+									pos:  position{line: 1371, col: 20, offset: 48909},
 									name: "Newline",
 								},
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1371, col: 11, offset: 48878},
+						pos:  position{line: 1372, col: 11, offset: 48927},
 						name: "QuotedString",
 					},
 					&seqExpr{
-						pos: position{line: 1372, col: 11, offset: 48901},
+						pos: position{line: 1373, col: 11, offset: 48950},
 						exprs: []interface{}{
 							&oneOrMoreExpr{
-								pos: position{line: 1372, col: 11, offset: 48901},
+								pos: position{line: 1373, col: 11, offset: 48950},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1372, col: 11, offset: 48901},
+									pos:  position{line: 1373, col: 11, offset: 48950},
 									name: "Space",
 								},
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 1372, col: 18, offset: 48908},
+								pos: position{line: 1373, col: 18, offset: 48957},
 								expr: &seqExpr{
-									pos: position{line: 1372, col: 19, offset: 48909},
+									pos: position{line: 1373, col: 19, offset: 48958},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 1372, col: 19, offset: 48909},
+											pos:        position{line: 1373, col: 19, offset: 48958},
 											val:        "#",
 											ignoreCase: false,
 											want:       "\"#\"",
 										},
 										&notExpr{
-											pos: position{line: 1372, col: 23, offset: 48913},
+											pos: position{line: 1373, col: 23, offset: 48962},
 											expr: &litMatcher{
-												pos:        position{line: 1372, col: 24, offset: 48914},
+												pos:        position{line: 1373, col: 24, offset: 48963},
 												val:        "#",
 												ignoreCase: false,
 												want:       "\"#\"",
@@ -8697,31 +8697,31 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1373, col: 11, offset: 48930},
+						pos:  position{line: 1374, col: 11, offset: 48979},
 						name: "BoldText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1374, col: 11, offset: 48949},
+						pos:  position{line: 1375, col: 11, offset: 48998},
 						name: "ItalicText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1375, col: 11, offset: 48970},
+						pos:  position{line: 1376, col: 11, offset: 49019},
 						name: "MonospaceText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1376, col: 11, offset: 48994},
+						pos:  position{line: 1377, col: 11, offset: 49043},
 						name: "SubscriptText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1377, col: 11, offset: 49018},
+						pos:  position{line: 1378, col: 11, offset: 49067},
 						name: "SuperscriptText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1378, col: 11, offset: 49044},
+						pos:  position{line: 1379, col: 11, offset: 49093},
 						name: "ElementPlaceHolder",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1379, col: 11, offset: 49073},
+						pos:  position{line: 1380, col: 11, offset: 49122},
 						name: "SingleQuoteMarkedTextFallbackCharacter",
 					},
 				},
@@ -8729,31 +8729,31 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuoteMarkedTextFallbackCharacter",
-			pos:  position{line: 1381, col: 1, offset: 49113},
+			pos:  position{line: 1382, col: 1, offset: 49162},
 			expr: &choiceExpr{
-				pos: position{line: 1382, col: 5, offset: 49159},
+				pos: position{line: 1383, col: 5, offset: 49208},
 				alternatives: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 1382, col: 5, offset: 49159},
+						pos:        position{line: 1383, col: 5, offset: 49208},
 						val:        "[^\\r\\n#]",
 						chars:      []rune{'\r', '\n', '#'},
 						ignoreCase: false,
 						inverted:   true,
 					},
 					&actionExpr{
-						pos: position{line: 1383, col: 7, offset: 49256},
+						pos: position{line: 1384, col: 7, offset: 49305},
 						run: (*parser).callonSingleQuoteMarkedTextFallbackCharacter3,
 						expr: &seqExpr{
-							pos: position{line: 1383, col: 7, offset: 49256},
+							pos: position{line: 1384, col: 7, offset: 49305},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1383, col: 7, offset: 49256},
+									pos:        position{line: 1384, col: 7, offset: 49305},
 									val:        "#",
 									ignoreCase: false,
 									want:       "\"#\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1383, col: 11, offset: 49260},
+									pos:  position{line: 1384, col: 11, offset: 49309},
 									name: "Alphanums",
 								},
 							},
@@ -8764,40 +8764,40 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedMarkedText",
-			pos:  position{line: 1387, col: 1, offset: 49423},
+			pos:  position{line: 1388, col: 1, offset: 49472},
 			expr: &choiceExpr{
-				pos: position{line: 1388, col: 5, offset: 49448},
+				pos: position{line: 1389, col: 5, offset: 49497},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1388, col: 5, offset: 49448},
+						pos: position{line: 1389, col: 5, offset: 49497},
 						run: (*parser).callonEscapedMarkedText2,
 						expr: &seqExpr{
-							pos: position{line: 1388, col: 5, offset: 49448},
+							pos: position{line: 1389, col: 5, offset: 49497},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1388, col: 5, offset: 49448},
+									pos:   position{line: 1389, col: 5, offset: 49497},
 									label: "backslashes",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1388, col: 18, offset: 49461},
+										pos:  position{line: 1389, col: 18, offset: 49510},
 										name: "TwoOrMoreBackslashes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1388, col: 40, offset: 49483},
+									pos:        position{line: 1389, col: 40, offset: 49532},
 									val:        "##",
 									ignoreCase: false,
 									want:       "\"##\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1388, col: 45, offset: 49488},
+									pos:   position{line: 1389, col: 45, offset: 49537},
 									label: "elements",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1388, col: 55, offset: 49498},
+										pos:  position{line: 1389, col: 55, offset: 49547},
 										name: "DoubleQuoteMarkedTextElements",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1388, col: 86, offset: 49529},
+									pos:        position{line: 1389, col: 86, offset: 49578},
 									val:        "##",
 									ignoreCase: false,
 									want:       "\"##\"",
@@ -8806,35 +8806,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1390, col: 9, offset: 49686},
+						pos: position{line: 1391, col: 9, offset: 49735},
 						run: (*parser).callonEscapedMarkedText10,
 						expr: &seqExpr{
-							pos: position{line: 1390, col: 9, offset: 49686},
+							pos: position{line: 1391, col: 9, offset: 49735},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1390, col: 9, offset: 49686},
+									pos:   position{line: 1391, col: 9, offset: 49735},
 									label: "backslashes",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1390, col: 22, offset: 49699},
+										pos:  position{line: 1391, col: 22, offset: 49748},
 										name: "OneOrMoreBackslashes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1390, col: 44, offset: 49721},
+									pos:        position{line: 1391, col: 44, offset: 49770},
 									val:        "##",
 									ignoreCase: false,
 									want:       "\"##\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1390, col: 49, offset: 49726},
+									pos:   position{line: 1391, col: 49, offset: 49775},
 									label: "elements",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1390, col: 59, offset: 49736},
+										pos:  position{line: 1391, col: 59, offset: 49785},
 										name: "SingleQuoteMarkedTextElements",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1390, col: 90, offset: 49767},
+									pos:        position{line: 1391, col: 90, offset: 49816},
 									val:        "#",
 									ignoreCase: false,
 									want:       "\"#\"",
@@ -8843,35 +8843,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1393, col: 9, offset: 49967},
+						pos: position{line: 1394, col: 9, offset: 50016},
 						run: (*parser).callonEscapedMarkedText18,
 						expr: &seqExpr{
-							pos: position{line: 1393, col: 9, offset: 49967},
+							pos: position{line: 1394, col: 9, offset: 50016},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 1393, col: 9, offset: 49967},
+									pos:   position{line: 1394, col: 9, offset: 50016},
 									label: "backslashes",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1393, col: 22, offset: 49980},
+										pos:  position{line: 1394, col: 22, offset: 50029},
 										name: "OneOrMoreBackslashes",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1393, col: 44, offset: 50002},
+									pos:        position{line: 1394, col: 44, offset: 50051},
 									val:        "#",
 									ignoreCase: false,
 									want:       "\"#\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1393, col: 48, offset: 50006},
+									pos:   position{line: 1394, col: 48, offset: 50055},
 									label: "elements",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1393, col: 58, offset: 50016},
+										pos:  position{line: 1394, col: 58, offset: 50065},
 										name: "SingleQuoteMarkedTextElements",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1393, col: 89, offset: 50047},
+									pos:        position{line: 1394, col: 89, offset: 50096},
 									val:        "#",
 									ignoreCase: false,
 									want:       "\"#\"",
@@ -8884,40 +8884,40 @@ var g = &grammar{
 		},
 		{
 			name: "SubscriptText",
-			pos:  position{line: 1398, col: 1, offset: 50197},
+			pos:  position{line: 1399, col: 1, offset: 50246},
 			expr: &actionExpr{
-				pos: position{line: 1398, col: 18, offset: 50214},
+				pos: position{line: 1399, col: 18, offset: 50263},
 				run: (*parser).callonSubscriptText1,
 				expr: &seqExpr{
-					pos: position{line: 1398, col: 18, offset: 50214},
+					pos: position{line: 1399, col: 18, offset: 50263},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1398, col: 18, offset: 50214},
+							pos:   position{line: 1399, col: 18, offset: 50263},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1398, col: 29, offset: 50225},
+								pos: position{line: 1399, col: 29, offset: 50274},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1398, col: 30, offset: 50226},
+									pos:  position{line: 1399, col: 30, offset: 50275},
 									name: "LongHandAttributes",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1398, col: 51, offset: 50247},
+							pos:        position{line: 1399, col: 51, offset: 50296},
 							val:        "~",
 							ignoreCase: false,
 							want:       "\"~\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1398, col: 55, offset: 50251},
+							pos:   position{line: 1399, col: 55, offset: 50300},
 							label: "element",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1398, col: 64, offset: 50260},
+								pos:  position{line: 1399, col: 64, offset: 50309},
 								name: "SubscriptTextElement",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1398, col: 86, offset: 50282},
+							pos:        position{line: 1399, col: 86, offset: 50331},
 							val:        "~",
 							ignoreCase: false,
 							want:       "\"~\"",
@@ -8928,16 +8928,16 @@ var g = &grammar{
 		},
 		{
 			name: "SubscriptTextElement",
-			pos:  position{line: 1402, col: 1, offset: 50383},
+			pos:  position{line: 1403, col: 1, offset: 50432},
 			expr: &choiceExpr{
-				pos: position{line: 1402, col: 25, offset: 50407},
+				pos: position{line: 1403, col: 25, offset: 50456},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1402, col: 25, offset: 50407},
+						pos:  position{line: 1403, col: 25, offset: 50456},
 						name: "QuotedText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1402, col: 38, offset: 50420},
+						pos:  position{line: 1403, col: 38, offset: 50469},
 						name: "NonSubscriptText",
 					},
 				},
@@ -8945,14 +8945,14 @@ var g = &grammar{
 		},
 		{
 			name: "NonSubscriptText",
-			pos:  position{line: 1404, col: 1, offset: 50439},
+			pos:  position{line: 1405, col: 1, offset: 50488},
 			expr: &actionExpr{
-				pos: position{line: 1404, col: 21, offset: 50459},
+				pos: position{line: 1405, col: 21, offset: 50508},
 				run: (*parser).callonNonSubscriptText1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1404, col: 21, offset: 50459},
+					pos: position{line: 1405, col: 21, offset: 50508},
 					expr: &charClassMatcher{
-						pos:        position{line: 1404, col: 21, offset: 50459},
+						pos:        position{line: 1405, col: 21, offset: 50508},
 						val:        "[^\\r\\n ~]",
 						chars:      []rune{'\r', '\n', ' ', '~'},
 						ignoreCase: false,
@@ -8963,37 +8963,37 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedSubscriptText",
-			pos:  position{line: 1408, col: 1, offset: 50536},
+			pos:  position{line: 1409, col: 1, offset: 50585},
 			expr: &actionExpr{
-				pos: position{line: 1408, col: 25, offset: 50560},
+				pos: position{line: 1409, col: 25, offset: 50609},
 				run: (*parser).callonEscapedSubscriptText1,
 				expr: &seqExpr{
-					pos: position{line: 1408, col: 25, offset: 50560},
+					pos: position{line: 1409, col: 25, offset: 50609},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1408, col: 25, offset: 50560},
+							pos:   position{line: 1409, col: 25, offset: 50609},
 							label: "backslashes",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1408, col: 38, offset: 50573},
+								pos:  position{line: 1409, col: 38, offset: 50622},
 								name: "OneOrMoreBackslashes",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1408, col: 60, offset: 50595},
+							pos:        position{line: 1409, col: 60, offset: 50644},
 							val:        "~",
 							ignoreCase: false,
 							want:       "\"~\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1408, col: 64, offset: 50599},
+							pos:   position{line: 1409, col: 64, offset: 50648},
 							label: "element",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1408, col: 73, offset: 50608},
+								pos:  position{line: 1409, col: 73, offset: 50657},
 								name: "SubscriptTextElement",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1408, col: 95, offset: 50630},
+							pos:        position{line: 1409, col: 95, offset: 50679},
 							val:        "~",
 							ignoreCase: false,
 							want:       "\"~\"",
@@ -9004,40 +9004,40 @@ var g = &grammar{
 		},
 		{
 			name: "SuperscriptText",
-			pos:  position{line: 1412, col: 1, offset: 50759},
+			pos:  position{line: 1413, col: 1, offset: 50808},
 			expr: &actionExpr{
-				pos: position{line: 1412, col: 20, offset: 50778},
+				pos: position{line: 1413, col: 20, offset: 50827},
 				run: (*parser).callonSuperscriptText1,
 				expr: &seqExpr{
-					pos: position{line: 1412, col: 20, offset: 50778},
+					pos: position{line: 1413, col: 20, offset: 50827},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1412, col: 20, offset: 50778},
+							pos:   position{line: 1413, col: 20, offset: 50827},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1412, col: 31, offset: 50789},
+								pos: position{line: 1413, col: 31, offset: 50838},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1412, col: 32, offset: 50790},
+									pos:  position{line: 1413, col: 32, offset: 50839},
 									name: "LongHandAttributes",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1412, col: 53, offset: 50811},
+							pos:        position{line: 1413, col: 53, offset: 50860},
 							val:        "^",
 							ignoreCase: false,
 							want:       "\"^\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1412, col: 57, offset: 50815},
+							pos:   position{line: 1413, col: 57, offset: 50864},
 							label: "element",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1412, col: 66, offset: 50824},
+								pos:  position{line: 1413, col: 66, offset: 50873},
 								name: "SuperscriptTextElement",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1412, col: 90, offset: 50848},
+							pos:        position{line: 1413, col: 90, offset: 50897},
 							val:        "^",
 							ignoreCase: false,
 							want:       "\"^\"",
@@ -9048,16 +9048,16 @@ var g = &grammar{
 		},
 		{
 			name: "SuperscriptTextElement",
-			pos:  position{line: 1416, col: 1, offset: 50951},
+			pos:  position{line: 1417, col: 1, offset: 51000},
 			expr: &choiceExpr{
-				pos: position{line: 1416, col: 27, offset: 50977},
+				pos: position{line: 1417, col: 27, offset: 51026},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1416, col: 27, offset: 50977},
+						pos:  position{line: 1417, col: 27, offset: 51026},
 						name: "QuotedText",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1416, col: 40, offset: 50990},
+						pos:  position{line: 1417, col: 40, offset: 51039},
 						name: "NonSuperscriptText",
 					},
 				},
@@ -9065,14 +9065,14 @@ var g = &grammar{
 		},
 		{
 			name: "NonSuperscriptText",
-			pos:  position{line: 1418, col: 1, offset: 51011},
+			pos:  position{line: 1419, col: 1, offset: 51060},
 			expr: &actionExpr{
-				pos: position{line: 1418, col: 23, offset: 51033},
+				pos: position{line: 1419, col: 23, offset: 51082},
 				run: (*parser).callonNonSuperscriptText1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1418, col: 23, offset: 51033},
+					pos: position{line: 1419, col: 23, offset: 51082},
 					expr: &charClassMatcher{
-						pos:        position{line: 1418, col: 23, offset: 51033},
+						pos:        position{line: 1419, col: 23, offset: 51082},
 						val:        "[^\\r\\n ^]",
 						chars:      []rune{'\r', '\n', ' ', '^'},
 						ignoreCase: false,
@@ -9083,37 +9083,37 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedSuperscriptText",
-			pos:  position{line: 1422, col: 1, offset: 51110},
+			pos:  position{line: 1423, col: 1, offset: 51159},
 			expr: &actionExpr{
-				pos: position{line: 1422, col: 27, offset: 51136},
+				pos: position{line: 1423, col: 27, offset: 51185},
 				run: (*parser).callonEscapedSuperscriptText1,
 				expr: &seqExpr{
-					pos: position{line: 1422, col: 27, offset: 51136},
+					pos: position{line: 1423, col: 27, offset: 51185},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1422, col: 27, offset: 51136},
+							pos:   position{line: 1423, col: 27, offset: 51185},
 							label: "backslashes",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1422, col: 40, offset: 51149},
+								pos:  position{line: 1423, col: 40, offset: 51198},
 								name: "OneOrMoreBackslashes",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1422, col: 62, offset: 51171},
+							pos:        position{line: 1423, col: 62, offset: 51220},
 							val:        "^",
 							ignoreCase: false,
 							want:       "\"^\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1422, col: 66, offset: 51175},
+							pos:   position{line: 1423, col: 66, offset: 51224},
 							label: "element",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1422, col: 75, offset: 51184},
+								pos:  position{line: 1423, col: 75, offset: 51233},
 								name: "SuperscriptTextElement",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1422, col: 99, offset: 51208},
+							pos:        position{line: 1423, col: 99, offset: 51257},
 							val:        "^",
 							ignoreCase: false,
 							want:       "\"^\"",
@@ -9124,20 +9124,20 @@ var g = &grammar{
 		},
 		{
 			name: "InlinePassthrough",
-			pos:  position{line: 1429, col: 1, offset: 51450},
+			pos:  position{line: 1430, col: 1, offset: 51499},
 			expr: &choiceExpr{
-				pos: position{line: 1429, col: 22, offset: 51471},
+				pos: position{line: 1430, col: 22, offset: 51520},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1429, col: 22, offset: 51471},
+						pos:  position{line: 1430, col: 22, offset: 51520},
 						name: "TriplePlusPassthrough",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1429, col: 46, offset: 51495},
+						pos:  position{line: 1430, col: 46, offset: 51544},
 						name: "SinglePlusPassthrough",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1429, col: 70, offset: 51519},
+						pos:  position{line: 1430, col: 70, offset: 51568},
 						name: "PassthroughMacro",
 					},
 				},
@@ -9145,9 +9145,9 @@ var g = &grammar{
 		},
 		{
 			name: "SinglePlusPassthroughPrefix",
-			pos:  position{line: 1431, col: 1, offset: 51537},
+			pos:  position{line: 1432, col: 1, offset: 51586},
 			expr: &litMatcher{
-				pos:        position{line: 1431, col: 32, offset: 51568},
+				pos:        position{line: 1432, col: 32, offset: 51617},
 				val:        "+",
 				ignoreCase: false,
 				want:       "\"+\"",
@@ -9155,33 +9155,33 @@ var g = &grammar{
 		},
 		{
 			name: "SinglePlusPassthrough",
-			pos:  position{line: 1433, col: 1, offset: 51573},
+			pos:  position{line: 1434, col: 1, offset: 51622},
 			expr: &actionExpr{
-				pos: position{line: 1433, col: 26, offset: 51598},
+				pos: position{line: 1434, col: 26, offset: 51647},
 				run: (*parser).callonSinglePlusPassthrough1,
 				expr: &seqExpr{
-					pos: position{line: 1433, col: 26, offset: 51598},
+					pos: position{line: 1434, col: 26, offset: 51647},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1433, col: 26, offset: 51598},
+							pos:  position{line: 1434, col: 26, offset: 51647},
 							name: "SinglePlusPassthroughPrefix",
 						},
 						&labeledExpr{
-							pos:   position{line: 1433, col: 54, offset: 51626},
+							pos:   position{line: 1434, col: 54, offset: 51675},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1433, col: 63, offset: 51635},
+								pos:  position{line: 1434, col: 63, offset: 51684},
 								name: "SinglePlusPassthroughContent",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1433, col: 93, offset: 51665},
+							pos:  position{line: 1434, col: 93, offset: 51714},
 							name: "SinglePlusPassthroughPrefix",
 						},
 						&notExpr{
-							pos: position{line: 1433, col: 121, offset: 51693},
+							pos: position{line: 1434, col: 121, offset: 51742},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1433, col: 122, offset: 51694},
+								pos:  position{line: 1434, col: 122, offset: 51743},
 								name: "Alphanum",
 							},
 						},
@@ -9191,85 +9191,85 @@ var g = &grammar{
 		},
 		{
 			name: "SinglePlusPassthroughContent",
-			pos:  position{line: 1437, col: 1, offset: 51799},
+			pos:  position{line: 1438, col: 1, offset: 51848},
 			expr: &choiceExpr{
-				pos: position{line: 1437, col: 33, offset: 51831},
+				pos: position{line: 1438, col: 33, offset: 51880},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1437, col: 34, offset: 51832},
+						pos: position{line: 1438, col: 34, offset: 51881},
 						run: (*parser).callonSinglePlusPassthroughContent2,
 						expr: &seqExpr{
-							pos: position{line: 1437, col: 34, offset: 51832},
+							pos: position{line: 1438, col: 34, offset: 51881},
 							exprs: []interface{}{
 								&seqExpr{
-									pos: position{line: 1437, col: 35, offset: 51833},
+									pos: position{line: 1438, col: 35, offset: 51882},
 									exprs: []interface{}{
 										&notExpr{
-											pos: position{line: 1437, col: 35, offset: 51833},
+											pos: position{line: 1438, col: 35, offset: 51882},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1437, col: 36, offset: 51834},
+												pos:  position{line: 1438, col: 36, offset: 51883},
 												name: "SinglePlusPassthroughPrefix",
 											},
 										},
 										&notExpr{
-											pos: position{line: 1437, col: 64, offset: 51862},
+											pos: position{line: 1438, col: 64, offset: 51911},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1437, col: 65, offset: 51863},
+												pos:  position{line: 1438, col: 65, offset: 51912},
 												name: "Space",
 											},
 										},
 										&notExpr{
-											pos: position{line: 1437, col: 71, offset: 51869},
+											pos: position{line: 1438, col: 71, offset: 51918},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1437, col: 72, offset: 51870},
+												pos:  position{line: 1438, col: 72, offset: 51919},
 												name: "Newline",
 											},
 										},
 										&anyMatcher{
-											line: 1437, col: 80, offset: 51878,
+											line: 1438, col: 80, offset: 51927,
 										},
 									},
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1437, col: 83, offset: 51881},
+									pos: position{line: 1438, col: 83, offset: 51930},
 									expr: &seqExpr{
-										pos: position{line: 1437, col: 84, offset: 51882},
+										pos: position{line: 1438, col: 84, offset: 51931},
 										exprs: []interface{}{
 											&notExpr{
-												pos: position{line: 1437, col: 84, offset: 51882},
+												pos: position{line: 1438, col: 84, offset: 51931},
 												expr: &seqExpr{
-													pos: position{line: 1437, col: 86, offset: 51884},
+													pos: position{line: 1438, col: 86, offset: 51933},
 													exprs: []interface{}{
 														&oneOrMoreExpr{
-															pos: position{line: 1437, col: 86, offset: 51884},
+															pos: position{line: 1438, col: 86, offset: 51933},
 															expr: &ruleRefExpr{
-																pos:  position{line: 1437, col: 86, offset: 51884},
+																pos:  position{line: 1438, col: 86, offset: 51933},
 																name: "Space",
 															},
 														},
 														&ruleRefExpr{
-															pos:  position{line: 1437, col: 93, offset: 51891},
+															pos:  position{line: 1438, col: 93, offset: 51940},
 															name: "SinglePlusPassthroughPrefix",
 														},
 													},
 												},
 											},
 											&notExpr{
-												pos: position{line: 1437, col: 122, offset: 51920},
+												pos: position{line: 1438, col: 122, offset: 51969},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1437, col: 123, offset: 51921},
+													pos:  position{line: 1438, col: 123, offset: 51970},
 													name: "SinglePlusPassthroughPrefix",
 												},
 											},
 											&notExpr{
-												pos: position{line: 1437, col: 151, offset: 51949},
+												pos: position{line: 1438, col: 151, offset: 51998},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1437, col: 152, offset: 51950},
+													pos:  position{line: 1438, col: 152, offset: 51999},
 													name: "Newline",
 												},
 											},
 											&anyMatcher{
-												line: 1437, col: 160, offset: 51958,
+												line: 1438, col: 160, offset: 52007,
 											},
 										},
 									},
@@ -9278,34 +9278,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1439, col: 7, offset: 52100},
+						pos: position{line: 1440, col: 7, offset: 52149},
 						run: (*parser).callonSinglePlusPassthroughContent24,
 						expr: &seqExpr{
-							pos: position{line: 1439, col: 8, offset: 52101},
+							pos: position{line: 1440, col: 8, offset: 52150},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1439, col: 8, offset: 52101},
+									pos: position{line: 1440, col: 8, offset: 52150},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1439, col: 9, offset: 52102},
+										pos:  position{line: 1440, col: 9, offset: 52151},
 										name: "Space",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1439, col: 15, offset: 52108},
+									pos: position{line: 1440, col: 15, offset: 52157},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1439, col: 16, offset: 52109},
+										pos:  position{line: 1440, col: 16, offset: 52158},
 										name: "Newline",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1439, col: 24, offset: 52117},
+									pos: position{line: 1440, col: 24, offset: 52166},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1439, col: 25, offset: 52118},
+										pos:  position{line: 1440, col: 25, offset: 52167},
 										name: "SinglePlusPassthroughPrefix",
 									},
 								},
 								&anyMatcher{
-									line: 1439, col: 53, offset: 52146,
+									line: 1440, col: 53, offset: 52195,
 								},
 							},
 						},
@@ -9315,9 +9315,9 @@ var g = &grammar{
 		},
 		{
 			name: "TriplePlusPassthroughPrefix",
-			pos:  position{line: 1443, col: 1, offset: 52228},
+			pos:  position{line: 1444, col: 1, offset: 52277},
 			expr: &litMatcher{
-				pos:        position{line: 1443, col: 32, offset: 52259},
+				pos:        position{line: 1444, col: 32, offset: 52308},
 				val:        "+++",
 				ignoreCase: false,
 				want:       "\"+++\"",
@@ -9325,33 +9325,33 @@ var g = &grammar{
 		},
 		{
 			name: "TriplePlusPassthrough",
-			pos:  position{line: 1445, col: 1, offset: 52266},
+			pos:  position{line: 1446, col: 1, offset: 52315},
 			expr: &actionExpr{
-				pos: position{line: 1445, col: 26, offset: 52291},
+				pos: position{line: 1446, col: 26, offset: 52340},
 				run: (*parser).callonTriplePlusPassthrough1,
 				expr: &seqExpr{
-					pos: position{line: 1445, col: 26, offset: 52291},
+					pos: position{line: 1446, col: 26, offset: 52340},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1445, col: 26, offset: 52291},
+							pos:  position{line: 1446, col: 26, offset: 52340},
 							name: "TriplePlusPassthroughPrefix",
 						},
 						&labeledExpr{
-							pos:   position{line: 1445, col: 54, offset: 52319},
+							pos:   position{line: 1446, col: 54, offset: 52368},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1445, col: 63, offset: 52328},
+								pos:  position{line: 1446, col: 63, offset: 52377},
 								name: "TriplePlusPassthroughContent",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1445, col: 93, offset: 52358},
+							pos:  position{line: 1446, col: 93, offset: 52407},
 							name: "TriplePlusPassthroughPrefix",
 						},
 						&notExpr{
-							pos: position{line: 1445, col: 121, offset: 52386},
+							pos: position{line: 1446, col: 121, offset: 52435},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1445, col: 122, offset: 52387},
+								pos:  position{line: 1446, col: 122, offset: 52436},
 								name: "Alphanum",
 							},
 						},
@@ -9361,63 +9361,63 @@ var g = &grammar{
 		},
 		{
 			name: "TriplePlusPassthroughContent",
-			pos:  position{line: 1449, col: 1, offset: 52492},
+			pos:  position{line: 1450, col: 1, offset: 52541},
 			expr: &choiceExpr{
-				pos: position{line: 1449, col: 33, offset: 52524},
+				pos: position{line: 1450, col: 33, offset: 52573},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1449, col: 34, offset: 52525},
+						pos: position{line: 1450, col: 34, offset: 52574},
 						run: (*parser).callonTriplePlusPassthroughContent2,
 						expr: &zeroOrMoreExpr{
-							pos: position{line: 1449, col: 34, offset: 52525},
+							pos: position{line: 1450, col: 34, offset: 52574},
 							expr: &seqExpr{
-								pos: position{line: 1449, col: 35, offset: 52526},
+								pos: position{line: 1450, col: 35, offset: 52575},
 								exprs: []interface{}{
 									&notExpr{
-										pos: position{line: 1449, col: 35, offset: 52526},
+										pos: position{line: 1450, col: 35, offset: 52575},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1449, col: 36, offset: 52527},
+											pos:  position{line: 1450, col: 36, offset: 52576},
 											name: "TriplePlusPassthroughPrefix",
 										},
 									},
 									&anyMatcher{
-										line: 1449, col: 64, offset: 52555,
+										line: 1450, col: 64, offset: 52604,
 									},
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1451, col: 7, offset: 52720},
+						pos: position{line: 1452, col: 7, offset: 52769},
 						run: (*parser).callonTriplePlusPassthroughContent8,
 						expr: &zeroOrOneExpr{
-							pos: position{line: 1451, col: 7, offset: 52720},
+							pos: position{line: 1452, col: 7, offset: 52769},
 							expr: &seqExpr{
-								pos: position{line: 1451, col: 8, offset: 52721},
+								pos: position{line: 1452, col: 8, offset: 52770},
 								exprs: []interface{}{
 									&notExpr{
-										pos: position{line: 1451, col: 8, offset: 52721},
+										pos: position{line: 1452, col: 8, offset: 52770},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1451, col: 9, offset: 52722},
+											pos:  position{line: 1452, col: 9, offset: 52771},
 											name: "Space",
 										},
 									},
 									&notExpr{
-										pos: position{line: 1451, col: 15, offset: 52728},
+										pos: position{line: 1452, col: 15, offset: 52777},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1451, col: 16, offset: 52729},
+											pos:  position{line: 1452, col: 16, offset: 52778},
 											name: "Newline",
 										},
 									},
 									&notExpr{
-										pos: position{line: 1451, col: 24, offset: 52737},
+										pos: position{line: 1452, col: 24, offset: 52786},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1451, col: 25, offset: 52738},
+											pos:  position{line: 1452, col: 25, offset: 52787},
 											name: "TriplePlusPassthroughPrefix",
 										},
 									},
 									&anyMatcher{
-										line: 1451, col: 53, offset: 52766,
+										line: 1452, col: 53, offset: 52815,
 									},
 								},
 							},
@@ -9428,35 +9428,35 @@ var g = &grammar{
 		},
 		{
 			name: "PassthroughMacro",
-			pos:  position{line: 1455, col: 1, offset: 52849},
+			pos:  position{line: 1456, col: 1, offset: 52898},
 			expr: &choiceExpr{
-				pos: position{line: 1455, col: 21, offset: 52869},
+				pos: position{line: 1456, col: 21, offset: 52918},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1455, col: 21, offset: 52869},
+						pos: position{line: 1456, col: 21, offset: 52918},
 						run: (*parser).callonPassthroughMacro2,
 						expr: &seqExpr{
-							pos: position{line: 1455, col: 21, offset: 52869},
+							pos: position{line: 1456, col: 21, offset: 52918},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1455, col: 21, offset: 52869},
+									pos:        position{line: 1456, col: 21, offset: 52918},
 									val:        "pass:[",
 									ignoreCase: false,
 									want:       "\"pass:[\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1455, col: 30, offset: 52878},
+									pos:   position{line: 1456, col: 30, offset: 52927},
 									label: "content",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1455, col: 38, offset: 52886},
+										pos: position{line: 1456, col: 38, offset: 52935},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1455, col: 39, offset: 52887},
+											pos:  position{line: 1456, col: 39, offset: 52936},
 											name: "PassthroughMacroCharacter",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1455, col: 67, offset: 52915},
+									pos:        position{line: 1456, col: 67, offset: 52964},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -9465,31 +9465,31 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1457, col: 5, offset: 53011},
+						pos: position{line: 1458, col: 5, offset: 53060},
 						run: (*parser).callonPassthroughMacro9,
 						expr: &seqExpr{
-							pos: position{line: 1457, col: 5, offset: 53011},
+							pos: position{line: 1458, col: 5, offset: 53060},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1457, col: 5, offset: 53011},
+									pos:        position{line: 1458, col: 5, offset: 53060},
 									val:        "pass:q[",
 									ignoreCase: false,
 									want:       "\"pass:q[\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1457, col: 15, offset: 53021},
+									pos:   position{line: 1458, col: 15, offset: 53070},
 									label: "content",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1457, col: 23, offset: 53029},
+										pos: position{line: 1458, col: 23, offset: 53078},
 										expr: &choiceExpr{
-											pos: position{line: 1457, col: 24, offset: 53030},
+											pos: position{line: 1458, col: 24, offset: 53079},
 											alternatives: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 1457, col: 24, offset: 53030},
+													pos:  position{line: 1458, col: 24, offset: 53079},
 													name: "QuotedText",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1457, col: 37, offset: 53043},
+													pos:  position{line: 1458, col: 37, offset: 53092},
 													name: "PassthroughMacroCharacter",
 												},
 											},
@@ -9497,7 +9497,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1457, col: 65, offset: 53071},
+									pos:        position{line: 1458, col: 65, offset: 53120},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -9510,12 +9510,12 @@ var g = &grammar{
 		},
 		{
 			name: "PassthroughMacroCharacter",
-			pos:  position{line: 1461, col: 1, offset: 53167},
+			pos:  position{line: 1462, col: 1, offset: 53216},
 			expr: &actionExpr{
-				pos: position{line: 1461, col: 30, offset: 53196},
+				pos: position{line: 1462, col: 30, offset: 53245},
 				run: (*parser).callonPassthroughMacroCharacter1,
 				expr: &charClassMatcher{
-					pos:        position{line: 1461, col: 30, offset: 53196},
+					pos:        position{line: 1462, col: 30, offset: 53245},
 					val:        "[^\\]]",
 					chars:      []rune{']'},
 					ignoreCase: false,
@@ -9525,16 +9525,16 @@ var g = &grammar{
 		},
 		{
 			name: "CrossReference",
-			pos:  position{line: 1468, col: 1, offset: 53369},
+			pos:  position{line: 1469, col: 1, offset: 53418},
 			expr: &choiceExpr{
-				pos: position{line: 1468, col: 19, offset: 53387},
+				pos: position{line: 1469, col: 19, offset: 53436},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1468, col: 19, offset: 53387},
+						pos:  position{line: 1469, col: 19, offset: 53436},
 						name: "InternalCrossReference",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1468, col: 44, offset: 53412},
+						pos:  position{line: 1469, col: 44, offset: 53461},
 						name: "ExternalCrossReference",
 					},
 				},
@@ -9542,53 +9542,53 @@ var g = &grammar{
 		},
 		{
 			name: "InternalCrossReference",
-			pos:  position{line: 1470, col: 1, offset: 53437},
+			pos:  position{line: 1471, col: 1, offset: 53486},
 			expr: &choiceExpr{
-				pos: position{line: 1470, col: 27, offset: 53463},
+				pos: position{line: 1471, col: 27, offset: 53512},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1470, col: 27, offset: 53463},
+						pos: position{line: 1471, col: 27, offset: 53512},
 						run: (*parser).callonInternalCrossReference2,
 						expr: &seqExpr{
-							pos: position{line: 1470, col: 27, offset: 53463},
+							pos: position{line: 1471, col: 27, offset: 53512},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1470, col: 27, offset: 53463},
+									pos:        position{line: 1471, col: 27, offset: 53512},
 									val:        "<<",
 									ignoreCase: false,
 									want:       "\"<<\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1470, col: 32, offset: 53468},
+									pos:   position{line: 1471, col: 32, offset: 53517},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1470, col: 36, offset: 53472},
+										pos:  position{line: 1471, col: 36, offset: 53521},
 										name: "Id",
 									},
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 1470, col: 40, offset: 53476},
+									pos: position{line: 1471, col: 40, offset: 53525},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1470, col: 40, offset: 53476},
+										pos:  position{line: 1471, col: 40, offset: 53525},
 										name: "Space",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1470, col: 47, offset: 53483},
+									pos:        position{line: 1471, col: 47, offset: 53532},
 									val:        ",",
 									ignoreCase: false,
 									want:       "\",\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1470, col: 51, offset: 53487},
+									pos:   position{line: 1471, col: 51, offset: 53536},
 									label: "label",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1470, col: 58, offset: 53494},
+										pos:  position{line: 1471, col: 58, offset: 53543},
 										name: "CrossReferenceLabel",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1470, col: 79, offset: 53515},
+									pos:        position{line: 1471, col: 79, offset: 53564},
 									val:        ">>",
 									ignoreCase: false,
 									want:       "\">>\"",
@@ -9597,27 +9597,27 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1472, col: 5, offset: 53580},
+						pos: position{line: 1473, col: 5, offset: 53629},
 						run: (*parser).callonInternalCrossReference13,
 						expr: &seqExpr{
-							pos: position{line: 1472, col: 5, offset: 53580},
+							pos: position{line: 1473, col: 5, offset: 53629},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1472, col: 5, offset: 53580},
+									pos:        position{line: 1473, col: 5, offset: 53629},
 									val:        "<<",
 									ignoreCase: false,
 									want:       "\"<<\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1472, col: 10, offset: 53585},
+									pos:   position{line: 1473, col: 10, offset: 53634},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1472, col: 14, offset: 53589},
+										pos:  position{line: 1473, col: 14, offset: 53638},
 										name: "Id",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1472, col: 18, offset: 53593},
+									pos:        position{line: 1473, col: 18, offset: 53642},
 									val:        ">>",
 									ignoreCase: false,
 									want:       "\">>\"",
@@ -9630,32 +9630,32 @@ var g = &grammar{
 		},
 		{
 			name: "ExternalCrossReference",
-			pos:  position{line: 1476, col: 1, offset: 53656},
+			pos:  position{line: 1477, col: 1, offset: 53705},
 			expr: &actionExpr{
-				pos: position{line: 1476, col: 27, offset: 53682},
+				pos: position{line: 1477, col: 27, offset: 53731},
 				run: (*parser).callonExternalCrossReference1,
 				expr: &seqExpr{
-					pos: position{line: 1476, col: 27, offset: 53682},
+					pos: position{line: 1477, col: 27, offset: 53731},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1476, col: 27, offset: 53682},
+							pos:        position{line: 1477, col: 27, offset: 53731},
 							val:        "xref:",
 							ignoreCase: false,
 							want:       "\"xref:\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1476, col: 35, offset: 53690},
+							pos:   position{line: 1477, col: 35, offset: 53739},
 							label: "url",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1476, col: 40, offset: 53695},
+								pos:  position{line: 1477, col: 40, offset: 53744},
 								name: "FileLocation",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1476, col: 54, offset: 53709},
+							pos:   position{line: 1477, col: 54, offset: 53758},
 							label: "inlineAttributes",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1476, col: 72, offset: 53727},
+								pos:  position{line: 1477, col: 72, offset: 53776},
 								name: "InlineAttributes",
 							},
 						},
@@ -9665,20 +9665,20 @@ var g = &grammar{
 		},
 		{
 			name: "CrossReferenceLabel",
-			pos:  position{line: 1480, col: 1, offset: 53852},
+			pos:  position{line: 1481, col: 1, offset: 53901},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 1480, col: 24, offset: 53875},
+				pos: position{line: 1481, col: 24, offset: 53924},
 				expr: &choiceExpr{
-					pos: position{line: 1481, col: 5, offset: 53881},
+					pos: position{line: 1482, col: 5, offset: 53930},
 					alternatives: []interface{}{
 						&actionExpr{
-							pos: position{line: 1481, col: 6, offset: 53882},
+							pos: position{line: 1482, col: 6, offset: 53931},
 							run: (*parser).callonCrossReferenceLabel3,
 							expr: &seqExpr{
-								pos: position{line: 1481, col: 6, offset: 53882},
+								pos: position{line: 1482, col: 6, offset: 53931},
 								exprs: []interface{}{
 									&charClassMatcher{
-										pos:        position{line: 1481, col: 6, offset: 53882},
+										pos:        position{line: 1482, col: 6, offset: 53931},
 										val:        "[\\pL0-9]",
 										ranges:     []rune{'0', '9'},
 										classes:    []*unicode.RangeTable{rangeTable("L")},
@@ -9686,9 +9686,9 @@ var g = &grammar{
 										inverted:   false,
 									},
 									&oneOrMoreExpr{
-										pos: position{line: 1481, col: 14, offset: 53890},
+										pos: position{line: 1482, col: 14, offset: 53939},
 										expr: &charClassMatcher{
-											pos:        position{line: 1481, col: 14, offset: 53890},
+											pos:        position{line: 1482, col: 14, offset: 53939},
 											val:        "[^\\r\\n{<>]",
 											chars:      []rune{'\r', '\n', '{', '<', '>'},
 											ignoreCase: false,
@@ -9699,14 +9699,14 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1484, col: 5, offset: 54085},
+							pos:  position{line: 1485, col: 5, offset: 54134},
 							name: "AttrSub",
 						},
 						&actionExpr{
-							pos: position{line: 1485, col: 6, offset: 54100},
+							pos: position{line: 1486, col: 6, offset: 54149},
 							run: (*parser).callonCrossReferenceLabel9,
 							expr: &litMatcher{
-								pos:        position{line: 1485, col: 6, offset: 54100},
+								pos:        position{line: 1486, col: 6, offset: 54149},
 								val:        "{",
 								ignoreCase: false,
 								want:       "\"{\"",
@@ -9718,16 +9718,16 @@ var g = &grammar{
 		},
 		{
 			name: "Link",
-			pos:  position{line: 1493, col: 1, offset: 54277},
+			pos:  position{line: 1494, col: 1, offset: 54326},
 			expr: &choiceExpr{
-				pos: position{line: 1493, col: 9, offset: 54285},
+				pos: position{line: 1494, col: 9, offset: 54334},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1493, col: 9, offset: 54285},
+						pos:  position{line: 1494, col: 9, offset: 54334},
 						name: "RelativeLink",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1493, col: 24, offset: 54300},
+						pos:  position{line: 1494, col: 24, offset: 54349},
 						name: "ExternalLink",
 					},
 				},
@@ -9735,32 +9735,32 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeLink",
-			pos:  position{line: 1496, col: 1, offset: 54381},
+			pos:  position{line: 1497, col: 1, offset: 54430},
 			expr: &actionExpr{
-				pos: position{line: 1496, col: 17, offset: 54397},
+				pos: position{line: 1497, col: 17, offset: 54446},
 				run: (*parser).callonRelativeLink1,
 				expr: &seqExpr{
-					pos: position{line: 1496, col: 17, offset: 54397},
+					pos: position{line: 1497, col: 17, offset: 54446},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1496, col: 17, offset: 54397},
+							pos:        position{line: 1497, col: 17, offset: 54446},
 							val:        "link:",
 							ignoreCase: false,
 							want:       "\"link:\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1496, col: 25, offset: 54405},
+							pos:   position{line: 1497, col: 25, offset: 54454},
 							label: "url",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1496, col: 30, offset: 54410},
+								pos:  position{line: 1497, col: 30, offset: 54459},
 								name: "Location",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1496, col: 40, offset: 54420},
+							pos:   position{line: 1497, col: 40, offset: 54469},
 							label: "inlineAttributes",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1496, col: 58, offset: 54438},
+								pos:  position{line: 1497, col: 58, offset: 54487},
 								name: "InlineAttributes",
 							},
 						},
@@ -9770,28 +9770,28 @@ var g = &grammar{
 		},
 		{
 			name: "ExternalLink",
-			pos:  position{line: 1500, col: 1, offset: 54551},
+			pos:  position{line: 1501, col: 1, offset: 54600},
 			expr: &actionExpr{
-				pos: position{line: 1500, col: 17, offset: 54567},
+				pos: position{line: 1501, col: 17, offset: 54616},
 				run: (*parser).callonExternalLink1,
 				expr: &seqExpr{
-					pos: position{line: 1500, col: 17, offset: 54567},
+					pos: position{line: 1501, col: 17, offset: 54616},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1500, col: 17, offset: 54567},
+							pos:   position{line: 1501, col: 17, offset: 54616},
 							label: "url",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1500, col: 22, offset: 54572},
+								pos:  position{line: 1501, col: 22, offset: 54621},
 								name: "LocationWithScheme",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1500, col: 42, offset: 54592},
+							pos:   position{line: 1501, col: 42, offset: 54641},
 							label: "inlineAttributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1500, col: 59, offset: 54609},
+								pos: position{line: 1501, col: 59, offset: 54658},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1500, col: 60, offset: 54610},
+									pos:  position{line: 1501, col: 60, offset: 54659},
 									name: "InlineAttributes",
 								},
 							},
@@ -9802,59 +9802,59 @@ var g = &grammar{
 		},
 		{
 			name: "ImageBlock",
-			pos:  position{line: 1507, col: 1, offset: 54807},
+			pos:  position{line: 1508, col: 1, offset: 54856},
 			expr: &actionExpr{
-				pos: position{line: 1508, col: 5, offset: 54826},
+				pos: position{line: 1509, col: 5, offset: 54875},
 				run: (*parser).callonImageBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1508, col: 5, offset: 54826},
+					pos: position{line: 1509, col: 5, offset: 54875},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1508, col: 5, offset: 54826},
+							pos:   position{line: 1509, col: 5, offset: 54875},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1508, col: 16, offset: 54837},
+								pos: position{line: 1509, col: 16, offset: 54886},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1508, col: 17, offset: 54838},
+									pos:  position{line: 1509, col: 17, offset: 54887},
 									name: "BlockAttributes",
 								},
 							},
 						},
 						&andCodeExpr{
-							pos: position{line: 1509, col: 5, offset: 54861},
+							pos: position{line: 1510, col: 5, offset: 54910},
 							run: (*parser).callonImageBlock6,
 						},
 						&litMatcher{
-							pos:        position{line: 1513, col: 5, offset: 54994},
+							pos:        position{line: 1514, col: 5, offset: 55043},
 							val:        "image::",
 							ignoreCase: false,
 							want:       "\"image::\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1513, col: 15, offset: 55004},
+							pos:   position{line: 1514, col: 15, offset: 55053},
 							label: "path",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1513, col: 21, offset: 55010},
+								pos:  position{line: 1514, col: 21, offset: 55059},
 								name: "Location",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1513, col: 31, offset: 55020},
+							pos:   position{line: 1514, col: 31, offset: 55069},
 							label: "inlineAttributes",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1513, col: 49, offset: 55038},
+								pos:  position{line: 1514, col: 49, offset: 55087},
 								name: "InlineAttributes",
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1513, col: 67, offset: 55056},
+							pos: position{line: 1514, col: 67, offset: 55105},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1513, col: 67, offset: 55056},
+								pos:  position{line: 1514, col: 67, offset: 55105},
 								name: "Space",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1513, col: 74, offset: 55063},
+							pos:  position{line: 1514, col: 74, offset: 55112},
 							name: "EOL",
 						},
 					},
@@ -9863,41 +9863,41 @@ var g = &grammar{
 		},
 		{
 			name: "InlineImage",
-			pos:  position{line: 1518, col: 1, offset: 55278},
+			pos:  position{line: 1519, col: 1, offset: 55327},
 			expr: &actionExpr{
-				pos: position{line: 1518, col: 16, offset: 55293},
+				pos: position{line: 1519, col: 16, offset: 55342},
 				run: (*parser).callonInlineImage1,
 				expr: &seqExpr{
-					pos: position{line: 1518, col: 16, offset: 55293},
+					pos: position{line: 1519, col: 16, offset: 55342},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1518, col: 16, offset: 55293},
+							pos:        position{line: 1519, col: 16, offset: 55342},
 							val:        "image:",
 							ignoreCase: false,
 							want:       "\"image:\"",
 						},
 						&notExpr{
-							pos: position{line: 1518, col: 25, offset: 55302},
+							pos: position{line: 1519, col: 25, offset: 55351},
 							expr: &litMatcher{
-								pos:        position{line: 1518, col: 26, offset: 55303},
+								pos:        position{line: 1519, col: 26, offset: 55352},
 								val:        ":",
 								ignoreCase: false,
 								want:       "\":\"",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1518, col: 30, offset: 55307},
+							pos:   position{line: 1519, col: 30, offset: 55356},
 							label: "path",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1518, col: 36, offset: 55313},
+								pos:  position{line: 1519, col: 36, offset: 55362},
 								name: "Location",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1518, col: 46, offset: 55323},
+							pos:   position{line: 1519, col: 46, offset: 55372},
 							label: "inlineAttributes",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1518, col: 64, offset: 55341},
+								pos:  position{line: 1519, col: 64, offset: 55390},
 								name: "InlineAttributes",
 							},
 						},
@@ -9907,29 +9907,29 @@ var g = &grammar{
 		},
 		{
 			name: "InlineIcon",
-			pos:  position{line: 1525, col: 1, offset: 55676},
+			pos:  position{line: 1526, col: 1, offset: 55725},
 			expr: &actionExpr{
-				pos: position{line: 1525, col: 15, offset: 55690},
+				pos: position{line: 1526, col: 15, offset: 55739},
 				run: (*parser).callonInlineIcon1,
 				expr: &seqExpr{
-					pos: position{line: 1525, col: 15, offset: 55690},
+					pos: position{line: 1526, col: 15, offset: 55739},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1525, col: 15, offset: 55690},
+							pos:        position{line: 1526, col: 15, offset: 55739},
 							val:        "icon:",
 							ignoreCase: false,
 							want:       "\"icon:\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1525, col: 23, offset: 55698},
+							pos:   position{line: 1526, col: 23, offset: 55747},
 							label: "icon",
 							expr: &actionExpr{
-								pos: position{line: 1525, col: 29, offset: 55704},
+								pos: position{line: 1526, col: 29, offset: 55753},
 								run: (*parser).callonInlineIcon5,
 								expr: &oneOrMoreExpr{
-									pos: position{line: 1525, col: 29, offset: 55704},
+									pos: position{line: 1526, col: 29, offset: 55753},
 									expr: &charClassMatcher{
-										pos:        position{line: 1525, col: 29, offset: 55704},
+										pos:        position{line: 1526, col: 29, offset: 55753},
 										val:        "[\\pL0-9_-]",
 										chars:      []rune{'_', '-'},
 										ranges:     []rune{'0', '9'},
@@ -9941,10 +9941,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1525, col: 73, offset: 55748},
+							pos:   position{line: 1526, col: 73, offset: 55797},
 							label: "attributes",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1525, col: 85, offset: 55760},
+								pos:  position{line: 1526, col: 85, offset: 55809},
 								name: "InlineAttributes",
 							},
 						},
@@ -9954,32 +9954,32 @@ var g = &grammar{
 		},
 		{
 			name: "InlineFootnote",
-			pos:  position{line: 1532, col: 1, offset: 56032},
+			pos:  position{line: 1533, col: 1, offset: 56081},
 			expr: &choiceExpr{
-				pos: position{line: 1532, col: 19, offset: 56050},
+				pos: position{line: 1533, col: 19, offset: 56099},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1532, col: 19, offset: 56050},
+						pos: position{line: 1533, col: 19, offset: 56099},
 						run: (*parser).callonInlineFootnote2,
 						expr: &seqExpr{
-							pos: position{line: 1532, col: 19, offset: 56050},
+							pos: position{line: 1533, col: 19, offset: 56099},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1532, col: 19, offset: 56050},
+									pos:        position{line: 1533, col: 19, offset: 56099},
 									val:        "footnote:[",
 									ignoreCase: false,
 									want:       "\"footnote:[\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1532, col: 32, offset: 56063},
+									pos:   position{line: 1533, col: 32, offset: 56112},
 									label: "content",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1532, col: 41, offset: 56072},
+										pos:  position{line: 1533, col: 41, offset: 56121},
 										name: "FootnoteContent",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1532, col: 58, offset: 56089},
+									pos:        position{line: 1533, col: 58, offset: 56138},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -9988,44 +9988,44 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1534, col: 5, offset: 56157},
+						pos: position{line: 1535, col: 5, offset: 56206},
 						run: (*parser).callonInlineFootnote8,
 						expr: &seqExpr{
-							pos: position{line: 1534, col: 5, offset: 56157},
+							pos: position{line: 1535, col: 5, offset: 56206},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1534, col: 5, offset: 56157},
+									pos:        position{line: 1535, col: 5, offset: 56206},
 									val:        "footnote:",
 									ignoreCase: false,
 									want:       "\"footnote:\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1534, col: 17, offset: 56169},
+									pos:   position{line: 1535, col: 17, offset: 56218},
 									label: "ref",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1534, col: 22, offset: 56174},
+										pos:  position{line: 1535, col: 22, offset: 56223},
 										name: "FootnoteRef",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1534, col: 35, offset: 56187},
+									pos:        position{line: 1535, col: 35, offset: 56236},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1534, col: 39, offset: 56191},
+									pos:   position{line: 1535, col: 39, offset: 56240},
 									label: "content",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1534, col: 47, offset: 56199},
+										pos: position{line: 1535, col: 47, offset: 56248},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1534, col: 48, offset: 56200},
+											pos:  position{line: 1535, col: 48, offset: 56249},
 											name: "FootnoteContent",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1534, col: 66, offset: 56218},
+									pos:        position{line: 1535, col: 66, offset: 56267},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
@@ -10038,37 +10038,37 @@ var g = &grammar{
 		},
 		{
 			name: "FootnoteRef",
-			pos:  position{line: 1538, col: 1, offset: 56279},
+			pos:  position{line: 1539, col: 1, offset: 56328},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1538, col: 16, offset: 56294},
+				pos:  position{line: 1539, col: 16, offset: 56343},
 				name: "Alphanums",
 			},
 		},
 		{
 			name: "FootnoteContent",
-			pos:  position{line: 1540, col: 1, offset: 56305},
+			pos:  position{line: 1541, col: 1, offset: 56354},
 			expr: &actionExpr{
-				pos: position{line: 1540, col: 20, offset: 56324},
+				pos: position{line: 1541, col: 20, offset: 56373},
 				run: (*parser).callonFootnoteContent1,
 				expr: &labeledExpr{
-					pos:   position{line: 1540, col: 20, offset: 56324},
+					pos:   position{line: 1541, col: 20, offset: 56373},
 					label: "elements",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 1540, col: 29, offset: 56333},
+						pos: position{line: 1541, col: 29, offset: 56382},
 						expr: &seqExpr{
-							pos: position{line: 1540, col: 30, offset: 56334},
+							pos: position{line: 1541, col: 30, offset: 56383},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1540, col: 30, offset: 56334},
+									pos: position{line: 1541, col: 30, offset: 56383},
 									expr: &litMatcher{
-										pos:        position{line: 1540, col: 31, offset: 56335},
+										pos:        position{line: 1541, col: 31, offset: 56384},
 										val:        "]",
 										ignoreCase: false,
 										want:       "\"]\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1540, col: 35, offset: 56339},
+									pos:  position{line: 1541, col: 35, offset: 56388},
 									name: "InlineElement",
 								},
 							},
@@ -10079,29 +10079,29 @@ var g = &grammar{
 		},
 		{
 			name: "Callout",
-			pos:  position{line: 1548, col: 1, offset: 56655},
+			pos:  position{line: 1549, col: 1, offset: 56704},
 			expr: &actionExpr{
-				pos: position{line: 1548, col: 12, offset: 56666},
+				pos: position{line: 1549, col: 12, offset: 56715},
 				run: (*parser).callonCallout1,
 				expr: &seqExpr{
-					pos: position{line: 1548, col: 12, offset: 56666},
+					pos: position{line: 1549, col: 12, offset: 56715},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1548, col: 12, offset: 56666},
+							pos:        position{line: 1549, col: 12, offset: 56715},
 							val:        "<",
 							ignoreCase: false,
 							want:       "\"<\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1548, col: 16, offset: 56670},
+							pos:   position{line: 1549, col: 16, offset: 56719},
 							label: "ref",
 							expr: &actionExpr{
-								pos: position{line: 1548, col: 21, offset: 56675},
+								pos: position{line: 1549, col: 21, offset: 56724},
 								run: (*parser).callonCallout5,
 								expr: &oneOrMoreExpr{
-									pos: position{line: 1548, col: 21, offset: 56675},
+									pos: position{line: 1549, col: 21, offset: 56724},
 									expr: &charClassMatcher{
-										pos:        position{line: 1548, col: 21, offset: 56675},
+										pos:        position{line: 1549, col: 21, offset: 56724},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10111,29 +10111,29 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1548, col: 69, offset: 56723},
+							pos:        position{line: 1549, col: 69, offset: 56772},
 							val:        ">",
 							ignoreCase: false,
 							want:       "\">\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1548, col: 73, offset: 56727},
+							pos: position{line: 1549, col: 73, offset: 56776},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1548, col: 73, offset: 56727},
+								pos:  position{line: 1549, col: 73, offset: 56776},
 								name: "Space",
 							},
 						},
 						&andExpr{
-							pos: position{line: 1548, col: 80, offset: 56734},
+							pos: position{line: 1549, col: 80, offset: 56783},
 							expr: &choiceExpr{
-								pos: position{line: 1548, col: 82, offset: 56736},
+								pos: position{line: 1549, col: 82, offset: 56785},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1548, col: 82, offset: 56736},
+										pos:  position{line: 1549, col: 82, offset: 56785},
 										name: "EOL",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1548, col: 88, offset: 56742},
+										pos:  position{line: 1549, col: 88, offset: 56791},
 										name: "Callout",
 									},
 								},
@@ -10145,28 +10145,28 @@ var g = &grammar{
 		},
 		{
 			name: "CalloutListItem",
-			pos:  position{line: 1552, col: 1, offset: 56795},
+			pos:  position{line: 1553, col: 1, offset: 56844},
 			expr: &actionExpr{
-				pos: position{line: 1552, col: 20, offset: 56814},
+				pos: position{line: 1553, col: 20, offset: 56863},
 				run: (*parser).callonCalloutListItem1,
 				expr: &seqExpr{
-					pos: position{line: 1552, col: 20, offset: 56814},
+					pos: position{line: 1553, col: 20, offset: 56863},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1552, col: 20, offset: 56814},
+							pos:   position{line: 1553, col: 20, offset: 56863},
 							label: "ref",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1552, col: 25, offset: 56819},
+								pos:  position{line: 1553, col: 25, offset: 56868},
 								name: "CalloutListItemPrefix",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1552, col: 48, offset: 56842},
+							pos:   position{line: 1553, col: 48, offset: 56891},
 							label: "description",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1552, col: 61, offset: 56855},
+								pos: position{line: 1553, col: 61, offset: 56904},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1552, col: 61, offset: 56855},
+									pos:  position{line: 1553, col: 61, offset: 56904},
 									name: "ListParagraph",
 								},
 							},
@@ -10177,29 +10177,29 @@ var g = &grammar{
 		},
 		{
 			name: "CalloutListItemPrefix",
-			pos:  position{line: 1556, col: 1, offset: 56952},
+			pos:  position{line: 1557, col: 1, offset: 57001},
 			expr: &actionExpr{
-				pos: position{line: 1556, col: 26, offset: 56977},
+				pos: position{line: 1557, col: 26, offset: 57026},
 				run: (*parser).callonCalloutListItemPrefix1,
 				expr: &seqExpr{
-					pos: position{line: 1556, col: 26, offset: 56977},
+					pos: position{line: 1557, col: 26, offset: 57026},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1556, col: 26, offset: 56977},
+							pos:        position{line: 1557, col: 26, offset: 57026},
 							val:        "<",
 							ignoreCase: false,
 							want:       "\"<\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1556, col: 30, offset: 56981},
+							pos:   position{line: 1557, col: 30, offset: 57030},
 							label: "ref",
 							expr: &actionExpr{
-								pos: position{line: 1556, col: 35, offset: 56986},
+								pos: position{line: 1557, col: 35, offset: 57035},
 								run: (*parser).callonCalloutListItemPrefix5,
 								expr: &oneOrMoreExpr{
-									pos: position{line: 1556, col: 35, offset: 56986},
+									pos: position{line: 1557, col: 35, offset: 57035},
 									expr: &charClassMatcher{
-										pos:        position{line: 1556, col: 35, offset: 56986},
+										pos:        position{line: 1557, col: 35, offset: 57035},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -10209,15 +10209,15 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1556, col: 83, offset: 57034},
+							pos:        position{line: 1557, col: 83, offset: 57083},
 							val:        ">",
 							ignoreCase: false,
 							want:       "\">\"",
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 1556, col: 87, offset: 57038},
+							pos: position{line: 1557, col: 87, offset: 57087},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1556, col: 87, offset: 57038},
+								pos:  position{line: 1557, col: 87, offset: 57087},
 								name: "Space",
 							},
 						},
@@ -10227,48 +10227,48 @@ var g = &grammar{
 		},
 		{
 			name: "ThematicBreak",
-			pos:  position{line: 1565, col: 1, offset: 57285},
+			pos:  position{line: 1566, col: 1, offset: 57334},
 			expr: &actionExpr{
-				pos: position{line: 1565, col: 18, offset: 57302},
+				pos: position{line: 1566, col: 18, offset: 57351},
 				run: (*parser).callonThematicBreak1,
 				expr: &seqExpr{
-					pos: position{line: 1565, col: 18, offset: 57302},
+					pos: position{line: 1566, col: 18, offset: 57351},
 					exprs: []interface{}{
 						&choiceExpr{
-							pos: position{line: 1565, col: 19, offset: 57303},
+							pos: position{line: 1566, col: 19, offset: 57352},
 							alternatives: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1565, col: 19, offset: 57303},
+									pos:        position{line: 1566, col: 19, offset: 57352},
 									val:        "***",
 									ignoreCase: false,
 									want:       "\"***\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1565, col: 27, offset: 57311},
+									pos:        position{line: 1566, col: 27, offset: 57360},
 									val:        "* * *",
 									ignoreCase: false,
 									want:       "\"* * *\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1565, col: 37, offset: 57321},
+									pos:        position{line: 1566, col: 37, offset: 57370},
 									val:        "---",
 									ignoreCase: false,
 									want:       "\"---\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1565, col: 45, offset: 57329},
+									pos:        position{line: 1566, col: 45, offset: 57378},
 									val:        "- - -",
 									ignoreCase: false,
 									want:       "\"- - -\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1565, col: 55, offset: 57339},
+									pos:        position{line: 1566, col: 55, offset: 57388},
 									val:        "___",
 									ignoreCase: false,
 									want:       "\"___\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1565, col: 63, offset: 57347},
+									pos:        position{line: 1566, col: 63, offset: 57396},
 									val:        "_ _ _",
 									ignoreCase: false,
 									want:       "\"_ _ _\"",
@@ -10276,7 +10276,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1565, col: 72, offset: 57356},
+							pos:  position{line: 1566, col: 72, offset: 57405},
 							name: "EOL",
 						},
 					},
@@ -10285,56 +10285,56 @@ var g = &grammar{
 		},
 		{
 			name: "DelimitedBlock",
-			pos:  position{line: 1575, col: 1, offset: 57606},
+			pos:  position{line: 1576, col: 1, offset: 57655},
 			expr: &actionExpr{
-				pos: position{line: 1575, col: 19, offset: 57624},
+				pos: position{line: 1576, col: 19, offset: 57673},
 				run: (*parser).callonDelimitedBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1575, col: 19, offset: 57624},
+					pos: position{line: 1576, col: 19, offset: 57673},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1575, col: 19, offset: 57624},
+							pos: position{line: 1576, col: 19, offset: 57673},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1575, col: 20, offset: 57625},
+								pos:  position{line: 1576, col: 20, offset: 57674},
 								name: "Alphanum",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1576, col: 5, offset: 57713},
+							pos:   position{line: 1577, col: 5, offset: 57762},
 							label: "block",
 							expr: &choiceExpr{
-								pos: position{line: 1576, col: 12, offset: 57720},
+								pos: position{line: 1577, col: 12, offset: 57769},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 1576, col: 12, offset: 57720},
+										pos:  position{line: 1577, col: 12, offset: 57769},
 										name: "FencedBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1577, col: 11, offset: 57743},
+										pos:  position{line: 1578, col: 11, offset: 57792},
 										name: "ListingBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1578, col: 11, offset: 57767},
+										pos:  position{line: 1579, col: 11, offset: 57816},
 										name: "ExampleBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1579, col: 11, offset: 57791},
+										pos:  position{line: 1580, col: 11, offset: 57840},
 										name: "VerseBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1580, col: 11, offset: 57812},
+										pos:  position{line: 1581, col: 11, offset: 57861},
 										name: "QuoteBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1581, col: 11, offset: 57833},
+										pos:  position{line: 1582, col: 11, offset: 57882},
 										name: "SidebarBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1582, col: 11, offset: 57856},
+										pos:  position{line: 1583, col: 11, offset: 57905},
 										name: "PassthroughBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1583, col: 11, offset: 57883},
+										pos:  position{line: 1584, col: 11, offset: 57932},
 										name: "CommentBlock",
 									},
 								},
@@ -10346,52 +10346,52 @@ var g = &grammar{
 		},
 		{
 			name: "BlockDelimiter",
-			pos:  position{line: 1587, col: 1, offset: 57924},
+			pos:  position{line: 1588, col: 1, offset: 57973},
 			expr: &choiceExpr{
-				pos: position{line: 1587, col: 19, offset: 57942},
+				pos: position{line: 1588, col: 19, offset: 57991},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 1587, col: 19, offset: 57942},
+						pos: position{line: 1588, col: 19, offset: 57991},
 						exprs: []interface{}{
 							&notExpr{
-								pos: position{line: 1587, col: 19, offset: 57942},
+								pos: position{line: 1588, col: 19, offset: 57991},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1587, col: 21, offset: 57944},
+									pos:  position{line: 1588, col: 21, offset: 57993},
 									name: "Alphanum",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1587, col: 31, offset: 57954},
+								pos:  position{line: 1588, col: 31, offset: 58003},
 								name: "LiteralBlockDelimiter",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1588, col: 19, offset: 58025},
+						pos:  position{line: 1589, col: 19, offset: 58074},
 						name: "FencedBlockDelimiter",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1589, col: 19, offset: 58065},
+						pos:  position{line: 1590, col: 19, offset: 58114},
 						name: "ListingBlockDelimiter",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1590, col: 19, offset: 58106},
+						pos:  position{line: 1591, col: 19, offset: 58155},
 						name: "ExampleBlockDelimiter",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1591, col: 19, offset: 58147},
+						pos:  position{line: 1592, col: 19, offset: 58196},
 						name: "CommentBlockDelimiter",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1592, col: 19, offset: 58188},
+						pos:  position{line: 1593, col: 19, offset: 58237},
 						name: "QuoteBlockDelimiter",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1593, col: 19, offset: 58226},
+						pos:  position{line: 1594, col: 19, offset: 58275},
 						name: "SidebarBlockDelimiter",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1594, col: 19, offset: 58266},
+						pos:  position{line: 1595, col: 19, offset: 58315},
 						name: "PassthroughBlockDelimiter",
 					},
 				},
@@ -10399,38 +10399,38 @@ var g = &grammar{
 		},
 		{
 			name: "ExampleBlock",
-			pos:  position{line: 1599, col: 1, offset: 58489},
+			pos:  position{line: 1600, col: 1, offset: 58538},
 			expr: &actionExpr{
-				pos: position{line: 1599, col: 17, offset: 58505},
+				pos: position{line: 1600, col: 17, offset: 58554},
 				run: (*parser).callonExampleBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1599, col: 17, offset: 58505},
+					pos: position{line: 1600, col: 17, offset: 58554},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1599, col: 17, offset: 58505},
+							pos:   position{line: 1600, col: 17, offset: 58554},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1599, col: 28, offset: 58516},
+								pos: position{line: 1600, col: 28, offset: 58565},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1599, col: 29, offset: 58517},
+									pos:  position{line: 1600, col: 29, offset: 58566},
 									name: "BlockAttributes",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1599, col: 47, offset: 58535},
+							pos:  position{line: 1600, col: 47, offset: 58584},
 							name: "ExampleBlockStartDelimiter",
 						},
 						&labeledExpr{
-							pos:   position{line: 1599, col: 74, offset: 58562},
+							pos:   position{line: 1600, col: 74, offset: 58611},
 							label: "blocks",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1599, col: 82, offset: 58570},
+								pos:  position{line: 1600, col: 82, offset: 58619},
 								name: "ExampleBlockRawContent",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1599, col: 106, offset: 58594},
+							pos:  position{line: 1600, col: 106, offset: 58643},
 							name: "ExampleBlockEndDelimiter",
 						},
 					},
@@ -10439,25 +10439,25 @@ var g = &grammar{
 		},
 		{
 			name: "ExampleBlockDelimiter",
-			pos:  position{line: 1603, col: 1, offset: 58693},
+			pos:  position{line: 1604, col: 1, offset: 58742},
 			expr: &seqExpr{
-				pos: position{line: 1603, col: 26, offset: 58718},
+				pos: position{line: 1604, col: 26, offset: 58767},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1603, col: 26, offset: 58718},
+						pos:        position{line: 1604, col: 26, offset: 58767},
 						val:        "====",
 						ignoreCase: false,
 						want:       "\"====\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1603, col: 33, offset: 58725},
+						pos: position{line: 1604, col: 33, offset: 58774},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1603, col: 33, offset: 58725},
+							pos:  position{line: 1604, col: 33, offset: 58774},
 							name: "Space",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1603, col: 40, offset: 58732},
+						pos:  position{line: 1604, col: 40, offset: 58781},
 						name: "EOL",
 					},
 				},
@@ -10465,25 +10465,25 @@ var g = &grammar{
 		},
 		{
 			name: "ExampleBlockStartDelimiter",
-			pos:  position{line: 1605, col: 1, offset: 58737},
+			pos:  position{line: 1606, col: 1, offset: 58786},
 			expr: &seqExpr{
-				pos: position{line: 1605, col: 31, offset: 58767},
+				pos: position{line: 1606, col: 31, offset: 58816},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1605, col: 31, offset: 58767},
+						pos:        position{line: 1606, col: 31, offset: 58816},
 						val:        "====",
 						ignoreCase: false,
 						want:       "\"====\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1605, col: 38, offset: 58774},
+						pos: position{line: 1606, col: 38, offset: 58823},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1605, col: 38, offset: 58774},
+							pos:  position{line: 1606, col: 38, offset: 58823},
 							name: "Space",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1605, col: 45, offset: 58781},
+						pos:  position{line: 1606, col: 45, offset: 58830},
 						name: "EOL",
 					},
 				},
@@ -10491,34 +10491,34 @@ var g = &grammar{
 		},
 		{
 			name: "ExampleBlockEndDelimiter",
-			pos:  position{line: 1607, col: 1, offset: 58786},
+			pos:  position{line: 1608, col: 1, offset: 58835},
 			expr: &choiceExpr{
-				pos: position{line: 1607, col: 29, offset: 58814},
+				pos: position{line: 1608, col: 29, offset: 58863},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 1607, col: 30, offset: 58815},
+						pos: position{line: 1608, col: 30, offset: 58864},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 1607, col: 30, offset: 58815},
+								pos:        position{line: 1608, col: 30, offset: 58864},
 								val:        "====",
 								ignoreCase: false,
 								want:       "\"====\"",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 1607, col: 37, offset: 58822},
+								pos: position{line: 1608, col: 37, offset: 58871},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1607, col: 37, offset: 58822},
+									pos:  position{line: 1608, col: 37, offset: 58871},
 									name: "Space",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1607, col: 44, offset: 58829},
+								pos:  position{line: 1608, col: 44, offset: 58878},
 								name: "EOL",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1607, col: 51, offset: 58836},
+						pos:  position{line: 1608, col: 51, offset: 58885},
 						name: "EOF",
 					},
 				},
@@ -10526,102 +10526,102 @@ var g = &grammar{
 		},
 		{
 			name: "ExampleBlockRawContent",
-			pos:  position{line: 1609, col: 1, offset: 58841},
+			pos:  position{line: 1610, col: 1, offset: 58890},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1609, col: 27, offset: 58867},
+				pos: position{line: 1610, col: 27, offset: 58916},
 				expr: &actionExpr{
-					pos: position{line: 1610, col: 8, offset: 58876},
+					pos: position{line: 1611, col: 8, offset: 58925},
 					run: (*parser).callonExampleBlockRawContent2,
 					expr: &seqExpr{
-						pos: position{line: 1610, col: 8, offset: 58876},
+						pos: position{line: 1611, col: 8, offset: 58925},
 						exprs: []interface{}{
 							&notExpr{
-								pos: position{line: 1610, col: 8, offset: 58876},
+								pos: position{line: 1611, col: 8, offset: 58925},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1610, col: 9, offset: 58877},
+									pos:  position{line: 1611, col: 9, offset: 58926},
 									name: "ExampleBlockEndDelimiter",
 								},
 							},
 							&labeledExpr{
-								pos:   position{line: 1611, col: 8, offset: 58910},
+								pos:   position{line: 1612, col: 8, offset: 58959},
 								label: "element",
 								expr: &choiceExpr{
-									pos: position{line: 1611, col: 17, offset: 58919},
+									pos: position{line: 1612, col: 17, offset: 58968},
 									alternatives: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 1611, col: 17, offset: 58919},
+											pos:  position{line: 1612, col: 17, offset: 58968},
 											name: "BlankLine",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1612, col: 15, offset: 58943},
+											pos:  position{line: 1613, col: 15, offset: 58992},
 											name: "ImageBlock",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1613, col: 15, offset: 58968},
+											pos:  position{line: 1614, col: 15, offset: 59017},
 											name: "ThematicBreak",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1614, col: 15, offset: 58996},
+											pos:  position{line: 1615, col: 15, offset: 59045},
 											name: "OrderedListItem",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1615, col: 15, offset: 59027},
+											pos:  position{line: 1616, col: 15, offset: 59076},
 											name: "UnorderedListItem",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1616, col: 15, offset: 59060},
+											pos:  position{line: 1617, col: 15, offset: 59109},
 											name: "LabeledListItem",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1617, col: 15, offset: 59091},
+											pos:  position{line: 1618, col: 15, offset: 59140},
 											name: "ContinuedListItemElement",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1618, col: 15, offset: 59130},
+											pos:  position{line: 1619, col: 15, offset: 59179},
 											name: "FencedBlock",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1619, col: 15, offset: 59157},
+											pos:  position{line: 1620, col: 15, offset: 59206},
 											name: "ListingBlock",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1620, col: 15, offset: 59185},
+											pos:  position{line: 1621, col: 15, offset: 59234},
 											name: "VerseBlock",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1621, col: 15, offset: 59210},
+											pos:  position{line: 1622, col: 15, offset: 59259},
 											name: "QuoteBlock",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1622, col: 15, offset: 59235},
+											pos:  position{line: 1623, col: 15, offset: 59284},
 											name: "SidebarBlock",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1623, col: 15, offset: 59262},
+											pos:  position{line: 1624, col: 15, offset: 59311},
 											name: "SingleLineComment",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1624, col: 15, offset: 59294},
+											pos:  position{line: 1625, col: 15, offset: 59343},
 											name: "PassthroughBlock",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1625, col: 15, offset: 59325},
+											pos:  position{line: 1626, col: 15, offset: 59374},
 											name: "Table",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1626, col: 15, offset: 59345},
+											pos:  position{line: 1627, col: 15, offset: 59394},
 											name: "CommentBlock",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1627, col: 15, offset: 59372},
+											pos:  position{line: 1628, col: 15, offset: 59421},
 											name: "LiteralBlock",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1628, col: 15, offset: 59400},
+											pos:  position{line: 1629, col: 15, offset: 59449},
 											name: "RawParagraph",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1629, col: 15, offset: 59427},
+											pos:  position{line: 1630, col: 15, offset: 59476},
 											name: "StandaloneAttributes",
 										},
 									},
@@ -10634,42 +10634,42 @@ var g = &grammar{
 		},
 		{
 			name: "QuoteBlock",
-			pos:  position{line: 1636, col: 1, offset: 59683},
+			pos:  position{line: 1637, col: 1, offset: 59732},
 			expr: &actionExpr{
-				pos: position{line: 1636, col: 15, offset: 59697},
+				pos: position{line: 1637, col: 15, offset: 59746},
 				run: (*parser).callonQuoteBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1636, col: 15, offset: 59697},
+					pos: position{line: 1637, col: 15, offset: 59746},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1636, col: 15, offset: 59697},
+							pos:   position{line: 1637, col: 15, offset: 59746},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1636, col: 26, offset: 59708},
+								pos: position{line: 1637, col: 26, offset: 59757},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1636, col: 27, offset: 59709},
+									pos:  position{line: 1637, col: 27, offset: 59758},
 									name: "BlockAttributes",
 								},
 							},
 						},
 						&andCodeExpr{
-							pos: position{line: 1637, col: 5, offset: 59732},
+							pos: position{line: 1638, col: 5, offset: 59781},
 							run: (*parser).callonQuoteBlock6,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1645, col: 5, offset: 60042},
+							pos:  position{line: 1646, col: 5, offset: 60091},
 							name: "QuoteBlockStartDelimiter",
 						},
 						&labeledExpr{
-							pos:   position{line: 1645, col: 30, offset: 60067},
+							pos:   position{line: 1646, col: 30, offset: 60116},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1645, col: 39, offset: 60076},
+								pos:  position{line: 1646, col: 39, offset: 60125},
 								name: "QuoteBlockRawContent",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1645, col: 61, offset: 60098},
+							pos:  position{line: 1646, col: 61, offset: 60147},
 							name: "QuoteBlockEndDelimiter",
 						},
 					},
@@ -10678,25 +10678,25 @@ var g = &grammar{
 		},
 		{
 			name: "QuoteBlockDelimiter",
-			pos:  position{line: 1649, col: 1, offset: 60202},
+			pos:  position{line: 1650, col: 1, offset: 60251},
 			expr: &seqExpr{
-				pos: position{line: 1649, col: 24, offset: 60225},
+				pos: position{line: 1650, col: 24, offset: 60274},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1649, col: 24, offset: 60225},
+						pos:        position{line: 1650, col: 24, offset: 60274},
 						val:        "____",
 						ignoreCase: false,
 						want:       "\"____\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1649, col: 31, offset: 60232},
+						pos: position{line: 1650, col: 31, offset: 60281},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1649, col: 31, offset: 60232},
+							pos:  position{line: 1650, col: 31, offset: 60281},
 							name: "Space",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1649, col: 38, offset: 60239},
+						pos:  position{line: 1650, col: 38, offset: 60288},
 						name: "EOL",
 					},
 				},
@@ -10704,25 +10704,25 @@ var g = &grammar{
 		},
 		{
 			name: "QuoteBlockStartDelimiter",
-			pos:  position{line: 1651, col: 1, offset: 60269},
+			pos:  position{line: 1652, col: 1, offset: 60318},
 			expr: &seqExpr{
-				pos: position{line: 1651, col: 29, offset: 60297},
+				pos: position{line: 1652, col: 29, offset: 60346},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1651, col: 29, offset: 60297},
+						pos:        position{line: 1652, col: 29, offset: 60346},
 						val:        "____",
 						ignoreCase: false,
 						want:       "\"____\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1651, col: 36, offset: 60304},
+						pos: position{line: 1652, col: 36, offset: 60353},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1651, col: 36, offset: 60304},
+							pos:  position{line: 1652, col: 36, offset: 60353},
 							name: "Space",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1651, col: 43, offset: 60311},
+						pos:  position{line: 1652, col: 43, offset: 60360},
 						name: "EOL",
 					},
 				},
@@ -10730,34 +10730,34 @@ var g = &grammar{
 		},
 		{
 			name: "QuoteBlockEndDelimiter",
-			pos:  position{line: 1653, col: 1, offset: 60341},
+			pos:  position{line: 1654, col: 1, offset: 60390},
 			expr: &choiceExpr{
-				pos: position{line: 1653, col: 27, offset: 60367},
+				pos: position{line: 1654, col: 27, offset: 60416},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 1653, col: 28, offset: 60368},
+						pos: position{line: 1654, col: 28, offset: 60417},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 1653, col: 28, offset: 60368},
+								pos:        position{line: 1654, col: 28, offset: 60417},
 								val:        "____",
 								ignoreCase: false,
 								want:       "\"____\"",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 1653, col: 35, offset: 60375},
+								pos: position{line: 1654, col: 35, offset: 60424},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1653, col: 35, offset: 60375},
+									pos:  position{line: 1654, col: 35, offset: 60424},
 									name: "Space",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1653, col: 42, offset: 60382},
+								pos:  position{line: 1654, col: 42, offset: 60431},
 								name: "EOL",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1653, col: 49, offset: 60389},
+						pos:  position{line: 1654, col: 49, offset: 60438},
 						name: "EOF",
 					},
 				},
@@ -10765,102 +10765,102 @@ var g = &grammar{
 		},
 		{
 			name: "QuoteBlockRawContent",
-			pos:  position{line: 1655, col: 1, offset: 60419},
+			pos:  position{line: 1656, col: 1, offset: 60468},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1655, col: 25, offset: 60443},
+				pos: position{line: 1656, col: 25, offset: 60492},
 				expr: &actionExpr{
-					pos: position{line: 1656, col: 8, offset: 60452},
+					pos: position{line: 1657, col: 8, offset: 60501},
 					run: (*parser).callonQuoteBlockRawContent2,
 					expr: &seqExpr{
-						pos: position{line: 1656, col: 8, offset: 60452},
+						pos: position{line: 1657, col: 8, offset: 60501},
 						exprs: []interface{}{
 							&notExpr{
-								pos: position{line: 1656, col: 8, offset: 60452},
+								pos: position{line: 1657, col: 8, offset: 60501},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1656, col: 9, offset: 60453},
+									pos:  position{line: 1657, col: 9, offset: 60502},
 									name: "QuoteBlockEndDelimiter",
 								},
 							},
 							&labeledExpr{
-								pos:   position{line: 1657, col: 8, offset: 60484},
+								pos:   position{line: 1658, col: 8, offset: 60533},
 								label: "element",
 								expr: &choiceExpr{
-									pos: position{line: 1657, col: 17, offset: 60493},
+									pos: position{line: 1658, col: 17, offset: 60542},
 									alternatives: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 1657, col: 17, offset: 60493},
+											pos:  position{line: 1658, col: 17, offset: 60542},
 											name: "BlankLine",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1658, col: 15, offset: 60517},
+											pos:  position{line: 1659, col: 15, offset: 60566},
 											name: "ImageBlock",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1659, col: 15, offset: 60542},
+											pos:  position{line: 1660, col: 15, offset: 60591},
 											name: "ThematicBreak",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1660, col: 15, offset: 60570},
+											pos:  position{line: 1661, col: 15, offset: 60619},
 											name: "OrderedListItem",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1661, col: 15, offset: 60601},
+											pos:  position{line: 1662, col: 15, offset: 60650},
 											name: "UnorderedListItem",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1662, col: 15, offset: 60634},
+											pos:  position{line: 1663, col: 15, offset: 60683},
 											name: "LabeledListItem",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1663, col: 15, offset: 60665},
+											pos:  position{line: 1664, col: 15, offset: 60714},
 											name: "ContinuedListItemElement",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1664, col: 15, offset: 60704},
+											pos:  position{line: 1665, col: 15, offset: 60753},
 											name: "FencedBlock",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1665, col: 15, offset: 60731},
+											pos:  position{line: 1666, col: 15, offset: 60780},
 											name: "ListingBlock",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1666, col: 15, offset: 60759},
+											pos:  position{line: 1667, col: 15, offset: 60808},
 											name: "VerseBlock",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1667, col: 15, offset: 60784},
+											pos:  position{line: 1668, col: 15, offset: 60833},
 											name: "ExampleBlock",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1668, col: 15, offset: 60811},
+											pos:  position{line: 1669, col: 15, offset: 60860},
 											name: "SidebarBlock",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1669, col: 15, offset: 60838},
+											pos:  position{line: 1670, col: 15, offset: 60887},
 											name: "SingleLineComment",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1670, col: 15, offset: 60870},
+											pos:  position{line: 1671, col: 15, offset: 60919},
 											name: "PassthroughBlock",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1671, col: 15, offset: 60901},
+											pos:  position{line: 1672, col: 15, offset: 60950},
 											name: "Table",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1672, col: 15, offset: 60921},
+											pos:  position{line: 1673, col: 15, offset: 60970},
 											name: "CommentBlock",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1673, col: 15, offset: 60948},
+											pos:  position{line: 1674, col: 15, offset: 60997},
 											name: "LiteralBlock",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1674, col: 15, offset: 60976},
+											pos:  position{line: 1675, col: 15, offset: 61025},
 											name: "RawParagraph",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1675, col: 15, offset: 61003},
+											pos:  position{line: 1676, col: 15, offset: 61052},
 											name: "StandaloneAttributes",
 										},
 									},
@@ -10873,38 +10873,38 @@ var g = &grammar{
 		},
 		{
 			name: "SidebarBlock",
-			pos:  position{line: 1682, col: 1, offset: 61261},
+			pos:  position{line: 1683, col: 1, offset: 61310},
 			expr: &actionExpr{
-				pos: position{line: 1682, col: 17, offset: 61277},
+				pos: position{line: 1683, col: 17, offset: 61326},
 				run: (*parser).callonSidebarBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1682, col: 17, offset: 61277},
+					pos: position{line: 1683, col: 17, offset: 61326},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1682, col: 17, offset: 61277},
+							pos:   position{line: 1683, col: 17, offset: 61326},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1682, col: 28, offset: 61288},
+								pos: position{line: 1683, col: 28, offset: 61337},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1682, col: 29, offset: 61289},
+									pos:  position{line: 1683, col: 29, offset: 61338},
 									name: "BlockAttributes",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1682, col: 47, offset: 61307},
+							pos:  position{line: 1683, col: 47, offset: 61356},
 							name: "SidebarBlockStartDelimiter",
 						},
 						&labeledExpr{
-							pos:   position{line: 1682, col: 74, offset: 61334},
+							pos:   position{line: 1683, col: 74, offset: 61383},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1682, col: 83, offset: 61343},
+								pos:  position{line: 1683, col: 83, offset: 61392},
 								name: "SidebarBlockRawContent",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1682, col: 107, offset: 61367},
+							pos:  position{line: 1683, col: 107, offset: 61416},
 							name: "SidebarBlockEndDelimiter",
 						},
 					},
@@ -10913,25 +10913,25 @@ var g = &grammar{
 		},
 		{
 			name: "SidebarBlockDelimiter",
-			pos:  position{line: 1686, col: 1, offset: 61467},
+			pos:  position{line: 1687, col: 1, offset: 61516},
 			expr: &seqExpr{
-				pos: position{line: 1686, col: 26, offset: 61492},
+				pos: position{line: 1687, col: 26, offset: 61541},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1686, col: 26, offset: 61492},
+						pos:        position{line: 1687, col: 26, offset: 61541},
 						val:        "****",
 						ignoreCase: false,
 						want:       "\"****\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1686, col: 33, offset: 61499},
+						pos: position{line: 1687, col: 33, offset: 61548},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1686, col: 33, offset: 61499},
+							pos:  position{line: 1687, col: 33, offset: 61548},
 							name: "Space",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1686, col: 40, offset: 61506},
+						pos:  position{line: 1687, col: 40, offset: 61555},
 						name: "EOL",
 					},
 				},
@@ -10939,25 +10939,25 @@ var g = &grammar{
 		},
 		{
 			name: "SidebarBlockStartDelimiter",
-			pos:  position{line: 1688, col: 1, offset: 61511},
+			pos:  position{line: 1689, col: 1, offset: 61560},
 			expr: &seqExpr{
-				pos: position{line: 1688, col: 31, offset: 61541},
+				pos: position{line: 1689, col: 31, offset: 61590},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1688, col: 31, offset: 61541},
+						pos:        position{line: 1689, col: 31, offset: 61590},
 						val:        "****",
 						ignoreCase: false,
 						want:       "\"****\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1688, col: 38, offset: 61548},
+						pos: position{line: 1689, col: 38, offset: 61597},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1688, col: 38, offset: 61548},
+							pos:  position{line: 1689, col: 38, offset: 61597},
 							name: "Space",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1688, col: 45, offset: 61555},
+						pos:  position{line: 1689, col: 45, offset: 61604},
 						name: "EOL",
 					},
 				},
@@ -10965,34 +10965,34 @@ var g = &grammar{
 		},
 		{
 			name: "SidebarBlockEndDelimiter",
-			pos:  position{line: 1690, col: 1, offset: 61560},
+			pos:  position{line: 1691, col: 1, offset: 61609},
 			expr: &choiceExpr{
-				pos: position{line: 1690, col: 29, offset: 61588},
+				pos: position{line: 1691, col: 29, offset: 61637},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 1690, col: 30, offset: 61589},
+						pos: position{line: 1691, col: 30, offset: 61638},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 1690, col: 30, offset: 61589},
+								pos:        position{line: 1691, col: 30, offset: 61638},
 								val:        "****",
 								ignoreCase: false,
 								want:       "\"****\"",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 1690, col: 37, offset: 61596},
+								pos: position{line: 1691, col: 37, offset: 61645},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1690, col: 37, offset: 61596},
+									pos:  position{line: 1691, col: 37, offset: 61645},
 									name: "Space",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1690, col: 44, offset: 61603},
+								pos:  position{line: 1691, col: 44, offset: 61652},
 								name: "EOL",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1690, col: 51, offset: 61610},
+						pos:  position{line: 1691, col: 51, offset: 61659},
 						name: "EOF",
 					},
 				},
@@ -11000,102 +11000,102 @@ var g = &grammar{
 		},
 		{
 			name: "SidebarBlockRawContent",
-			pos:  position{line: 1692, col: 1, offset: 61615},
+			pos:  position{line: 1693, col: 1, offset: 61664},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1692, col: 27, offset: 61641},
+				pos: position{line: 1693, col: 27, offset: 61690},
 				expr: &actionExpr{
-					pos: position{line: 1693, col: 8, offset: 61650},
+					pos: position{line: 1694, col: 8, offset: 61699},
 					run: (*parser).callonSidebarBlockRawContent2,
 					expr: &seqExpr{
-						pos: position{line: 1693, col: 8, offset: 61650},
+						pos: position{line: 1694, col: 8, offset: 61699},
 						exprs: []interface{}{
 							&notExpr{
-								pos: position{line: 1693, col: 8, offset: 61650},
+								pos: position{line: 1694, col: 8, offset: 61699},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1693, col: 9, offset: 61651},
+									pos:  position{line: 1694, col: 9, offset: 61700},
 									name: "SidebarBlockEndDelimiter",
 								},
 							},
 							&labeledExpr{
-								pos:   position{line: 1694, col: 8, offset: 61684},
+								pos:   position{line: 1695, col: 8, offset: 61733},
 								label: "element",
 								expr: &choiceExpr{
-									pos: position{line: 1694, col: 17, offset: 61693},
+									pos: position{line: 1695, col: 17, offset: 61742},
 									alternatives: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 1694, col: 17, offset: 61693},
+											pos:  position{line: 1695, col: 17, offset: 61742},
 											name: "BlankLine",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1695, col: 15, offset: 61717},
+											pos:  position{line: 1696, col: 15, offset: 61766},
 											name: "ImageBlock",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1696, col: 15, offset: 61742},
+											pos:  position{line: 1697, col: 15, offset: 61791},
 											name: "ThematicBreak",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1697, col: 15, offset: 61770},
+											pos:  position{line: 1698, col: 15, offset: 61819},
 											name: "OrderedListItem",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1698, col: 15, offset: 61801},
+											pos:  position{line: 1699, col: 15, offset: 61850},
 											name: "UnorderedListItem",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1699, col: 15, offset: 61834},
+											pos:  position{line: 1700, col: 15, offset: 61883},
 											name: "LabeledListItem",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1700, col: 15, offset: 61865},
+											pos:  position{line: 1701, col: 15, offset: 61914},
 											name: "ContinuedListItemElement",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1701, col: 15, offset: 61904},
+											pos:  position{line: 1702, col: 15, offset: 61953},
 											name: "FencedBlock",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1702, col: 15, offset: 61931},
+											pos:  position{line: 1703, col: 15, offset: 61980},
 											name: "ListingBlock",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1703, col: 15, offset: 61958},
+											pos:  position{line: 1704, col: 15, offset: 62007},
 											name: "VerseBlock",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1704, col: 15, offset: 61984},
+											pos:  position{line: 1705, col: 15, offset: 62033},
 											name: "ExampleBlock",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1705, col: 15, offset: 62011},
+											pos:  position{line: 1706, col: 15, offset: 62060},
 											name: "QuoteBlock",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1706, col: 15, offset: 62036},
+											pos:  position{line: 1707, col: 15, offset: 62085},
 											name: "SingleLineComment",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1707, col: 15, offset: 62068},
+											pos:  position{line: 1708, col: 15, offset: 62117},
 											name: "PassthroughBlock",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1708, col: 15, offset: 62099},
+											pos:  position{line: 1709, col: 15, offset: 62148},
 											name: "Table",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1709, col: 15, offset: 62119},
+											pos:  position{line: 1710, col: 15, offset: 62168},
 											name: "CommentBlock",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1710, col: 15, offset: 62146},
+											pos:  position{line: 1711, col: 15, offset: 62195},
 											name: "LiteralBlock",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1711, col: 15, offset: 62174},
+											pos:  position{line: 1712, col: 15, offset: 62223},
 											name: "RawParagraph",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1712, col: 15, offset: 62201},
+											pos:  position{line: 1713, col: 15, offset: 62250},
 											name: "StandaloneAttributes",
 										},
 									},
@@ -11108,38 +11108,38 @@ var g = &grammar{
 		},
 		{
 			name: "FencedBlock",
-			pos:  position{line: 1719, col: 1, offset: 62458},
+			pos:  position{line: 1720, col: 1, offset: 62507},
 			expr: &actionExpr{
-				pos: position{line: 1719, col: 16, offset: 62473},
+				pos: position{line: 1720, col: 16, offset: 62522},
 				run: (*parser).callonFencedBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1719, col: 16, offset: 62473},
+					pos: position{line: 1720, col: 16, offset: 62522},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1719, col: 16, offset: 62473},
+							pos:   position{line: 1720, col: 16, offset: 62522},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1719, col: 27, offset: 62484},
+								pos: position{line: 1720, col: 27, offset: 62533},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1719, col: 28, offset: 62485},
+									pos:  position{line: 1720, col: 28, offset: 62534},
 									name: "BlockAttributes",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1719, col: 46, offset: 62503},
+							pos:  position{line: 1720, col: 46, offset: 62552},
 							name: "FencedBlockStartDelimiter",
 						},
 						&labeledExpr{
-							pos:   position{line: 1719, col: 72, offset: 62529},
+							pos:   position{line: 1720, col: 72, offset: 62578},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1719, col: 81, offset: 62538},
+								pos:  position{line: 1720, col: 81, offset: 62587},
 								name: "FencedBlockRawContent",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1719, col: 104, offset: 62561},
+							pos:  position{line: 1720, col: 104, offset: 62610},
 							name: "FencedBlockEndDelimiter",
 						},
 					},
@@ -11148,25 +11148,25 @@ var g = &grammar{
 		},
 		{
 			name: "FencedBlockDelimiter",
-			pos:  position{line: 1723, col: 1, offset: 62659},
+			pos:  position{line: 1724, col: 1, offset: 62708},
 			expr: &seqExpr{
-				pos: position{line: 1723, col: 25, offset: 62683},
+				pos: position{line: 1724, col: 25, offset: 62732},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1723, col: 25, offset: 62683},
+						pos:        position{line: 1724, col: 25, offset: 62732},
 						val:        "```",
 						ignoreCase: false,
 						want:       "\"```\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1723, col: 31, offset: 62689},
+						pos: position{line: 1724, col: 31, offset: 62738},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1723, col: 31, offset: 62689},
+							pos:  position{line: 1724, col: 31, offset: 62738},
 							name: "Space",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1723, col: 38, offset: 62696},
+						pos:  position{line: 1724, col: 38, offset: 62745},
 						name: "EOL",
 					},
 				},
@@ -11174,25 +11174,25 @@ var g = &grammar{
 		},
 		{
 			name: "FencedBlockStartDelimiter",
-			pos:  position{line: 1725, col: 1, offset: 62756},
+			pos:  position{line: 1726, col: 1, offset: 62805},
 			expr: &seqExpr{
-				pos: position{line: 1725, col: 30, offset: 62785},
+				pos: position{line: 1726, col: 30, offset: 62834},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1725, col: 30, offset: 62785},
+						pos:        position{line: 1726, col: 30, offset: 62834},
 						val:        "```",
 						ignoreCase: false,
 						want:       "\"```\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1725, col: 36, offset: 62791},
+						pos: position{line: 1726, col: 36, offset: 62840},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1725, col: 36, offset: 62791},
+							pos:  position{line: 1726, col: 36, offset: 62840},
 							name: "Space",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1725, col: 43, offset: 62798},
+						pos:  position{line: 1726, col: 43, offset: 62847},
 						name: "EOL",
 					},
 				},
@@ -11200,34 +11200,34 @@ var g = &grammar{
 		},
 		{
 			name: "FencedBlockEndDelimiter",
-			pos:  position{line: 1727, col: 1, offset: 62803},
+			pos:  position{line: 1728, col: 1, offset: 62852},
 			expr: &choiceExpr{
-				pos: position{line: 1727, col: 28, offset: 62830},
+				pos: position{line: 1728, col: 28, offset: 62879},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 1727, col: 29, offset: 62831},
+						pos: position{line: 1728, col: 29, offset: 62880},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 1727, col: 29, offset: 62831},
+								pos:        position{line: 1728, col: 29, offset: 62880},
 								val:        "```",
 								ignoreCase: false,
 								want:       "\"```\"",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 1727, col: 35, offset: 62837},
+								pos: position{line: 1728, col: 35, offset: 62886},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1727, col: 35, offset: 62837},
+									pos:  position{line: 1728, col: 35, offset: 62886},
 									name: "Space",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1727, col: 42, offset: 62844},
+								pos:  position{line: 1728, col: 42, offset: 62893},
 								name: "EOL",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1727, col: 49, offset: 62851},
+						pos:  position{line: 1728, col: 49, offset: 62900},
 						name: "EOF",
 					},
 				},
@@ -11235,27 +11235,27 @@ var g = &grammar{
 		},
 		{
 			name: "FencedBlockRawContent",
-			pos:  position{line: 1729, col: 1, offset: 62856},
+			pos:  position{line: 1730, col: 1, offset: 62905},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1729, col: 26, offset: 62881},
+				pos: position{line: 1730, col: 26, offset: 62930},
 				expr: &actionExpr{
-					pos: position{line: 1729, col: 27, offset: 62882},
+					pos: position{line: 1730, col: 27, offset: 62931},
 					run: (*parser).callonFencedBlockRawContent2,
 					expr: &seqExpr{
-						pos: position{line: 1729, col: 27, offset: 62882},
+						pos: position{line: 1730, col: 27, offset: 62931},
 						exprs: []interface{}{
 							&notExpr{
-								pos: position{line: 1729, col: 27, offset: 62882},
+								pos: position{line: 1730, col: 27, offset: 62931},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1729, col: 28, offset: 62883},
+									pos:  position{line: 1730, col: 28, offset: 62932},
 									name: "FencedBlockEndDelimiter",
 								},
 							},
 							&labeledExpr{
-								pos:   position{line: 1729, col: 52, offset: 62907},
+								pos:   position{line: 1730, col: 52, offset: 62956},
 								label: "line",
 								expr: &ruleRefExpr{
-									pos:  position{line: 1729, col: 58, offset: 62913},
+									pos:  position{line: 1730, col: 58, offset: 62962},
 									name: "RawLine",
 								},
 							},
@@ -11266,38 +11266,38 @@ var g = &grammar{
 		},
 		{
 			name: "ListingBlock",
-			pos:  position{line: 1736, col: 1, offset: 63147},
+			pos:  position{line: 1737, col: 1, offset: 63196},
 			expr: &actionExpr{
-				pos: position{line: 1736, col: 17, offset: 63163},
+				pos: position{line: 1737, col: 17, offset: 63212},
 				run: (*parser).callonListingBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1736, col: 17, offset: 63163},
+					pos: position{line: 1737, col: 17, offset: 63212},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1736, col: 17, offset: 63163},
+							pos:   position{line: 1737, col: 17, offset: 63212},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1736, col: 28, offset: 63174},
+								pos: position{line: 1737, col: 28, offset: 63223},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1736, col: 29, offset: 63175},
+									pos:  position{line: 1737, col: 29, offset: 63224},
 									name: "BlockAttributes",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1736, col: 47, offset: 63193},
+							pos:  position{line: 1737, col: 47, offset: 63242},
 							name: "ListingBlockStartDelimiter",
 						},
 						&labeledExpr{
-							pos:   position{line: 1736, col: 74, offset: 63220},
+							pos:   position{line: 1737, col: 74, offset: 63269},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1736, col: 83, offset: 63229},
+								pos:  position{line: 1737, col: 83, offset: 63278},
 								name: "ListingBlockRawContent",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1736, col: 107, offset: 63253},
+							pos:  position{line: 1737, col: 107, offset: 63302},
 							name: "ListingBlockEndDelimiter",
 						},
 					},
@@ -11306,25 +11306,25 @@ var g = &grammar{
 		},
 		{
 			name: "ListingBlockDelimiter",
-			pos:  position{line: 1740, col: 1, offset: 63353},
+			pos:  position{line: 1741, col: 1, offset: 63402},
 			expr: &seqExpr{
-				pos: position{line: 1740, col: 26, offset: 63378},
+				pos: position{line: 1741, col: 26, offset: 63427},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1740, col: 26, offset: 63378},
+						pos:        position{line: 1741, col: 26, offset: 63427},
 						val:        "----",
 						ignoreCase: false,
 						want:       "\"----\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1740, col: 33, offset: 63385},
+						pos: position{line: 1741, col: 33, offset: 63434},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1740, col: 33, offset: 63385},
+							pos:  position{line: 1741, col: 33, offset: 63434},
 							name: "Space",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1740, col: 40, offset: 63392},
+						pos:  position{line: 1741, col: 40, offset: 63441},
 						name: "EOL",
 					},
 				},
@@ -11332,25 +11332,25 @@ var g = &grammar{
 		},
 		{
 			name: "ListingBlockStartDelimiter",
-			pos:  position{line: 1742, col: 1, offset: 63397},
+			pos:  position{line: 1743, col: 1, offset: 63446},
 			expr: &seqExpr{
-				pos: position{line: 1742, col: 31, offset: 63427},
+				pos: position{line: 1743, col: 31, offset: 63476},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1742, col: 31, offset: 63427},
+						pos:        position{line: 1743, col: 31, offset: 63476},
 						val:        "----",
 						ignoreCase: false,
 						want:       "\"----\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1742, col: 38, offset: 63434},
+						pos: position{line: 1743, col: 38, offset: 63483},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1742, col: 38, offset: 63434},
+							pos:  position{line: 1743, col: 38, offset: 63483},
 							name: "Space",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1742, col: 45, offset: 63441},
+						pos:  position{line: 1743, col: 45, offset: 63490},
 						name: "EOL",
 					},
 				},
@@ -11358,34 +11358,34 @@ var g = &grammar{
 		},
 		{
 			name: "ListingBlockEndDelimiter",
-			pos:  position{line: 1744, col: 1, offset: 63446},
+			pos:  position{line: 1745, col: 1, offset: 63495},
 			expr: &choiceExpr{
-				pos: position{line: 1744, col: 29, offset: 63474},
+				pos: position{line: 1745, col: 29, offset: 63523},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 1744, col: 30, offset: 63475},
+						pos: position{line: 1745, col: 30, offset: 63524},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 1744, col: 30, offset: 63475},
+								pos:        position{line: 1745, col: 30, offset: 63524},
 								val:        "----",
 								ignoreCase: false,
 								want:       "\"----\"",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 1744, col: 37, offset: 63482},
+								pos: position{line: 1745, col: 37, offset: 63531},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1744, col: 37, offset: 63482},
+									pos:  position{line: 1745, col: 37, offset: 63531},
 									name: "Space",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1744, col: 44, offset: 63489},
+								pos:  position{line: 1745, col: 44, offset: 63538},
 								name: "EOL",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1744, col: 51, offset: 63496},
+						pos:  position{line: 1745, col: 51, offset: 63545},
 						name: "EOF",
 					},
 				},
@@ -11393,27 +11393,27 @@ var g = &grammar{
 		},
 		{
 			name: "ListingBlockRawContent",
-			pos:  position{line: 1746, col: 1, offset: 63501},
+			pos:  position{line: 1747, col: 1, offset: 63550},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1746, col: 27, offset: 63527},
+				pos: position{line: 1747, col: 27, offset: 63576},
 				expr: &actionExpr{
-					pos: position{line: 1746, col: 28, offset: 63528},
+					pos: position{line: 1747, col: 28, offset: 63577},
 					run: (*parser).callonListingBlockRawContent2,
 					expr: &seqExpr{
-						pos: position{line: 1746, col: 28, offset: 63528},
+						pos: position{line: 1747, col: 28, offset: 63577},
 						exprs: []interface{}{
 							&notExpr{
-								pos: position{line: 1746, col: 28, offset: 63528},
+								pos: position{line: 1747, col: 28, offset: 63577},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1746, col: 29, offset: 63529},
+									pos:  position{line: 1747, col: 29, offset: 63578},
 									name: "ListingBlockEndDelimiter",
 								},
 							},
 							&labeledExpr{
-								pos:   position{line: 1746, col: 54, offset: 63554},
+								pos:   position{line: 1747, col: 54, offset: 63603},
 								label: "line",
 								expr: &ruleRefExpr{
-									pos:  position{line: 1746, col: 60, offset: 63560},
+									pos:  position{line: 1747, col: 60, offset: 63609},
 									name: "RawLine",
 								},
 							},
@@ -11424,42 +11424,42 @@ var g = &grammar{
 		},
 		{
 			name: "VerseBlock",
-			pos:  position{line: 1753, col: 1, offset: 63792},
+			pos:  position{line: 1754, col: 1, offset: 63841},
 			expr: &actionExpr{
-				pos: position{line: 1753, col: 15, offset: 63806},
+				pos: position{line: 1754, col: 15, offset: 63855},
 				run: (*parser).callonVerseBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1753, col: 15, offset: 63806},
+					pos: position{line: 1754, col: 15, offset: 63855},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1753, col: 15, offset: 63806},
+							pos:   position{line: 1754, col: 15, offset: 63855},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1753, col: 26, offset: 63817},
+								pos: position{line: 1754, col: 26, offset: 63866},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1753, col: 27, offset: 63818},
+									pos:  position{line: 1754, col: 27, offset: 63867},
 									name: "BlockAttributes",
 								},
 							},
 						},
 						&andCodeExpr{
-							pos: position{line: 1754, col: 5, offset: 63841},
+							pos: position{line: 1755, col: 5, offset: 63890},
 							run: (*parser).callonVerseBlock6,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1758, col: 5, offset: 64002},
+							pos:  position{line: 1759, col: 5, offset: 64051},
 							name: "QuoteBlockStartDelimiter",
 						},
 						&labeledExpr{
-							pos:   position{line: 1758, col: 30, offset: 64027},
+							pos:   position{line: 1759, col: 30, offset: 64076},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1758, col: 39, offset: 64036},
+								pos:  position{line: 1759, col: 39, offset: 64085},
 								name: "VerseBlockRawContent",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1758, col: 61, offset: 64058},
+							pos:  position{line: 1759, col: 61, offset: 64107},
 							name: "QuoteBlockEndDelimiter",
 						},
 					},
@@ -11468,27 +11468,27 @@ var g = &grammar{
 		},
 		{
 			name: "VerseBlockRawContent",
-			pos:  position{line: 1762, col: 1, offset: 64162},
+			pos:  position{line: 1763, col: 1, offset: 64211},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1762, col: 25, offset: 64186},
+				pos: position{line: 1763, col: 25, offset: 64235},
 				expr: &actionExpr{
-					pos: position{line: 1762, col: 26, offset: 64187},
+					pos: position{line: 1763, col: 26, offset: 64236},
 					run: (*parser).callonVerseBlockRawContent2,
 					expr: &seqExpr{
-						pos: position{line: 1762, col: 26, offset: 64187},
+						pos: position{line: 1763, col: 26, offset: 64236},
 						exprs: []interface{}{
 							&notExpr{
-								pos: position{line: 1762, col: 26, offset: 64187},
+								pos: position{line: 1763, col: 26, offset: 64236},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1762, col: 27, offset: 64188},
+									pos:  position{line: 1763, col: 27, offset: 64237},
 									name: "QuoteBlockEndDelimiter",
 								},
 							},
 							&labeledExpr{
-								pos:   position{line: 1762, col: 50, offset: 64211},
+								pos:   position{line: 1763, col: 50, offset: 64260},
 								label: "line",
 								expr: &ruleRefExpr{
-									pos:  position{line: 1762, col: 56, offset: 64217},
+									pos:  position{line: 1763, col: 56, offset: 64266},
 									name: "RawLine",
 								},
 							},
@@ -11499,38 +11499,38 @@ var g = &grammar{
 		},
 		{
 			name: "PassthroughBlock",
-			pos:  position{line: 1769, col: 1, offset: 64455},
+			pos:  position{line: 1770, col: 1, offset: 64504},
 			expr: &actionExpr{
-				pos: position{line: 1769, col: 21, offset: 64475},
+				pos: position{line: 1770, col: 21, offset: 64524},
 				run: (*parser).callonPassthroughBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1769, col: 21, offset: 64475},
+					pos: position{line: 1770, col: 21, offset: 64524},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1769, col: 21, offset: 64475},
+							pos:   position{line: 1770, col: 21, offset: 64524},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1769, col: 32, offset: 64486},
+								pos: position{line: 1770, col: 32, offset: 64535},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1769, col: 33, offset: 64487},
+									pos:  position{line: 1770, col: 33, offset: 64536},
 									name: "BlockAttributes",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1769, col: 51, offset: 64505},
+							pos:  position{line: 1770, col: 51, offset: 64554},
 							name: "PassthroughBlockStartDelimiter",
 						},
 						&labeledExpr{
-							pos:   position{line: 1769, col: 82, offset: 64536},
+							pos:   position{line: 1770, col: 82, offset: 64585},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1769, col: 91, offset: 64545},
+								pos:  position{line: 1770, col: 91, offset: 64594},
 								name: "PassthroughBlockRawContent",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1769, col: 119, offset: 64573},
+							pos:  position{line: 1770, col: 119, offset: 64622},
 							name: "PassthroughBlockEndDelimiter",
 						},
 					},
@@ -11539,25 +11539,25 @@ var g = &grammar{
 		},
 		{
 			name: "PassthroughBlockDelimiter",
-			pos:  position{line: 1773, col: 1, offset: 64681},
+			pos:  position{line: 1774, col: 1, offset: 64730},
 			expr: &seqExpr{
-				pos: position{line: 1773, col: 30, offset: 64710},
+				pos: position{line: 1774, col: 30, offset: 64759},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1773, col: 30, offset: 64710},
+						pos:        position{line: 1774, col: 30, offset: 64759},
 						val:        "++++",
 						ignoreCase: false,
 						want:       "\"++++\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1773, col: 37, offset: 64717},
+						pos: position{line: 1774, col: 37, offset: 64766},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1773, col: 37, offset: 64717},
+							pos:  position{line: 1774, col: 37, offset: 64766},
 							name: "Space",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1773, col: 44, offset: 64724},
+						pos:  position{line: 1774, col: 44, offset: 64773},
 						name: "EOL",
 					},
 				},
@@ -11565,25 +11565,25 @@ var g = &grammar{
 		},
 		{
 			name: "PassthroughBlockStartDelimiter",
-			pos:  position{line: 1775, col: 1, offset: 64729},
+			pos:  position{line: 1776, col: 1, offset: 64778},
 			expr: &seqExpr{
-				pos: position{line: 1775, col: 35, offset: 64763},
+				pos: position{line: 1776, col: 35, offset: 64812},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1775, col: 35, offset: 64763},
+						pos:        position{line: 1776, col: 35, offset: 64812},
 						val:        "++++",
 						ignoreCase: false,
 						want:       "\"++++\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1775, col: 42, offset: 64770},
+						pos: position{line: 1776, col: 42, offset: 64819},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1775, col: 42, offset: 64770},
+							pos:  position{line: 1776, col: 42, offset: 64819},
 							name: "Space",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1775, col: 49, offset: 64777},
+						pos:  position{line: 1776, col: 49, offset: 64826},
 						name: "EOL",
 					},
 				},
@@ -11591,34 +11591,34 @@ var g = &grammar{
 		},
 		{
 			name: "PassthroughBlockEndDelimiter",
-			pos:  position{line: 1777, col: 1, offset: 64782},
+			pos:  position{line: 1778, col: 1, offset: 64831},
 			expr: &choiceExpr{
-				pos: position{line: 1777, col: 33, offset: 64814},
+				pos: position{line: 1778, col: 33, offset: 64863},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 1777, col: 34, offset: 64815},
+						pos: position{line: 1778, col: 34, offset: 64864},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 1777, col: 34, offset: 64815},
+								pos:        position{line: 1778, col: 34, offset: 64864},
 								val:        "++++",
 								ignoreCase: false,
 								want:       "\"++++\"",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 1777, col: 41, offset: 64822},
+								pos: position{line: 1778, col: 41, offset: 64871},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1777, col: 41, offset: 64822},
+									pos:  position{line: 1778, col: 41, offset: 64871},
 									name: "Space",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1777, col: 48, offset: 64829},
+								pos:  position{line: 1778, col: 48, offset: 64878},
 								name: "EOL",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1777, col: 55, offset: 64836},
+						pos:  position{line: 1778, col: 55, offset: 64885},
 						name: "EOF",
 					},
 				},
@@ -11626,27 +11626,27 @@ var g = &grammar{
 		},
 		{
 			name: "PassthroughBlockRawContent",
-			pos:  position{line: 1779, col: 1, offset: 64841},
+			pos:  position{line: 1780, col: 1, offset: 64890},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1779, col: 31, offset: 64871},
+				pos: position{line: 1780, col: 31, offset: 64920},
 				expr: &actionExpr{
-					pos: position{line: 1779, col: 32, offset: 64872},
+					pos: position{line: 1780, col: 32, offset: 64921},
 					run: (*parser).callonPassthroughBlockRawContent2,
 					expr: &seqExpr{
-						pos: position{line: 1779, col: 32, offset: 64872},
+						pos: position{line: 1780, col: 32, offset: 64921},
 						exprs: []interface{}{
 							&notExpr{
-								pos: position{line: 1779, col: 32, offset: 64872},
+								pos: position{line: 1780, col: 32, offset: 64921},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1779, col: 33, offset: 64873},
+									pos:  position{line: 1780, col: 33, offset: 64922},
 									name: "PassthroughBlockEndDelimiter",
 								},
 							},
 							&labeledExpr{
-								pos:   position{line: 1779, col: 62, offset: 64902},
+								pos:   position{line: 1780, col: 62, offset: 64951},
 								label: "line",
 								expr: &ruleRefExpr{
-									pos:  position{line: 1779, col: 68, offset: 64908},
+									pos:  position{line: 1780, col: 68, offset: 64957},
 									name: "RawLine",
 								},
 							},
@@ -11657,25 +11657,25 @@ var g = &grammar{
 		},
 		{
 			name: "CommentBlockDelimiter",
-			pos:  position{line: 1786, col: 1, offset: 65142},
+			pos:  position{line: 1787, col: 1, offset: 65191},
 			expr: &seqExpr{
-				pos: position{line: 1786, col: 26, offset: 65167},
+				pos: position{line: 1787, col: 26, offset: 65216},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1786, col: 26, offset: 65167},
+						pos:        position{line: 1787, col: 26, offset: 65216},
 						val:        "////",
 						ignoreCase: false,
 						want:       "\"////\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1786, col: 33, offset: 65174},
+						pos: position{line: 1787, col: 33, offset: 65223},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1786, col: 33, offset: 65174},
+							pos:  position{line: 1787, col: 33, offset: 65223},
 							name: "Space",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1786, col: 40, offset: 65181},
+						pos:  position{line: 1787, col: 40, offset: 65230},
 						name: "EOL",
 					},
 				},
@@ -11683,25 +11683,25 @@ var g = &grammar{
 		},
 		{
 			name: "CommentBlockStartDelimiter",
-			pos:  position{line: 1788, col: 1, offset: 65186},
+			pos:  position{line: 1789, col: 1, offset: 65235},
 			expr: &seqExpr{
-				pos: position{line: 1788, col: 31, offset: 65216},
+				pos: position{line: 1789, col: 31, offset: 65265},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1788, col: 31, offset: 65216},
+						pos:        position{line: 1789, col: 31, offset: 65265},
 						val:        "////",
 						ignoreCase: false,
 						want:       "\"////\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1788, col: 38, offset: 65223},
+						pos: position{line: 1789, col: 38, offset: 65272},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1788, col: 38, offset: 65223},
+							pos:  position{line: 1789, col: 38, offset: 65272},
 							name: "Space",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1788, col: 45, offset: 65230},
+						pos:  position{line: 1789, col: 45, offset: 65279},
 						name: "EOL",
 					},
 				},
@@ -11709,34 +11709,34 @@ var g = &grammar{
 		},
 		{
 			name: "CommentBlockEndDelimiter",
-			pos:  position{line: 1790, col: 1, offset: 65235},
+			pos:  position{line: 1791, col: 1, offset: 65284},
 			expr: &choiceExpr{
-				pos: position{line: 1790, col: 29, offset: 65263},
+				pos: position{line: 1791, col: 29, offset: 65312},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 1790, col: 30, offset: 65264},
+						pos: position{line: 1791, col: 30, offset: 65313},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 1790, col: 30, offset: 65264},
+								pos:        position{line: 1791, col: 30, offset: 65313},
 								val:        "////",
 								ignoreCase: false,
 								want:       "\"////\"",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 1790, col: 37, offset: 65271},
+								pos: position{line: 1791, col: 37, offset: 65320},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1790, col: 37, offset: 65271},
+									pos:  position{line: 1791, col: 37, offset: 65320},
 									name: "Space",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1790, col: 44, offset: 65278},
+								pos:  position{line: 1791, col: 44, offset: 65327},
 								name: "EOL",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1790, col: 51, offset: 65285},
+						pos:  position{line: 1791, col: 51, offset: 65334},
 						name: "EOF",
 					},
 				},
@@ -11744,27 +11744,27 @@ var g = &grammar{
 		},
 		{
 			name: "CommentBlock",
-			pos:  position{line: 1792, col: 1, offset: 65290},
+			pos:  position{line: 1793, col: 1, offset: 65339},
 			expr: &actionExpr{
-				pos: position{line: 1792, col: 17, offset: 65306},
+				pos: position{line: 1793, col: 17, offset: 65355},
 				run: (*parser).callonCommentBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1792, col: 17, offset: 65306},
+					pos: position{line: 1793, col: 17, offset: 65355},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1792, col: 17, offset: 65306},
+							pos:  position{line: 1793, col: 17, offset: 65355},
 							name: "CommentBlockStartDelimiter",
 						},
 						&labeledExpr{
-							pos:   position{line: 1792, col: 44, offset: 65333},
+							pos:   position{line: 1793, col: 44, offset: 65382},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1792, col: 53, offset: 65342},
+								pos:  position{line: 1793, col: 53, offset: 65391},
 								name: "CommentBlockRawContent",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1792, col: 78, offset: 65367},
+							pos:  position{line: 1793, col: 78, offset: 65416},
 							name: "CommentBlockEndDelimiter",
 						},
 					},
@@ -11773,27 +11773,27 @@ var g = &grammar{
 		},
 		{
 			name: "CommentBlockRawContent",
-			pos:  position{line: 1796, col: 1, offset: 65460},
+			pos:  position{line: 1797, col: 1, offset: 65509},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1796, col: 27, offset: 65486},
+				pos: position{line: 1797, col: 27, offset: 65535},
 				expr: &actionExpr{
-					pos: position{line: 1796, col: 28, offset: 65487},
+					pos: position{line: 1797, col: 28, offset: 65536},
 					run: (*parser).callonCommentBlockRawContent2,
 					expr: &seqExpr{
-						pos: position{line: 1796, col: 28, offset: 65487},
+						pos: position{line: 1797, col: 28, offset: 65536},
 						exprs: []interface{}{
 							&notExpr{
-								pos: position{line: 1796, col: 28, offset: 65487},
+								pos: position{line: 1797, col: 28, offset: 65536},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1796, col: 29, offset: 65488},
+									pos:  position{line: 1797, col: 29, offset: 65537},
 									name: "CommentBlockEndDelimiter",
 								},
 							},
 							&labeledExpr{
-								pos:   position{line: 1796, col: 54, offset: 65513},
+								pos:   position{line: 1797, col: 54, offset: 65562},
 								label: "line",
 								expr: &ruleRefExpr{
-									pos:  position{line: 1796, col: 60, offset: 65519},
+									pos:  position{line: 1797, col: 60, offset: 65568},
 									name: "RawLine",
 								},
 							},
@@ -11804,36 +11804,36 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineComment",
-			pos:  position{line: 1800, col: 1, offset: 65557},
+			pos:  position{line: 1801, col: 1, offset: 65606},
 			expr: &actionExpr{
-				pos: position{line: 1800, col: 22, offset: 65578},
+				pos: position{line: 1801, col: 22, offset: 65627},
 				run: (*parser).callonSingleLineComment1,
 				expr: &seqExpr{
-					pos: position{line: 1800, col: 22, offset: 65578},
+					pos: position{line: 1801, col: 22, offset: 65627},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1800, col: 22, offset: 65578},
+							pos: position{line: 1801, col: 22, offset: 65627},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1800, col: 23, offset: 65579},
+								pos:  position{line: 1801, col: 23, offset: 65628},
 								name: "CommentBlockDelimiter",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1800, col: 45, offset: 65601},
+							pos:        position{line: 1801, col: 45, offset: 65650},
 							val:        "//",
 							ignoreCase: false,
 							want:       "\"//\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1800, col: 50, offset: 65606},
+							pos:   position{line: 1801, col: 50, offset: 65655},
 							label: "content",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1800, col: 59, offset: 65615},
+								pos:  position{line: 1801, col: 59, offset: 65664},
 								name: "SingleLineCommentContent",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1800, col: 85, offset: 65641},
+							pos:  position{line: 1801, col: 85, offset: 65690},
 							name: "EOL",
 						},
 					},
@@ -11842,14 +11842,14 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineCommentContent",
-			pos:  position{line: 1804, col: 1, offset: 65706},
+			pos:  position{line: 1805, col: 1, offset: 65755},
 			expr: &actionExpr{
-				pos: position{line: 1804, col: 29, offset: 65734},
+				pos: position{line: 1805, col: 29, offset: 65783},
 				run: (*parser).callonSingleLineCommentContent1,
 				expr: &zeroOrMoreExpr{
-					pos: position{line: 1804, col: 29, offset: 65734},
+					pos: position{line: 1805, col: 29, offset: 65783},
 					expr: &charClassMatcher{
-						pos:        position{line: 1804, col: 29, offset: 65734},
+						pos:        position{line: 1805, col: 29, offset: 65783},
 						val:        "[^\\r\\n]",
 						chars:      []rune{'\r', '\n'},
 						ignoreCase: false,
@@ -11860,48 +11860,48 @@ var g = &grammar{
 		},
 		{
 			name: "InlineMacros",
-			pos:  position{line: 1812, col: 1, offset: 66023},
+			pos:  position{line: 1813, col: 1, offset: 66072},
 			expr: &choiceExpr{
-				pos: position{line: 1812, col: 17, offset: 66039},
+				pos: position{line: 1813, col: 17, offset: 66088},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1812, col: 17, offset: 66039},
+						pos:  position{line: 1813, col: 17, offset: 66088},
 						name: "InlineIcon",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1813, col: 19, offset: 66068},
+						pos:  position{line: 1814, col: 19, offset: 66117},
 						name: "InlineImage",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1814, col: 19, offset: 66099},
+						pos:  position{line: 1815, col: 19, offset: 66148},
 						name: "Link",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1815, col: 19, offset: 66123},
+						pos:  position{line: 1816, col: 19, offset: 66172},
 						name: "InlinePassthrough",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1816, col: 19, offset: 66160},
+						pos:  position{line: 1817, col: 19, offset: 66209},
 						name: "InlineFootnote",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1817, col: 19, offset: 66194},
+						pos:  position{line: 1818, col: 19, offset: 66243},
 						name: "CrossReference",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1818, col: 19, offset: 66228},
+						pos:  position{line: 1819, col: 19, offset: 66277},
 						name: "InlineUserMacro",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1819, col: 19, offset: 66263},
+						pos:  position{line: 1820, col: 19, offset: 66312},
 						name: "InlineElementID",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1820, col: 19, offset: 66297},
+						pos:  position{line: 1821, col: 19, offset: 66346},
 						name: "ConcealedIndexTerm",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1821, col: 19, offset: 66334},
+						pos:  position{line: 1822, col: 19, offset: 66383},
 						name: "IndexTerm",
 					},
 				},
@@ -11909,29 +11909,29 @@ var g = &grammar{
 		},
 		{
 			name: "ElementPlaceHolder",
-			pos:  position{line: 1823, col: 1, offset: 66345},
+			pos:  position{line: 1824, col: 1, offset: 66394},
 			expr: &actionExpr{
-				pos: position{line: 1823, col: 23, offset: 66367},
+				pos: position{line: 1824, col: 23, offset: 66416},
 				run: (*parser).callonElementPlaceHolder1,
 				expr: &seqExpr{
-					pos: position{line: 1823, col: 23, offset: 66367},
+					pos: position{line: 1824, col: 23, offset: 66416},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1823, col: 23, offset: 66367},
+							pos:        position{line: 1824, col: 23, offset: 66416},
 							val:        "�",
 							ignoreCase: false,
 							want:       "\"�\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1823, col: 32, offset: 66376},
+							pos:   position{line: 1824, col: 32, offset: 66425},
 							label: "ref",
 							expr: &actionExpr{
-								pos: position{line: 1823, col: 37, offset: 66381},
+								pos: position{line: 1824, col: 37, offset: 66430},
 								run: (*parser).callonElementPlaceHolder5,
 								expr: &oneOrMoreExpr{
-									pos: position{line: 1823, col: 37, offset: 66381},
+									pos: position{line: 1824, col: 37, offset: 66430},
 									expr: &charClassMatcher{
-										pos:        position{line: 1823, col: 37, offset: 66381},
+										pos:        position{line: 1824, col: 37, offset: 66430},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -11941,7 +11941,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1823, col: 76, offset: 66420},
+							pos:        position{line: 1824, col: 76, offset: 66469},
 							val:        "�",
 							ignoreCase: false,
 							want:       "\"�\"",
@@ -11952,47 +11952,47 @@ var g = &grammar{
 		},
 		{
 			name: "InlinePassthroughSubs",
-			pos:  position{line: 1828, col: 1, offset: 66572},
+			pos:  position{line: 1829, col: 1, offset: 66621},
 			expr: &seqExpr{
-				pos: position{line: 1829, col: 5, offset: 66602},
+				pos: position{line: 1830, col: 5, offset: 66651},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1829, col: 5, offset: 66602},
+						pos: position{line: 1830, col: 5, offset: 66651},
 						expr: &choiceExpr{
-							pos: position{line: 1829, col: 6, offset: 66603},
+							pos: position{line: 1830, col: 6, offset: 66652},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 1829, col: 6, offset: 66603},
+									pos:  position{line: 1830, col: 6, offset: 66652},
 									name: "InlinePassthrough",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1830, col: 11, offset: 66632},
+									pos:  position{line: 1831, col: 11, offset: 66681},
 									name: "InlineWord",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1831, col: 11, offset: 66693},
+									pos:  position{line: 1832, col: 11, offset: 66742},
 									name: "ElementPlaceHolder",
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1832, col: 11, offset: 66722},
+									pos: position{line: 1833, col: 11, offset: 66771},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1832, col: 11, offset: 66722},
+										pos:  position{line: 1833, col: 11, offset: 66771},
 										name: "Space",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1833, col: 11, offset: 66740},
+									pos:  position{line: 1834, col: 11, offset: 66789},
 									name: "AnyChar",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1834, col: 11, offset: 66758},
+									pos:  position{line: 1835, col: 11, offset: 66807},
 									name: "Newline",
 								},
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1834, col: 21, offset: 66768},
+						pos:  position{line: 1835, col: 21, offset: 66817},
 						name: "EOF",
 					},
 				},
@@ -12000,47 +12000,47 @@ var g = &grammar{
 		},
 		{
 			name: "SpecialCharacterSubs",
-			pos:  position{line: 1837, col: 1, offset: 66889},
+			pos:  position{line: 1838, col: 1, offset: 66938},
 			expr: &seqExpr{
-				pos: position{line: 1838, col: 5, offset: 66918},
+				pos: position{line: 1839, col: 5, offset: 66967},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1838, col: 5, offset: 66918},
+						pos: position{line: 1839, col: 5, offset: 66967},
 						expr: &choiceExpr{
-							pos: position{line: 1838, col: 6, offset: 66919},
+							pos: position{line: 1839, col: 6, offset: 66968},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 1838, col: 6, offset: 66919},
+									pos:  position{line: 1839, col: 6, offset: 66968},
 									name: "InlineWord",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1839, col: 11, offset: 66980},
+									pos:  position{line: 1840, col: 11, offset: 67029},
 									name: "SpecialCharacter",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1840, col: 11, offset: 67007},
+									pos:  position{line: 1841, col: 11, offset: 67056},
 									name: "ElementPlaceHolder",
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1841, col: 11, offset: 67036},
+									pos: position{line: 1842, col: 11, offset: 67085},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1841, col: 11, offset: 67036},
+										pos:  position{line: 1842, col: 11, offset: 67085},
 										name: "Space",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1842, col: 11, offset: 67053},
+									pos:  position{line: 1843, col: 11, offset: 67102},
 									name: "AnyChar",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1843, col: 11, offset: 67071},
+									pos:  position{line: 1844, col: 11, offset: 67120},
 									name: "Newline",
 								},
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1843, col: 21, offset: 67081},
+						pos:  position{line: 1844, col: 21, offset: 67130},
 						name: "EOF",
 					},
 				},
@@ -12048,51 +12048,51 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedTextSubs",
-			pos:  position{line: 1846, col: 1, offset: 67135},
+			pos:  position{line: 1847, col: 1, offset: 67184},
 			expr: &seqExpr{
-				pos: position{line: 1847, col: 5, offset: 67158},
+				pos: position{line: 1848, col: 5, offset: 67207},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1847, col: 5, offset: 67158},
+						pos: position{line: 1848, col: 5, offset: 67207},
 						expr: &choiceExpr{
-							pos: position{line: 1847, col: 6, offset: 67159},
+							pos: position{line: 1848, col: 6, offset: 67208},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 1847, col: 6, offset: 67159},
+									pos:  position{line: 1848, col: 6, offset: 67208},
 									name: "InlineWord",
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1848, col: 11, offset: 67220},
+									pos: position{line: 1849, col: 11, offset: 67269},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1848, col: 11, offset: 67220},
+										pos:  position{line: 1849, col: 11, offset: 67269},
 										name: "Space",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1849, col: 11, offset: 67238},
+									pos:  position{line: 1850, col: 11, offset: 67287},
 									name: "QuotedText",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1850, col: 11, offset: 67260},
+									pos:  position{line: 1851, col: 11, offset: 67309},
 									name: "QuotedString",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1851, col: 11, offset: 67283},
+									pos:  position{line: 1852, col: 11, offset: 67332},
 									name: "ElementPlaceHolder",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1852, col: 11, offset: 67312},
+									pos:  position{line: 1853, col: 11, offset: 67361},
 									name: "AnyChar",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1853, col: 11, offset: 67330},
+									pos:  position{line: 1854, col: 11, offset: 67379},
 									name: "Newline",
 								},
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1853, col: 21, offset: 67340},
+						pos:  position{line: 1854, col: 21, offset: 67389},
 						name: "EOF",
 					},
 				},
@@ -12100,47 +12100,47 @@ var g = &grammar{
 		},
 		{
 			name: "AttributeSubs",
-			pos:  position{line: 1856, col: 1, offset: 67398},
+			pos:  position{line: 1857, col: 1, offset: 67447},
 			expr: &seqExpr{
-				pos: position{line: 1857, col: 5, offset: 67420},
+				pos: position{line: 1858, col: 5, offset: 67469},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1857, col: 5, offset: 67420},
+						pos: position{line: 1858, col: 5, offset: 67469},
 						expr: &choiceExpr{
-							pos: position{line: 1857, col: 6, offset: 67421},
+							pos: position{line: 1858, col: 6, offset: 67470},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 1857, col: 6, offset: 67421},
+									pos:  position{line: 1858, col: 6, offset: 67470},
 									name: "InlineWord",
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1858, col: 11, offset: 67482},
+									pos: position{line: 1859, col: 11, offset: 67531},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1858, col: 11, offset: 67482},
+										pos:  position{line: 1859, col: 11, offset: 67531},
 										name: "Space",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1859, col: 11, offset: 67500},
+									pos:  position{line: 1860, col: 11, offset: 67549},
 									name: "AttributeSubstitution",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1860, col: 11, offset: 67532},
+									pos:  position{line: 1861, col: 11, offset: 67581},
 									name: "ElementPlaceHolder",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1861, col: 11, offset: 67561},
+									pos:  position{line: 1862, col: 11, offset: 67610},
 									name: "AnyChar",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1862, col: 11, offset: 67579},
+									pos:  position{line: 1863, col: 11, offset: 67628},
 									name: "Newline",
 								},
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1862, col: 21, offset: 67589},
+						pos:  position{line: 1863, col: 21, offset: 67638},
 						name: "EOF",
 					},
 				},
@@ -12148,47 +12148,47 @@ var g = &grammar{
 		},
 		{
 			name: "InlineMacroSubs",
-			pos:  position{line: 1865, col: 1, offset: 67643},
+			pos:  position{line: 1866, col: 1, offset: 67692},
 			expr: &seqExpr{
-				pos: position{line: 1866, col: 5, offset: 67667},
+				pos: position{line: 1867, col: 5, offset: 67716},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1866, col: 5, offset: 67667},
+						pos: position{line: 1867, col: 5, offset: 67716},
 						expr: &choiceExpr{
-							pos: position{line: 1866, col: 6, offset: 67668},
+							pos: position{line: 1867, col: 6, offset: 67717},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 1866, col: 6, offset: 67668},
+									pos:  position{line: 1867, col: 6, offset: 67717},
 									name: "InlineWord",
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1867, col: 11, offset: 67729},
+									pos: position{line: 1868, col: 11, offset: 67778},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1867, col: 11, offset: 67729},
+										pos:  position{line: 1868, col: 11, offset: 67778},
 										name: "Space",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1868, col: 11, offset: 67747},
+									pos:  position{line: 1869, col: 11, offset: 67796},
 									name: "InlineMacros",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1869, col: 11, offset: 67770},
+									pos:  position{line: 1870, col: 11, offset: 67819},
 									name: "ElementPlaceHolder",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1870, col: 11, offset: 67799},
+									pos:  position{line: 1871, col: 11, offset: 67848},
 									name: "AnyChar",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1871, col: 11, offset: 67817},
+									pos:  position{line: 1872, col: 11, offset: 67866},
 									name: "Newline",
 								},
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1871, col: 21, offset: 67827},
+						pos:  position{line: 1872, col: 21, offset: 67876},
 						name: "EOF",
 					},
 				},
@@ -12196,26 +12196,26 @@ var g = &grammar{
 		},
 		{
 			name: "MarkdownQuoteMacroSubs",
-			pos:  position{line: 1874, col: 1, offset: 67907},
+			pos:  position{line: 1875, col: 1, offset: 67956},
 			expr: &actionExpr{
-				pos: position{line: 1874, col: 27, offset: 67933},
+				pos: position{line: 1875, col: 27, offset: 67982},
 				run: (*parser).callonMarkdownQuoteMacroSubs1,
 				expr: &seqExpr{
-					pos: position{line: 1874, col: 27, offset: 67933},
+					pos: position{line: 1875, col: 27, offset: 67982},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1874, col: 27, offset: 67933},
+							pos:   position{line: 1875, col: 27, offset: 67982},
 							label: "lines",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1874, col: 33, offset: 67939},
+								pos: position{line: 1875, col: 33, offset: 67988},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1874, col: 34, offset: 67940},
+									pos:  position{line: 1875, col: 34, offset: 67989},
 									name: "MarkdownQuoteLine",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1874, col: 54, offset: 67960},
+							pos:  position{line: 1875, col: 54, offset: 68009},
 							name: "EOF",
 						},
 					},
@@ -12224,42 +12224,42 @@ var g = &grammar{
 		},
 		{
 			name: "MarkdownQuoteLine",
-			pos:  position{line: 1878, col: 1, offset: 68027},
+			pos:  position{line: 1879, col: 1, offset: 68076},
 			expr: &actionExpr{
-				pos: position{line: 1879, col: 5, offset: 68053},
+				pos: position{line: 1880, col: 5, offset: 68102},
 				run: (*parser).callonMarkdownQuoteLine1,
 				expr: &seqExpr{
-					pos: position{line: 1879, col: 5, offset: 68053},
+					pos: position{line: 1880, col: 5, offset: 68102},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1879, col: 5, offset: 68053},
+							pos:   position{line: 1880, col: 5, offset: 68102},
 							label: "elements",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1879, col: 14, offset: 68062},
+								pos: position{line: 1880, col: 14, offset: 68111},
 								expr: &choiceExpr{
-									pos: position{line: 1879, col: 15, offset: 68063},
+									pos: position{line: 1880, col: 15, offset: 68112},
 									alternatives: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 1879, col: 15, offset: 68063},
+											pos:  position{line: 1880, col: 15, offset: 68112},
 											name: "InlineWord",
 										},
 										&oneOrMoreExpr{
-											pos: position{line: 1880, col: 11, offset: 68124},
+											pos: position{line: 1881, col: 11, offset: 68173},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1880, col: 11, offset: 68124},
+												pos:  position{line: 1881, col: 11, offset: 68173},
 												name: "Space",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1881, col: 11, offset: 68142},
+											pos:  position{line: 1882, col: 11, offset: 68191},
 											name: "InlineMacros",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1882, col: 11, offset: 68165},
+											pos:  position{line: 1883, col: 11, offset: 68214},
 											name: "ElementPlaceHolder",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1883, col: 11, offset: 68194},
+											pos:  position{line: 1884, col: 11, offset: 68243},
 											name: "AnyChar",
 										},
 									},
@@ -12267,7 +12267,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1883, col: 21, offset: 68204},
+							pos:  position{line: 1884, col: 21, offset: 68253},
 							name: "EOL",
 						},
 					},
@@ -12276,29 +12276,29 @@ var g = &grammar{
 		},
 		{
 			name: "MarkdownQuoteAttribution",
-			pos:  position{line: 1887, col: 1, offset: 68275},
+			pos:  position{line: 1888, col: 1, offset: 68324},
 			expr: &actionExpr{
-				pos: position{line: 1887, col: 29, offset: 68303},
+				pos: position{line: 1888, col: 29, offset: 68352},
 				run: (*parser).callonMarkdownQuoteAttribution1,
 				expr: &seqExpr{
-					pos: position{line: 1887, col: 29, offset: 68303},
+					pos: position{line: 1888, col: 29, offset: 68352},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1887, col: 29, offset: 68303},
+							pos:        position{line: 1888, col: 29, offset: 68352},
 							val:        "-- ",
 							ignoreCase: false,
 							want:       "\"-- \"",
 						},
 						&labeledExpr{
-							pos:   position{line: 1887, col: 35, offset: 68309},
+							pos:   position{line: 1888, col: 35, offset: 68358},
 							label: "author",
 							expr: &actionExpr{
-								pos: position{line: 1887, col: 43, offset: 68317},
+								pos: position{line: 1888, col: 43, offset: 68366},
 								run: (*parser).callonMarkdownQuoteAttribution5,
 								expr: &oneOrMoreExpr{
-									pos: position{line: 1887, col: 44, offset: 68318},
+									pos: position{line: 1888, col: 44, offset: 68367},
 									expr: &charClassMatcher{
-										pos:        position{line: 1887, col: 44, offset: 68318},
+										pos:        position{line: 1888, col: 44, offset: 68367},
 										val:        "[^\\r\\n]",
 										chars:      []rune{'\r', '\n'},
 										ignoreCase: false,
@@ -12308,7 +12308,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1889, col: 8, offset: 68368},
+							pos:  position{line: 1890, col: 8, offset: 68417},
 							name: "EOL",
 						},
 					},
@@ -12317,47 +12317,47 @@ var g = &grammar{
 		},
 		{
 			name: "ReplacementSubs",
-			pos:  position{line: 1894, col: 1, offset: 68455},
+			pos:  position{line: 1895, col: 1, offset: 68504},
 			expr: &seqExpr{
-				pos: position{line: 1895, col: 5, offset: 68479},
+				pos: position{line: 1896, col: 5, offset: 68528},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1895, col: 5, offset: 68479},
+						pos: position{line: 1896, col: 5, offset: 68528},
 						expr: &choiceExpr{
-							pos: position{line: 1895, col: 6, offset: 68480},
+							pos: position{line: 1896, col: 6, offset: 68529},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 1895, col: 6, offset: 68480},
+									pos:  position{line: 1896, col: 6, offset: 68529},
 									name: "InlineWord",
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1896, col: 11, offset: 68541},
+									pos: position{line: 1897, col: 11, offset: 68590},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1896, col: 11, offset: 68541},
+										pos:  position{line: 1897, col: 11, offset: 68590},
 										name: "Space",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1897, col: 11, offset: 68559},
+									pos:  position{line: 1898, col: 11, offset: 68608},
 									name: "Symbol",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1898, col: 11, offset: 68577},
+									pos:  position{line: 1899, col: 11, offset: 68626},
 									name: "ElementPlaceHolder",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1899, col: 11, offset: 68606},
+									pos:  position{line: 1900, col: 11, offset: 68655},
 									name: "AnyChar",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1900, col: 11, offset: 68624},
+									pos:  position{line: 1901, col: 11, offset: 68673},
 									name: "Newline",
 								},
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1900, col: 21, offset: 68634},
+						pos:  position{line: 1901, col: 21, offset: 68683},
 						name: "EOF",
 					},
 				},
@@ -12365,47 +12365,47 @@ var g = &grammar{
 		},
 		{
 			name: "PostReplacementSubs",
-			pos:  position{line: 1904, col: 1, offset: 68782},
+			pos:  position{line: 1905, col: 1, offset: 68831},
 			expr: &seqExpr{
-				pos: position{line: 1904, col: 24, offset: 68805},
+				pos: position{line: 1905, col: 24, offset: 68854},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1904, col: 24, offset: 68805},
+						pos: position{line: 1905, col: 24, offset: 68854},
 						expr: &choiceExpr{
-							pos: position{line: 1905, col: 5, offset: 68811},
+							pos: position{line: 1906, col: 5, offset: 68860},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 1905, col: 5, offset: 68811},
+									pos:  position{line: 1906, col: 5, offset: 68860},
 									name: "InlineWord",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1906, col: 7, offset: 68868},
+									pos:  position{line: 1907, col: 7, offset: 68917},
 									name: "ElementPlaceHolder",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1907, col: 7, offset: 68893},
+									pos:  position{line: 1908, col: 7, offset: 68942},
 									name: "LineBreak",
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1908, col: 7, offset: 68936},
+									pos: position{line: 1909, col: 7, offset: 68985},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1908, col: 7, offset: 68936},
+										pos:  position{line: 1909, col: 7, offset: 68985},
 										name: "Space",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1909, col: 7, offset: 68950},
+									pos:  position{line: 1910, col: 7, offset: 68999},
 									name: "AnyChar",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1910, col: 7, offset: 68964},
+									pos:  position{line: 1911, col: 7, offset: 69013},
 									name: "Newline",
 								},
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1910, col: 17, offset: 68974},
+						pos:  position{line: 1911, col: 17, offset: 69023},
 						name: "EOF",
 					},
 				},
@@ -12413,47 +12413,47 @@ var g = &grammar{
 		},
 		{
 			name: "CalloutSubs",
-			pos:  position{line: 1913, col: 1, offset: 69031},
+			pos:  position{line: 1914, col: 1, offset: 69080},
 			expr: &seqExpr{
-				pos: position{line: 1914, col: 5, offset: 69051},
+				pos: position{line: 1915, col: 5, offset: 69100},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1914, col: 5, offset: 69051},
+						pos: position{line: 1915, col: 5, offset: 69100},
 						expr: &choiceExpr{
-							pos: position{line: 1914, col: 6, offset: 69052},
+							pos: position{line: 1915, col: 6, offset: 69101},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 1914, col: 6, offset: 69052},
+									pos:  position{line: 1915, col: 6, offset: 69101},
 									name: "InlineWord",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1915, col: 11, offset: 69113},
+									pos:  position{line: 1916, col: 11, offset: 69162},
 									name: "ElementPlaceHolder",
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 1916, col: 11, offset: 69142},
+									pos: position{line: 1917, col: 11, offset: 69191},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1916, col: 11, offset: 69142},
+										pos:  position{line: 1917, col: 11, offset: 69191},
 										name: "Space",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1917, col: 11, offset: 69159},
+									pos:  position{line: 1918, col: 11, offset: 69208},
 									name: "Callout",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1918, col: 11, offset: 69177},
+									pos:  position{line: 1919, col: 11, offset: 69226},
 									name: "AnyChar",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1919, col: 11, offset: 69195},
+									pos:  position{line: 1920, col: 11, offset: 69244},
 									name: "Newline",
 								},
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1919, col: 21, offset: 69205},
+						pos:  position{line: 1920, col: 21, offset: 69254},
 						name: "EOF",
 					},
 				},
@@ -12461,36 +12461,36 @@ var g = &grammar{
 		},
 		{
 			name: "NoneSubs",
-			pos:  position{line: 1922, col: 1, offset: 69257},
+			pos:  position{line: 1923, col: 1, offset: 69306},
 			expr: &seqExpr{
-				pos: position{line: 1922, col: 13, offset: 69269},
+				pos: position{line: 1923, col: 13, offset: 69318},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1922, col: 13, offset: 69269},
+						pos: position{line: 1923, col: 13, offset: 69318},
 						expr: &choiceExpr{
-							pos: position{line: 1923, col: 5, offset: 69275},
+							pos: position{line: 1924, col: 5, offset: 69324},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 1923, col: 5, offset: 69275},
+									pos:  position{line: 1924, col: 5, offset: 69324},
 									name: "ElementPlaceHolder",
 								},
 								&actionExpr{
-									pos: position{line: 1924, col: 8, offset: 69302},
+									pos: position{line: 1925, col: 8, offset: 69351},
 									run: (*parser).callonNoneSubs5,
 									expr: &seqExpr{
-										pos: position{line: 1924, col: 8, offset: 69302},
+										pos: position{line: 1925, col: 8, offset: 69351},
 										exprs: []interface{}{
 											&notExpr{
-												pos: position{line: 1924, col: 8, offset: 69302},
+												pos: position{line: 1925, col: 8, offset: 69351},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1924, col: 9, offset: 69303},
+													pos:  position{line: 1925, col: 9, offset: 69352},
 													name: "EOF",
 												},
 											},
 											&zeroOrMoreExpr{
-												pos: position{line: 1924, col: 13, offset: 69307},
+												pos: position{line: 1925, col: 13, offset: 69356},
 												expr: &charClassMatcher{
-													pos:        position{line: 1924, col: 13, offset: 69307},
+													pos:        position{line: 1925, col: 13, offset: 69356},
 													val:        "[^\\r\\n]",
 													chars:      []rune{'\r', '\n'},
 													ignoreCase: false,
@@ -12498,7 +12498,7 @@ var g = &grammar{
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1924, col: 22, offset: 69316},
+												pos:  position{line: 1925, col: 22, offset: 69365},
 												name: "EOL",
 											},
 										},
@@ -12508,7 +12508,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1926, col: 10, offset: 69421},
+						pos:  position{line: 1927, col: 10, offset: 69470},
 						name: "EOF",
 					},
 				},
@@ -12516,59 +12516,59 @@ var g = &grammar{
 		},
 		{
 			name: "Table",
-			pos:  position{line: 1931, col: 1, offset: 69614},
+			pos:  position{line: 1932, col: 1, offset: 69663},
 			expr: &actionExpr{
-				pos: position{line: 1931, col: 10, offset: 69623},
+				pos: position{line: 1932, col: 10, offset: 69672},
 				run: (*parser).callonTable1,
 				expr: &seqExpr{
-					pos: position{line: 1931, col: 10, offset: 69623},
+					pos: position{line: 1932, col: 10, offset: 69672},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1931, col: 10, offset: 69623},
+							pos:   position{line: 1932, col: 10, offset: 69672},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1931, col: 21, offset: 69634},
+								pos: position{line: 1932, col: 21, offset: 69683},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1931, col: 22, offset: 69635},
+									pos:  position{line: 1932, col: 22, offset: 69684},
 									name: "BlockAttributes",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1931, col: 40, offset: 69653},
+							pos:  position{line: 1932, col: 40, offset: 69702},
 							name: "TableDelimiter",
 						},
 						&labeledExpr{
-							pos:   position{line: 1932, col: 5, offset: 69672},
+							pos:   position{line: 1933, col: 5, offset: 69721},
 							label: "header",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1932, col: 12, offset: 69679},
+								pos: position{line: 1933, col: 12, offset: 69728},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1932, col: 13, offset: 69680},
+									pos:  position{line: 1933, col: 13, offset: 69729},
 									name: "TableLineHeader",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1933, col: 5, offset: 69702},
+							pos:   position{line: 1934, col: 5, offset: 69751},
 							label: "lines",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1933, col: 11, offset: 69708},
+								pos: position{line: 1934, col: 11, offset: 69757},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1933, col: 12, offset: 69709},
+									pos:  position{line: 1934, col: 12, offset: 69758},
 									name: "TableLine",
 								},
 							},
 						},
 						&choiceExpr{
-							pos: position{line: 1934, col: 6, offset: 69726},
+							pos: position{line: 1935, col: 6, offset: 69775},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 1934, col: 6, offset: 69726},
+									pos:  position{line: 1935, col: 6, offset: 69775},
 									name: "TableDelimiter",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1934, col: 23, offset: 69743},
+									pos:  position{line: 1935, col: 23, offset: 69792},
 									name: "EOF",
 								},
 							},
@@ -12579,20 +12579,20 @@ var g = &grammar{
 		},
 		{
 			name: "TableCellSeparator",
-			pos:  position{line: 1938, col: 1, offset: 69862},
+			pos:  position{line: 1939, col: 1, offset: 69911},
 			expr: &seqExpr{
-				pos: position{line: 1938, col: 23, offset: 69884},
+				pos: position{line: 1939, col: 23, offset: 69933},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1938, col: 23, offset: 69884},
+						pos:        position{line: 1939, col: 23, offset: 69933},
 						val:        "|",
 						ignoreCase: false,
 						want:       "\"|\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1938, col: 27, offset: 69888},
+						pos: position{line: 1939, col: 27, offset: 69937},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1938, col: 27, offset: 69888},
+							pos:  position{line: 1939, col: 27, offset: 69937},
 							name: "Space",
 						},
 					},
@@ -12601,25 +12601,25 @@ var g = &grammar{
 		},
 		{
 			name: "TableDelimiter",
-			pos:  position{line: 1940, col: 1, offset: 69896},
+			pos:  position{line: 1941, col: 1, offset: 69945},
 			expr: &seqExpr{
-				pos: position{line: 1940, col: 19, offset: 69914},
+				pos: position{line: 1941, col: 19, offset: 69963},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1940, col: 19, offset: 69914},
+						pos:        position{line: 1941, col: 19, offset: 69963},
 						val:        "|===",
 						ignoreCase: false,
 						want:       "\"|===\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1940, col: 26, offset: 69921},
+						pos: position{line: 1941, col: 26, offset: 69970},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1940, col: 26, offset: 69921},
+							pos:  position{line: 1941, col: 26, offset: 69970},
 							name: "Space",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1940, col: 33, offset: 69928},
+						pos:  position{line: 1941, col: 33, offset: 69977},
 						name: "EOL",
 					},
 				},
@@ -12627,37 +12627,37 @@ var g = &grammar{
 		},
 		{
 			name: "TableLineHeader",
-			pos:  position{line: 1943, col: 1, offset: 69996},
+			pos:  position{line: 1944, col: 1, offset: 70045},
 			expr: &actionExpr{
-				pos: position{line: 1943, col: 20, offset: 70015},
+				pos: position{line: 1944, col: 20, offset: 70064},
 				run: (*parser).callonTableLineHeader1,
 				expr: &seqExpr{
-					pos: position{line: 1943, col: 20, offset: 70015},
+					pos: position{line: 1944, col: 20, offset: 70064},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1943, col: 20, offset: 70015},
+							pos: position{line: 1944, col: 20, offset: 70064},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1943, col: 21, offset: 70016},
+								pos:  position{line: 1944, col: 21, offset: 70065},
 								name: "TableDelimiter",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1943, col: 36, offset: 70031},
+							pos:   position{line: 1944, col: 36, offset: 70080},
 							label: "cells",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1943, col: 42, offset: 70037},
+								pos: position{line: 1944, col: 42, offset: 70086},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1943, col: 43, offset: 70038},
+									pos:  position{line: 1944, col: 43, offset: 70087},
 									name: "TableCell",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1943, col: 55, offset: 70050},
+							pos:  position{line: 1944, col: 55, offset: 70099},
 							name: "EOL",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1943, col: 59, offset: 70054},
+							pos:  position{line: 1944, col: 59, offset: 70103},
 							name: "BlankLine",
 						},
 					},
@@ -12666,39 +12666,39 @@ var g = &grammar{
 		},
 		{
 			name: "TableLine",
-			pos:  position{line: 1947, col: 1, offset: 70122},
+			pos:  position{line: 1948, col: 1, offset: 70171},
 			expr: &actionExpr{
-				pos: position{line: 1947, col: 14, offset: 70135},
+				pos: position{line: 1948, col: 14, offset: 70184},
 				run: (*parser).callonTableLine1,
 				expr: &seqExpr{
-					pos: position{line: 1947, col: 14, offset: 70135},
+					pos: position{line: 1948, col: 14, offset: 70184},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 1947, col: 14, offset: 70135},
+							pos: position{line: 1948, col: 14, offset: 70184},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1947, col: 15, offset: 70136},
+								pos:  position{line: 1948, col: 15, offset: 70185},
 								name: "TableDelimiter",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1947, col: 30, offset: 70151},
+							pos:   position{line: 1948, col: 30, offset: 70200},
 							label: "cells",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1947, col: 36, offset: 70157},
+								pos: position{line: 1948, col: 36, offset: 70206},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1947, col: 37, offset: 70158},
+									pos:  position{line: 1948, col: 37, offset: 70207},
 									name: "TableCell",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1947, col: 49, offset: 70170},
+							pos:  position{line: 1948, col: 49, offset: 70219},
 							name: "EOL",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1947, col: 53, offset: 70174},
+							pos: position{line: 1948, col: 53, offset: 70223},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1947, col: 53, offset: 70174},
+								pos:  position{line: 1948, col: 53, offset: 70223},
 								name: "BlankLine",
 							},
 						},
@@ -12708,54 +12708,54 @@ var g = &grammar{
 		},
 		{
 			name: "TableCell",
-			pos:  position{line: 1951, col: 1, offset: 70243},
+			pos:  position{line: 1952, col: 1, offset: 70292},
 			expr: &actionExpr{
-				pos: position{line: 1951, col: 14, offset: 70256},
+				pos: position{line: 1952, col: 14, offset: 70305},
 				run: (*parser).callonTableCell1,
 				expr: &seqExpr{
-					pos: position{line: 1951, col: 14, offset: 70256},
+					pos: position{line: 1952, col: 14, offset: 70305},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 1951, col: 14, offset: 70256},
+							pos:  position{line: 1952, col: 14, offset: 70305},
 							name: "TableCellSeparator",
 						},
 						&labeledExpr{
-							pos:   position{line: 1951, col: 33, offset: 70275},
+							pos:   position{line: 1952, col: 33, offset: 70324},
 							label: "elements",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 1951, col: 42, offset: 70284},
+								pos: position{line: 1952, col: 42, offset: 70333},
 								expr: &seqExpr{
-									pos: position{line: 1951, col: 43, offset: 70285},
+									pos: position{line: 1952, col: 43, offset: 70334},
 									exprs: []interface{}{
 										&notExpr{
-											pos: position{line: 1951, col: 43, offset: 70285},
+											pos: position{line: 1952, col: 43, offset: 70334},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1951, col: 44, offset: 70286},
+												pos:  position{line: 1952, col: 44, offset: 70335},
 												name: "TableCellSeparator",
 											},
 										},
 										&notExpr{
-											pos: position{line: 1951, col: 63, offset: 70305},
+											pos: position{line: 1952, col: 63, offset: 70354},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1951, col: 64, offset: 70306},
+												pos:  position{line: 1952, col: 64, offset: 70355},
 												name: "EOL",
 											},
 										},
 										&zeroOrMoreExpr{
-											pos: position{line: 1951, col: 68, offset: 70310},
+											pos: position{line: 1952, col: 68, offset: 70359},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1951, col: 68, offset: 70310},
+												pos:  position{line: 1952, col: 68, offset: 70359},
 												name: "Space",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1951, col: 75, offset: 70317},
+											pos:  position{line: 1952, col: 75, offset: 70366},
 											name: "InlineElement",
 										},
 										&zeroOrMoreExpr{
-											pos: position{line: 1951, col: 89, offset: 70331},
+											pos: position{line: 1952, col: 89, offset: 70380},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1951, col: 89, offset: 70331},
+												pos:  position{line: 1952, col: 89, offset: 70380},
 												name: "Space",
 											},
 										},
@@ -12769,20 +12769,20 @@ var g = &grammar{
 		},
 		{
 			name: "LiteralBlock",
-			pos:  position{line: 1958, col: 1, offset: 70657},
+			pos:  position{line: 1959, col: 1, offset: 70706},
 			expr: &choiceExpr{
-				pos: position{line: 1958, col: 17, offset: 70673},
+				pos: position{line: 1959, col: 17, offset: 70722},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1958, col: 17, offset: 70673},
+						pos:  position{line: 1959, col: 17, offset: 70722},
 						name: "ParagraphWithLiteralAttribute",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1958, col: 49, offset: 70705},
+						pos:  position{line: 1959, col: 49, offset: 70754},
 						name: "ParagraphWithHeadingSpaces",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1958, col: 78, offset: 70734},
+						pos:  position{line: 1959, col: 78, offset: 70783},
 						name: "ParagraphWithLiteralBlockDelimiter",
 					},
 				},
@@ -12790,9 +12790,9 @@ var g = &grammar{
 		},
 		{
 			name: "LiteralBlockDelimiter",
-			pos:  position{line: 1960, col: 1, offset: 70770},
+			pos:  position{line: 1961, col: 1, offset: 70819},
 			expr: &litMatcher{
-				pos:        position{line: 1960, col: 26, offset: 70795},
+				pos:        position{line: 1961, col: 26, offset: 70844},
 				val:        "....",
 				ignoreCase: false,
 				want:       "\"....\"",
@@ -12800,29 +12800,29 @@ var g = &grammar{
 		},
 		{
 			name: "ParagraphWithHeadingSpaces",
-			pos:  position{line: 1963, col: 1, offset: 70867},
+			pos:  position{line: 1964, col: 1, offset: 70916},
 			expr: &actionExpr{
-				pos: position{line: 1963, col: 31, offset: 70897},
+				pos: position{line: 1964, col: 31, offset: 70946},
 				run: (*parser).callonParagraphWithHeadingSpaces1,
 				expr: &seqExpr{
-					pos: position{line: 1963, col: 31, offset: 70897},
+					pos: position{line: 1964, col: 31, offset: 70946},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1963, col: 31, offset: 70897},
+							pos:   position{line: 1964, col: 31, offset: 70946},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1963, col: 42, offset: 70908},
+								pos: position{line: 1964, col: 42, offset: 70957},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1963, col: 43, offset: 70909},
+									pos:  position{line: 1964, col: 43, offset: 70958},
 									name: "BlockAttributes",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1963, col: 61, offset: 70927},
+							pos:   position{line: 1964, col: 61, offset: 70976},
 							label: "lines",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1963, col: 68, offset: 70934},
+								pos:  position{line: 1964, col: 68, offset: 70983},
 								name: "ParagraphWithHeadingSpacesLines",
 							},
 						},
@@ -12832,28 +12832,28 @@ var g = &grammar{
 		},
 		{
 			name: "ParagraphWithHeadingSpacesLines",
-			pos:  position{line: 1968, col: 1, offset: 71164},
+			pos:  position{line: 1969, col: 1, offset: 71213},
 			expr: &actionExpr{
-				pos: position{line: 1969, col: 5, offset: 71204},
+				pos: position{line: 1970, col: 5, offset: 71253},
 				run: (*parser).callonParagraphWithHeadingSpacesLines1,
 				expr: &seqExpr{
-					pos: position{line: 1969, col: 5, offset: 71204},
+					pos: position{line: 1970, col: 5, offset: 71253},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1969, col: 5, offset: 71204},
+							pos:   position{line: 1970, col: 5, offset: 71253},
 							label: "firstLine",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1969, col: 16, offset: 71215},
+								pos:  position{line: 1970, col: 16, offset: 71264},
 								name: "ParagraphWithHeadingSpacesLine",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1970, col: 5, offset: 71251},
+							pos:   position{line: 1971, col: 5, offset: 71300},
 							label: "otherLines",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1970, col: 16, offset: 71262},
+								pos: position{line: 1971, col: 16, offset: 71311},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1970, col: 17, offset: 71263},
+									pos:  position{line: 1971, col: 17, offset: 71312},
 									name: "LiteralParagraphLine",
 								},
 							},
@@ -12864,33 +12864,33 @@ var g = &grammar{
 		},
 		{
 			name: "ParagraphWithHeadingSpacesLine",
-			pos:  position{line: 1974, col: 1, offset: 71372},
+			pos:  position{line: 1975, col: 1, offset: 71421},
 			expr: &actionExpr{
-				pos: position{line: 1974, col: 35, offset: 71406},
+				pos: position{line: 1975, col: 35, offset: 71455},
 				run: (*parser).callonParagraphWithHeadingSpacesLine1,
 				expr: &seqExpr{
-					pos: position{line: 1974, col: 35, offset: 71406},
+					pos: position{line: 1975, col: 35, offset: 71455},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1974, col: 35, offset: 71406},
+							pos:   position{line: 1975, col: 35, offset: 71455},
 							label: "line",
 							expr: &actionExpr{
-								pos: position{line: 1974, col: 41, offset: 71412},
+								pos: position{line: 1975, col: 41, offset: 71461},
 								run: (*parser).callonParagraphWithHeadingSpacesLine4,
 								expr: &seqExpr{
-									pos: position{line: 1974, col: 41, offset: 71412},
+									pos: position{line: 1975, col: 41, offset: 71461},
 									exprs: []interface{}{
 										&oneOrMoreExpr{
-											pos: position{line: 1974, col: 41, offset: 71412},
+											pos: position{line: 1975, col: 41, offset: 71461},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1974, col: 41, offset: 71412},
+												pos:  position{line: 1975, col: 41, offset: 71461},
 												name: "Space",
 											},
 										},
 										&oneOrMoreExpr{
-											pos: position{line: 1974, col: 48, offset: 71419},
+											pos: position{line: 1975, col: 48, offset: 71468},
 											expr: &charClassMatcher{
-												pos:        position{line: 1974, col: 48, offset: 71419},
+												pos:        position{line: 1975, col: 48, offset: 71468},
 												val:        "[^\\r\\n]",
 												chars:      []rune{'\r', '\n'},
 												ignoreCase: false,
@@ -12902,7 +12902,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1976, col: 8, offset: 71485},
+							pos:  position{line: 1977, col: 8, offset: 71534},
 							name: "EOL",
 						},
 					},
@@ -12911,72 +12911,72 @@ var g = &grammar{
 		},
 		{
 			name: "ParagraphWithLiteralBlockDelimiter",
-			pos:  position{line: 1981, col: 1, offset: 71625},
+			pos:  position{line: 1982, col: 1, offset: 71674},
 			expr: &actionExpr{
-				pos: position{line: 1981, col: 39, offset: 71663},
+				pos: position{line: 1982, col: 39, offset: 71712},
 				run: (*parser).callonParagraphWithLiteralBlockDelimiter1,
 				expr: &seqExpr{
-					pos: position{line: 1981, col: 39, offset: 71663},
+					pos: position{line: 1982, col: 39, offset: 71712},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1981, col: 39, offset: 71663},
+							pos:   position{line: 1982, col: 39, offset: 71712},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1981, col: 50, offset: 71674},
+								pos: position{line: 1982, col: 50, offset: 71723},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1981, col: 51, offset: 71675},
+									pos:  position{line: 1982, col: 51, offset: 71724},
 									name: "BlockAttributes",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1982, col: 9, offset: 71701},
+							pos:  position{line: 1983, col: 9, offset: 71750},
 							name: "LiteralBlockDelimiter",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1982, col: 31, offset: 71723},
+							pos: position{line: 1983, col: 31, offset: 71772},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1982, col: 31, offset: 71723},
+								pos:  position{line: 1983, col: 31, offset: 71772},
 								name: "Space",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1982, col: 38, offset: 71730},
+							pos:  position{line: 1983, col: 38, offset: 71779},
 							name: "Newline",
 						},
 						&labeledExpr{
-							pos:   position{line: 1982, col: 46, offset: 71738},
+							pos:   position{line: 1983, col: 46, offset: 71787},
 							label: "lines",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1982, col: 53, offset: 71745},
+								pos:  position{line: 1983, col: 53, offset: 71794},
 								name: "ParagraphWithLiteralBlockDelimiterLines",
 							},
 						},
 						&choiceExpr{
-							pos: position{line: 1982, col: 95, offset: 71787},
+							pos: position{line: 1983, col: 95, offset: 71836},
 							alternatives: []interface{}{
 								&seqExpr{
-									pos: position{line: 1982, col: 96, offset: 71788},
+									pos: position{line: 1983, col: 96, offset: 71837},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 1982, col: 96, offset: 71788},
+											pos:  position{line: 1983, col: 96, offset: 71837},
 											name: "LiteralBlockDelimiter",
 										},
 										&zeroOrMoreExpr{
-											pos: position{line: 1982, col: 118, offset: 71810},
+											pos: position{line: 1983, col: 118, offset: 71859},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1982, col: 118, offset: 71810},
+												pos:  position{line: 1983, col: 118, offset: 71859},
 												name: "Space",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1982, col: 125, offset: 71817},
+											pos:  position{line: 1983, col: 125, offset: 71866},
 											name: "EOL",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1982, col: 132, offset: 71824},
+									pos:  position{line: 1983, col: 132, offset: 71873},
 									name: "EOF",
 								},
 							},
@@ -12987,17 +12987,17 @@ var g = &grammar{
 		},
 		{
 			name: "ParagraphWithLiteralBlockDelimiterLines",
-			pos:  position{line: 1987, col: 1, offset: 71983},
+			pos:  position{line: 1988, col: 1, offset: 72032},
 			expr: &actionExpr{
-				pos: position{line: 1987, col: 44, offset: 72026},
+				pos: position{line: 1988, col: 44, offset: 72075},
 				run: (*parser).callonParagraphWithLiteralBlockDelimiterLines1,
 				expr: &labeledExpr{
-					pos:   position{line: 1987, col: 44, offset: 72026},
+					pos:   position{line: 1988, col: 44, offset: 72075},
 					label: "lines",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 1987, col: 50, offset: 72032},
+						pos: position{line: 1988, col: 50, offset: 72081},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1987, col: 51, offset: 72033},
+							pos:  position{line: 1988, col: 51, offset: 72082},
 							name: "ParagraphWithLiteralBlockDelimiterLine",
 						},
 					},
@@ -13006,33 +13006,33 @@ var g = &grammar{
 		},
 		{
 			name: "ParagraphWithLiteralBlockDelimiterLine",
-			pos:  position{line: 1991, col: 1, offset: 72117},
+			pos:  position{line: 1992, col: 1, offset: 72166},
 			expr: &actionExpr{
-				pos: position{line: 1992, col: 5, offset: 72172},
+				pos: position{line: 1993, col: 5, offset: 72221},
 				run: (*parser).callonParagraphWithLiteralBlockDelimiterLine1,
 				expr: &seqExpr{
-					pos: position{line: 1992, col: 5, offset: 72172},
+					pos: position{line: 1993, col: 5, offset: 72221},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 1992, col: 5, offset: 72172},
+							pos:   position{line: 1993, col: 5, offset: 72221},
 							label: "line",
 							expr: &actionExpr{
-								pos: position{line: 1992, col: 11, offset: 72178},
+								pos: position{line: 1993, col: 11, offset: 72227},
 								run: (*parser).callonParagraphWithLiteralBlockDelimiterLine4,
 								expr: &seqExpr{
-									pos: position{line: 1992, col: 11, offset: 72178},
+									pos: position{line: 1993, col: 11, offset: 72227},
 									exprs: []interface{}{
 										&notExpr{
-											pos: position{line: 1992, col: 11, offset: 72178},
+											pos: position{line: 1993, col: 11, offset: 72227},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1992, col: 12, offset: 72179},
+												pos:  position{line: 1993, col: 12, offset: 72228},
 												name: "LiteralBlockDelimiter",
 											},
 										},
 										&zeroOrMoreExpr{
-											pos: position{line: 1992, col: 34, offset: 72201},
+											pos: position{line: 1993, col: 34, offset: 72250},
 											expr: &charClassMatcher{
-												pos:        position{line: 1992, col: 34, offset: 72201},
+												pos:        position{line: 1993, col: 34, offset: 72250},
 												val:        "[^\\r\\n]",
 												chars:      []rune{'\r', '\n'},
 												ignoreCase: false,
@@ -13044,7 +13044,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1994, col: 8, offset: 72267},
+							pos:  position{line: 1995, col: 8, offset: 72316},
 							name: "EOL",
 						},
 					},
@@ -13053,35 +13053,35 @@ var g = &grammar{
 		},
 		{
 			name: "ParagraphWithLiteralAttribute",
-			pos:  position{line: 1999, col: 1, offset: 72393},
+			pos:  position{line: 2000, col: 1, offset: 72442},
 			expr: &actionExpr{
-				pos: position{line: 2000, col: 5, offset: 72431},
+				pos: position{line: 2001, col: 5, offset: 72480},
 				run: (*parser).callonParagraphWithLiteralAttribute1,
 				expr: &seqExpr{
-					pos: position{line: 2000, col: 5, offset: 72431},
+					pos: position{line: 2001, col: 5, offset: 72480},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 2000, col: 5, offset: 72431},
+							pos:   position{line: 2001, col: 5, offset: 72480},
 							label: "attributes",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2000, col: 16, offset: 72442},
+								pos: position{line: 2001, col: 16, offset: 72491},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2000, col: 17, offset: 72443},
+									pos:  position{line: 2001, col: 17, offset: 72492},
 									name: "BlockAttributes",
 								},
 							},
 						},
 						&andCodeExpr{
-							pos: position{line: 2001, col: 5, offset: 72465},
+							pos: position{line: 2002, col: 5, offset: 72514},
 							run: (*parser).callonParagraphWithLiteralAttribute6,
 						},
 						&labeledExpr{
-							pos:   position{line: 2004, col: 5, offset: 72576},
+							pos:   position{line: 2005, col: 5, offset: 72625},
 							label: "lines",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 2004, col: 11, offset: 72582},
+								pos: position{line: 2005, col: 11, offset: 72631},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2004, col: 12, offset: 72583},
+									pos:  position{line: 2005, col: 12, offset: 72632},
 									name: "LiteralParagraphLine",
 								},
 							},
@@ -13092,12 +13092,12 @@ var g = &grammar{
 		},
 		{
 			name: "LiteralKind",
-			pos:  position{line: 2008, col: 1, offset: 72720},
+			pos:  position{line: 2009, col: 1, offset: 72769},
 			expr: &actionExpr{
-				pos: position{line: 2008, col: 16, offset: 72735},
+				pos: position{line: 2009, col: 16, offset: 72784},
 				run: (*parser).callonLiteralKind1,
 				expr: &litMatcher{
-					pos:        position{line: 2008, col: 16, offset: 72735},
+					pos:        position{line: 2009, col: 16, offset: 72784},
 					val:        "literal",
 					ignoreCase: false,
 					want:       "\"literal\"",
@@ -13106,30 +13106,30 @@ var g = &grammar{
 		},
 		{
 			name: "LiteralParagraphLine",
-			pos:  position{line: 2012, col: 1, offset: 72781},
+			pos:  position{line: 2013, col: 1, offset: 72830},
 			expr: &actionExpr{
-				pos: position{line: 2012, col: 25, offset: 72805},
+				pos: position{line: 2013, col: 25, offset: 72854},
 				run: (*parser).callonLiteralParagraphLine1,
 				expr: &seqExpr{
-					pos: position{line: 2012, col: 25, offset: 72805},
+					pos: position{line: 2013, col: 25, offset: 72854},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 2012, col: 25, offset: 72805},
+							pos: position{line: 2013, col: 25, offset: 72854},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2012, col: 26, offset: 72806},
+								pos:  position{line: 2013, col: 26, offset: 72855},
 								name: "BlankLine",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2012, col: 36, offset: 72816},
+							pos:   position{line: 2013, col: 36, offset: 72865},
 							label: "content",
 							expr: &actionExpr{
-								pos: position{line: 2012, col: 45, offset: 72825},
+								pos: position{line: 2013, col: 45, offset: 72874},
 								run: (*parser).callonLiteralParagraphLine6,
 								expr: &oneOrMoreExpr{
-									pos: position{line: 2012, col: 45, offset: 72825},
+									pos: position{line: 2013, col: 45, offset: 72874},
 									expr: &charClassMatcher{
-										pos:        position{line: 2012, col: 45, offset: 72825},
+										pos:        position{line: 2013, col: 45, offset: 72874},
 										val:        "[^\\r\\n]",
 										chars:      []rune{'\r', '\n'},
 										ignoreCase: false,
@@ -13139,7 +13139,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2014, col: 4, offset: 72883},
+							pos:  position{line: 2015, col: 4, offset: 72932},
 							name: "EOL",
 						},
 					},
@@ -13148,29 +13148,29 @@ var g = &grammar{
 		},
 		{
 			name: "IndexTerm",
-			pos:  position{line: 2021, col: 1, offset: 73060},
+			pos:  position{line: 2022, col: 1, offset: 73109},
 			expr: &actionExpr{
-				pos: position{line: 2021, col: 14, offset: 73073},
+				pos: position{line: 2022, col: 14, offset: 73122},
 				run: (*parser).callonIndexTerm1,
 				expr: &seqExpr{
-					pos: position{line: 2021, col: 14, offset: 73073},
+					pos: position{line: 2022, col: 14, offset: 73122},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 2021, col: 14, offset: 73073},
+							pos:        position{line: 2022, col: 14, offset: 73122},
 							val:        "((",
 							ignoreCase: false,
 							want:       "\"((\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 2021, col: 19, offset: 73078},
+							pos:   position{line: 2022, col: 19, offset: 73127},
 							label: "term",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2021, col: 25, offset: 73084},
+								pos:  position{line: 2022, col: 25, offset: 73133},
 								name: "IndexTermContent",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 2021, col: 43, offset: 73102},
+							pos:        position{line: 2022, col: 43, offset: 73151},
 							val:        "))",
 							ignoreCase: false,
 							want:       "\"))\"",
@@ -13181,59 +13181,59 @@ var g = &grammar{
 		},
 		{
 			name: "IndexTermContent",
-			pos:  position{line: 2025, col: 1, offset: 73167},
+			pos:  position{line: 2026, col: 1, offset: 73216},
 			expr: &actionExpr{
-				pos: position{line: 2025, col: 21, offset: 73187},
+				pos: position{line: 2026, col: 21, offset: 73236},
 				run: (*parser).callonIndexTermContent1,
 				expr: &labeledExpr{
-					pos:   position{line: 2025, col: 21, offset: 73187},
+					pos:   position{line: 2026, col: 21, offset: 73236},
 					label: "elements",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 2025, col: 30, offset: 73196},
+						pos: position{line: 2026, col: 30, offset: 73245},
 						expr: &choiceExpr{
-							pos: position{line: 2025, col: 31, offset: 73197},
+							pos: position{line: 2026, col: 31, offset: 73246},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 2025, col: 31, offset: 73197},
+									pos:  position{line: 2026, col: 31, offset: 73246},
 									name: "Word",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2025, col: 38, offset: 73204},
+									pos:  position{line: 2026, col: 38, offset: 73253},
 									name: "QuotedString",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2025, col: 53, offset: 73219},
+									pos:  position{line: 2026, col: 53, offset: 73268},
 									name: "QuotedText",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2025, col: 66, offset: 73232},
+									pos:  position{line: 2026, col: 66, offset: 73281},
 									name: "Space",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2025, col: 74, offset: 73240},
+									pos:  position{line: 2026, col: 74, offset: 73289},
 									name: "SpecialCharacter",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2025, col: 93, offset: 73259},
+									pos:  position{line: 2026, col: 93, offset: 73308},
 									name: "ElementPlaceHolder",
 								},
 								&actionExpr{
-									pos: position{line: 2025, col: 114, offset: 73280},
+									pos: position{line: 2026, col: 114, offset: 73329},
 									run: (*parser).callonIndexTermContent11,
 									expr: &seqExpr{
-										pos: position{line: 2025, col: 115, offset: 73281},
+										pos: position{line: 2026, col: 115, offset: 73330},
 										exprs: []interface{}{
 											&notExpr{
-												pos: position{line: 2025, col: 115, offset: 73281},
+												pos: position{line: 2026, col: 115, offset: 73330},
 												expr: &litMatcher{
-													pos:        position{line: 2025, col: 116, offset: 73282},
+													pos:        position{line: 2026, col: 116, offset: 73331},
 													val:        "))",
 													ignoreCase: false,
 													want:       "\"))\"",
 												},
 											},
 											&anyMatcher{
-												line: 2025, col: 121, offset: 73287,
+												line: 2026, col: 121, offset: 73336,
 											},
 										},
 									},
@@ -13246,63 +13246,63 @@ var g = &grammar{
 		},
 		{
 			name: "ConcealedIndexTerm",
-			pos:  position{line: 2031, col: 1, offset: 73393},
+			pos:  position{line: 2032, col: 1, offset: 73442},
 			expr: &actionExpr{
-				pos: position{line: 2031, col: 23, offset: 73415},
+				pos: position{line: 2032, col: 23, offset: 73464},
 				run: (*parser).callonConcealedIndexTerm1,
 				expr: &seqExpr{
-					pos: position{line: 2031, col: 23, offset: 73415},
+					pos: position{line: 2032, col: 23, offset: 73464},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 2031, col: 23, offset: 73415},
+							pos:        position{line: 2032, col: 23, offset: 73464},
 							val:        "(((",
 							ignoreCase: false,
 							want:       "\"(((\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 2031, col: 29, offset: 73421},
+							pos:   position{line: 2032, col: 29, offset: 73470},
 							label: "term1",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2031, col: 36, offset: 73428},
+								pos:  position{line: 2032, col: 36, offset: 73477},
 								name: "ConcealedIndexTermContent",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2032, col: 5, offset: 73460},
+							pos:   position{line: 2033, col: 5, offset: 73509},
 							label: "term2",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2032, col: 11, offset: 73466},
+								pos: position{line: 2033, col: 11, offset: 73515},
 								expr: &actionExpr{
-									pos: position{line: 2032, col: 12, offset: 73467},
+									pos: position{line: 2033, col: 12, offset: 73516},
 									run: (*parser).callonConcealedIndexTerm8,
 									expr: &seqExpr{
-										pos: position{line: 2032, col: 12, offset: 73467},
+										pos: position{line: 2033, col: 12, offset: 73516},
 										exprs: []interface{}{
 											&zeroOrMoreExpr{
-												pos: position{line: 2032, col: 12, offset: 73467},
+												pos: position{line: 2033, col: 12, offset: 73516},
 												expr: &ruleRefExpr{
-													pos:  position{line: 2032, col: 12, offset: 73467},
+													pos:  position{line: 2033, col: 12, offset: 73516},
 													name: "Space",
 												},
 											},
 											&litMatcher{
-												pos:        position{line: 2032, col: 19, offset: 73474},
+												pos:        position{line: 2033, col: 19, offset: 73523},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&zeroOrMoreExpr{
-												pos: position{line: 2032, col: 23, offset: 73478},
+												pos: position{line: 2033, col: 23, offset: 73527},
 												expr: &ruleRefExpr{
-													pos:  position{line: 2032, col: 23, offset: 73478},
+													pos:  position{line: 2033, col: 23, offset: 73527},
 													name: "Space",
 												},
 											},
 											&labeledExpr{
-												pos:   position{line: 2032, col: 30, offset: 73485},
+												pos:   position{line: 2033, col: 30, offset: 73534},
 												label: "content",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2032, col: 39, offset: 73494},
+													pos:  position{line: 2033, col: 39, offset: 73543},
 													name: "ConcealedIndexTermContent",
 												},
 											},
@@ -13312,41 +13312,41 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2033, col: 5, offset: 73552},
+							pos:   position{line: 2034, col: 5, offset: 73601},
 							label: "term3",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2033, col: 11, offset: 73558},
+								pos: position{line: 2034, col: 11, offset: 73607},
 								expr: &actionExpr{
-									pos: position{line: 2033, col: 12, offset: 73559},
+									pos: position{line: 2034, col: 12, offset: 73608},
 									run: (*parser).callonConcealedIndexTerm19,
 									expr: &seqExpr{
-										pos: position{line: 2033, col: 12, offset: 73559},
+										pos: position{line: 2034, col: 12, offset: 73608},
 										exprs: []interface{}{
 											&zeroOrMoreExpr{
-												pos: position{line: 2033, col: 12, offset: 73559},
+												pos: position{line: 2034, col: 12, offset: 73608},
 												expr: &ruleRefExpr{
-													pos:  position{line: 2033, col: 12, offset: 73559},
+													pos:  position{line: 2034, col: 12, offset: 73608},
 													name: "Space",
 												},
 											},
 											&litMatcher{
-												pos:        position{line: 2033, col: 19, offset: 73566},
+												pos:        position{line: 2034, col: 19, offset: 73615},
 												val:        ",",
 												ignoreCase: false,
 												want:       "\",\"",
 											},
 											&zeroOrMoreExpr{
-												pos: position{line: 2033, col: 23, offset: 73570},
+												pos: position{line: 2034, col: 23, offset: 73619},
 												expr: &ruleRefExpr{
-													pos:  position{line: 2033, col: 23, offset: 73570},
+													pos:  position{line: 2034, col: 23, offset: 73619},
 													name: "Space",
 												},
 											},
 											&labeledExpr{
-												pos:   position{line: 2033, col: 30, offset: 73577},
+												pos:   position{line: 2034, col: 30, offset: 73626},
 												label: "content",
 												expr: &ruleRefExpr{
-													pos:  position{line: 2033, col: 39, offset: 73586},
+													pos:  position{line: 2034, col: 39, offset: 73635},
 													name: "ConcealedIndexTermContent",
 												},
 											},
@@ -13356,7 +13356,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 2034, col: 5, offset: 73644},
+							pos:        position{line: 2035, col: 5, offset: 73693},
 							val:        ")))",
 							ignoreCase: false,
 							want:       "\")))\"",
@@ -13367,21 +13367,21 @@ var g = &grammar{
 		},
 		{
 			name: "ConcealedIndexTermContent",
-			pos:  position{line: 2038, col: 1, offset: 73723},
+			pos:  position{line: 2039, col: 1, offset: 73772},
 			expr: &actionExpr{
-				pos: position{line: 2038, col: 30, offset: 73752},
+				pos: position{line: 2039, col: 30, offset: 73801},
 				run: (*parser).callonConcealedIndexTermContent1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 2038, col: 30, offset: 73752},
+					pos: position{line: 2039, col: 30, offset: 73801},
 					expr: &choiceExpr{
-						pos: position{line: 2038, col: 31, offset: 73753},
+						pos: position{line: 2039, col: 31, offset: 73802},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 2038, col: 31, offset: 73753},
+								pos:  position{line: 2039, col: 31, offset: 73802},
 								name: "Alphanum",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2038, col: 42, offset: 73764},
+								pos:  position{line: 2039, col: 42, offset: 73813},
 								name: "Space",
 							},
 						},
@@ -13391,29 +13391,29 @@ var g = &grammar{
 		},
 		{
 			name: "BlankLine",
-			pos:  position{line: 2045, col: 1, offset: 73913},
+			pos:  position{line: 2046, col: 1, offset: 73962},
 			expr: &actionExpr{
-				pos: position{line: 2045, col: 14, offset: 73926},
+				pos: position{line: 2046, col: 14, offset: 73975},
 				run: (*parser).callonBlankLine1,
 				expr: &seqExpr{
-					pos: position{line: 2045, col: 14, offset: 73926},
+					pos: position{line: 2046, col: 14, offset: 73975},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 2045, col: 14, offset: 73926},
+							pos: position{line: 2046, col: 14, offset: 73975},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2045, col: 15, offset: 73927},
+								pos:  position{line: 2046, col: 15, offset: 73976},
 								name: "EOF",
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 2045, col: 19, offset: 73931},
+							pos: position{line: 2046, col: 19, offset: 73980},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2045, col: 19, offset: 73931},
+								pos:  position{line: 2046, col: 19, offset: 73980},
 								name: "Space",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2045, col: 26, offset: 73938},
+							pos:  position{line: 2046, col: 26, offset: 73987},
 							name: "EOL",
 						},
 					},
@@ -13422,32 +13422,32 @@ var g = &grammar{
 		},
 		{
 			name: "Symbol",
-			pos:  position{line: 2053, col: 1, offset: 74083},
+			pos:  position{line: 2054, col: 1, offset: 74132},
 			expr: &choiceExpr{
-				pos: position{line: 2053, col: 11, offset: 74093},
+				pos: position{line: 2054, col: 11, offset: 74142},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 2053, col: 11, offset: 74093},
+						pos:  position{line: 2054, col: 11, offset: 74142},
 						name: "Apostrophe",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2053, col: 24, offset: 74106},
+						pos:  position{line: 2054, col: 24, offset: 74155},
 						name: "Copyright",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2053, col: 36, offset: 74118},
+						pos:  position{line: 2054, col: 36, offset: 74167},
 						name: "Trademark",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2053, col: 48, offset: 74130},
+						pos:  position{line: 2054, col: 48, offset: 74179},
 						name: "Registered",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2053, col: 61, offset: 74143},
+						pos:  position{line: 2054, col: 61, offset: 74192},
 						name: "Ellipsis",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2053, col: 72, offset: 74154},
+						pos:  position{line: 2054, col: 72, offset: 74203},
 						name: "ImpliedApostrophe",
 					},
 				},
@@ -13455,12 +13455,12 @@ var g = &grammar{
 		},
 		{
 			name: "Apostrophe",
-			pos:  position{line: 2055, col: 1, offset: 74173},
+			pos:  position{line: 2056, col: 1, offset: 74222},
 			expr: &actionExpr{
-				pos: position{line: 2055, col: 15, offset: 74187},
+				pos: position{line: 2056, col: 15, offset: 74236},
 				run: (*parser).callonApostrophe1,
 				expr: &litMatcher{
-					pos:        position{line: 2055, col: 15, offset: 74187},
+					pos:        position{line: 2056, col: 15, offset: 74236},
 					val:        "`'",
 					ignoreCase: false,
 					want:       "\"`'\"",
@@ -13469,12 +13469,12 @@ var g = &grammar{
 		},
 		{
 			name: "Copyright",
-			pos:  position{line: 2058, col: 1, offset: 74240},
+			pos:  position{line: 2059, col: 1, offset: 74289},
 			expr: &actionExpr{
-				pos: position{line: 2058, col: 14, offset: 74253},
+				pos: position{line: 2059, col: 14, offset: 74302},
 				run: (*parser).callonCopyright1,
 				expr: &litMatcher{
-					pos:        position{line: 2058, col: 14, offset: 74253},
+					pos:        position{line: 2059, col: 14, offset: 74302},
 					val:        "(C)",
 					ignoreCase: false,
 					want:       "\"(C)\"",
@@ -13483,12 +13483,12 @@ var g = &grammar{
 		},
 		{
 			name: "Trademark",
-			pos:  position{line: 2061, col: 1, offset: 74307},
+			pos:  position{line: 2062, col: 1, offset: 74356},
 			expr: &actionExpr{
-				pos: position{line: 2061, col: 14, offset: 74320},
+				pos: position{line: 2062, col: 14, offset: 74369},
 				run: (*parser).callonTrademark1,
 				expr: &litMatcher{
-					pos:        position{line: 2061, col: 14, offset: 74320},
+					pos:        position{line: 2062, col: 14, offset: 74369},
 					val:        "(TM)",
 					ignoreCase: false,
 					want:       "\"(TM)\"",
@@ -13497,12 +13497,12 @@ var g = &grammar{
 		},
 		{
 			name: "Registered",
-			pos:  position{line: 2064, col: 1, offset: 74375},
+			pos:  position{line: 2065, col: 1, offset: 74424},
 			expr: &actionExpr{
-				pos: position{line: 2064, col: 15, offset: 74389},
+				pos: position{line: 2065, col: 15, offset: 74438},
 				run: (*parser).callonRegistered1,
 				expr: &litMatcher{
-					pos:        position{line: 2064, col: 15, offset: 74389},
+					pos:        position{line: 2065, col: 15, offset: 74438},
 					val:        "(R)",
 					ignoreCase: false,
 					want:       "\"(R)\"",
@@ -13511,12 +13511,12 @@ var g = &grammar{
 		},
 		{
 			name: "Ellipsis",
-			pos:  position{line: 2067, col: 1, offset: 74443},
+			pos:  position{line: 2068, col: 1, offset: 74492},
 			expr: &actionExpr{
-				pos: position{line: 2067, col: 13, offset: 74455},
+				pos: position{line: 2068, col: 13, offset: 74504},
 				run: (*parser).callonEllipsis1,
 				expr: &litMatcher{
-					pos:        position{line: 2067, col: 13, offset: 74455},
+					pos:        position{line: 2068, col: 13, offset: 74504},
 					val:        "...",
 					ignoreCase: false,
 					want:       "\"...\"",
@@ -13525,27 +13525,27 @@ var g = &grammar{
 		},
 		{
 			name: "ImpliedApostrophe",
-			pos:  position{line: 2075, col: 1, offset: 74732},
+			pos:  position{line: 2076, col: 1, offset: 74781},
 			expr: &actionExpr{
-				pos: position{line: 2075, col: 22, offset: 74753},
+				pos: position{line: 2076, col: 22, offset: 74802},
 				run: (*parser).callonImpliedApostrophe1,
 				expr: &seqExpr{
-					pos: position{line: 2075, col: 22, offset: 74753},
+					pos: position{line: 2076, col: 22, offset: 74802},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 2075, col: 22, offset: 74753},
+							pos:  position{line: 2076, col: 22, offset: 74802},
 							name: "Alphanum",
 						},
 						&litMatcher{
-							pos:        position{line: 2075, col: 31, offset: 74762},
+							pos:        position{line: 2076, col: 31, offset: 74811},
 							val:        "'",
 							ignoreCase: false,
 							want:       "\"'\"",
 						},
 						&andExpr{
-							pos: position{line: 2075, col: 35, offset: 74766},
+							pos: position{line: 2076, col: 35, offset: 74815},
 							expr: &charClassMatcher{
-								pos:        position{line: 2075, col: 36, offset: 74767},
+								pos:        position{line: 2076, col: 36, offset: 74816},
 								val:        "[\\pL]",
 								classes:    []*unicode.RangeTable{rangeTable("L")},
 								ignoreCase: false,
@@ -13558,38 +13558,38 @@ var g = &grammar{
 		},
 		{
 			name: "SpecialCharacter",
-			pos:  position{line: 2084, col: 1, offset: 75129},
+			pos:  position{line: 2085, col: 1, offset: 75178},
 			expr: &choiceExpr{
-				pos: position{line: 2084, col: 21, offset: 75149},
+				pos: position{line: 2085, col: 21, offset: 75198},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 2084, col: 21, offset: 75149},
+						pos: position{line: 2085, col: 21, offset: 75198},
 						run: (*parser).callonSpecialCharacter2,
 						expr: &ruleRefExpr{
-							pos:  position{line: 2084, col: 21, offset: 75149},
+							pos:  position{line: 2085, col: 21, offset: 75198},
 							name: "InternalCrossReference",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2087, col: 9, offset: 75312},
+						pos: position{line: 2088, col: 9, offset: 75361},
 						run: (*parser).callonSpecialCharacter4,
 						expr: &choiceExpr{
-							pos: position{line: 2087, col: 10, offset: 75313},
+							pos: position{line: 2088, col: 10, offset: 75362},
 							alternatives: []interface{}{
 								&litMatcher{
-									pos:        position{line: 2087, col: 10, offset: 75313},
+									pos:        position{line: 2088, col: 10, offset: 75362},
 									val:        "<",
 									ignoreCase: false,
 									want:       "\"<\"",
 								},
 								&litMatcher{
-									pos:        position{line: 2087, col: 16, offset: 75319},
+									pos:        position{line: 2088, col: 16, offset: 75368},
 									val:        ">",
 									ignoreCase: false,
 									want:       "\">\"",
 								},
 								&litMatcher{
-									pos:        position{line: 2087, col: 22, offset: 75325},
+									pos:        position{line: 2088, col: 22, offset: 75374},
 									val:        "&",
 									ignoreCase: false,
 									want:       "\"&\"",
@@ -13602,9 +13602,9 @@ var g = &grammar{
 		},
 		{
 			name: "Alphanum",
-			pos:  position{line: 2094, col: 1, offset: 75503},
+			pos:  position{line: 2095, col: 1, offset: 75552},
 			expr: &charClassMatcher{
-				pos:        position{line: 2094, col: 13, offset: 75515},
+				pos:        position{line: 2095, col: 13, offset: 75564},
 				val:        "[\\pL0-9]",
 				ranges:     []rune{'0', '9'},
 				classes:    []*unicode.RangeTable{rangeTable("L")},
@@ -13614,42 +13614,42 @@ var g = &grammar{
 		},
 		{
 			name: "Parenthesis",
-			pos:  position{line: 2096, col: 1, offset: 75525},
+			pos:  position{line: 2097, col: 1, offset: 75574},
 			expr: &choiceExpr{
-				pos: position{line: 2096, col: 16, offset: 75540},
+				pos: position{line: 2097, col: 16, offset: 75589},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 2096, col: 16, offset: 75540},
+						pos:        position{line: 2097, col: 16, offset: 75589},
 						val:        "(",
 						ignoreCase: false,
 						want:       "\"(\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2096, col: 22, offset: 75546},
+						pos:        position{line: 2097, col: 22, offset: 75595},
 						val:        ")",
 						ignoreCase: false,
 						want:       "\")\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2096, col: 28, offset: 75552},
+						pos:        position{line: 2097, col: 28, offset: 75601},
 						val:        "[",
 						ignoreCase: false,
 						want:       "\"[\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2096, col: 34, offset: 75558},
+						pos:        position{line: 2097, col: 34, offset: 75607},
 						val:        "]",
 						ignoreCase: false,
 						want:       "\"]\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2096, col: 40, offset: 75564},
+						pos:        position{line: 2097, col: 40, offset: 75613},
 						val:        "{",
 						ignoreCase: false,
 						want:       "\"{\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2096, col: 46, offset: 75570},
+						pos:        position{line: 2097, col: 46, offset: 75619},
 						val:        "}",
 						ignoreCase: false,
 						want:       "\"}\"",
@@ -13659,14 +13659,14 @@ var g = &grammar{
 		},
 		{
 			name: "Alphanums",
-			pos:  position{line: 2098, col: 1, offset: 75576},
+			pos:  position{line: 2099, col: 1, offset: 75625},
 			expr: &actionExpr{
-				pos: position{line: 2098, col: 14, offset: 75589},
+				pos: position{line: 2099, col: 14, offset: 75638},
 				run: (*parser).callonAlphanums1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 2098, col: 14, offset: 75589},
+					pos: position{line: 2099, col: 14, offset: 75638},
 					expr: &charClassMatcher{
-						pos:        position{line: 2098, col: 14, offset: 75589},
+						pos:        position{line: 2099, col: 14, offset: 75638},
 						val:        "[\\pL0-9]",
 						ranges:     []rune{'0', '9'},
 						classes:    []*unicode.RangeTable{rangeTable("L")},
@@ -13678,20 +13678,20 @@ var g = &grammar{
 		},
 		{
 			name: "Word",
-			pos:  position{line: 2102, col: 1, offset: 75635},
+			pos:  position{line: 2103, col: 1, offset: 75684},
 			expr: &choiceExpr{
-				pos: position{line: 2106, col: 5, offset: 75962},
+				pos: position{line: 2107, col: 5, offset: 76011},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 2106, col: 5, offset: 75962},
+						pos: position{line: 2107, col: 5, offset: 76011},
 						run: (*parser).callonWord2,
 						expr: &seqExpr{
-							pos: position{line: 2106, col: 5, offset: 75962},
+							pos: position{line: 2107, col: 5, offset: 76011},
 							exprs: []interface{}{
 								&oneOrMoreExpr{
-									pos: position{line: 2106, col: 5, offset: 75962},
+									pos: position{line: 2107, col: 5, offset: 76011},
 									expr: &charClassMatcher{
-										pos:        position{line: 2106, col: 5, offset: 75962},
+										pos:        position{line: 2107, col: 5, offset: 76011},
 										val:        "[\\pL0-9]",
 										ranges:     []rune{'0', '9'},
 										classes:    []*unicode.RangeTable{rangeTable("L")},
@@ -13700,19 +13700,19 @@ var g = &grammar{
 									},
 								},
 								&andExpr{
-									pos: position{line: 2106, col: 15, offset: 75972},
+									pos: position{line: 2107, col: 15, offset: 76021},
 									expr: &choiceExpr{
-										pos: position{line: 2106, col: 17, offset: 75974},
+										pos: position{line: 2107, col: 17, offset: 76023},
 										alternatives: []interface{}{
 											&charClassMatcher{
-												pos:        position{line: 2106, col: 17, offset: 75974},
+												pos:        position{line: 2107, col: 17, offset: 76023},
 												val:        "[\\r\\n ,\\]]",
 												chars:      []rune{'\r', '\n', ' ', ',', ']'},
 												ignoreCase: false,
 												inverted:   false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2106, col: 30, offset: 75987},
+												pos:  position{line: 2107, col: 30, offset: 76036},
 												name: "EOF",
 											},
 										},
@@ -13722,15 +13722,15 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2108, col: 9, offset: 76057},
+						pos: position{line: 2109, col: 9, offset: 76106},
 						run: (*parser).callonWord10,
 						expr: &seqExpr{
-							pos: position{line: 2108, col: 9, offset: 76057},
+							pos: position{line: 2109, col: 9, offset: 76106},
 							exprs: []interface{}{
 								&oneOrMoreExpr{
-									pos: position{line: 2108, col: 9, offset: 76057},
+									pos: position{line: 2109, col: 9, offset: 76106},
 									expr: &charClassMatcher{
-										pos:        position{line: 2108, col: 9, offset: 76057},
+										pos:        position{line: 2109, col: 9, offset: 76106},
 										val:        "[\\pL0-9]",
 										ranges:     []rune{'0', '9'},
 										classes:    []*unicode.RangeTable{rangeTable("L")},
@@ -13739,21 +13739,21 @@ var g = &grammar{
 									},
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 2108, col: 19, offset: 76067},
+									pos: position{line: 2109, col: 19, offset: 76116},
 									expr: &seqExpr{
-										pos: position{line: 2108, col: 20, offset: 76068},
+										pos: position{line: 2109, col: 20, offset: 76117},
 										exprs: []interface{}{
 											&charClassMatcher{
-												pos:        position{line: 2108, col: 20, offset: 76068},
+												pos:        position{line: 2109, col: 20, offset: 76117},
 												val:        "[=*_`]",
 												chars:      []rune{'=', '*', '_', '`'},
 												ignoreCase: false,
 												inverted:   false,
 											},
 											&oneOrMoreExpr{
-												pos: position{line: 2108, col: 27, offset: 76075},
+												pos: position{line: 2109, col: 27, offset: 76124},
 												expr: &charClassMatcher{
-													pos:        position{line: 2108, col: 27, offset: 76075},
+													pos:        position{line: 2109, col: 27, offset: 76124},
 													val:        "[\\pL0-9]",
 													ranges:     []rune{'0', '9'},
 													classes:    []*unicode.RangeTable{rangeTable("L")},
@@ -13772,20 +13772,20 @@ var g = &grammar{
 		},
 		{
 			name: "InlineWord",
-			pos:  position{line: 2112, col: 1, offset: 76162},
+			pos:  position{line: 2113, col: 1, offset: 76211},
 			expr: &choiceExpr{
-				pos: position{line: 2113, col: 5, offset: 76243},
+				pos: position{line: 2114, col: 5, offset: 76292},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 2113, col: 5, offset: 76243},
+						pos: position{line: 2114, col: 5, offset: 76292},
 						run: (*parser).callonInlineWord2,
 						expr: &seqExpr{
-							pos: position{line: 2113, col: 5, offset: 76243},
+							pos: position{line: 2114, col: 5, offset: 76292},
 							exprs: []interface{}{
 								&oneOrMoreExpr{
-									pos: position{line: 2113, col: 5, offset: 76243},
+									pos: position{line: 2114, col: 5, offset: 76292},
 									expr: &charClassMatcher{
-										pos:        position{line: 2113, col: 5, offset: 76243},
+										pos:        position{line: 2114, col: 5, offset: 76292},
 										val:        "[\\pL0-9,?!;]",
 										chars:      []rune{',', '?', '!', ';'},
 										ranges:     []rune{'0', '9'},
@@ -13795,19 +13795,19 @@ var g = &grammar{
 									},
 								},
 								&andExpr{
-									pos: position{line: 2113, col: 19, offset: 76257},
+									pos: position{line: 2114, col: 19, offset: 76306},
 									expr: &choiceExpr{
-										pos: position{line: 2113, col: 21, offset: 76259},
+										pos: position{line: 2114, col: 21, offset: 76308},
 										alternatives: []interface{}{
 											&charClassMatcher{
-												pos:        position{line: 2113, col: 21, offset: 76259},
+												pos:        position{line: 2114, col: 21, offset: 76308},
 												val:        "[\\r\\n ]",
 												chars:      []rune{'\r', '\n', ' '},
 												ignoreCase: false,
 												inverted:   false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2113, col: 31, offset: 76269},
+												pos:  position{line: 2114, col: 31, offset: 76318},
 												name: "EOF",
 											},
 										},
@@ -13817,7 +13817,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2115, col: 9, offset: 76338},
+						pos:  position{line: 2116, col: 9, offset: 76387},
 						name: "Word",
 					},
 				},
@@ -13825,12 +13825,12 @@ var g = &grammar{
 		},
 		{
 			name: "AnyChar",
-			pos:  position{line: 2118, col: 1, offset: 76438},
+			pos:  position{line: 2119, col: 1, offset: 76487},
 			expr: &actionExpr{
-				pos: position{line: 2118, col: 12, offset: 76449},
+				pos: position{line: 2119, col: 12, offset: 76498},
 				run: (*parser).callonAnyChar1,
 				expr: &charClassMatcher{
-					pos:        position{line: 2118, col: 12, offset: 76449},
+					pos:        position{line: 2119, col: 12, offset: 76498},
 					val:        "[^\\r\\n]",
 					chars:      []rune{'\r', '\n'},
 					ignoreCase: false,
@@ -13840,24 +13840,24 @@ var g = &grammar{
 		},
 		{
 			name: "FileLocation",
-			pos:  position{line: 2122, col: 1, offset: 76514},
+			pos:  position{line: 2123, col: 1, offset: 76563},
 			expr: &actionExpr{
-				pos: position{line: 2122, col: 17, offset: 76530},
+				pos: position{line: 2123, col: 17, offset: 76579},
 				run: (*parser).callonFileLocation1,
 				expr: &labeledExpr{
-					pos:   position{line: 2122, col: 17, offset: 76530},
+					pos:   position{line: 2123, col: 17, offset: 76579},
 					label: "path",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 2122, col: 22, offset: 76535},
+						pos: position{line: 2123, col: 22, offset: 76584},
 						expr: &choiceExpr{
-							pos: position{line: 2122, col: 23, offset: 76536},
+							pos: position{line: 2123, col: 23, offset: 76585},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 2122, col: 23, offset: 76536},
+									pos:  position{line: 2123, col: 23, offset: 76585},
 									name: "Filename",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2122, col: 34, offset: 76547},
+									pos:  position{line: 2123, col: 34, offset: 76596},
 									name: "ElementPlaceHolder",
 								},
 							},
@@ -13868,38 +13868,38 @@ var g = &grammar{
 		},
 		{
 			name: "Location",
-			pos:  position{line: 2126, col: 1, offset: 76628},
+			pos:  position{line: 2127, col: 1, offset: 76677},
 			expr: &actionExpr{
-				pos: position{line: 2126, col: 13, offset: 76640},
+				pos: position{line: 2127, col: 13, offset: 76689},
 				run: (*parser).callonLocation1,
 				expr: &seqExpr{
-					pos: position{line: 2126, col: 13, offset: 76640},
+					pos: position{line: 2127, col: 13, offset: 76689},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 2126, col: 13, offset: 76640},
+							pos:   position{line: 2127, col: 13, offset: 76689},
 							label: "scheme",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2126, col: 20, offset: 76647},
+								pos: position{line: 2127, col: 20, offset: 76696},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2126, col: 21, offset: 76648},
+									pos:  position{line: 2127, col: 21, offset: 76697},
 									name: "Scheme",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2126, col: 30, offset: 76657},
+							pos:   position{line: 2127, col: 30, offset: 76706},
 							label: "path",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 2126, col: 35, offset: 76662},
+								pos: position{line: 2127, col: 35, offset: 76711},
 								expr: &choiceExpr{
-									pos: position{line: 2126, col: 36, offset: 76663},
+									pos: position{line: 2127, col: 36, offset: 76712},
 									alternatives: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 2126, col: 36, offset: 76663},
+											pos:  position{line: 2127, col: 36, offset: 76712},
 											name: "Filename",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2126, col: 47, offset: 76674},
+											pos:  position{line: 2127, col: 47, offset: 76723},
 											name: "ElementPlaceHolder",
 										},
 									},
@@ -13912,35 +13912,35 @@ var g = &grammar{
 		},
 		{
 			name: "LocationWithScheme",
-			pos:  position{line: 2130, col: 1, offset: 76759},
+			pos:  position{line: 2131, col: 1, offset: 76808},
 			expr: &actionExpr{
-				pos: position{line: 2130, col: 23, offset: 76781},
+				pos: position{line: 2131, col: 23, offset: 76830},
 				run: (*parser).callonLocationWithScheme1,
 				expr: &seqExpr{
-					pos: position{line: 2130, col: 23, offset: 76781},
+					pos: position{line: 2131, col: 23, offset: 76830},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 2130, col: 23, offset: 76781},
+							pos:   position{line: 2131, col: 23, offset: 76830},
 							label: "scheme",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2130, col: 31, offset: 76789},
+								pos:  position{line: 2131, col: 31, offset: 76838},
 								name: "Scheme",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2130, col: 39, offset: 76797},
+							pos:   position{line: 2131, col: 39, offset: 76846},
 							label: "path",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 2130, col: 44, offset: 76802},
+								pos: position{line: 2131, col: 44, offset: 76851},
 								expr: &choiceExpr{
-									pos: position{line: 2130, col: 45, offset: 76803},
+									pos: position{line: 2131, col: 45, offset: 76852},
 									alternatives: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 2130, col: 45, offset: 76803},
+											pos:  position{line: 2131, col: 45, offset: 76852},
 											name: "Filename",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2130, col: 56, offset: 76814},
+											pos:  position{line: 2131, col: 56, offset: 76863},
 											name: "ElementPlaceHolder",
 										},
 									},
@@ -13953,14 +13953,14 @@ var g = &grammar{
 		},
 		{
 			name: "Filename",
-			pos:  position{line: 2134, col: 1, offset: 76899},
+			pos:  position{line: 2135, col: 1, offset: 76948},
 			expr: &actionExpr{
-				pos: position{line: 2134, col: 13, offset: 76911},
+				pos: position{line: 2135, col: 13, offset: 76960},
 				run: (*parser).callonFilename1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 2134, col: 13, offset: 76911},
+					pos: position{line: 2135, col: 13, offset: 76960},
 					expr: &charClassMatcher{
-						pos:        position{line: 2134, col: 14, offset: 76912},
+						pos:        position{line: 2135, col: 14, offset: 76961},
 						val:        "[^\\r\\n[\\]\\uFFFD ]",
 						chars:      []rune{'\r', '\n', '[', ']', '�', ' '},
 						ignoreCase: false,
@@ -13971,36 +13971,36 @@ var g = &grammar{
 		},
 		{
 			name: "Scheme",
-			pos:  position{line: 2138, col: 1, offset: 77034},
+			pos:  position{line: 2139, col: 1, offset: 77083},
 			expr: &choiceExpr{
-				pos: position{line: 2138, col: 11, offset: 77044},
+				pos: position{line: 2139, col: 11, offset: 77093},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 2138, col: 11, offset: 77044},
+						pos:        position{line: 2139, col: 11, offset: 77093},
 						val:        "http://",
 						ignoreCase: false,
 						want:       "\"http://\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2138, col: 23, offset: 77056},
+						pos:        position{line: 2139, col: 23, offset: 77105},
 						val:        "https://",
 						ignoreCase: false,
 						want:       "\"https://\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2138, col: 36, offset: 77069},
+						pos:        position{line: 2139, col: 36, offset: 77118},
 						val:        "ftp://",
 						ignoreCase: false,
 						want:       "\"ftp://\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2138, col: 47, offset: 77080},
+						pos:        position{line: 2139, col: 47, offset: 77129},
 						val:        "irc://",
 						ignoreCase: false,
 						want:       "\"irc://\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2138, col: 58, offset: 77091},
+						pos:        position{line: 2139, col: 58, offset: 77140},
 						val:        "mailto:",
 						ignoreCase: false,
 						want:       "\"mailto:\"",
@@ -14010,14 +14010,14 @@ var g = &grammar{
 		},
 		{
 			name: "Id",
-			pos:  position{line: 2140, col: 1, offset: 77102},
+			pos:  position{line: 2141, col: 1, offset: 77151},
 			expr: &actionExpr{
-				pos: position{line: 2140, col: 7, offset: 77108},
+				pos: position{line: 2141, col: 7, offset: 77157},
 				run: (*parser).callonId1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 2140, col: 7, offset: 77108},
+					pos: position{line: 2141, col: 7, offset: 77157},
 					expr: &charClassMatcher{
-						pos:        position{line: 2140, col: 7, offset: 77108},
+						pos:        position{line: 2141, col: 7, offset: 77157},
 						val:        "[^[\\]<>,]",
 						chars:      []rune{'[', ']', '<', '>', ','},
 						ignoreCase: false,
@@ -14028,12 +14028,12 @@ var g = &grammar{
 		},
 		{
 			name: "Digit",
-			pos:  position{line: 2144, col: 1, offset: 77233},
+			pos:  position{line: 2145, col: 1, offset: 77282},
 			expr: &actionExpr{
-				pos: position{line: 2144, col: 10, offset: 77242},
+				pos: position{line: 2145, col: 10, offset: 77291},
 				run: (*parser).callonDigit1,
 				expr: &charClassMatcher{
-					pos:        position{line: 2144, col: 10, offset: 77242},
+					pos:        position{line: 2145, col: 10, offset: 77291},
 					val:        "[0-9]",
 					ranges:     []rune{'0', '9'},
 					ignoreCase: false,
@@ -14043,26 +14043,26 @@ var g = &grammar{
 		},
 		{
 			name: "Number",
-			pos:  position{line: 2148, col: 1, offset: 77284},
+			pos:  position{line: 2149, col: 1, offset: 77333},
 			expr: &actionExpr{
-				pos: position{line: 2148, col: 11, offset: 77294},
+				pos: position{line: 2149, col: 11, offset: 77343},
 				run: (*parser).callonNumber1,
 				expr: &seqExpr{
-					pos: position{line: 2148, col: 11, offset: 77294},
+					pos: position{line: 2149, col: 11, offset: 77343},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 2148, col: 11, offset: 77294},
+							pos: position{line: 2149, col: 11, offset: 77343},
 							expr: &litMatcher{
-								pos:        position{line: 2148, col: 11, offset: 77294},
+								pos:        position{line: 2149, col: 11, offset: 77343},
 								val:        "-",
 								ignoreCase: false,
 								want:       "\"-\"",
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 2148, col: 16, offset: 77299},
+							pos: position{line: 2149, col: 16, offset: 77348},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2148, col: 16, offset: 77299},
+								pos:  position{line: 2149, col: 16, offset: 77348},
 								name: "Digit",
 							},
 						},
@@ -14072,21 +14072,21 @@ var g = &grammar{
 		},
 		{
 			name: "Space",
-			pos:  position{line: 2152, col: 1, offset: 77351},
+			pos:  position{line: 2153, col: 1, offset: 77400},
 			expr: &choiceExpr{
-				pos: position{line: 2152, col: 10, offset: 77360},
+				pos: position{line: 2153, col: 10, offset: 77409},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 2152, col: 10, offset: 77360},
+						pos:        position{line: 2153, col: 10, offset: 77409},
 						val:        " ",
 						ignoreCase: false,
 						want:       "\" \"",
 					},
 					&actionExpr{
-						pos: position{line: 2152, col: 16, offset: 77366},
+						pos: position{line: 2153, col: 16, offset: 77415},
 						run: (*parser).callonSpace3,
 						expr: &litMatcher{
-							pos:        position{line: 2152, col: 16, offset: 77366},
+							pos:        position{line: 2153, col: 16, offset: 77415},
 							val:        "\t",
 							ignoreCase: false,
 							want:       "\"\\t\"",
@@ -14097,24 +14097,24 @@ var g = &grammar{
 		},
 		{
 			name: "Newline",
-			pos:  position{line: 2156, col: 1, offset: 77407},
+			pos:  position{line: 2157, col: 1, offset: 77456},
 			expr: &choiceExpr{
-				pos: position{line: 2156, col: 12, offset: 77418},
+				pos: position{line: 2157, col: 12, offset: 77467},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 2156, col: 12, offset: 77418},
+						pos:        position{line: 2157, col: 12, offset: 77467},
 						val:        "\r\n",
 						ignoreCase: false,
 						want:       "\"\\r\\n\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2156, col: 21, offset: 77427},
+						pos:        position{line: 2157, col: 21, offset: 77476},
 						val:        "\r",
 						ignoreCase: false,
 						want:       "\"\\r\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2156, col: 28, offset: 77434},
+						pos:        position{line: 2157, col: 28, offset: 77483},
 						val:        "\n",
 						ignoreCase: false,
 						want:       "\"\\n\"",
@@ -14124,26 +14124,26 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 2158, col: 1, offset: 77440},
+			pos:  position{line: 2159, col: 1, offset: 77489},
 			expr: &notExpr{
-				pos: position{line: 2158, col: 8, offset: 77447},
+				pos: position{line: 2159, col: 8, offset: 77496},
 				expr: &anyMatcher{
-					line: 2158, col: 9, offset: 77448,
+					line: 2159, col: 9, offset: 77497,
 				},
 			},
 		},
 		{
 			name: "EOL",
-			pos:  position{line: 2160, col: 1, offset: 77451},
+			pos:  position{line: 2161, col: 1, offset: 77500},
 			expr: &choiceExpr{
-				pos: position{line: 2160, col: 8, offset: 77458},
+				pos: position{line: 2161, col: 8, offset: 77507},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 2160, col: 8, offset: 77458},
+						pos:  position{line: 2161, col: 8, offset: 77507},
 						name: "Newline",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2160, col: 18, offset: 77468},
+						pos:  position{line: 2161, col: 18, offset: 77517},
 						name: "EOF",
 					},
 				},

--- a/pkg/parser/parser.peg
+++ b/pkg/parser/parser.peg
@@ -202,6 +202,7 @@ AttrSub <- "{" name:AttributeName "}" {
     return types.NewAttributeSubstitution(name.(string))
 }
 
+// TODO: simplify the 'start' optional attribute
 CounterSub <- CounterSub1 / CounterSub2 / CounterSubAlpha / CounterSubAlpha2 / CounterSubStart / CounterSubStart2
 
 CounterSub1 <- "{counter:" name:AttributeName "}" {

--- a/pkg/parser/parser.peg
+++ b/pkg/parser/parser.peg
@@ -63,11 +63,11 @@ RawBlocks <- Newline* header:(DocumentHeader?) blocks:(DocumentRawBlock*) {
 
 DocumentRawBlock <- 
         block:(LabeledListItem // must appear before simple paragraph
-        / ImageBlock
         / SimpleRawParagraph
         / BlankLine // must be before LiteralBlock 
         / Section
         / DelimitedBlock
+        / ImageBlock
         / SingleLineComment
         / Table
         / ThematicBreak
@@ -228,122 +228,207 @@ CounterSubStart2 <- "{counter2:" name:AttributeName ":" num:([0-9]+ { return str
     return types.NewCounterSubstitution(name.(string), true, num.(int))
 }
 
-ElementAttribute <- &("[" / "." ) // skip if the content does not start with one of those characters // TODO: use something like '&([\[.])' instead
-    attr:(ElementID / 
-        ElementTitle / 
-        ElementShortHandAttributes /
-        LiteralBlockAttribute / 
-        SourceAttributes / 
-        ExampleBlockAttribute /
-        ListingBlockAttribute /
-        QuoteAttributes / 
-        VerseAttributes / 
-        AdmonitionMarkerAttribute / 
-        PassthroughBlockAttribute /
-        AttributeGroup) BlankLine* {
-    return attr, nil // avoid returning something like `[]interface{}{attr, EOL}`
-}
-
-ElementID <- "[[" id:(Id) "]]" Space* EOL {
-    return types.NewElementID(id)
-}
-
 InlineElementID <- "[[" id:(Id) "]]" Space* { // no EOL here since there can be multiple InlineElementID on the same line
-    return types.NewInlineElementID(id.(string))
+    return types.NewInlineIDAttribute(id.(string))
 }
 
-// a title attached to an element, such as a ImageBlock
-// a title starts with a single "." followed by the value, without space in-between
-ElementTitle <- "." title:(ElementTitleContent) Space* EOL {
-    return types.NewElementTitle(title.([]interface{}))
+StandaloneAttributeKey <- !"quote" !"verse" !"literal" key:(NamedAttributeKey) ("," Space*)? { // value is not defined
+    return types.NewNamedAttribute(key.(string), nil)
 }
 
-ElementTitleContent <- (
-    ([\pL0-9][^\r\n{<>]+ { // `{`, `>` and `>` characters are not allowed as they are used for attribute substitutions and cross-references 
+// ------------------------------------------
+// Attributes, refactored
+// ------------------------------------------
+BlockAttributes <- 
+    attributes:(
+        // shorthand syntax for anchors. Eg: `[[an_id]]`
+        (anchor:(ShortHandAnchor) (Space* Newline)+ {
+            return anchor, nil
+        })
+        // shorthand syntax for titles. Eg: `.a title`
+        / (title:(ShortHandTitle) (Space* Newline)+ {
+            return title, nil
+        })
+        // default syntax
+        / (attributes:(LongHandAttributes) (Space* Newline)+ {
+            return attributes, nil
+        })
+    )+ {
+        return types.NewAttributes(attributes.([]interface{})...)
+    }
+
+InlineAttributes <-
+    #{
+        return initPositionalIndex(c)
+    }
+    "["
+    attributes:(PositionalAttribute/NamedAttribute)*
+    "]" {
+        return types.NewAttributes(attributes.([]interface{})...)
+    }
+
+// standalone attributes, i.e., no attached to a block
+StandaloneAttributes <- attributes:(BlockAttributes) BlankLine* { 
+    return attributes, nil
+}
+
+// shorthand syntax for anchors. Eg: `[[An ID]]`
+ShortHandAnchor <-
+   "[[" 
+    id:(
+        elements:(
+            ([^=\r\n\uFFFD{\]]+ { // spaces, commas and dots are allowed in this syntax
+                return types.NewStringElement(string(c.text))
+            }) / 
+            ElementPlaceHolder /
+            AttrSub /
+            ("{" { 
+                return types.NewStringElement(string(c.text))
+            }))+ {
+                return types.Reduce(elements, strings.TrimSpace), nil
+            }
+        )
+    "]]" {
+        return types.NewIDAttribute(id)
+    }
+
+// shorthand syntax for titles. Eg: `.a title`
+ShortHandTitle <- `.` title:(
+    ![. ] // may not start with a dot or a space, to avoid confusion with list items or literal block delimiters
+    elements:(
+        ([^\r\n\uFFFD{]+ {
+            return types.NewStringElement(string(c.text))
+        }) / 
+        ElementPlaceHolder /
+        AttrSub /
+        ("{" { 
+            return types.NewStringElement(string(c.text))
+        }))+ {
+            return types.Reduce(elements, strings.TrimSpace), nil
+        }
+    ) {
+        return types.NewTitleAttribute(title)
+    }
+
+// LongHandAttributes. Eg: `[positional1,positional2,...,named1,named2,...]
+// positional attributes are optional, and `positional1` can be combined with options and roles ("extras")
+LongHandAttributes <-
+    #{
+        return initPositionalIndex(c)
+    }
+    "[" 
+    // !Space // no space allowed on the first character
+    firstPositionalAttribute:(FirstPositionalAttribute)?
+    otherAttributes:(PositionalAttribute / NamedAttribute)*
+    "]" {
+        attributes:=[]interface{}{}
+        if firstPositionalAttribute != nil {
+            attributes=append(attributes, firstPositionalAttribute.([]interface{})...)
+        }
+        attributes=append(attributes, otherAttributes.([]interface{})...)
+        return types.NewAttributes(attributes...)
+    }
+
+// First Positional Attribute may be an ID or a style, with extra roles and options.
+// Or sometimes, it's just 1 or more roles or options...
+FirstPositionalAttribute <- 
+    main:(
+        ShortHandAttribute
+    )?
+    extras:( 
+        ShortHandIDAttribute 
+        / ShortHandOptionAttribute
+        / ShortHandDotRoleAttribute
+    )* ("," Space*)? 
+    &{
+        // make sure there was a match
+        return main != nil || len(extras.([]interface{})) > 0, nil
+    }
+    {
+        attrs:=[]interface{}{}
+        if main != nil {
+            attrs = append(attrs, main)
+        }
+        attrs = append(attrs, extras.([]interface{})...)
+        return attrs, nil
+    }
+
+// an `id` must be prefixed with a `#` 
+ShortHandIDAttribute <- "#" id:(ShortHandAttributeValue) {
+    _, err := incrementPositionalIndex(c)
+	if err != nil {
+		return types.Attribute{}, err
+    }
+    return types.NewIDAttribute(id)
+}
+
+ShortHandAttribute <- value:(ShortHandAttributeValue) {
+    i, err := incrementPositionalIndex(c)
+	if err != nil {
+		return types.Attribute{}, err
+    }
+    return types.NewPositionalAttribute(i, value)
+}
+
+// a `role` must be prefixed with a `.` 
+ShortHandDotRoleAttribute <- "." role:(ShortHandAttributeValue) {
+    return types.NewRoleAttribute(role)
+}
+
+// an `option` must be prefixed with a `%` 
+ShortHandOptionAttribute <- "%" option:(ShortHandAttributeValue) {
+    return types.NewOptionAttribute(option)
+}
+
+// Shorthand Attribute Value. 
+ShortHandAttributeValue <- 
+    SingleQuotedAttributeValue 
+    / DoubleQuotedAttributeValue 
+    / elements:(
+    // unquoted shorthand value may include placeholders and substitutions but NOT comma, space, equal sign and dots
+    // also, cannot be followed by an `=` sign
+    ([^,=.%# \r\n\uFFFD{\]]+ {
         return types.NewStringElement(string(c.text))
-    }) /
+    }) / 
+    ElementPlaceHolder /
     AttrSub /
     ("{" { 
         return types.NewStringElement(string(c.text))
+    }))+ &[^=] {
+        return types.Reduce(elements, strings.TrimSpace), nil
+    }
+
+PositionalAttribute <- (
+    value:(AttributeValue) (("," Space*)? / &"]") { 
+    	i, err := incrementPositionalIndex(c)
+    	if err != nil {
+    		return types.Attribute{}, err
+        }
+        return types.NewPositionalAttribute(i, value)
+    }) 
+    / 
+    // empty value. Eg: `[ ]`, `[, a, b]`, `[a, ,b]`, etc.
+    (value:(Space* (("," Space*) / &"]"))
+    &{
+        // here we can't rely on `c.text` if the content is empty 
+        // (in which case, `c.text` contains the char sequence of the previous 
+        // rule that matched)
+        v := types.Merge(value)
+        return len(v) > 0, nil
+    }
+    { 
+        i, err := incrementPositionalIndex(c)
+    	if err != nil {
+            return types.Attribute{}, err
+        }
+        return types.NewPositionalAttribute(i, nil)
     })
-    )+
 
-// These are elements that do not start with a leading positional attribute, except
-// perhaps the shorthand attributes.
-ElementShortHandAttributes <- "[" attributes:(ShortHandAttr* NamedAttribute*) "]" Space* EOL {
-    return types.NewAttributeGroup(attributes.([]interface{})...)
-}
-
-BlockAttribute <- BlockAttributeList / ElementTitle / ElementID
-
-// All blocks have style as their first element, and no block has more than 3 positional elements.
-// This allows us to keep the grammar simpler, and use context to determine what the second and third attributes are.
-BlockAttributeList <- '[' attributes:(BlockAttrStyle? ShortHandAttr* BlockAttrPositional2? BlockAttrPositional3? NamedAttribute*) ']' EOL {
-    return types.NewAttributeGroup(attributes.([]interface{})...)
-}
-
-BlockAttrStyle <- style:PositionalValue {
-    return types.NewElementStyle(style)
-}
-
-BlockAttrPositional2 <- Space* "," Space* value:PositionalValue? {
-    if value != nil {
-        return types.NewNamedAttribute(types.AttrPositional2, value)
+NamedAttribute <- key:(NamedAttributeKey) "=" Space* value:(AttributeValue) ("," Space*)? { // TODO: include `,` or expect `]`
+    _, err := incrementPositionalIndex(c)
+	if err != nil {
+		return types.Attribute{}, err
     }
-    return nil, nil
-}
-
-BlockAttrPositional3 <- Space* "," Space* value:PositionalValue? {
-    if value != nil {
-        return types.NewNamedAttribute(types.AttrPositional3, value)
-    }
-    return nil, nil
-}
-
-LiteralBlockAttribute <- "[literal]" Space* Newline {
-    return types.NewLiteralBlockAttribute()
-}
-
-PassthroughBlockAttribute <- "[pass]" Space* Newline {
-    return types.NewPassthroughBlockAttribute()
-}
-
-ExampleBlockAttribute <- "[example]" Space* EOL {
-    return types.NewExampleBlockAttribute()
-}
-
-ListingBlockAttribute <- "[listing]" Space* EOL {
-    return types.NewListingBlockAttribute()
-}
-
-// expression for the whole admonition marker, but only retains the actual kind
-AdmonitionMarkerAttribute <- "[" k:(AdmonitionKind) "]" Space* EOL {
-    return types.NewAdmonitionAttribute(k.(types.AdmonitionKind))
-}
-
-// a paragraph or a delimited block may contain source code in a given language
-SourceAttributes <- "[source" 
-    option:("%nowrap" {
-        return "nowrap", nil
-    })?
-    language:("," attr:(AttributeValue)? { return attr, nil })? 
-    others:("," attr:(NamedAttribute / StandaloneAttributeKey)? { return attr, nil })* 
-    "]" Space* EOL {
-    return types.NewSourceAttributes(language, option, others.([]interface{})...)
-}
-
-// one or more attributes. eg: [foo, key1=value1, key2 = value2 , ]
-AttributeGroup <- "[" attributes:(Attributes) "]" Space* EOL {
-    return types.NewAttributeGroup(attributes.([]interface{})...)
-}
-
-Attributes <- (NamedAttribute / StandaloneAttributeKey)*
-
-NamedAttributes <- attributes:(NamedAttribute)* {
-    return types.NewAttributeGroup(attributes.([]interface{})...)
-}
-
-NamedAttribute <- key:(NamedAttributeKey)  "=" value:(AttributeValue) ("," Space*)? {
     return types.NewNamedAttribute(key.(string), value)
 }
 
@@ -352,119 +437,79 @@ NamedAttributeKey <- !Space [^\r\n=,\]]+ Space* {
     return strings.TrimSpace(string(c.text)), nil
 }
 
-AttributeValue <- Space* value:(SingleQuotedAttributeValue / DoubleQuotedAttributeValue / UnquotedAttributeValue) Space* &[,\]] {
-    return value, nil
-}
-
-SingleQuotedAttributeValue <- "'" elements:(
-    ([^'\r\n\uFFFD\\{]+ { // '=' and `,` signs are allowed within quotes
-        return types.NewStringElement(string(c.text))
-    }) / 
-    ElementPlaceHolder /
-    AttrSub /
-    (`\'` { return `'`, nil }) / 
-    ([{\\] { // `{` or `\`
-        return types.NewStringElement(string(c.text))
-    })
-)+ "'" {
-    return types.Reduce(elements), nil
-}
-
-DoubleQuotedAttributeValue <- "\"" elements:(
-    ([^\r\n\uFFFD"\\{]+ { // '=' and `,` signs are allowed within quotes
-        return types.NewStringElement(string(c.text))
-    }) / 
-    ElementPlaceHolder /
-    AttrSub /
-    (`\"` { // escaped "
-        return types.NewStringElement(`"`) // escaped "
-    }) /
-    ( [{\\] { // `{` or `\`
-        return types.NewStringElement(string(c.text))
-    })
-)+ "\"" {
-    return types.Reduce(elements), nil
-}
-
-// Fallback Named Attribute Value, may include equals
-UnquotedAttributeValue <- elements:(
-    ([^,=\r\n\uFFFD{\]]+ {
-        return types.NewStringElement(string(c.text))
-    }) / 
-    ElementPlaceHolder /
-    AttrSub /
-    ("{" { 
-        return types.NewStringElement(string(c.text))
-    }))+ {
-        return types.Reduce(elements, strings.TrimSpace), nil
+AttributeValue <- 
+    value:(
+        SingleQuotedAttributeValue 
+        / DoubleQuotedAttributeValue 
+        / UnquotedAttributeValue
+    ) 
+    &(!(Space* "=")) {
+        return value, nil
     }
 
-StandaloneAttributeKey <- !"quote" !"verse" !"literal" key:(NamedAttributeKey) ("," Space*)? { // value is not defined
-    return types.NewNamedAttribute(key.(string), nil)
-}
-
-QuoteAttributes <- "[quote" Space* ","? author:(QuoteAttribute)? ","? title:(QuoteAttribute)? "]" Space* EOL {
-    return types.NewQuoteAttributes("quote", author, title)
-}
-
-VerseAttributes <- "[verse" Space* ","? author:(QuoteAttribute)? ","? title:(QuoteAttribute)? "]" Space* EOL {
-    return types.NewQuoteAttributes("verse", author.(string), title.(string))
-}
-
-QuoteAttribute <- ([^\r\n,\]]*) {
-    return string(c.text), nil
-}
-
-QuotedTextAttributes <- "[" attributes:(QuotedTextAttrRole? ShortHandAttr* NamedAttribute*) "]" {
-    return types.NewAttributeGroup(attributes.([]interface{})...)
-}
-
-QuotedTextAttrRole <- role:PositionalValue ("," Space*)? {
-    return types.NewElementRole(role)
-}
-
-StandaloneAttributes <- attributes:(ElementAttribute)+ BlankLine* { // standalone attributes, i.e., with nothing afterwards
-    return types.NewAttributeGroup(attributes.([]interface{})...)
-}
-
-ShortHandAttr <- ShortHandAttrID / ShortHandAttrOption / ShortHandAttrRole
-
-ShortHandAttrOption <- "%" option:(ShortHandValue) &[,#%.\r\n\]] ("," Space*)? {
-    return types.NewElementOption(option)
-}
-
-ShortHandAttrID <- "#" id:(ShortHandValue) &[,#%.\r\n\]] ("," Space*)? {
-    return types.NewElementID(id)
-}
-
-ShortHandAttrRole <- '.' role:(ShortHandValue) &[,#%.\r\n\]] ("," Space*)? {
-    return types.NewElementRole(role)
-}
-
-// PositionalValue is an unnamed attribute.
-PositionalValue <- value:(ShortHandValue) &[,#%.\]] {
-    return types.Reduce(value, strings.TrimSpace), nil
-}
-
-ShortHandValue <- ShortHandValuePlain / SingleQuotedAttributeValue / DoubleQuotedAttributeValue
-
-// ShortHandValuePlain is sort of like AttrValuePlain, but it also needs to exclude the characters
-// used to start a short hand role, id, or option, as well as equals signs.
-ShortHandValuePlain <- first:([^,\r\n"' \t.#%=\]] {
-       return types.NewStringElement(string(c.text))
-    })
-    others: (ElementPlaceHolder 
-        / ([^ \t,\r\n"'.#%=\]] / [ \t][^ \t,\r\n"'.#%=\]] {
+SingleQuotedAttributeValue <- 
+    "'" 
+    elements:(
+        ([^'\r\n\uFFFD\\{]+ { // = and , signs are allowed within ' quotes 
             return types.NewStringElement(string(c.text))
         })
-    )* {
-        return append([]interface{}{first}, others.([]interface{})...), nil
+        / ElementPlaceHolder
+        / AttrSub
+        / (`\'` { 
+            return types.NewStringElement(`'`) // escaped quote
+        }
+        / `{` / `\` { 
+            return types.NewStringElement(string(c.text)) 
+        })
+    )+ 
+    "'" {
+        return types.Reduce(elements), nil
+    }
+
+DoubleQuotedAttributeValue <- 
+    "\"" 
+    elements:(
+        ([^\r\n\uFFFD"\\{]+ { // = and , signs are allowed within " quotes
+            return types.NewStringElement(string(c.text))
+        }) 
+        / ElementPlaceHolder
+        / AttrSub
+        / (`\"` { 
+            return types.NewStringElement(`"`) // escaped quote
+        }
+        / `{` / `\` { 
+            return types.NewStringElement(string(c.text)) 
+        })
+    )+ 
+    "\"" {
+        return types.Reduce(elements), nil
+    }
+
+// Unquoted Attribute Value, may include spaces but not on the first position
+UnquotedAttributeValue <- 
+    !Space
+    elements:(
+        ([^,=\r\n\uFFFD{\]]+ {
+            return types.NewStringElement(string(c.text))
+        }) 
+        / ElementPlaceHolder
+        / AttrSub
+        / ("{" { 
+            return types.NewStringElement(string(c.text))
+        })
+    )+ 
+    &{
+        // empty string is not a valid value
+        return types.Reduce(elements, strings.TrimSpace) != "", nil
+    }
+    {
+        return types.Reduce(elements, strings.TrimSpace), nil
     }
 
 // ------------------------------------------
 // Sections
 // ------------------------------------------
-Section <- attributes:(BlockAttribute)*
+Section <- attributes:(BlockAttributes)?
     level:(("=")+ {   
         // `=` is level 0, etc.
         return (len(c.text)-1), nil 
@@ -474,7 +519,7 @@ Section <- attributes:(BlockAttribute)*
         return level.(int) <= 5, nil 
     } 
     Space+ title:(TitleElements) id:(InlineElementID*) EOL {
-    return types.NewSection(level.(int), title.([]interface{}), id.([]interface{}), attributes.([]interface{})) 
+    return types.NewSection(level.(int), title.([]interface{}), id.([]interface{}), attributes) 
 }
 
 TitleElements <- elements:(!Newline !InlineElementID TitleElement)+ { // absorbs heading and trailing spaces
@@ -497,12 +542,12 @@ TableOfContentsPlaceHolder <- "toc::[]" EOL
 // ------------------------------------------
 // User Macro
 // ------------------------------------------
-UserMacroBlock <- name:(UserMacroName) "::" value:(UserMacroValue) attributes:(UserMacroAttributes) {
-    return types.NewUserMacroBlock(name.(string), value.(string), attributes.(types.Attributes), string(c.text))
+UserMacroBlock <- name:(UserMacroName) "::" value:(UserMacroValue) inlineAttributes:(InlineAttributes) {
+    return types.NewUserMacroBlock(name.(string), value.(string), inlineAttributes, string(c.text))
 }
 
-InlineUserMacro <- name:(UserMacroName) ":" value:(UserMacroValue) attributes:(UserMacroAttributes) {
-    return types.NewInlineUserMacro(name.(string), value.(string), attributes.(types.Attributes), string(c.text))
+InlineUserMacro <- name:(UserMacroName) ":" value:(UserMacroValue) inlineAttributes:(InlineAttributes) {
+    return types.NewInlineUserMacro(name.(string), value.(string), inlineAttributes, string(c.text))
 }
 
 UserMacroName <- !"include" ([\pL0-9_-]+) {
@@ -513,48 +558,37 @@ UserMacroValue <- [^:[ \r\n]* {
     return string(c.text), nil
 }
 
-UserMacroAttributes <- "[" attributes:(NamedAttribute)* "]" {
-    return types.NewAttributeGroup(attributes.([]interface{})...)
-}
-
 // ------------------------------------------
 // File inclusions
 // ------------------------------------------
-FileInclusion <- incl:("include::" path:(FileLocation) inlineAttributes:(FileIncludeAttributes) { 
-        return types.NewFileInclusion(path.(types.Location), inlineAttributes.(types.Attributes), string(c.text))
-    }) Space* EOL {
-    return incl.(types.FileInclusion), nil
-}
+FileInclusion <- 
+    incl:(
+        "include::" 
+        path:(FileLocation) 
+        inlineAttributes:(InlineAttributes) { 
+            return types.NewFileInclusion(path.(types.Location), inlineAttributes.(types.Attributes), string(c.text))
+        }
+    ) 
+    Space* EOL {
+        return incl.(types.FileInclusion), nil
+    }
 
-FileIncludeAttributes <- "[" attributes:(LineRangesAttribute / TagRangesAttribute / NamedAttribute / StandaloneAttributeKey)* "]" {
-    return types.NewAttributeGroup(attributes.([]interface{})...)
-} 
+FileIncludeAttributes <- LongHandAttributes
 
-LineRangesAttribute <- "lines=" lines:(LineRangesAttributeValue) ","? { 
-    return types.NewLineRangesAttribute(lines)
-} 
-
-LineRangesAttributeValue <- value:(MultipleLineRanges // TODO: just have MultipleLineRanges, MultipleQuotedLineRanges and UndefinedLineRange?
-        / MultipleQuotedLineRanges 
+// extra entrypoint
+LineRanges <- value:(MultipleLineRanges 
         / MultiLineRange 
-        / MultiLineQuotedRange 
-        / SingleLineQuotedRange
         / SingleLineRange 
-        / UndefinedLineRange) Space* (&"," / &"]") {
+        ) EOF { // must make sure that the whole content is parsed
     return value, nil
 }
 
 MultipleLineRanges <- first:(MultiLineRange / SingleLineRange) 
-    others:(";" other:(MultiLineRange / SingleLineRange) {
-        return other, nil
+    others:(
+        ("," / ";") // at this point, we already got rid of the surrounding quotes, so we can accept both `,` and `;`
+        other:(MultiLineRange / SingleLineRange) {
+            return other, nil
     })+ {
-        return append([]interface{}{first}, others.([]interface{})...), nil
-    }
-
-MultipleQuotedLineRanges <- "\"" first:(MultiLineRange / SingleLineRange) 
-    others:("," other:(MultiLineRange / SingleLineRange) {
-        return other, nil
-    })+ "\"" {
         return append([]interface{}{first}, others.([]interface{})...), nil
     }
 
@@ -562,33 +596,20 @@ MultiLineRange <- start:(Number) ".." end:(Number) { // eg: lines=12..14
     return types.NewLineRange(start.(int), end.(int))
 } 
 
-MultiLineQuotedRange <- "\"" start:(Number) ".." end:(Number) "\"" { // eg: lines=12..14
-    return types.NewLineRange(start.(int), end.(int))
-} 
-
 SingleLineRange <- singleline:(Number) { // eg: lines=12
     return types.NewLineRange(singleline.(int), singleline.(int))
 }
 
-SingleLineQuotedRange <- "\"" singleline:(Number) "\"" { // eg: lines=12
-    return types.NewLineRange(singleline.(int), singleline.(int))
-}
-
-UndefinedLineRange <- [^\], ]* {
-    return string(c.text), nil
-}
-
-TagRangesAttribute <- ("tags=" / "tag=") tags:(TagRangesAttributeValue) ","? { //TODO: check if 'tags'/'tag' is allowed for both single and multiple values
-    return types.NewTagRangesAttribute(tags.([]interface{}))
-} 
-
-TagRangesAttributeValue <- value:(MultipleTagRanges) Space* (&"," / &"]") {
+// extra entrypoint
+TagRanges <- value:(MultipleTagRanges) EOF { // must make sure that the whole content is parsed
     return value, nil
 }
 
 MultipleTagRanges <- first:(TagRange)
-    others:(";" other:(TagRange) {
-        return other, nil
+    others:(
+        ("," / ";") // at this point, we already got rid of the surrounding quotes, so we can accept both `,` and `;`
+        other:(TagRange) {
+            return other, nil
     })* {
         return append([]interface{}{first}, others.([]interface{})...), nil
     }
@@ -640,7 +661,7 @@ ListParagraphLine <- !EOF
     !UnorderedListItemPrefix
     !CalloutListItemPrefix
     !ListItemContinuation
-    !ElementAttribute
+    !BlockAttributes
     !BlockDelimiter
     !LabeledListItemPrefix 
     line:(Space* elements:(InlineElement)+ { 
@@ -677,8 +698,8 @@ ContinuedListItemContent <- !EOF
 // ------------------------------------------
 // Ordered List Items
 // ------------------------------------------
-OrderedListItem <- attributes:(BlockAttribute)* prefix:(OrderedListItemPrefix) content:(OrderedListItemContent) {
-    return types.NewOrderedListItem(prefix.(types.OrderedListItemPrefix), content.([]interface{}), attributes.([]interface{}))
+OrderedListItem <- attributes:(BlockAttributes)? prefix:(OrderedListItemPrefix) content:(OrderedListItemContent) {
+    return types.NewOrderedListItem(prefix.(types.OrderedListItemPrefix), content.([]interface{}), attributes)
 }
 
 OrderedListItemPrefix <- 
@@ -728,8 +749,8 @@ OrderedListItemContent <- elements:(ListParagraph+) {
 // ------------------------------------------
 // Unordered List Items
 // ------------------------------------------
-UnorderedListItem <- attributes:(BlockAttribute)* prefix:(UnorderedListItemPrefix) checkstyle:(UnorderedListItemCheckStyle)? content:(UnorderedListItemContent) {
-    return types.NewUnorderedListItem(prefix.(types.UnorderedListItemPrefix), checkstyle, content.([]interface{}), attributes.([]interface{}))
+UnorderedListItem <- attributes:(BlockAttributes)? prefix:(UnorderedListItemPrefix) checkstyle:(UnorderedListItemCheckStyle)? content:(UnorderedListItemContent) {
+    return types.NewUnorderedListItem(prefix.(types.UnorderedListItemPrefix), checkstyle, content.([]interface{}), attributes)
 }
 
 UnorderedListItemPrefix <- 
@@ -777,8 +798,8 @@ UnorderedListItemContent <- elements:(ListParagraph+) { // Another list or a lit
 // ------------------------------------------
 // Labeled List Items
 // ------------------------------------------
-LabeledListItem <- attributes:(BlockAttribute)* term:(VerbatimLabeledListItemTerm) separator:(LabeledListItemSeparator) description:(LabeledListItemDescription)? {
-    return types.NewLabeledListItem(len(separator.(string)) - 1, term.([]interface{}), description, attributes.([]interface{}))
+LabeledListItem <- attributes:(BlockAttributes)? term:(VerbatimLabeledListItemTerm) separator:(LabeledListItemSeparator) description:(LabeledListItemDescription)? {
+    return types.NewLabeledListItem(len(separator.(string)) - 1, term.([]interface{}), description, attributes)
 }
 
 LabeledListItemPrefix <- VerbatimLabeledListItemTerm LabeledListItemSeparator
@@ -790,7 +811,8 @@ VerbatimLabeledListItemTerm <- content:( VerbatimLabeledListItemChars + {
     return types.NewInlineElements(content)
 }
 
-LabeledListItemTerm <- elements:(!Newline !"::" LabeledListItemTermElement)+ { // rule as an extra entrypoint
+// extra entrypoint
+LabeledListItemTerm <- elements:(!Newline !"::" LabeledListItemTermElement)+ { 
     return types.NewInlineElements(elements.([]interface{}))
 } 
 
@@ -855,24 +877,24 @@ AdmonitionKind <- "TIP" {
 // TODO: refactor to avoid multiple 'Attributes?' rule evaluations?
 RawParagraph <- 
     // admonition paragraph 
-     attributes:(ElementAttribute)* t:(AdmonitionKind) ": " lines:(SingleLineComment / RawParagraphLine)+ { 
-        return types.NewAdmonitionParagraph(lines.([]interface{}), t.(types.AdmonitionKind), attributes.([]interface{}))
+     attributes:(BlockAttributes)? t:(AdmonitionKind) ": " lines:(SingleLineComment / RawParagraphLine)+ { 
+        return types.NewAdmonitionParagraph(lines.([]interface{}), t.(string), attributes)
     } / 
     // markdown-style blockquote paragraph
     // TODO: move with other Delimited block rules?
-    attributes:(ElementAttribute)* "> " content:(MarkdownQuoteBlockRawContent) {
-        return types.NewMarkdownQuoteBlock(content.([]interface{}), attributes.([]interface{}))
+    attributes:(BlockAttributes)? "> " content:(MarkdownQuoteBlockRawContent) {
+        return types.NewMarkdownQuoteBlock(content.([]interface{}), attributes)
     } /
     // passthrough open block: requires `[pass]`
-    attributes:(ElementAttribute)* &{
+    attributes:(BlockAttributes)? &{
         // verify that one of the attributes is `kind:passthrough`
-        return types.HasAttributeWithValue(attributes, types.AttrBlockKind, types.Passthrough), nil
+        return types.HasAttributeWithValue(attributes, types.AttrPositional1, types.Passthrough), nil
     } content:(RawParagraphLine)+ { 
-        return types.NewPassthroughBlock(content.([]interface{}), attributes.([]interface{}))
+        return types.NewPassthroughBlock(content.([]interface{}), attributes)
     } /
     // other kind of paragraph (verse, regular, etc.)
-    attributes:(ElementAttribute)* lines:(SingleLineComment / RawParagraphLine)+ { 
-        return types.NewParagraph(lines.([]interface{}), attributes.([]interface{}))
+    attributes:(BlockAttributes)? lines:(SingleLineComment / RawParagraphLine)+ { 
+        return types.NewParagraph(lines.([]interface{}), attributes)
     }
 
 MarkdownQuoteBlockRawContent <- (!BlankLine "> "? content:(RawLine) { 
@@ -895,13 +917,13 @@ RawParagraphLineContent <- [^\r\n]+ {
 }
 
 // a paragraph whose first line begins with a word followed by spaces
-SimpleRawParagraph <- attributes:(ElementAttribute)* 
+SimpleRawParagraph <- attributes:(BlockAttributes)? 
     &{
-        return !types.HasAttributeWithValue(attributes, types.AttrBlockKind, types.Literal), nil
+        return !types.HasAttributeWithValue(attributes, types.AttrPositional1, types.Literal), nil
     }
     firstLine: FirstParagraphRawLine
     otherLines:(SingleLineComment / RawParagraphLine)* { 
-    return types.NewParagraph(append([]interface{}{firstLine}, otherLines.([]interface{})...), attributes.([]interface{}))
+    return types.NewParagraph(append([]interface{}{firstLine}, otherLines.([]interface{})...), attributes)
 }
 
 FirstParagraphRawLine <- 
@@ -918,12 +940,12 @@ FirstParagraphRawLine <-
 // same as RawParagraph, but without allowing for ListItemContinuation (`+`)
 ContinuedRawParagraph <- 
     // admonition paragraph 
-    attributes:(ElementAttribute)* t:(AdmonitionKind) ": " lines:(ContinuedRawParagraphLines) { 
-        return types.NewAdmonitionParagraph(lines.([]interface{}), t.(types.AdmonitionKind), attributes.([]interface{}))
+    attributes:(BlockAttributes)? t:(AdmonitionKind) ": " lines:(ContinuedRawParagraphLines) { 
+        return types.NewAdmonitionParagraph(lines.([]interface{}), t.(string), attributes)
     } / 
     // other kind of paragraph (verse, regular, etc.)
-    attributes:(ElementAttribute)* lines:(ContinuedRawParagraphLines) { 
-        return types.NewParagraph(lines.([]interface{}), attributes.([]interface{}))
+    attributes:(BlockAttributes)? lines:(ContinuedRawParagraphLines) { 
+        return types.NewParagraph(lines.([]interface{}), attributes)
 } 
 
 ContinuedRawParagraphLines <- firstLine:(FirstParagraphRawLine) otherLines:(!ListItemContinuation line:(SingleLineComment / RawParagraphLine) { return line, nil })* {
@@ -1024,7 +1046,7 @@ TwoOrMoreBackslashes <- `\\` `\`* {
 
 BoldText <- DoubleQuoteBoldText / SingleQuoteBoldText // double punctuation must be evaluated first
 
-DoubleQuoteBoldText <- attributes:(QuotedTextAttributes)? "**" elements:(DoubleQuoteBoldTextElements) "**" {
+DoubleQuoteBoldText <- attributes:(LongHandAttributes)? "**" elements:(DoubleQuoteBoldTextElements) "**" {
     return types.NewQuotedText(types.Bold, attributes, elements.([]interface{}))
 } 
 
@@ -1051,9 +1073,9 @@ DoubleQuoteBoldTextFallbackCharacter <-
     return types.NewStringElement(string(c.text))
 }
 
-SingleQuoteBoldText <- attributes:(QuotedTextAttributes)? ( "*" !"*") elements:(SingleQuoteBoldTextElements) "*" &(!Alphanum) { // single punctuation cannot be followed by a character (needs '**' to emphazise a portion of a word)
+SingleQuoteBoldText <- attributes:(LongHandAttributes)? ( "*" !"*") elements:(SingleQuoteBoldTextElements) "*" &(!Alphanum) { // single punctuation cannot be followed by a character (needs '**' to emphazise a portion of a word)
     return types.NewQuotedText(types.Bold, attributes, elements.([]interface{}))
-} / attributes:(QuotedTextAttributes)? "*" elements:("*" SingleQuoteBoldTextElements) "*" { // unbalanced `**` vs `*` punctuation.
+} / attributes:(LongHandAttributes)? "*" elements:("*" SingleQuoteBoldTextElements) "*" { // unbalanced `**` vs `*` punctuation.
     return types.NewQuotedText(types.Bold, attributes, elements.([]interface{})) // include the second heading `*` as a regular StringElement in the bold content
 } 
 
@@ -1094,7 +1116,7 @@ EscapedBoldText <-
 
 ItalicText <- DoubleQuoteItalicText / SingleQuoteItalicText
 
-DoubleQuoteItalicText <- attributes:(QuotedTextAttributes)? "__" elements:(DoubleQuoteItalicTextElements) "__" { // double punctuation must be evaluated first
+DoubleQuoteItalicText <- attributes:(LongHandAttributes)? "__" elements:(DoubleQuoteItalicTextElements) "__" { // double punctuation must be evaluated first
     return types.NewQuotedText(types.Italic, attributes, elements.([]interface{}))
 }
 
@@ -1121,9 +1143,9 @@ DoubleQuoteItalicTextFallbackCharacter <-
     return types.NewStringElement(string(c.text))
 }
 
-SingleQuoteItalicText <- attributes:(QuotedTextAttributes)? ("_" !"_") elements:(SingleQuoteItalicTextElements) "_" { // single punctuation cannot be followed by a character (needs '__' to emphazise a portion of a word)
+SingleQuoteItalicText <- attributes:(LongHandAttributes)? ("_" !"_") elements:(SingleQuoteItalicTextElements) "_" { // single punctuation cannot be followed by a character (needs '__' to emphazise a portion of a word)
     return types.NewQuotedText(types.Italic, attributes, elements.([]interface{}))
-} / attributes:(QuotedTextAttributes)? "_" elements:("_" SingleQuoteItalicTextElements) "_" { // unbalanced `__` vs `_` punctuation.
+} / attributes:(LongHandAttributes)? "_" elements:("_" SingleQuoteItalicTextElements) "_" { // unbalanced `__` vs `_` punctuation.
     return types.NewQuotedText(types.Italic, attributes, elements.([]interface{})) // include the second heading `_` as a regular StringElement in the italic content
 } 
 
@@ -1163,7 +1185,7 @@ EscapedItalicText <-
 // -----------------
 MonospaceText <- DoubleQuoteMonospaceText / SingleQuoteMonospaceText
 
-DoubleQuoteMonospaceText <- attributes:(QuotedTextAttributes)? "``" elements:(DoubleQuoteMonospaceTextElements) "``" { // double punctuation must be evaluated first
+DoubleQuoteMonospaceText <- attributes:(LongHandAttributes)? "``" elements:(DoubleQuoteMonospaceTextElements) "``" { // double punctuation must be evaluated first
     return types.NewQuotedText(types.Monospace, attributes, elements.([]interface{}))
 }
 
@@ -1194,9 +1216,9 @@ DoubleQuoteMonospaceTextFallbackCharacter <-
     return types.NewStringElement(string(c.text))
 }
 
-SingleQuoteMonospaceText <- attributes:(QuotedTextAttributes)? ("`" !"`") elements:(SingleQuoteMonospaceTextElements) "`" { // single punctuation cannot be followed by a character (needs "``" to emphazise a portion of a word)
+SingleQuoteMonospaceText <- attributes:(LongHandAttributes)? ("`" !"`") elements:(SingleQuoteMonospaceTextElements) "`" { // single punctuation cannot be followed by a character (needs "``" to emphazise a portion of a word)
     return types.NewQuotedText(types.Monospace, attributes, elements.([]interface{}))
-} / attributes:(QuotedTextAttributes)? "`" elements:("`" SingleQuoteMonospaceTextElements) "`" { // unbalanced "``" vs "`" punctuation.
+} / attributes:(LongHandAttributes)? "`" elements:("`" SingleQuoteMonospaceTextElements) "`" { // unbalanced "``" vs "`" punctuation.
    return types.NewQuotedText(types.Monospace, attributes, elements.([]interface{})) // include the second heading "`" as a regular StringElement in the monospace content
 }
 
@@ -1311,7 +1333,7 @@ DoubleQuotedStringFallbackCharacter <-  ([^\r\n\t `] / "`" !"\"") {
 
 MarkedText <- DoubleQuoteMarkedText / SingleQuoteMarkedText
 
-DoubleQuoteMarkedText <- attributes:(QuotedTextAttributes)? "##" elements:(DoubleQuoteMarkedTextElements) "##" { // double punctuation must be evaluated first
+DoubleQuoteMarkedText <- attributes:(LongHandAttributes)? "##" elements:(DoubleQuoteMarkedTextElements) "##" { // double punctuation must be evaluated first
     return types.NewQuotedText(types.Marked, attributes, elements.([]interface{}))
 }
 
@@ -1335,9 +1357,9 @@ DoubleQuoteMarkedTextFallbackCharacter <-
     return types.NewStringElement(string(c.text))
 }
 
-SingleQuoteMarkedText <- attributes:(QuotedTextAttributes)? ("#" !"#") elements:(SingleQuoteMarkedTextElements) "#" { // single punctuation cannot be followed by a character (needs '##' to emphazise a portion of a word)
+SingleQuoteMarkedText <- attributes:(LongHandAttributes)? ("#" !"#") elements:(SingleQuoteMarkedTextElements) "#" { // single punctuation cannot be followed by a character (needs '##' to emphazise a portion of a word)
     return types.NewQuotedText(types.Marked, attributes, elements.([]interface{}))
-} / attributes:(QuotedTextAttributes)? "#" elements:("#" SingleQuoteMarkedTextElements) "#" { // unbalanced `##` vs `#` punctuation.
+} / attributes:(LongHandAttributes)? "#" elements:("#" SingleQuoteMarkedTextElements) "#" { // unbalanced `##` vs `#` punctuation.
     return types.NewQuotedText(types.Marked, attributes, elements.([]interface{})) // include the second heading `_` as a regular StringElement in the italic content
 }
 
@@ -1373,7 +1395,7 @@ EscapedMarkedText <-
 }
 
 
-SubscriptText <- attributes:(QuotedTextAttributes)? "~" element:(SubscriptTextElement) "~" { // wraps a single word
+SubscriptText <- attributes:(LongHandAttributes)? "~" element:(SubscriptTextElement) "~" { // wraps a single word
     return types.NewQuotedText(types.Subscript, attributes, element)
 }
 
@@ -1387,7 +1409,7 @@ EscapedSubscriptText <- backslashes:(OneOrMoreBackslashes) "~" element:(Subscrip
     return types.NewEscapedQuotedText(backslashes.(string), "~", element)
 } 
 
-SuperscriptText <- attributes:(QuotedTextAttributes)? "^" element:(SuperscriptTextElement) "^" { // wraps a single word
+SuperscriptText <- attributes:(LongHandAttributes)? "^" element:(SuperscriptTextElement) "^" { // wraps a single word
     return types.NewQuotedText(types.Superscript, attributes, element)
 }
 
@@ -1451,11 +1473,19 @@ InternalCrossReference <- "<<" id:(Id) Space* "," label:(CrossReferenceLabel) ">
     return types.NewInternalCrossReference(id, nil)
 } 
 
-ExternalCrossReference <- "xref:" url:(FileLocation) inlineAttributes:(LinkAttributes) {
+ExternalCrossReference <- "xref:" url:(FileLocation) inlineAttributes:(InlineAttributes) {
     return types.NewExternalCrossReference(url.(types.Location), inlineAttributes.(types.Attributes))
 }
 
-CrossReferenceLabel <- ElementTitleContent
+CrossReferenceLabel <- (
+    ([\pL0-9][^\r\n{<>]+ { // `{`, `>` and `>` characters are not allowed as they are used for attribute substitutions and cross-references 
+        return types.NewStringElement(string(c.text))
+    }) /
+    AttrSub /
+    ("{" { 
+        return types.NewStringElement(string(c.text))
+    })
+    )+
 
 // ------------------------------------------
 // Links
@@ -1463,91 +1493,37 @@ CrossReferenceLabel <- ElementTitleContent
 Link <- RelativeLink / ExternalLink
 
 // url preceeding with `link:` MUST be followed by square brackets
-RelativeLink <- "link:" url:(Location) inlineAttributes:(LinkAttributes) {
+RelativeLink <- "link:" url:(Location) inlineAttributes:(InlineAttributes) {
     return types.NewInlineLink(url.(types.Location), inlineAttributes.(types.Attributes))
 }
 
-ExternalLink <- url:(LocationWithScheme) inlineAttributes:(LinkAttributes)? {
+ExternalLink <- url:(LocationWithScheme) inlineAttributes:(InlineAttributes)? {
     return types.NewInlineLink(url.(types.Location), inlineAttributes)
-}
-
-LinkAttributes <- "[" firstAttr:(FirstLinkAttributeElement)*
-    Space* otherAttrs:(NamedAttribute)* "]" {
-    return types.NewInlineLinkAttributes(append(firstAttr.([]interface{}), otherAttrs.([]interface{})...))
-} 
-
-FirstLinkAttributeElement <- element:(
-    // surrounded with double quotes
-    ("\"" elements:(QuotedString / QuotedText / ElementPlaceHolder / QuotedAttributeChar)+ "\"" &(!"=") ","? {
-        return types.NewInlineElements(elements.([]interface{}))
-    }) /
-    // not surrounded with double quotes
-    (elements:(QuotedString / QuotedText / ElementPlaceHolder / UnquotedAttributeChar)+ &(!"=") ","? {
-        return types.NewInlineElements(elements.([]interface{}))
-    }))  {
-        return element, nil
-}
-
-AttributeChar <- [^\r\n"=\],] { // excludes comma
-    return types.NewStringElement(string(c.text))
-}
-
-QuotedAttributeChar <- [^\r\n"=\]] { // does not exclude comma
-    return types.NewStringElement(string(c.text))
-}
-
-UnquotedAttributeChar <- [^\r\n"=\],] { // excludes comma
-    return types.NewStringElement(string(c.text))
 }
 
 // ------------------------------------------
 // Images
 // ------------------------------------------
-ImageBlock <- attributes:(ImageBlockAttributes) "image::" path:(Location) inlineAttributes:(InlineImageAttributes) Space* EOL {
+ImageBlock <- 
+    attributes:(BlockAttributes)? 
+    &{
+        // AttrPositional1 must not be set
+        return types.HasNotAttribute(attributes, types.AttrPositional1), nil
+    }
+    "image::" path:(Location) inlineAttributes:(InlineAttributes) Space* EOL {
     // 'imagesdir' attribute is added after applying the attribute substitutions on the image location
-    return types.NewImageBlock(path.(types.Location), inlineAttributes.(types.Attributes), attributes.([]interface{}))
+    return types.NewImageBlock(path.(types.Location), inlineAttributes.(types.Attributes), attributes)
 }
 
-ImageBlockAttributes <- (!VerseAttributes attribute:(ElementShortHandAttributes / ElementTitle / ElementID) { return attribute, nil })* 
-
-ImageAttrList <- '[' alt:(ImageAlt)? shortHands:(ShortHandAttr)* ("," Space*)? width:(ImageWidth)? ("," Space*)? height:(ImageHeight)? ("," Space*)? others:(NamedAttributes) ']' Space* EOL {
-    return types.NewAttributeGroup(alt, width, height, others)
-}
-
-InlineImage <- "image:" !":" path:(Location) inlineAttributes:(InlineImageAttributes) {
+InlineImage <- "image:" !":" path:(Location) inlineAttributes:(InlineAttributes) {
     return types.NewInlineImage(path.(types.Location), inlineAttributes.(types.Attributes), c.globalStore["imagesdir"])
-}
-
-InlineImageAttributes <- '[' Space* alt:(ImageAlt)? ("," Space*)? width:(ImageWidth)? ("," Space*)? height:(ImageHeight)? ("," Space*)? others:(NamedAttributes) ']' {
-    return types.NewAttributeGroup(alt, width, height, others)
-}
-
-ImageAlt <- value:(AttributeValue) {
-    return types.NewInlineAttribute(types.AttrImageAlt, value)
-}
-
-ImageWidth <- value:(AttributeValue) {
-    return types.NewInlineAttribute(types.AttrWidth, value)
-}
-
-ImageHeight <- value:(AttributeValue) {
-    return types.NewInlineAttribute(types.AttrImageHeight, value)
 }
 
 // ------------------------------------------------------------------------------------
 // Inline icons
 // ------------------------------------------------------------------------------------
-InlineIcon <- "icon:" icon:([\pL0-9_-]+ { return string(c.text), nil }) attributes:(IconAttributes) {
-    return types.NewIcon(icon.(string), attributes.(types.Attributes))
-}
-
-IconAttributes <- '[' size:(IconSize)? others:(NamedAttributes) ']' {
-    // TODO: use ellipsis on `nv`?
-    return types.NewAttributeGroup(size, others)
-}
-
-IconSize <- value:(AttributeValue) ("," Space*)? {
-    return types.NewInlineAttribute(types.AttrIconSize, value)
+InlineIcon <- "icon:" icon:([\pL0-9_-]+ { return string(c.text), nil }) attributes:(InlineAttributes) {
+    return types.NewIcon(icon.(string), attributes)
 }
 
 // ------------------------------------------------------------------------------------
@@ -1620,8 +1596,8 @@ BlockDelimiter <- !(Alphanum) LiteralBlockDelimiter //TODO: use "start" delimite
 // -------------------------------------------------------------------------------------
 // Example blocks
 // -------------------------------------------------------------------------------------
-ExampleBlock <- attributes:(ElementAttribute)* ExampleBlockStartDelimiter blocks:(ExampleBlockRawContent) ExampleBlockEndDelimiter {
-    return types.NewExampleBlock(blocks.([]interface{}), attributes.([]interface{}))
+ExampleBlock <- attributes:(BlockAttributes)? ExampleBlockStartDelimiter blocks:(ExampleBlockRawContent) ExampleBlockEndDelimiter {
+    return types.NewExampleBlock(blocks.([]interface{}), attributes)
 }
 
 ExampleBlockDelimiter <- "====" Space* EOL
@@ -1657,17 +1633,17 @@ ExampleBlockRawContent <- (
 // -------------------------------------------------------------------------------------
 // Quote blocks
 // -------------------------------------------------------------------------------------
-QuoteBlock <- attributes:(ElementAttribute)* 
+QuoteBlock <- attributes:(BlockAttributes)? 
     &{
-        // AttrBlockKind may be missing or must be equal to `quote`
-        if types.HasNotAttribute(attributes, types.AttrBlockKind) || 
-            types.HasAttributeWithValue(attributes, types.AttrBlockKind, types.Quote) {
+        // AttrPositional1 may be missing or must be equal to `quote`
+        if types.HasNotAttribute(attributes, types.AttrPositional1) || 
+            types.HasAttributeWithValue(attributes, types.AttrPositional1, types.Quote) {
             return true, nil
         }
         return false, nil
     }
     QuoteBlockStartDelimiter content:(QuoteBlockRawContent) QuoteBlockEndDelimiter {
-        return types.NewQuoteBlock(content.([]interface{}), attributes.([]interface{}))
+        return types.NewQuoteBlock(content.([]interface{}), attributes)
     }
 
 QuoteBlockDelimiter <- "____" Space* EOL // same for verse blocks
@@ -1703,8 +1679,8 @@ QuoteBlockRawContent <- (
 // -------------------------------------------------------------------------------------
 // Sidebar blocks
 // -------------------------------------------------------------------------------------
-SidebarBlock <- attributes:(ElementAttribute)* SidebarBlockStartDelimiter content:(SidebarBlockRawContent) SidebarBlockEndDelimiter {
-    return types.NewSidebarBlock(content.([]interface{}), attributes.([]interface{}))
+SidebarBlock <- attributes:(BlockAttributes)? SidebarBlockStartDelimiter content:(SidebarBlockRawContent) SidebarBlockEndDelimiter {
+    return types.NewSidebarBlock(content.([]interface{}), attributes)
 }
 
 SidebarBlockDelimiter <- "****" Space* EOL
@@ -1740,8 +1716,8 @@ SidebarBlockRawContent <- (
 // -------------------------------------------------------------------------------------
 // Fenced blocks
 // -------------------------------------------------------------------------------------
-FencedBlock <- attributes:(ElementAttribute)* FencedBlockStartDelimiter content:(FencedBlockRawContent) FencedBlockEndDelimiter {
-    return types.NewFencedBlock(content.([]interface{}), attributes.([]interface{}))
+FencedBlock <- attributes:(BlockAttributes)? FencedBlockStartDelimiter content:(FencedBlockRawContent) FencedBlockEndDelimiter {
+    return types.NewFencedBlock(content.([]interface{}), attributes)
 }
 
 FencedBlockDelimiter <- "```" Space* EOL // Deprecated: use 'FencedBlockStartDelimiter' instead
@@ -1757,8 +1733,8 @@ FencedBlockRawContent <- (!FencedBlockEndDelimiter line:(RawLine) {
 // -------------------------------------------------------------------------------------
 // Listing blocks
 // -------------------------------------------------------------------------------------
-ListingBlock <- attributes:(ElementAttribute)* ListingBlockStartDelimiter content:(ListingBlockRawContent) ListingBlockEndDelimiter {
-    return types.NewListingBlock(content.([]interface{}), attributes.([]interface{}))
+ListingBlock <- attributes:(BlockAttributes)? ListingBlockStartDelimiter content:(ListingBlockRawContent) ListingBlockEndDelimiter {
+    return types.NewListingBlock(content.([]interface{}), attributes)
 }
 
 ListingBlockDelimiter <- "----" Space* EOL
@@ -1774,13 +1750,13 @@ ListingBlockRawContent <- (!ListingBlockEndDelimiter line:(RawLine) {
 // -------------------------------------------------------------------------------------
 // Verse blocks
 // -------------------------------------------------------------------------------------
-VerseBlock <- attributes:(ElementAttribute)* 
+VerseBlock <- attributes:(BlockAttributes)? 
     &{
-        // AttrBlockKind must be equal to `verse`
-        return types.HasAttributeWithValue(attributes, types.AttrBlockKind, types.Verse), nil
+        // AttrPositional1 must be equal to `verse`
+        return types.HasAttributeWithValue(attributes, types.AttrPositional1, types.Verse), nil
     }
     QuoteBlockStartDelimiter content:(VerseBlockRawContent) QuoteBlockEndDelimiter {
-        return types.NewVerseBlock(content.([]interface{}), attributes.([]interface{}))
+        return types.NewVerseBlock(content.([]interface{}), attributes)
     }
 
 VerseBlockRawContent <- (!QuoteBlockEndDelimiter line:(RawLine) { 
@@ -1790,8 +1766,8 @@ VerseBlockRawContent <- (!QuoteBlockEndDelimiter line:(RawLine) {
 // -------------------------------------------------------------------------------------
 // Passthrough blocks
 // -------------------------------------------------------------------------------------
-PassthroughBlock <- attributes:(ElementAttribute)* PassthroughBlockStartDelimiter content:(PassthroughBlockRawContent) PassthroughBlockEndDelimiter {
-    return types.NewPassthroughBlock(content.([]interface{}), attributes.([]interface{}))
+PassthroughBlock <- attributes:(BlockAttributes)? PassthroughBlockStartDelimiter content:(PassthroughBlockRawContent) PassthroughBlockEndDelimiter {
+    return types.NewPassthroughBlock(content.([]interface{}), attributes)
 }
 
 PassthroughBlockDelimiter <- "++++" Space* EOL
@@ -1952,11 +1928,11 @@ NoneSubs <- (
 // -------------------------------------------------------------------------------------
 // Tables
 // -------------------------------------------------------------------------------------
-Table <- attributes:(BlockAttribute)* TableDelimiter
+Table <- attributes:(BlockAttributes)? TableDelimiter
     header:(TableLineHeader)?
     lines:(TableLine)*
     (TableDelimiter / EOF) { // end delimiter or end of file
-        return types.NewTable(header, lines.([]interface{}), attributes.([]interface{}))
+        return types.NewTable(header, lines.([]interface{}), attributes)
     }
 
 TableCellSeparator <- "|" Space*
@@ -1984,8 +1960,8 @@ LiteralBlock <- ParagraphWithLiteralAttribute / ParagraphWithHeadingSpaces / Par
 LiteralBlockDelimiter <- "...."
 
 // paragraph indented with one or more spaces on the first line
-ParagraphWithHeadingSpaces <- attributes:(ElementAttribute)* lines:(ParagraphWithHeadingSpacesLines) {
-    return types.NewLiteralBlock(types.LiteralBlockWithSpacesOnFirstLine, lines.([]interface{}), attributes.([]interface{}))
+ParagraphWithHeadingSpaces <- attributes:(BlockAttributes)? lines:(ParagraphWithHeadingSpacesLines) {
+    return types.NewLiteralBlock(types.LiteralBlockWithSpacesOnFirstLine, lines.([]interface{}), attributes)
 }
 
 // first line MUST start with one (or more) space. Stop when reaching a blank line
@@ -2002,9 +1978,9 @@ ParagraphWithHeadingSpacesLine <- line:(Space+ [^\r\n]+ {
 }
 
 // paragraph with the literal block delimiter (`....`)
-ParagraphWithLiteralBlockDelimiter <- attributes:(ElementAttribute)*
+ParagraphWithLiteralBlockDelimiter <- attributes:(BlockAttributes)?
         LiteralBlockDelimiter Space* Newline lines:(ParagraphWithLiteralBlockDelimiterLines) ((LiteralBlockDelimiter Space* EOL) / EOF) {
-    return types.NewLiteralBlock(types.LiteralBlockWithDelimiter, lines.([]interface{}), attributes.([]interface{}))
+    return types.NewLiteralBlock(types.LiteralBlockWithDelimiter, lines.([]interface{}), attributes)
 }
 
 // include all lines until delimiter is reached
@@ -2021,12 +1997,12 @@ ParagraphWithLiteralBlockDelimiterLine <-
 
 // paragraph with the literal attribute (`[literal]`)
 ParagraphWithLiteralAttribute <- 
-    attributes:(ElementAttribute)*
+    attributes:(BlockAttributes)?
     &{
-        return types.HasAttributeWithValue(attributes, types.AttrBlockKind, types.Literal), nil
+        return types.HasAttributeWithValue(attributes, types.AttrPositional1, types.Literal), nil
     }
     lines:(LiteralParagraphLine)+ {
-        return types.NewLiteralBlock(types.LiteralBlockWithAttribute, lines.([]interface{}), attributes.([]interface{}))
+        return types.NewLiteralBlock(types.LiteralBlockWithAttribute, lines.([]interface{}), attributes)
     }
 
 LiteralKind <- "literal" {
@@ -2129,7 +2105,7 @@ Word <-
     // then followed by spaces but not the "+" signs because it needs a heading space to become a LineBreak element
     [\pL0-9]+ &([\r\n ,\]] / EOF) { 
         return types.NewStringElement(string(c.text))
-    } / [\pL0-9]+ ([=*_`] [\pL0-9]+)+ { 
+    } / [\pL0-9]+ ([=*_`] [\pL0-9]+)+ {  // allow `
         return types.NewStringElement(string(c.text))
     }
 

--- a/pkg/parser/parser_state.go
+++ b/pkg/parser/parser_state.go
@@ -1,0 +1,25 @@
+package parser
+
+import (
+	"fmt"
+
+	"github.com/bytesparadise/libasciidoc/pkg/types"
+)
+
+// initPositionalIndex sets the `types.AttrPositionalIndex` value to 0 in the current state
+func initPositionalIndex(c *current) error {
+	c.globalStore[types.AttrPositionalIndex] = 0
+	return nil
+}
+
+// incrementPositionalIndex increments the value of `types.AttrPositionalIndex`
+// returns the current index (after increment) or an error if the value is not an `int`
+func incrementPositionalIndex(c *current) (int, error) {
+	p, ok := c.globalStore[types.AttrPositionalIndex].(int)
+	if !ok {
+		return 0, fmt.Errorf("unexpected kind attribute positional index: '%T'", c.globalStore[types.AttrPositionalPrefix])
+	}
+	p = p + 1
+	c.globalStore[types.AttrPositionalIndex] = p
+	return p, nil
+}

--- a/pkg/parser/q_a_list_test.go
+++ b/pkg/parser/q_a_list_test.go
@@ -84,11 +84,10 @@ What is the answer to the Ultimate Question?:: 42`
 			Elements: []interface{}{
 				types.LabeledList{
 					Attributes: types.Attributes{
-						types.AttrTitle:    "Q&A",
-						types.AttrStyle:    "qanda",
-						types.AttrID:       "quiz",
-						types.AttrCustomID: true,
-						types.AttrRole:     []interface{}{types.ElementRole{"role1"}, types.ElementRole{"role2"}},
+						types.AttrTitle: "Q&A",
+						types.AttrStyle: "qanda",
+						types.AttrID:    "quiz",
+						types.AttrRoles: []interface{}{"role1", "role2"},
 					},
 					Items: []types.LabeledListItem{
 						{

--- a/pkg/parser/quoted_string_test.go
+++ b/pkg/parser/quoted_string_test.go
@@ -136,7 +136,7 @@ var _ = Describe("quoted strings", func() {
 			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 		It("span in single quoted string", func() {
-			source := "'`curly [strikeout]#was#_is_ single`'"
+			source := "'`curly [.strikeout]#was#_is_ single`'"
 			expected := types.DraftDocument{
 				Elements: []interface{}{
 					types.Paragraph{
@@ -145,22 +145,32 @@ var _ = Describe("quoted strings", func() {
 								types.QuotedString{
 									Kind: types.SingleQuote,
 									Elements: []interface{}{
-										types.StringElement{Content: "curly "},
+										types.StringElement{
+											Content: "curly ",
+										},
 										types.QuotedText{
-											Kind:       types.Marked,
-											Attributes: types.Attributes{types.AttrRole: types.ElementRole{"strikeout"}},
+											Kind: types.Marked,
+											Attributes: types.Attributes{
+												types.AttrRoles: []interface{}{"strikeout"},
+											},
 											Elements: []interface{}{
-												types.StringElement{Content: "was"},
+												types.StringElement{
+													Content: "was",
+												},
 											},
 										},
 										types.QuotedText{
 											Kind: types.Italic,
 											Elements: []interface{}{
-												types.StringElement{Content: "is"},
+												types.StringElement{
+													Content: "is",
+												},
 											},
 										},
 
-										types.StringElement{Content: " single"},
+										types.StringElement{
+											Content: " single",
+										},
 									},
 								},
 							},
@@ -341,7 +351,7 @@ var _ = Describe("quoted strings", func() {
 										},
 									},
 									Attributes: types.Attributes{
-										"positional-1": []interface{}{
+										types.AttrInlineLinkText: []interface{}{
 											types.QuotedString{
 												Kind: types.SingleQuote,
 												Elements: []interface{}{
@@ -375,7 +385,7 @@ var _ = Describe("quoted strings", func() {
 										},
 									},
 									Attributes: types.Attributes{
-										"positional-1": []interface{}{
+										types.AttrInlineLinkText: []interface{}{
 											types.StringElement{
 												Content: "an ",
 											},
@@ -575,7 +585,7 @@ var _ = Describe("quoted strings", func() {
 		})
 
 		It("span in double quoted string", func() {
-			source := "\"`curly [strikeout]#was#_is_ single`\""
+			source := "\"`curly [.strikeout]#was#_is_ single`\""
 			expected := types.DraftDocument{
 				Elements: []interface{}{
 					types.Paragraph{
@@ -584,22 +594,31 @@ var _ = Describe("quoted strings", func() {
 								types.QuotedString{
 									Kind: types.DoubleQuote,
 									Elements: []interface{}{
-										types.StringElement{Content: "curly "},
+										types.StringElement{
+											Content: "curly ",
+										},
 										types.QuotedText{
-											Kind:       types.Marked,
-											Attributes: types.Attributes{types.AttrRole: types.ElementRole{"strikeout"}},
+											Kind: types.Marked,
+											Attributes: types.Attributes{
+												types.AttrRoles: []interface{}{"strikeout"},
+											},
 											Elements: []interface{}{
-												types.StringElement{Content: "was"},
+												types.StringElement{
+													Content: "was",
+												},
 											},
 										},
 										types.QuotedText{
 											Kind: types.Italic,
 											Elements: []interface{}{
-												types.StringElement{Content: "is"},
+												types.StringElement{
+													Content: "is",
+												},
 											},
 										},
-
-										types.StringElement{Content: " single"},
+										types.StringElement{
+											Content: " single",
+										},
 									},
 								},
 							},
@@ -781,7 +800,7 @@ var _ = Describe("quoted strings", func() {
 										},
 									},
 									Attributes: types.Attributes{
-										"positional-1": []interface{}{
+										types.AttrInlineLinkText: []interface{}{
 											types.QuotedString{
 												Kind: types.DoubleQuote,
 												Elements: []interface{}{
@@ -817,7 +836,7 @@ var _ = Describe("quoted strings", func() {
 										},
 									},
 									Attributes: types.Attributes{
-										"positional-1": []interface{}{
+										types.AttrInlineLinkText: []interface{}{
 											types.QuotedString{
 												Kind: types.DoubleQuote,
 												Elements: []interface{}{

--- a/pkg/parser/quoted_text_test.go
+++ b/pkg/parser/quoted_text_test.go
@@ -897,8 +897,8 @@ var _ = Describe("quoted texts", func() {
 
 		Context("with attributes", func() {
 
-			It("simple role italics", func() {
-				source := "[myrole]_italics_"
+			It("simple dot.role italics", func() {
+				source := "[.myrole]_italics_"
 				expected := types.DraftDocument{
 					Elements: []interface{}{
 						types.Paragraph{
@@ -910,7 +910,7 @@ var _ = Describe("quoted texts", func() {
 											types.StringElement{Content: "italics"},
 										},
 										Attributes: types.Attributes{
-											types.AttrRole: types.ElementRole{"myrole"},
+											types.AttrRoles: []interface{}{"myrole"},
 										},
 									},
 								},
@@ -921,8 +921,8 @@ var _ = Describe("quoted texts", func() {
 				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
-			It("simple role italics unconstrained", func() {
-				source := "it[uncle]__al__ic"
+			It("simple dot.role italics unconstrained", func() {
+				source := "it[.uncle]__al__ic"
 				expected := types.DraftDocument{
 					Elements: []interface{}{
 						types.Paragraph{
@@ -937,7 +937,7 @@ var _ = Describe("quoted texts", func() {
 											types.StringElement{Content: "al"},
 										},
 										Attributes: types.Attributes{
-											types.AttrRole: types.ElementRole{"uncle"},
+											types.AttrRoles: []interface{}{"uncle"},
 										},
 									},
 									types.StringElement{
@@ -951,8 +951,8 @@ var _ = Describe("quoted texts", func() {
 				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
-			It("simple role bold", func() {
-				source := "[myrole]*bold*"
+			It("simple dot.role bold", func() {
+				source := "[.myrole]*bold*"
 				expected := types.DraftDocument{
 					Elements: []interface{}{
 						types.Paragraph{
@@ -964,7 +964,7 @@ var _ = Describe("quoted texts", func() {
 											types.StringElement{Content: "bold"},
 										},
 										Attributes: types.Attributes{
-											types.AttrRole: types.ElementRole{"myrole"},
+											types.AttrRoles: []interface{}{"myrole"},
 										},
 									},
 								},
@@ -975,8 +975,8 @@ var _ = Describe("quoted texts", func() {
 				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
-			It("simple role bold unconstrained", func() {
-				source := "it[uncle]**al**ic"
+			It("simple dot.role bold unconstrained", func() {
+				source := "it[.uncle]**al**ic"
 				expected := types.DraftDocument{
 					Elements: []interface{}{
 						types.Paragraph{
@@ -991,7 +991,7 @@ var _ = Describe("quoted texts", func() {
 											types.StringElement{Content: "al"},
 										},
 										Attributes: types.Attributes{
-											types.AttrRole: types.ElementRole{"uncle"},
+											types.AttrRoles: []interface{}{"uncle"},
 										},
 									},
 									types.StringElement{
@@ -1005,8 +1005,8 @@ var _ = Describe("quoted texts", func() {
 				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
-			It("simple role mono", func() {
-				source := "[myrole]`true`"
+			It("simple dot.role mono", func() {
+				source := "[.myrole]`true`"
 				expected := types.DraftDocument{
 					Elements: []interface{}{
 						types.Paragraph{
@@ -1018,7 +1018,7 @@ var _ = Describe("quoted texts", func() {
 											types.StringElement{Content: "true"},
 										},
 										Attributes: types.Attributes{
-											types.AttrRole: types.ElementRole{"myrole"},
+											types.AttrRoles: []interface{}{"myrole"},
 										},
 									},
 								},
@@ -1029,8 +1029,8 @@ var _ = Describe("quoted texts", func() {
 				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
-			It("simple role mono unconstrained", func() {
-				source := "int[uncle]``eg``rate"
+			It("simple dot.role mono unconstrained", func() {
+				source := "int[.uncle]``eg``rate"
 				expected := types.DraftDocument{
 					Elements: []interface{}{
 						types.Paragraph{
@@ -1045,7 +1045,7 @@ var _ = Describe("quoted texts", func() {
 											types.StringElement{Content: "eg"},
 										},
 										Attributes: types.Attributes{
-											types.AttrRole: types.ElementRole{"uncle"},
+											types.AttrRoles: []interface{}{"uncle"},
 										},
 									},
 									types.StringElement{
@@ -1059,7 +1059,7 @@ var _ = Describe("quoted texts", func() {
 				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
-			It("role with comma truncates", func() {
+			It("role with extra attribute", func() {
 				source := "[myrole,and=nothing]_italics_"
 				expected := types.DraftDocument{
 					Elements: []interface{}{
@@ -1069,8 +1069,33 @@ var _ = Describe("quoted texts", func() {
 									types.QuotedText{
 										Kind: types.Italic,
 										Attributes: types.Attributes{
-											types.AttrRole: types.ElementRole{"myrole"},
-											"and":          "nothing",
+											types.AttrRoles: []interface{}{"myrole"},
+											"and":           "nothing",
+										},
+										Elements: []interface{}{
+											types.StringElement{Content: "italics"},
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
+			})
+
+			It("dot.role with extra attribute", func() {
+				source := "[.myrole,and=nothing]_italics_"
+				expected := types.DraftDocument{
+					Elements: []interface{}{
+						types.Paragraph{
+							Lines: [][]interface{}{
+								{
+									types.QuotedText{
+										Kind: types.Italic,
+										Attributes: types.Attributes{
+											types.AttrRoles: []interface{}{"myrole"},
+											"and":           "nothing",
 										},
 										Elements: []interface{}{
 											types.StringElement{Content: "italics"},
@@ -1097,8 +1122,7 @@ var _ = Describe("quoted texts", func() {
 											types.StringElement{Content: "bold"},
 										},
 										Attributes: types.Attributes{
-											types.AttrID:       "here",
-											types.AttrCustomID: true,
+											types.AttrID: "here",
 										},
 									},
 								},
@@ -1110,6 +1134,30 @@ var _ = Describe("quoted texts", func() {
 			})
 
 			It("short-hand role only", func() {
+				source := "[bob]**bold**"
+				expected := types.DraftDocument{
+					Elements: []interface{}{
+						types.Paragraph{
+							Lines: [][]interface{}{
+								{
+									types.QuotedText{
+										Kind: types.Bold,
+										Elements: []interface{}{
+											types.StringElement{Content: "bold"},
+										},
+										Attributes: types.Attributes{
+											types.AttrRoles: []interface{}{"bob"},
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
+			})
+
+			It("short-hand dot.role only", func() {
 				source := "[.bob]**bold**"
 				expected := types.DraftDocument{
 					Elements: []interface{}{
@@ -1122,7 +1170,7 @@ var _ = Describe("quoted texts", func() {
 											types.StringElement{Content: "bold"},
 										},
 										Attributes: types.Attributes{
-											types.AttrRole: types.ElementRole{"bob"},
+											types.AttrRoles: []interface{}{"bob"},
 										},
 									},
 								},
@@ -1134,7 +1182,7 @@ var _ = Describe("quoted texts", func() {
 			})
 
 			It("short-hand role with special characters", func() {
-				source := "[\"a <role>\"]**bold**"
+				source := `["a <role>"]**bold**`
 				expected := types.DraftDocument{
 					Elements: []interface{}{
 						types.Paragraph{
@@ -1143,19 +1191,20 @@ var _ = Describe("quoted texts", func() {
 									types.QuotedText{
 										Kind: types.Bold,
 										Attributes: types.Attributes{
-											types.AttrRole: types.ElementRole{
-												types.StringElement{
-													Content: "a ",
-												},
-												// wrapping quotes are not preserved
-												types.SpecialCharacter{
-													Name: "<",
-												},
-												types.StringElement{
-													Content: "role",
-												},
-												types.SpecialCharacter{
-													Name: ">",
+											types.AttrRoles: []interface{}{
+												[]interface{}{
+													types.StringElement{
+														Content: "a ",
+													},
+													types.SpecialCharacter{
+														Name: "<",
+													},
+													types.StringElement{
+														Content: "role",
+													},
+													types.SpecialCharacter{
+														Name: ">",
+													},
 												},
 											},
 										},
@@ -1171,7 +1220,46 @@ var _ = Describe("quoted texts", func() {
 				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
-			It("marked short-hand role only", func() {
+			It("short-hand dot.role with special characters", func() {
+				source := `[."a <role>"]**bold**`
+				expected := types.DraftDocument{
+					Elements: []interface{}{
+						types.Paragraph{
+							Lines: [][]interface{}{
+								{
+									types.QuotedText{
+										Kind: types.Bold,
+										Attributes: types.Attributes{
+											types.AttrRoles: []interface{}{
+												[]interface{}{
+													types.StringElement{
+														Content: "a ",
+													},
+													types.SpecialCharacter{
+														Name: "<",
+													},
+													types.StringElement{
+														Content: "role",
+													},
+													types.SpecialCharacter{
+														Name: ">",
+													},
+												},
+											},
+										},
+										Elements: []interface{}{
+											types.StringElement{Content: "bold"},
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
+			})
+
+			It("marked short-hand dot.role only", func() {
 				source := "[.bob]##the builder##"
 				expected := types.DraftDocument{
 					Elements: []interface{}{
@@ -1184,7 +1272,7 @@ var _ = Describe("quoted texts", func() {
 											types.StringElement{Content: "the builder"},
 										},
 										Attributes: types.Attributes{
-											types.AttrRole: types.ElementRole{"bob"},
+											types.AttrRoles: []interface{}{"bob"},
 										},
 									},
 								},
@@ -1204,24 +1292,22 @@ var _ = Describe("quoted texts", func() {
 								{
 									types.QuotedText{
 										Kind: types.Bold,
+										Attributes: types.Attributes{
+											types.AttrRoles: []interface{}{"role1", "role2", "role3"},
+											types.AttrID:    "anchor",
+										},
 										Elements: []interface{}{
 											types.StringElement{Content: "bold"},
-										},
-										Attributes: types.Attributes{
-											types.AttrRole:     []interface{}{types.ElementRole{"role1"}, types.ElementRole{"role2"}, types.ElementRole{"role3"}},
-											types.AttrID:       "anchor",
-											types.AttrCustomID: true,
 										},
 									},
 									types.QuotedText{
 										Kind: types.Italic,
+										Attributes: types.Attributes{
+											types.AttrRoles: []interface{}{"second", "class"},
+											types.AttrID:    "here",
+										},
 										Elements: []interface{}{
 											types.StringElement{Content: "text"},
-										},
-										Attributes: types.Attributes{
-											types.AttrRole:     []interface{}{types.ElementRole{"second"}, types.ElementRole{"class"}},
-											types.AttrID:       "here",
-											types.AttrCustomID: true,
 										},
 									},
 								},
@@ -1253,8 +1339,8 @@ var _ = Describe("quoted texts", func() {
 				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
-			It("quoted role", func() {
-				source := "['here, again']**bold**"
+			It("quoted dot.role", func() {
+				source := "[.'here, again']**bold**"
 				expected := types.DraftDocument{
 					Elements: []interface{}{
 						types.Paragraph{
@@ -1267,7 +1353,7 @@ var _ = Describe("quoted texts", func() {
 										},
 										// NB: This will confuse the renderer.
 										Attributes: types.Attributes{
-											types.AttrRole: types.ElementRole{"here, again"},
+											types.AttrRoles: []interface{}{"here, again"},
 										},
 									},
 								},
@@ -1278,8 +1364,8 @@ var _ = Describe("quoted texts", func() {
 				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
-			It("quoted role with special chars", func() {
-				source := "[\"something <wicked>\"]**bold**"
+			It("quoted dot.role with special chars", func() {
+				source := "[.\"something <wicked>\"]**bold**"
 				expected := types.DraftDocument{
 					Elements: []interface{}{
 						types.Paragraph{
@@ -1292,18 +1378,20 @@ var _ = Describe("quoted texts", func() {
 										},
 										// NB: This will confuse the renderer.
 										Attributes: types.Attributes{
-											types.AttrRole: types.ElementRole{
-												types.StringElement{
-													Content: "something ",
-												},
-												types.SpecialCharacter{
-													Name: "<",
-												},
-												types.StringElement{
-													Content: "wicked",
-												},
-												types.SpecialCharacter{
-													Name: ">",
+											types.AttrRoles: []interface{}{
+												[]interface{}{
+													types.StringElement{
+														Content: "something ",
+													},
+													types.SpecialCharacter{
+														Name: "<",
+													},
+													types.StringElement{
+														Content: "wicked",
+													},
+													types.SpecialCharacter{
+														Name: ">",
+													},
 												},
 											},
 										},
@@ -2010,11 +2098,7 @@ var _ = Describe("quoted texts", func() {
 											types.StringElement{Content: "a "},
 											types.InlineLink{
 												Attributes: types.Attributes{
-													"positional-1": []interface{}{
-														types.StringElement{
-															Content: "b",
-														},
-													},
+													types.AttrInlineLinkText: "b",
 												},
 												Location: types.Location{
 													Path: []interface{}{
@@ -2131,11 +2215,7 @@ var _ = Describe("quoted texts", func() {
 											types.StringElement{Content: "a "},
 											types.InlineLink{
 												Attributes: types.Attributes{
-													"positional-1": []interface{}{
-														types.StringElement{
-															Content: "b",
-														},
-													},
+													types.AttrInlineLinkText: "b",
 												},
 												Location: types.Location{
 													Path: []interface{}{
@@ -2252,11 +2332,7 @@ var _ = Describe("quoted texts", func() {
 											types.StringElement{Content: "a "},
 											types.InlineLink{
 												Attributes: types.Attributes{
-													"positional-1": []interface{}{
-														types.StringElement{
-															Content: "b",
-														},
-													},
+													types.AttrInlineLinkText: "b",
 												},
 												Location: types.Location{
 													Path: []interface{}{
@@ -4876,11 +4952,7 @@ var _ = Describe("quoted texts", func() {
 											types.StringElement{Content: "a "},
 											types.InlineLink{
 												Attributes: types.Attributes{
-													"positional-1": []interface{}{
-														types.StringElement{
-															Content: "b",
-														},
-													},
+													types.AttrInlineLinkText: "b",
 												},
 												Location: types.Location{
 													Path: []interface{}{
@@ -4997,11 +5069,7 @@ var _ = Describe("quoted texts", func() {
 											types.StringElement{Content: "a "},
 											types.InlineLink{
 												Attributes: types.Attributes{
-													"positional-1": []interface{}{
-														types.StringElement{
-															Content: "b",
-														},
-													},
+													types.AttrInlineLinkText: "b",
 												},
 												Location: types.Location{
 													Path: []interface{}{
@@ -5118,11 +5186,7 @@ var _ = Describe("quoted texts", func() {
 											types.StringElement{Content: "a "},
 											types.InlineLink{
 												Attributes: types.Attributes{
-													"positional-1": []interface{}{
-														types.StringElement{
-															Content: "b",
-														},
-													},
+													types.AttrInlineLinkText: "b",
 												},
 												Location: types.Location{
 													Path: []interface{}{

--- a/pkg/parser/section_test.go
+++ b/pkg/parser/section_test.go
@@ -139,7 +139,9 @@ and a paragraph`
 						},
 					},
 				}
-				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
+				result, err := ParseDraftDocument(source)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(MatchDraftDocument(expected))
 			})
 
 			It("section level 1 with custom idseparator", func() {
@@ -787,7 +789,7 @@ a short preamble
 					Elements: []interface{}{
 						types.LiteralBlock{
 							Attributes: types.Attributes{
-								types.AttrBlockKind:        types.Literal,
+								types.AttrStyle:            types.Literal,
 								types.AttrLiteralBlockType: types.LiteralBlockWithSpacesOnFirstLine,
 							},
 							Lines: [][]interface{}{
@@ -825,7 +827,7 @@ a short preamble
 						types.BlankLine{},
 						types.LiteralBlock{
 							Attributes: types.Attributes{
-								types.AttrBlockKind:        types.Literal,
+								types.AttrStyle:            types.Literal,
 								types.AttrLiteralBlockType: types.LiteralBlockWithSpacesOnFirstLine,
 							},
 							Lines: [][]interface{}{
@@ -1944,7 +1946,7 @@ a short preamble
 					Elements: []interface{}{
 						types.LiteralBlock{
 							Attributes: types.Attributes{
-								types.AttrBlockKind:        types.Literal,
+								types.AttrStyle:            types.Literal,
 								types.AttrLiteralBlockType: types.LiteralBlockWithSpacesOnFirstLine,
 							},
 							Lines: [][]interface{}{
@@ -1981,7 +1983,7 @@ a short preamble
 							Elements: []interface{}{
 								types.LiteralBlock{
 									Attributes: types.Attributes{
-										types.AttrBlockKind:        types.Literal,
+										types.AttrStyle:            types.Literal,
 										types.AttrLiteralBlockType: types.LiteralBlockWithSpacesOnFirstLine,
 									},
 									Lines: [][]interface{}{

--- a/pkg/parser/table_test.go
+++ b/pkg/parser/table_test.go
@@ -204,11 +204,10 @@ var _ = Describe("tables", func() {
 			Elements: []interface{}{
 				types.Table{
 					Attributes: types.Attributes{
-						types.AttrTitle:    "table title",
-						types.AttrOptions:  map[string]bool{"autowidth": true},
-						types.AttrRole:     []interface{}{types.ElementRole{"role1"}, types.ElementRole{"stretch"}},
-						types.AttrID:       "anchor",
-						types.AttrCustomID: true,
+						types.AttrTitle:   "table title",
+						types.AttrOptions: []interface{}{"autowidth"},
+						types.AttrRoles:   []interface{}{"role1", "stretch"},
+						types.AttrID:      "anchor",
 					},
 					Header: types.TableLine{
 						Cells: [][]interface{}{
@@ -226,8 +225,8 @@ var _ = Describe("tables", func() {
 					},
 					Columns: []types.TableColumn{
 						// autowidth clears width
-						{Width: "", HAlign: "left", VAlign: "top"},
-						{Width: "", HAlign: "left", VAlign: "top"},
+						{HAlign: "left", VAlign: "top"},
+						{HAlign: "left", VAlign: "top"},
 					},
 					Lines: []types.TableLine{
 						{
@@ -305,13 +304,13 @@ var _ = Describe("tables", func() {
 			Elements: []interface{}{
 				types.Table{
 					Attributes: types.Attributes{
-						types.AttrOptions: map[string]bool{"autowidth": true},
+						types.AttrOptions: []interface{}{"autowidth"},
 						types.AttrCols:    "3,2,5",
 					},
 					Columns: []types.TableColumn{
-						{Width: "", HAlign: "left", VAlign: "top"},
-						{Width: "", HAlign: "left", VAlign: "top"},
-						{Width: "", HAlign: "left", VAlign: "top"},
+						{HAlign: "left", VAlign: "top"},
+						{HAlign: "left", VAlign: "top"},
+						{HAlign: "left", VAlign: "top"},
 					},
 					Lines: []types.TableLine{},
 				},
@@ -330,8 +329,8 @@ var _ = Describe("tables", func() {
 					},
 					Columns: []types.TableColumn{
 						{Width: "30", HAlign: "left", VAlign: "top"},
-						{Width: "", HAlign: "left", VAlign: "top"},
-						{Width: "", HAlign: "left", VAlign: "top"},
+						{HAlign: "left", VAlign: "top"},
+						{HAlign: "left", VAlign: "top"},
 					},
 					Lines: []types.TableLine{},
 				},
@@ -352,8 +351,8 @@ var _ = Describe("tables", func() {
 						{Width: "10", HAlign: "left", VAlign: "top"},
 						{Width: "10", HAlign: "left", VAlign: "top"},
 						{Width: "10", HAlign: "left", VAlign: "top"},
-						{Width: "", HAlign: "left", VAlign: "top"},
-						{Width: "", HAlign: "left", VAlign: "top"},
+						{HAlign: "left", VAlign: "top"},
+						{HAlign: "left", VAlign: "top"},
 					},
 					Lines: []types.TableLine{},
 				},

--- a/pkg/parser/unordered_list_test.go
+++ b/pkg/parser/unordered_list_test.go
@@ -46,10 +46,9 @@ var _ = Describe("unordered lists", func() {
 					Elements: []interface{}{
 						types.UnorderedListItem{
 							Attributes: types.Attributes{
-								types.AttrTitle:    "mytitle",
-								types.AttrID:       "listID",
-								types.AttrCustomID: true,
-								types.AttrRole:     types.ElementRole{"myrole"},
+								types.AttrTitle: "mytitle",
+								types.AttrID:    "listID",
+								types.AttrRoles: []interface{}{"myrole"},
 							},
 							Level:       1,
 							BulletStyle: types.OneAsterisk,
@@ -78,11 +77,10 @@ var _ = Describe("unordered lists", func() {
 					Elements: []interface{}{
 						types.UnorderedListItem{
 							Attributes: types.Attributes{
-								types.AttrTitle:    "mytitle",
-								types.AttrID:       "listID",
-								types.AttrCustomID: true,
-								types.AttrRole:     types.ElementRole{"myrole"},
-								types.AttrStyle:    "square",
+								types.AttrTitle: "mytitle",
+								types.AttrID:    "listID",
+								types.AttrRoles: []interface{}{"myrole"},
+								types.AttrStyle: "square",
 							},
 							Level:       1,
 							BulletStyle: types.OneAsterisk,
@@ -1549,10 +1547,9 @@ paragraph attached to parent list item`
 					Elements: []interface{}{
 						types.UnorderedList{
 							Attributes: types.Attributes{
-								types.AttrID:       "listID",
-								types.AttrCustomID: true,
-								types.AttrTitle:    "mytitle",
-								types.AttrRole:     types.ElementRole{"myrole"},
+								types.AttrID:    "listID",
+								types.AttrTitle: "mytitle",
+								types.AttrRoles: []interface{}{"myrole"},
 							},
 							Items: []types.UnorderedListItem{
 								{

--- a/pkg/renderer/sgml/cross_reference.go
+++ b/pkg/renderer/sgml/cross_reference.go
@@ -49,9 +49,17 @@ func (r *sgmlRenderer) renderInternalCrossReference(ctx *renderer.Context, xref 
 func (r *sgmlRenderer) renderExternalCrossReference(ctx *renderer.Context, xref types.ExternalCrossReference) (string, error) {
 	log.Debugf("rendering cross reference with ID: %s", xref.Location)
 	result := &strings.Builder{}
-	label, err := r.renderInlineElements(ctx, xref.Label)
-	if err != nil {
-		return "", errors.Wrap(err, "unable to render external cross reference")
+	var label string
+	var err error
+	switch l := xref.Label.(type) {
+	case string:
+		label = l
+	case []interface{}:
+		if label, err = r.renderInlineElements(ctx, l); err != nil {
+			return "", errors.Wrap(err, "unable to render external cross reference")
+		}
+	default:
+		return "", errors.Errorf("unable to render external cross reference label of type '%T'", xref.Label)
 	}
 	err = r.externalCrossReference.Execute(result, struct {
 		Href  string

--- a/pkg/renderer/sgml/delimited_block_admonition.go
+++ b/pkg/renderer/sgml/delimited_block_admonition.go
@@ -10,8 +10,9 @@ import (
 )
 
 func (r *sgmlRenderer) renderAdmonitionBlock(ctx *renderer.Context, b types.ExampleBlock) (string, error) {
-	kind, _ := b.Attributes[types.AttrAdmonitionKind].(types.AdmonitionKind)
-	icon, err := r.renderIcon(ctx, types.Icon{Class: string(kind), Attributes: b.Attributes}, true)
+	kind, _ := b.Attributes.GetAsString(types.AttrStyle)
+	kind = strings.ToLower(kind)
+	icon, err := r.renderIcon(ctx, types.Icon{Class: strings.ToLower(kind), Attributes: b.Attributes}, true)
 	if err != nil {
 		return "", err
 	}
@@ -29,7 +30,7 @@ func (r *sgmlRenderer) renderAdmonitionBlock(ctx *renderer.Context, b types.Exam
 		Context *renderer.Context
 		ID      string
 		Title   string
-		Kind    types.AdmonitionKind
+		Kind    string
 		Roles   string
 		Icon    string
 		Content string
@@ -48,11 +49,12 @@ func (r *sgmlRenderer) renderAdmonitionBlock(ctx *renderer.Context, b types.Exam
 func (r *sgmlRenderer) renderAdmonitionParagraph(ctx *renderer.Context, p types.Paragraph) (string, error) {
 	log.Debug("rendering admonition paragraph...")
 	result := &strings.Builder{}
-	k, ok := p.Attributes[types.AttrAdmonitionKind].(types.AdmonitionKind)
+	kind, ok := p.Attributes.GetAsString(types.AttrStyle)
 	if !ok {
-		return "", errors.Errorf("failed to render admonition with unknown kind: %T", p.Attributes[types.AttrAdmonitionKind])
+		return "", errors.Errorf("failed to render admonition with unknown kind: %T", p.Attributes[types.AttrStyle])
 	}
-	icon, err := r.renderIcon(ctx, types.Icon{Class: string(k), Attributes: p.Attributes}, true)
+	kind = strings.ToLower(kind)
+	icon, err := r.renderIcon(ctx, types.Icon{Class: kind, Attributes: p.Attributes}, true)
 	if err != nil {
 		return "", err
 	}
@@ -77,10 +79,10 @@ func (r *sgmlRenderer) renderAdmonitionParagraph(ctx *renderer.Context, p types.
 		Context: ctx,
 		ID:      r.renderElementID(p.Attributes),
 		Title:   r.renderElementTitle(p.Attributes),
-		Kind:    string(k),
+		Kind:    kind,
 		Roles:   roles,
 		Icon:    icon,
-		Content: string(content),
+		Content: content,
 		Lines:   p.Lines,
 	})
 

--- a/pkg/renderer/sgml/delimited_block_example.go
+++ b/pkg/renderer/sgml/delimited_block_example.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (r *sgmlRenderer) renderExampleBlock(ctx *renderer.Context, b types.ExampleBlock) (string, error) {
-	if b.Attributes.Has(types.AttrAdmonitionKind) {
+	if b.Attributes.Has(types.AttrStyle) {
 		return r.renderAdmonitionBlock(ctx, b)
 	}
 	result := &strings.Builder{}

--- a/pkg/renderer/sgml/delimited_block_listing.go
+++ b/pkg/renderer/sgml/delimited_block_listing.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (r *sgmlRenderer) renderListingBlock(ctx *renderer.Context, b types.ListingBlock) (string, error) {
-	if k, found := b.Attributes[types.AttrBlockKind]; found && k == types.Source {
+	if k, found := b.Attributes[types.AttrStyle]; found && k == types.Source {
 		return r.renderSourceBlock(ctx, b)
 	}
 	previousWithinDelimitedBlock := ctx.WithinDelimitedBlock

--- a/pkg/renderer/sgml/delimited_block_source.go
+++ b/pkg/renderer/sgml/delimited_block_source.go
@@ -114,7 +114,6 @@ func (r *sgmlRenderer) renderSourceLines(ctx *renderer.Context, b types.ListingB
 				return "", "", "", err
 			}
 			highlightedLineBuf := &strings.Builder{}
-			// iterator, err := lexer.Tokenise(nil, content)
 			iterator, err := lexer.Tokenise(nil, renderedLine)
 			if err != nil {
 				return "", "", "", err

--- a/pkg/renderer/sgml/delimited_block_source.go
+++ b/pkg/renderer/sgml/delimited_block_source.go
@@ -25,14 +25,22 @@ func (r *sgmlRenderer) renderSourceBlock(ctx *renderer.Context, b types.ListingB
 	if err != nil {
 		return "", errors.Wrap(err, "unable to render source block roles")
 	}
-	option := b.Attributes.GetAsStringWithDefault(types.AttrSourceBlockOption, "")
+	var nowrap bool
+	if options, ok := b.Attributes[types.AttrOptions].([]interface{}); ok {
+		for _, opt := range options {
+			if opt == "nowrap" {
+				nowrap = true
+				break
+			}
+		}
+	}
 	result := &bytes.Buffer{}
 	err = r.sourceBlock.Execute(result, struct {
 		ID                string
 		Title             string
 		Roles             string
 		Language          string
-		Option            string
+		Nowrap            bool
 		SyntaxHighlighter string
 		Content           string
 	}{
@@ -41,7 +49,7 @@ func (r *sgmlRenderer) renderSourceBlock(ctx *renderer.Context, b types.ListingB
 		SyntaxHighlighter: highlighter,
 		Roles:             roles,
 		Language:          language,
-		Option:            option,
+		Nowrap:            nowrap,
 		Content:           content,
 	})
 
@@ -52,7 +60,7 @@ func (r *sgmlRenderer) renderSourceParagraph(ctx *renderer.Context, p types.Para
 	lines := make([][]interface{}, len(p.Lines))
 	copy(lines, p.Lines)
 	attributes := p.Attributes
-	attributes[types.AttrBlockKind] = types.Source
+	attributes[types.AttrStyle] = types.Source
 	return r.renderSourceBlock(ctx, types.ListingBlock{
 		Attributes: attributes,
 		Lines:      lines,

--- a/pkg/renderer/sgml/elements.go
+++ b/pkg/renderer/sgml/elements.go
@@ -35,7 +35,6 @@ func (r *sgmlRenderer) renderElements(ctx *renderer.Context, elements []interfac
 		}
 		buff.WriteString(renderedElement)
 	}
-	// log.Debugf("rendered elements: '%s'", buff.String())
 	return buff.String(), nil
 }
 
@@ -57,7 +56,6 @@ func (r *sgmlRenderer) renderListElements(ctx *renderer.Context, elements []inte
 		}
 		buff.WriteString(renderedElement)
 	}
-	// log.Debugf("rendered elements: '%s'", buff.String())
 	return buff.String(), nil
 }
 
@@ -156,8 +154,6 @@ func (r *sgmlRenderer) renderPlainText(ctx *renderer.Context, element interface{
 	switch element := element.(type) {
 	case []interface{}:
 		return r.renderInlineElements(ctx, element, r.withVerbatim())
-	// case []interface{}:
-	// 	return r.renderLines(ctx, element, r.withPlainText())
 	case types.QuotedText:
 		return r.renderPlainText(ctx, element.Elements)
 	case types.Icon:

--- a/pkg/renderer/sgml/html5/check_list_test.go
+++ b/pkg/renderer/sgml/html5/check_list_test.go
@@ -1,0 +1,233 @@
+package html5_test
+
+import (
+	. "github.com/bytesparadise/libasciidoc/testsupport"
+
+	. "github.com/onsi/ginkgo" //nolint golint
+	. "github.com/onsi/gomega" //nolint golint
+)
+
+var _ = Describe("checklists", func() {
+
+	It("with title and dashes", func() {
+		source := `.Checklist
+- [*] checked
+- [x] also checked
+- [ ] not checked
+-     normal list item`
+		expected := `<div class="ulist checklist">
+<div class="title">Checklist</div>
+<ul class="checklist">
+<li>
+<p>&#10003; checked</p>
+</li>
+<li>
+<p>&#10003; also checked</p>
+</li>
+<li>
+<p>&#10063; not checked</p>
+</li>
+<li>
+<p>normal list item</p>
+</li>
+</ul>
+</div>
+`
+		Expect(RenderHTML(source)).To(MatchHTML(expected))
+	})
+
+	It("with style id, title and role", func() {
+		// style is overridden to checklist on ul, but div keeps it (asciidoctor compat)
+		source := `.mytitle
+[#foo]
+[disc.myrole]
+* [x] item 1
+* [x] item 2`
+		expected := `<div id="foo" class="ulist checklist disc myrole">
+<div class="title">mytitle</div>
+<ul class="checklist">
+<li>
+<p>&#10003; item 1</p>
+</li>
+<li>
+<p>&#10003; item 2</p>
+</li>
+</ul>
+</div>
+`
+		Expect(RenderHTML(source)).To(MatchHTML(expected))
+	})
+
+	It("with title and nested checklist", func() {
+		source := `.Checklist
+* [ ] parent not checked
+** [*] checked
+** [x] also checked
+** [ ] not checked
+*     normal list item`
+		expected := `<div class="ulist checklist">
+<div class="title">Checklist</div>
+<ul class="checklist">
+<li>
+<p>&#10063; parent not checked</p>
+<div class="ulist checklist">
+<ul class="checklist">
+<li>
+<p>&#10003; checked</p>
+</li>
+<li>
+<p>&#10003; also checked</p>
+</li>
+<li>
+<p>&#10063; not checked</p>
+</li>
+</ul>
+</div>
+</li>
+<li>
+<p>normal list item</p>
+</li>
+</ul>
+</div>
+`
+		Expect(RenderHTML(source)).To(MatchHTML(expected))
+	})
+
+	It("with role and nested normal list", func() {
+		source := `[.Checklist]
+* [ ] parent not checked
+** a normal list item
+** another normal list item
+*     normal list item`
+		expected := `<div class="ulist checklist Checklist">
+<ul class="checklist">
+<li>
+<p>&#10063; parent not checked</p>
+<div class="ulist">
+<ul>
+<li>
+<p>a normal list item</p>
+</li>
+<li>
+<p>another normal list item</p>
+</li>
+</ul>
+</div>
+</li>
+<li>
+<p>normal list item</p>
+</li>
+</ul>
+</div>
+`
+		Expect(RenderHTML(source)).To(MatchHTML(expected))
+	})
+
+	Context("attach to unordered list item ancestor", func() {
+
+		It("attach to grandparent unordered list item", func() {
+			source := `* grandparent list item
+** parent list item
+*** child list item
+
+
++
+paragraph attached to grandparent list item`
+			expected := `<div class="ulist">
+<ul>
+<li>
+<p>grandparent list item</p>
+<div class="ulist">
+<ul>
+<li>
+<p>parent list item</p>
+<div class="ulist">
+<ul>
+<li>
+<p>child list item</p>
+</li>
+</ul>
+</div>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>paragraph attached to grandparent list item</p>
+</div>
+</li>
+</ul>
+</div>
+`
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+		})
+
+		It("attach to parent unordered list item", func() {
+			source := `* grandparent list item
+** parent list item
+*** child list item
+
++
+paragraph attached to parent list item`
+			expected := `<div class="ulist">
+<ul>
+<li>
+<p>grandparent list item</p>
+<div class="ulist">
+<ul>
+<li>
+<p>parent list item</p>
+<div class="ulist">
+<ul>
+<li>
+<p>child list item</p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>paragraph attached to parent list item</p>
+</div>
+</li>
+</ul>
+</div>
+</li>
+</ul>
+</div>
+`
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+		})
+
+		It("attach to child unordered list item", func() {
+			source := `* grandparent list item
+** parent list item
+*** child list item
++
+paragraph attached to child list item`
+			expected := `<div class="ulist">
+<ul>
+<li>
+<p>grandparent list item</p>
+<div class="ulist">
+<ul>
+<li>
+<p>parent list item</p>
+<div class="ulist">
+<ul>
+<li>
+<p>child list item</p>
+<div class="paragraph">
+<p>paragraph attached to child list item</p>
+</div>
+</li>
+</ul>
+</div>
+</li>
+</ul>
+</div>
+</li>
+</ul>
+</div>
+`
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+		})
+	})
+})

--- a/pkg/renderer/sgml/html5/delimited_block_source_tmpl.go
+++ b/pkg/renderer/sgml/html5/delimited_block_source_tmpl.go
@@ -8,7 +8,7 @@ const (
 		"<pre class=\"" +
 		`{{ if .SyntaxHighlighter }}{{ .SyntaxHighlighter }} {{ end }}` +
 		`highlight` +
-		`{{ if .Option }} {{ .Option }}{{ end }}` + // space before the option as it's the last value in the 'class' attribute
+		`{{ if .Nowrap }} nowrap{{ end }}` + // space before the `nowrap` option as it's the last value in the 'class' attribute
 		`">` +
 		`<code{{ if .Language }}{{ if not .SyntaxHighlighter }} class="language-{{ .Language}}"{{ end }} ` +
 		`data-lang="{{ .Language}}"{{ end }}>` +

--- a/pkg/renderer/sgml/html5/icon_test.go
+++ b/pkg/renderer/sgml/html5/icon_test.go
@@ -295,7 +295,7 @@ icon:tip[]:: tip of the day`
 			It("icon in quoted text", func() {
 				source := `:icons: font
 
-here [strikeout]##we go icon:stop[]##`
+here [.strikeout]##we go icon:stop[]##`
 				expected := `<div class="paragraph">
 <p>here <span class="strikeout">we go <span class="icon"><i class="fa fa-stop"></i></span></span></p>
 </div>

--- a/pkg/renderer/sgml/html5/link_test.go
+++ b/pkg/renderer/sgml/html5/link_test.go
@@ -32,8 +32,10 @@ var _ = Describe("links", func() {
 
 		It("with unquoted text having comma", func() {
 			source := "https://foo.com[A, B, and C]"
+			// here, `B` and `and C` are considered as other positional args,
+			// not as part of the link text.
 			expected := `<div class="paragraph">
-<p><a href="https://foo.com">A, B, and C</a></p>
+<p><a href="https://foo.com">A</a></p>
 </div>
 `
 			Expect(RenderHTML(source)).To(MatchHTML(expected))
@@ -179,6 +181,18 @@ a link to {scheme}://{path} and https://foo.baz`
 
 		It("relative link with text having comma", func() {
 			source := "a link to link:foo.adoc[A, B, and C]"
+			expected := `<div class="paragraph">
+<p>a link to <a href="foo.adoc">A</a></p>
+</div>
+`
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+		})
+
+		It("relative link with quoted text having comma", func() {
+			// must wrap link text in quotes to retain it all,
+			// otherwise, it's cut after the first comma
+			// TODO: expect `target=b` and `role= 'and C'` attributes
+			source := "a link to link:foo.adoc['A, B, and C']"
 			expected := `<div class="paragraph">
 <p>a link to <a href="foo.adoc">A, B, and C</a></p>
 </div>

--- a/pkg/renderer/sgml/html5/paragraph_test.go
+++ b/pkg/renderer/sgml/html5/paragraph_test.go
@@ -160,6 +160,20 @@ baz</p>
 			Expect(RenderHTML(source)).To(MatchHTML(expected))
 		})
 
+		It("with multiple substitutions in attributes", func() {
+			source := `:role1: ROLE1
+:role2: ROLE2
+
+[.{role1}.{role2}]
+some content`
+
+			expected := `<div class="paragraph ROLE1 ROLE2">
+<p>some content</p>
+</div>
+`
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+		})
+
 		Context("with custom substitutions", func() {
 
 			It("with attributes substitution", func() {

--- a/pkg/renderer/sgml/html5/quoted_string_test.go
+++ b/pkg/renderer/sgml/html5/quoted_string_test.go
@@ -63,7 +63,7 @@ var _ = Describe("quoted strings", func() {
 
 		})
 		It("span in single quoted string", func() {
-			source := "'`curly [strikeout]#was#_is_ single`'"
+			source := "'`curly [.strikeout]#was#_is_ single`'"
 			expected := `<div class="paragraph">
 <p>&#8216;curly <span class="strikeout">was</span><em>is</em> single&#8217;</p>
 </div>
@@ -169,7 +169,7 @@ var _ = Describe("quoted strings", func() {
 `
 			Expect(RenderHTML(source)).To(MatchHTML(expected))
 		})
-		It("curly in quoted link", func() {
+		It("curly in single quoted link", func() {
 			source := "https://www.example.com/a[\"an '`example`'\"]"
 			expected := `<div class="paragraph">
 <p><a href="https://www.example.com/a">an &#8216;example&#8217;</a></p>
@@ -232,7 +232,7 @@ var _ = Describe("quoted strings", func() {
 		})
 
 		It("span in double quoted string", func() {
-			source := "\"`curly [strikeout]#was#_is_ single`\""
+			source := "\"`curly [.strikeout]#was#_is_ single`\""
 			expected := `<div class="paragraph">
 <p>&#8220;curly <span class="strikeout">was</span><em>is</em> single&#8221;</p>
 </div>
@@ -342,7 +342,7 @@ var _ = Describe("quoted strings", func() {
 		})
 
 		// This is the unambiguous form.
-		It("curly in quoted link", func() {
+		It("curly in double quoted link", func() {
 			source := "https://www.example.com/a[\"\"`example`\"\"]"
 			expected := `<div class="paragraph">
 <p><a href="https://www.example.com/a">&#8220;example&#8221;</a></p>

--- a/pkg/renderer/sgml/html5/quoted_text_test.go
+++ b/pkg/renderer/sgml/html5/quoted_text_test.go
@@ -353,7 +353,7 @@ content</mark>.</p>
 		})
 
 		It("simple role mono", func() {
-			source := "[myrole]`true`"
+			source := "[.myrole]`true`"
 			expected := `<div class="paragraph">
 <p><code class="myrole">true</code></p>
 </div>
@@ -362,7 +362,7 @@ content</mark>.</p>
 		})
 
 		It("short-hand role with special characters", func() {
-			source := `["a <role>"]**bold**`
+			source := `[."a <role>"]**bold**`
 			// wrapping quotes are not preserved
 			expected := `<div class="paragraph">
 <p><strong class="a &lt;role&gt;">bold</strong></p>
@@ -372,7 +372,7 @@ content</mark>.</p>
 		})
 
 		It("simple role mono unconstrained", func() {
-			source := "int[uncle]``eg``rate"
+			source := "int[.uncle]``eg``rate"
 			expected := `<div class="paragraph">
 <p>int<code class="uncle">eg</code>rate</p>
 </div>
@@ -381,7 +381,7 @@ content</mark>.</p>
 		})
 
 		It("role with comma truncates", func() {
-			source := "[myrole,and=nothing_else]_italics_"
+			source := "[.myrole,and=nothing_else]_italics_"
 			expected := `<div class="paragraph">
 <p><em class="myrole">italics</em></p>
 </div>
@@ -446,7 +446,7 @@ content</mark>.</p>
 		// This is a departure from asciidoctor, as we support quoting the role in first position.
 		// (Asciidoctor passes it, but does not sanitize it, leading to invalid HTML.)
 		It("quoted role", func() {
-			source := "[\"something <wicked>\"]**bold**"
+			source := "[.\"something <wicked>\"]**bold**"
 			expected := `<div class="paragraph">
 <p><strong class="something &lt;wicked&gt;">bold</strong></p>
 </div>
@@ -507,7 +507,7 @@ content</mark>.</p>
 		})
 
 		It("span content within italic quote in sentence", func() {
-			source := "some *bold and [strikeout]#span content#* together."
+			source := "some *bold and [.strikeout]#span content#* together."
 			expected := `<div class="paragraph">
 <p>some <strong>bold and <span class="strikeout">span content</span></strong> together.</p>
 </div>

--- a/pkg/renderer/sgml/icon.go
+++ b/pkg/renderer/sgml/icon.go
@@ -33,7 +33,7 @@ func (r *sgmlRenderer) renderInlineIcon(ctx *renderer.Context, icon types.Icon) 
 		ID:     r.renderElementID(icon.Attributes),
 		Link:   icon.Attributes.GetAsStringWithDefault(types.AttrInlineLink, ""),
 		Window: icon.Attributes.GetAsStringWithDefault(types.AttrImageWindow, ""),
-		Role:   icon.Attributes.GetAsStringWithDefault(types.AttrRole, ""),
+		Role:   icon.Attributes.GetAsStringWithDefault(types.AttrRoles, ""),
 	})
 
 	if err != nil {
@@ -105,7 +105,7 @@ func (r *sgmlRenderer) renderIcon(ctx *renderer.Context, icon types.Icon, admoni
 		Alt:        alt,
 		Title:      title,
 		Width:      icon.Attributes.GetAsStringWithDefault(types.AttrWidth, ""),
-		Height:     icon.Attributes.GetAsStringWithDefault(types.AttrImageHeight, ""),
+		Height:     icon.Attributes.GetAsStringWithDefault(types.AttrHeight, ""),
 		Size:       icon.Attributes.GetAsStringWithDefault(types.AttrIconSize, ""),
 		Rotate:     icon.Attributes.GetAsStringWithDefault(types.AttrIconRotate, ""),
 		Flip:       icon.Attributes.GetAsStringWithDefault(types.AttrIconFlip, ""),

--- a/pkg/renderer/sgml/image.go
+++ b/pkg/renderer/sgml/image.go
@@ -66,7 +66,7 @@ func (r *sgmlRenderer) renderImageBlock(ctx *renderer.Context, img types.ImageBl
 		Href:        img.Attributes.GetAsStringWithDefault(types.AttrInlineLink, ""),
 		Alt:         alt,
 		Width:       img.Attributes.GetAsStringWithDefault(types.AttrWidth, ""),
-		Height:      img.Attributes.GetAsStringWithDefault(types.AttrImageHeight, ""),
+		Height:      img.Attributes.GetAsStringWithDefault(types.AttrHeight, ""),
 		Path:        path,
 	})
 
@@ -102,7 +102,7 @@ func (r *sgmlRenderer) renderInlineImage(ctx *Context, img types.InlineImage) (s
 		Href:   img.Attributes.GetAsStringWithDefault(types.AttrInlineLink, ""),
 		Alt:    alt,
 		Width:  img.Attributes.GetAsStringWithDefault(types.AttrWidth, ""),
-		Height: img.Attributes.GetAsStringWithDefault(types.AttrImageHeight, ""),
+		Height: img.Attributes.GetAsStringWithDefault(types.AttrHeight, ""),
 		Path:   path,
 	})
 

--- a/pkg/renderer/sgml/image.go
+++ b/pkg/renderer/sgml/image.go
@@ -73,7 +73,6 @@ func (r *sgmlRenderer) renderImageBlock(ctx *renderer.Context, img types.ImageBl
 	if err != nil {
 		return "", errors.Wrap(err, "unable to render image")
 	}
-	// log.Debugf("rendered block image: %s", result.Bytes())
 	return result.String(), nil
 }
 

--- a/pkg/renderer/sgml/inline_elements.go
+++ b/pkg/renderer/sgml/inline_elements.go
@@ -42,7 +42,6 @@ func (r *sgmlRenderer) renderInlineElements(ctx *renderer.Context, elements []in
 			if _, ok := element.(types.StringElement); ok { // TODO: only for StringElement? or for any kind of element?
 				// trim trailing spaces before returning the line
 				buf.WriteString(strings.TrimRight(string(renderedElement), " "))
-				// log.Debugf("trimmed spaces on '%v'", string(renderedElement))
 			} else {
 				buf.WriteString(renderedElement)
 			}

--- a/pkg/renderer/sgml/labeled_list.go
+++ b/pkg/renderer/sgml/labeled_list.go
@@ -46,7 +46,6 @@ func (r *sgmlRenderer) renderLabeledList(ctx *renderer.Context, l types.LabeledL
 	if err != nil {
 		return "", errors.Wrap(err, "unable to render labeled list")
 	}
-	// log.Debugf("rendered labeled list: %s", result.Bytes())
 	return result.String(), nil
 }
 

--- a/pkg/renderer/sgml/link.go
+++ b/pkg/renderer/sgml/link.go
@@ -16,24 +16,39 @@ func (r *sgmlRenderer) renderLink(ctx *renderer.Context, l types.InlineLink) (st
 	text := ""
 	class := ""
 	// TODO; support `mailto:` positional attributes
-	positionals := l.Attributes.Positionals()
-	if len(positionals) > 0 {
-		buf := &strings.Builder{}
-		for i, arg := range positionals {
-			t, err := r.renderInlineElements(ctx, arg)
-			if err != nil {
+	// positionals := l.Attributes.Positionals()
+	// if len(positionals) > 0 {
+	// 	buf := &strings.Builder{}
+	// 	for i, arg := range positionals {
+	// 		t, err := r.renderInlineElements(ctx, arg)
+	// 		if err != nil {
+	// 			return "", errors.Wrap(err, "unable to render link")
+	// 		}
+	// 		buf.WriteString(t)
+	// 		if i < len(positionals)-1 {
+	// 			buf.WriteString(",")
+	// 		}
+	// 	}
+	// 	text = buf.String()
+	// } else {
+	// 	class = "bare"
+	// 	text = html.EscapeString(location)
+	// }
+	if t, exists := l.Attributes[types.AttrInlineLinkText]; exists {
+		switch t := t.(type) {
+		case string:
+			text = t
+		case []interface{}:
+			var err error
+			if text, err = r.renderInlineElements(ctx, t); err != nil {
 				return "", errors.Wrap(err, "unable to render link")
 			}
-			buf.WriteString(t)
-			if i < len(positionals)-1 {
-				buf.WriteString(",")
-			}
 		}
-		text = buf.String()
 	} else {
 		class = "bare"
 		text = html.EscapeString(location)
 	}
+
 	err := r.link.Execute(result, struct {
 		URL   string
 		Text  string

--- a/pkg/renderer/sgml/link.go
+++ b/pkg/renderer/sgml/link.go
@@ -16,24 +16,6 @@ func (r *sgmlRenderer) renderLink(ctx *renderer.Context, l types.InlineLink) (st
 	text := ""
 	class := ""
 	// TODO; support `mailto:` positional attributes
-	// positionals := l.Attributes.Positionals()
-	// if len(positionals) > 0 {
-	// 	buf := &strings.Builder{}
-	// 	for i, arg := range positionals {
-	// 		t, err := r.renderInlineElements(ctx, arg)
-	// 		if err != nil {
-	// 			return "", errors.Wrap(err, "unable to render link")
-	// 		}
-	// 		buf.WriteString(t)
-	// 		if i < len(positionals)-1 {
-	// 			buf.WriteString(",")
-	// 		}
-	// 	}
-	// 	text = buf.String()
-	// } else {
-	// 	class = "bare"
-	// 	text = html.EscapeString(location)
-	// }
 	if t, exists := l.Attributes[types.AttrInlineLinkText]; exists {
 		switch t := t.(type) {
 		case string:

--- a/pkg/renderer/sgml/renderer.go
+++ b/pkg/renderer/sgml/renderer.go
@@ -291,7 +291,7 @@ func (r *sgmlRenderer) renderDocumentRoles(ctx *Context, doc types.Document) (st
 func (r *sgmlRenderer) renderDocumentID(doc types.Document) string {
 	if header, found := doc.Header(); found {
 		if header.Attributes.Has(types.AttrCustomID) {
-			// We only want to emit a document body ID, if one was explicitly set
+			// We only want to emit a document body ID if one was explicitly set
 			return r.renderElementID(header.Attributes)
 		}
 	}
@@ -362,7 +362,7 @@ func (r *sgmlRenderer) renderManpageHeader(ctx *renderer.Context, header types.S
 	if description.Attributes == nil {
 		description.Attributes = types.Attributes{}
 	}
-	description.Attributes.AddNonEmpty(types.AttrBlockKind, "manpage")
+	description.Attributes.AddNonEmpty(types.AttrStyle, "manpage")
 	renderedContent, err := r.renderParagraph(ctx, description)
 	if err != nil {
 		return "", err

--- a/pkg/renderer/sgml/xhtml5/icon_test.go
+++ b/pkg/renderer/sgml/xhtml5/icon_test.go
@@ -295,7 +295,7 @@ icon:tip[]:: tip of the day`
 			It("icon in quoted text", func() {
 				source := `:icons: font
 
-here [strikeout]##we go icon:stop[]##`
+here [.strikeout]##we go icon:stop[]##`
 				expected := `<div class="paragraph">
 <p>here <span class="strikeout">we go <span class="icon"><i class="fa fa-stop"></i></span></span></p>
 </div>

--- a/pkg/renderer/sgml/xhtml5/link_test.go
+++ b/pkg/renderer/sgml/xhtml5/link_test.go
@@ -31,9 +31,9 @@ var _ = Describe("links", func() {
 		})
 
 		It("external link with unquoted text having comma", func() {
-			source := "https://foo.com[A, B, and C]"
+			source := "https://foo.com[A, B, and C]" // `B` and `and C` are considered as other positional attributes
 			expected := `<div class="paragraph">
-<p><a href="https://foo.com">A, B, and C</a></p>
+<p><a href="https://foo.com">A</a></p>
 </div>
 `
 			Expect(RenderXHTML(source)).To(MatchHTML(expected))
@@ -169,7 +169,16 @@ a link to {scheme}://{path} and https://foo.baz`
 		})
 
 		It("relative link with text having comma", func() {
-			source := "a link to link:foo.adoc[A, B, and C]"
+			source := `a link to link:foo.adoc[A, B, and C]` // `B` and `and C` are considered as other positional attributes
+			expected := `<div class="paragraph">
+<p>a link to <a href="foo.adoc">A</a></p>
+</div>
+`
+			Expect(RenderXHTML(source)).To(MatchHTML(expected))
+		})
+
+		It("relative link with quoted text having comma", func() {
+			source := `a link to link:foo.adoc["A, B, and C"]`
 			expected := `<div class="paragraph">
 <p>a link to <a href="foo.adoc">A, B, and C</a></p>
 </div>

--- a/pkg/renderer/sgml/xhtml5/quoted_string_test.go
+++ b/pkg/renderer/sgml/xhtml5/quoted_string_test.go
@@ -55,7 +55,7 @@ var _ = Describe("quoted strings", func() {
 
 		})
 		It("span in single quoted string", func() {
-			source := "'`curly [strikeout]#was#_is_ single`'"
+			source := "'`curly [.strikeout]#was#_is_ single`'"
 			expected := `<div class="paragraph">
 <p>&#8216;curly <span class="strikeout">was</span><em>is</em> single&#8217;</p>
 </div>
@@ -224,7 +224,7 @@ var _ = Describe("quoted strings", func() {
 		})
 
 		It("span in double quoted string", func() {
-			source := "\"`curly [strikeout]#was#_is_ single`\""
+			source := "\"`curly [.strikeout]#was#_is_ single`\""
 			expected := `<div class="paragraph">
 <p>&#8220;curly <span class="strikeout">was</span><em>is</em> single&#8221;</p>
 </div>

--- a/pkg/renderer/sgml/xhtml5/quoted_text_test.go
+++ b/pkg/renderer/sgml/xhtml5/quoted_text_test.go
@@ -299,7 +299,7 @@ var _ = Describe("quoted texts", func() {
 		})
 
 		It("span content within italic quote in sentence", func() {
-			source := "some *bold and [strikeout]#span content#* together."
+			source := "some *bold and [.strikeout]#span content#* together."
 			expected := `<div class="paragraph">
 <p>some <strong>bold and <span class="strikeout">span content</span></strong> together.</p>
 </div>

--- a/pkg/types/attributes.go
+++ b/pkg/types/attributes.go
@@ -259,10 +259,7 @@ func NewAttributeGroup(attributes ...interface{}) (Attributes, error) {
 			switch k {
 			case AttrID:
 				// The first ID set wins.
-				// if !result.Has(AttrID) {
 				result[AttrID] = v
-				// result[AttrCustomID] = true
-				// }
 			case AttrRoles:
 				result.append(AttrRoles, v)
 			case AttrOptions, AttrOpts: // TODO handle the split in the `NewOptionAttribute` func
@@ -352,24 +349,6 @@ func NewPositionalAttribute(index int, value interface{}) (Attribute, error) {
 	return result, nil
 }
 
-// // NewIDAttribute initializes a new attribute map with a single entry for the ID using the given value
-// func NewIDAttribute(id interface{}) (Attributes, error) {
-// 	// log.Debugf("initializing a new ElementID with ID=%s", id)
-// 	return Attributes{
-// 		AttrID:       Reduce(id),
-// 		AttrCustomID: true,
-// 	}, nil
-// }
-
-// // NewIDAttribute initializes a new attribute map with a single entry for the ID using the given value
-// func NewIDAttribute(id interface{}) (Attribute, error) {
-// 	// log.Debugf("initializing a new ElementID with ID=%s", id)
-// 	return Attribute{
-// 		Key:   AttrID,
-// 		Value: Reduce(id),
-// 	}, nil
-// }
-
 // NewOptionAttribute sets a boolean option.
 func NewOptionAttribute(options interface{}) (Attribute, error) {
 	return Attribute{
@@ -384,9 +363,6 @@ func NewNamedAttribute(key string, value interface{}) (Attribute, error) {
 	if key == AttrOpts { // Handle the alias
 		key = AttrOptions
 	}
-	// if key == AttrRoles {
-	// 	value = []interface{}{value} // wrap value in an `[]interface{}`
-	// }
 	if log.IsLevelEnabled(log.DebugLevel) {
 		log.Debugf("new named attribute '%s':", key)
 		spew.Fdump(log.StandardLogger().Out, value)
@@ -417,7 +393,6 @@ func NewTitleAttribute(title interface{}) (Attribute, error) {
 
 // NewRoleAttribute initializes a new attribute map with a single entry for the title using the given value
 func NewRoleAttribute(role interface{}) (Attribute, error) {
-	// log.Debugf("initializing a new ElementRoles with content=%s", role)
 	role = Reduce(role)
 	return Attribute{
 		Key:   AttrRole,
@@ -588,9 +563,6 @@ func (a Attributes) SetAll(attr interface{}) Attributes {
 			a = Attributes{}
 		}
 		a[attr.Key] = attr.Value
-		// if attr.Key == AttrID {
-		// 	a[AttrCustomID] = true
-		// }
 	case Attributes:
 		if len(attr) == 0 {
 			return a
@@ -600,9 +572,6 @@ func (a Attributes) SetAll(attr interface{}) Attributes {
 		}
 		for k, v := range attr {
 			a[k] = v
-			// if k == AttrID {
-			// 	a[AttrCustomID] = true
-			// }
 		}
 	case []interface{}:
 		for i := range attr {

--- a/pkg/types/attributes.go
+++ b/pkg/types/attributes.go
@@ -44,12 +44,18 @@ const (
 	AttrAuthors = "authors"
 	// AttrRevision the key to the revision declared after the section level 0 (at the beginning of the doc)
 	AttrRevision = "revision"
-	// AttrRole the key to retrieve the role
+	// AttrRole the key for a single role attribute
 	AttrRole = "role"
+	// AttrRoles the key to retrieve the roles attribute
+	AttrRoles = "roles"
+	// AttrOption the key for a single option attribute
+	AttrOption = "option"
+	// AttrOptions the key to retrieve the options attribute
+	AttrOptions = "options"
+	// AttrOpts alias for AttrOptions
+	AttrOpts = "opts"
 	// AttrInlineLink the key to retrieve the link
 	AttrInlineLink = "link"
-	// AttrAdmonitionKind the key to retrieve the kind of admonition , if a "masquerade" is used
-	AttrAdmonitionKind = "admonitionKind"
 	// AttrQuoteAuthor attribute for the author of a verse
 	AttrQuoteAuthor = "quoteAuthor"
 	// AttrQuoteTitle attribute for the title of a verse
@@ -74,8 +80,8 @@ const (
 	AttrLastUpdated = "LastUpdated"
 	// AttrImageAlt the image `alt` attribute
 	AttrImageAlt = "alt"
-	// AttrImageHeight the image `height` attribute
-	AttrImageHeight = "height"
+	// AttrHeight the image `height` attribute
+	AttrHeight = "height"
 	// AttrImageWindow the `window` attribute, which becomes the target for the link
 	AttrImageWindow = "window"
 	// AttrImageAlign is for image alignment
@@ -88,14 +94,12 @@ const (
 	AttrIconFlip = "flip"
 	// AttrUnicode local libasciidoc attribute to encode output as UTF-8 instead of ASCII.
 	AttrUnicode = "unicode"
-	// AttrOptions element options (boolean, comma separated)
-	AttrOptions = "options"
-	// AttrOpts alias for AttrOptions
-	AttrOpts = "opts"
 	// AttrCaption is the caption for block images, tables, and so forth
 	AttrCaption = "caption"
 	// AttrStyle block or list style
 	AttrStyle = "style"
+	// AttrInlineLinkText the text attribute (first positional) of links
+	AttrInlineLinkText = "text"
 	// AttrWidth the `width` attribute used ior images, tables, and so forth
 	AttrWidth = "width"
 	// AttrFrame the frame used mostly for tables (all, topbot, sides, none)
@@ -108,10 +112,16 @@ const (
 	AttrFloat = "float"
 	// AttrCols the table columns attribute
 	AttrCols = "cols"
+	// AttrPositionalPrefix positional parameter prefix (DEPRECATED - use `AttrPositionalIndex`)
+	AttrPositionalPrefix = "@"
+	// AttrPositionalIndex positional parameter index
+	AttrPositionalIndex = "@positional-"
+	// AttrPositional1 positional parameter 1
+	AttrPositional1 = "@positional-1"
 	// AttrPositional2 positional parameter 2
-	AttrPositional2 = "@2"
+	AttrPositional2 = "@positional-2"
 	// AttrPositional3 positional parameter 3
-	AttrPositional3 = "@3"
+	AttrPositional3 = "@positional-3"
 	// AttrVersionLabel labels the version number in the document
 	AttrVersionLabel = "version-label"
 	// AttrExampleCaption is the example caption
@@ -153,9 +163,11 @@ func NewAttributes(attributes ...interface{}) (Attributes, error) {
 	for _, attr := range attributes {
 		switch attr := attr.(type) {
 		case Attribute:
-			result[attr.Key] = attr.Value
+			result.Set(attr.Key, attr.Value)
 		case Attributes: // when an there were multiple attributes, eg: `[quote,author,title]`
-			result.Add(attr)
+			result.SetAll(attr)
+		case nil:
+			// ignore
 		default:
 			return nil, fmt.Errorf("unexpected type of attribute: '%[1]T' (%[1]v)", attr)
 		}
@@ -163,11 +175,59 @@ func NewAttributes(attributes ...interface{}) (Attributes, error) {
 	return result, nil
 }
 
+func toAttributes(attrs interface{}) Attributes {
+	if attrs, ok := attrs.(Attributes); ok {
+		return attrs
+	}
+	return nil
+}
+
+func toAttributesWithMapping(attrs interface{}, mapping map[string]string) Attributes {
+	if log.IsLevelEnabled(log.DebugLevel) {
+		log.Debug("processing attributes with mapping on")
+		spew.Fdump(log.StandardLogger().Out, attrs)
+	}
+	if attrs, ok := attrs.(Attributes); ok {
+		for source, target := range mapping {
+			if v, exists := attrs[source]; exists {
+				if v != nil {
+					// (a bit hack-ish) make sure that `roles` is an `[]interface{}` if it came from a positional (1) attribute
+					if source == AttrPositional1 && target == AttrRoles {
+						v = []interface{}{v}
+					}
+
+					// do not override if already exists
+					if _, exists := attrs[target]; !exists {
+						// if key == value, replace value with `true`, so we don't have something
+						// like `linenums=linenums`
+						if target == v {
+							attrs[target] = true
+						} else {
+							attrs[target] = v
+						}
+					}
+				}
+				delete(attrs, source)
+			}
+		}
+		if log.IsLevelEnabled(log.DebugLevel) {
+			log.Debug("processed attributes with mapping:")
+			spew.Fdump(log.StandardLogger().Out, attrs)
+		}
+		if len(attrs) == 0 {
+			return nil
+		}
+		return attrs
+	}
+
+	return nil
+}
+
 // NewAttributeGroup initializes an AttributeGroup
 // We always pass in an array of Attributes.  Special handling for certain attributes:
 //
 // AttrID - these are strings, the first occurrence of this wins, and we set AttrCustomID
-// AttrRole - these are strings, we append them into an array
+// AttrRoles - these are strings, we append them into an array
 // AttrOptions - comma separated list, we split and put into a map
 func NewAttributeGroup(attributes ...interface{}) (Attributes, error) {
 	if len(attributes) == 0 {
@@ -201,11 +261,11 @@ func NewAttributeGroup(attributes ...interface{}) (Attributes, error) {
 				// The first ID set wins.
 				// if !result.Has(AttrID) {
 				result[AttrID] = v
-				result[AttrCustomID] = true
+				// result[AttrCustomID] = true
 				// }
-			case AttrRole:
-				result.append(AttrRole, v)
-			case AttrOptions, AttrOpts: // TODO handle the split in the `NewElementOption` func
+			case AttrRoles:
+				result.append(AttrRoles, v)
+			case AttrOptions, AttrOpts: // TODO handle the split in the `NewOptionAttribute` func
 				if !result.Has(AttrOptions) {
 					result[AttrOptions] = map[string]bool{}
 				}
@@ -237,29 +297,41 @@ func NewAttributeGroup(attributes ...interface{}) (Attributes, error) {
 
 // HasAttributeWithValue checks that there is an entry for the given key/value pair
 func HasAttributeWithValue(attributes interface{}, key string, value interface{}) bool {
-	if attrs, ok := attributes.([]interface{}); ok {
-		for _, attr := range attrs {
-			switch attr := attr.(type) {
-			case Attribute:
-				if attr.Key == key && attr.Value == value {
-					return true
-				}
-			case Attributes:
-				if v, ok := attr[key]; ok && v == value {
-					return true
-				}
+	switch a := attributes.(type) {
+	case Attribute:
+		if a.Key == key && a.Value == value {
+			return true
+		}
+	case Attributes:
+		if v, ok := a[key]; ok && v == value {
+			return true
+		}
+	case []interface{}:
+		for _, attr := range a {
+			if HasAttributeWithValue(attr, key, value) {
+				return true
 			}
 		}
 	}
+	// make sure we return false here in case there was no match, so we can print the log msg
 	log.Debugf("no attribute '%s:%v' found in %v", key, value, attributes)
 	return false
 }
 
 // HasNotAttribute checks that there is no entry for the given key
 func HasNotAttribute(attributes interface{}, key string) bool {
-	if attrs, ok := attributes.([]interface{}); ok {
-		for _, attr := range attrs {
-			if attr, ok := attr.(Attribute); ok && attr.Key == key {
+	switch a := attributes.(type) {
+	case Attribute:
+		if a.Key == key {
+			return false
+		}
+	case Attributes:
+		if _, ok := a[key]; ok {
+			return false
+		}
+	case []interface{}:
+		for _, attr := range a {
+			if !HasNotAttribute(attr, key) {
 				return false
 			}
 		}
@@ -267,19 +339,41 @@ func HasNotAttribute(attributes interface{}, key string) bool {
 	return true
 }
 
-// NewElementID initializes a new attribute map with a single entry for the ID using the given value
-func NewElementID(id interface{}) (Attributes, error) {
-	// log.Debugf("initializing a new ElementID with ID=%s", id)
-	return Attributes{
-		AttrID:       Reduce(id),
-		AttrCustomID: true,
-	}, nil
+// NewPositionalAttribute returns a new attribute who key is the position in the group
+func NewPositionalAttribute(index int, value interface{}) (Attribute, error) {
+	result := Attribute{
+		Key:   AttrPositionalIndex + strconv.Itoa(index),
+		Value: value,
+	}
+	if log.IsLevelEnabled(log.DebugLevel) {
+		log.Debug("new positional attribute:")
+		spew.Fdump(log.StandardLogger().Out, result)
+	}
+	return result, nil
 }
 
-// NewElementOption sets a boolean option.
-func NewElementOption(options interface{}) (Attribute, error) {
+// // NewIDAttribute initializes a new attribute map with a single entry for the ID using the given value
+// func NewIDAttribute(id interface{}) (Attributes, error) {
+// 	// log.Debugf("initializing a new ElementID with ID=%s", id)
+// 	return Attributes{
+// 		AttrID:       Reduce(id),
+// 		AttrCustomID: true,
+// 	}, nil
+// }
+
+// // NewIDAttribute initializes a new attribute map with a single entry for the ID using the given value
+// func NewIDAttribute(id interface{}) (Attribute, error) {
+// 	// log.Debugf("initializing a new ElementID with ID=%s", id)
+// 	return Attribute{
+// 		Key:   AttrID,
+// 		Value: Reduce(id),
+// 	}, nil
+// }
+
+// NewOptionAttribute sets a boolean option.
+func NewOptionAttribute(options interface{}) (Attribute, error) {
 	return Attribute{
-		Key:   AttrOptions,
+		Key:   AttrOption,
 		Value: Reduce(options),
 	}, nil
 }
@@ -290,18 +384,21 @@ func NewNamedAttribute(key string, value interface{}) (Attribute, error) {
 	if key == AttrOpts { // Handle the alias
 		key = AttrOptions
 	}
-	if key == AttrRole {
-		value = ElementRole{value} // wrap value in an `ElementRole` type
+	// if key == AttrRoles {
+	// 	value = []interface{}{value} // wrap value in an `[]interface{}`
+	// }
+	if log.IsLevelEnabled(log.DebugLevel) {
+		log.Debugf("new named attribute '%s':", key)
+		spew.Fdump(log.StandardLogger().Out, value)
 	}
-	log.Debugf("new named attribute: '%[1]s':'%[2]v' (%[2]T)", key, value)
 	return Attribute{
 		Key:   key,
 		Value: value,
 	}, nil
 }
 
-// NewInlineElementID initializes a new attribute map with a single entry for the ID using the given value
-func NewInlineElementID(id string) (Attribute, error) {
+// NewInlineIDAttribute initializes a new attribute map with a single entry for the ID using the given value
+func NewInlineIDAttribute(id string) (Attribute, error) {
 	log.Debugf("initializing a new inline ElementID with ID=%s", id)
 	return Attribute{
 		Key:   AttrID,
@@ -309,48 +406,81 @@ func NewInlineElementID(id string) (Attribute, error) {
 	}, nil
 }
 
-// NewElementTitle initializes a new attribute map with a single entry for the title using the given value
-func NewElementTitle(title []interface{}) (Attribute, error) {
-	log.Debugf("initializing a new ElementTitle with content=%v", title)
+// NewTitleAttribute initializes a new attribute map with a single entry for the title using the given value
+func NewTitleAttribute(title interface{}) (Attribute, error) {
+	log.Debugf("initializing a new Title attribute with content=%v", title)
 	return Attribute{
 		Key:   AttrTitle,
-		Value: Reduce(title),
+		Value: title,
 	}, nil
 }
 
-// ElementRole the attribute value of an element role
-type ElementRole []interface{}
-
-// NewElementRole initializes a new attribute map with a single entry for the title using the given value
-func NewElementRole(role interface{}) (Attribute, error) {
-	// log.Debugf("initializing a new ElementRole with content=%s", role)
+// NewRoleAttribute initializes a new attribute map with a single entry for the title using the given value
+func NewRoleAttribute(role interface{}) (Attribute, error) {
+	// log.Debugf("initializing a new ElementRoles with content=%s", role)
 	role = Reduce(role)
-	switch role := role.(type) {
-	case []interface{}:
-		return Attribute{
-			Key:   AttrRole,
-			Value: ElementRole(role), // convert
-		}, nil
-	default:
-		return Attribute{
-			Key:   AttrRole,
-			Value: ElementRole{role}, // wrap
-		}, nil
-	}
+	return Attribute{
+		Key:   AttrRole,
+		Value: role,
+	}, nil
 }
 
-// NewElementStyle initializes a new attribute map with a single entry for the style
-func NewElementStyle(style interface{}) (Attribute, error) {
+// NewIDAttribute initializes a new attribute map with a single entry for the ID using the given value
+func NewIDAttribute(id interface{}) (Attribute, error) {
+	log.Debugf("initializing a new ID attribute with ID='%v'", id)
 	return Attribute{
-		Key:   AttrStyle,
-		Value: Reduce(style),
+		Key:   AttrID,
+		Value: id,
 	}, nil
+}
+
+// NewStyleAttribute initializes a new attribute map with a single entry for the style
+// TODO: remove the `extras` parameter
+func NewStyleAttribute(style interface{}, extras ...interface{}) (Attributes, error) {
+	result := Attributes{
+		AttrStyle: style,
+	}
+	extraAttrs, _ := NewExtraAttributes(extras...)
+	result.SetAll(extraAttrs)
+	if log.IsLevelEnabled(log.DebugLevel) {
+		log.Debug("new style/roles/options attributes:")
+		spew.Fdump(log.StandardLogger().Out, result)
+	}
+	return result, nil
+}
+
+// NewExtraAttributes return all the "extra" role and option attributes in an `Attributes` object
+func NewExtraAttributes(extras ...interface{}) (Attributes, error) {
+	roles := make([]interface{}, 0, len(extras))
+	options := make([]interface{}, 0, len(extras))
+	for _, extra := range extras {
+		if a, ok := extra.(Attribute); ok {
+			switch a.Key {
+			case AttrRole:
+				roles = append(roles, a.Value)
+			case AttrOption:
+				options = append(options, a.Value)
+			}
+		}
+	}
+	result := Attributes{}
+	if len(roles) > 0 {
+		result[AttrRoles] = roles
+	}
+	if len(options) > 0 {
+		result[AttrOptions] = options
+	}
+	// if log.IsLevelEnabled(log.DebugLevel) {
+	// 	log.Debug("new roles/options attributes:")
+	// 	spew.Fdump(log.StandardLogger().Out, result)
+	// }
+	return result, nil
 }
 
 // NewAdmonitionAttribute initializes a new attribute map with a single entry for the admonition kind using the given value
-func NewAdmonitionAttribute(kind AdmonitionKind) (Attribute, error) {
+func NewAdmonitionAttribute(kind string) (Attribute, error) {
 	return Attribute{
-		Key:   AttrAdmonitionKind,
+		Key:   AttrStyle,
 		Value: kind,
 	}, nil
 }
@@ -360,9 +490,9 @@ func NewQuoteAttributes(kind string, author, title interface{}) (Attributes, err
 	result := make(map[string]interface{}, 3)
 	switch kind {
 	case "verse":
-		result[AttrBlockKind] = Verse
+		result[AttrStyle] = Verse
 	default:
-		result[AttrBlockKind] = Quote
+		result[AttrStyle] = Quote
 	}
 	if author, ok := author.(string); ok {
 		author = strings.TrimSpace(author)
@@ -382,7 +512,7 @@ func NewQuoteAttributes(kind string, author, title interface{}) (Attributes, err
 // NewLiteralBlockAttribute initializes a new attribute map with a single entry for the `literal` kind of block
 func NewLiteralBlockAttribute() (Attribute, error) {
 	return Attribute{
-		Key:   AttrBlockKind,
+		Key:   AttrStyle,
 		Value: Literal,
 	}, nil
 }
@@ -390,7 +520,7 @@ func NewLiteralBlockAttribute() (Attribute, error) {
 // NewPassthroughBlockAttribute initializes a new attribute map with a single entry for the `passthrough` kind of block
 func NewPassthroughBlockAttribute() (Attribute, error) {
 	return Attribute{
-		Key:   AttrBlockKind,
+		Key:   AttrStyle,
 		Value: Passthrough,
 	}, nil
 }
@@ -398,7 +528,7 @@ func NewPassthroughBlockAttribute() (Attribute, error) {
 // NewExampleBlockAttribute initializes a new attribute map with a single entry for the `example`` kind of block
 func NewExampleBlockAttribute() (Attribute, error) {
 	return Attribute{
-		Key:   AttrBlockKind,
+		Key:   AttrStyle,
 		Value: Example,
 	}, nil
 }
@@ -406,7 +536,7 @@ func NewExampleBlockAttribute() (Attribute, error) {
 // NewListingBlockAttribute initializes a new attribute map with a single entry for the `listing`` kind of block
 func NewListingBlockAttribute() (Attribute, error) {
 	return Attribute{
-		Key:   AttrBlockKind,
+		Key:   AttrStyle,
 		Value: Listing,
 	}, nil
 }
@@ -414,7 +544,7 @@ func NewListingBlockAttribute() (Attribute, error) {
 // NewSourceAttributes initializes a new attribute map with two entries, one for the kind of element ("source") and another optional one for the language of the source code
 func NewSourceAttributes(language interface{}, option interface{}, others ...interface{}) (Attributes, error) {
 	result := Attributes{
-		AttrBlockKind: Source,
+		AttrStyle: Source,
 	}
 	if language := Reduce(language); language != nil {
 		result[AttrLanguage] = language
@@ -423,32 +553,48 @@ func NewSourceAttributes(language interface{}, option interface{}, others ...int
 		result[AttrSourceBlockOption] = strings.TrimSpace(option)
 	}
 	for _, other := range others {
-		result = result.Add(other)
+		result = result.SetAll(other)
 	}
 	return result, nil
 }
 
-// Set sets the key/value entry in the Attributes.
+// Set adds the given attribute to the current ones
+// with some `key` replacements/grouping (Role->Roles and Option->Options)
 func (a Attributes) Set(key string, value interface{}) Attributes {
+	log.Debugf("setting attribute %s=%v", key, value)
 	if a == nil {
 		a = Attributes{}
 	}
-	a[key] = value
+	switch key {
+	case AttrRole:
+		if roles, ok := a[AttrRoles].([]interface{}); ok {
+			a[AttrRoles] = append(roles, value)
+		} else {
+			a[AttrRoles] = []interface{}{value}
+		}
+	case AttrOption:
+		if options, ok := a[AttrOptions].([]interface{}); ok {
+			a[AttrOptions] = append(options, value)
+		} else {
+			a[AttrOptions] = []interface{}{value}
+		}
+	default:
+		a[key] = value
+	}
 	return a
 }
 
-// Add adds the given attributes to the current ones
-func (a Attributes) Add(attr interface{}) Attributes {
-	log.Debugf("adding attribute of type '%[1]T': %[1]v", attr)
+// SetAll adds the given attributes to the current ones
+func (a Attributes) SetAll(attr interface{}) Attributes {
 	switch attr := attr.(type) {
 	case Attribute:
 		if a == nil {
 			a = Attributes{}
 		}
 		a[attr.Key] = attr.Value
-		if attr.Key == AttrID {
-			a[AttrCustomID] = true
-		}
+		// if attr.Key == AttrID {
+		// 	a[AttrCustomID] = true
+		// }
 	case Attributes:
 		if len(attr) == 0 {
 			return a
@@ -458,16 +604,15 @@ func (a Attributes) Add(attr interface{}) Attributes {
 		}
 		for k, v := range attr {
 			a[k] = v
-			if k == AttrID {
-				a[AttrCustomID] = true
-			}
+			// if k == AttrID {
+			// 	a[AttrCustomID] = true
+			// }
 		}
 	case []interface{}:
 		for i := range attr {
-			a.Add(attr[i])
+			a = a.SetAll(attr[i])
 		}
 	}
-
 	// will return nil if it was nil before and nothing was added
 	return a
 }
@@ -480,9 +625,17 @@ func (a Attributes) Has(key string) bool {
 
 // HasOption returns true if the option is set.
 func (a Attributes) HasOption(key string) bool {
-	if opts, ok := a[AttrOptions].(map[string]bool); ok {
-		key = strings.TrimPrefix(key, "%")
-		return opts[key]
+	// in block attributes: search key in the `Options`
+	if opts, ok := a[AttrOptions].([]interface{}); ok {
+		for _, opt := range opts {
+			if opt == key {
+				return true
+			}
+		}
+	}
+	// in document attributes: direct lookup
+	if a.Has(key) {
+		return true
 	}
 	return false
 }

--- a/pkg/types/attributes.go
+++ b/pkg/types/attributes.go
@@ -470,10 +470,6 @@ func NewExtraAttributes(extras ...interface{}) (Attributes, error) {
 	if len(options) > 0 {
 		result[AttrOptions] = options
 	}
-	// if log.IsLevelEnabled(log.DebugLevel) {
-	// 	log.Debug("new roles/options attributes:")
-	// 	spew.Fdump(log.StandardLogger().Out, result)
-	// }
 	return result, nil
 }
 

--- a/pkg/types/table.go
+++ b/pkg/types/table.go
@@ -193,15 +193,12 @@ func (t Table) processColumnWidths() ([]TableColumn, error) {
 }
 
 // NewTable initializes a new table with the given lines and attributes
-func NewTable(header interface{}, lines []interface{}, attributes []interface{}) (Table, error) {
-	attrs, err := NewAttributes(attributes...)
-	if err != nil {
-		return Table{}, errors.Wrap(err, "failed to initialize a Table element")
-	}
+func NewTable(header interface{}, lines []interface{}, attributes interface{}) (Table, error) {
 	t := Table{
-		Attributes: attrs,
+		Attributes: toAttributes(attributes),
 	}
 
+	var err error
 	if t.Columns, err = t.parseColumnsAttr(); err != nil {
 		return Table{}, errors.Wrap(err, "failed to initialize a Table element")
 	}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -226,14 +226,6 @@ func (d Document) Authors() ([]DocumentAuthor, bool) {
 	return []DocumentAuthor{}, false
 }
 
-// Revision retrieves the document revision from the document header, or empty array if no revision was found
-func (d Document) Revision() (DocumentRevision, bool) {
-	if rev, ok := d.Attributes[AttrRevision].(DocumentRevision); ok {
-		return rev, true
-	}
-	return DocumentRevision{}, false
-}
-
 // Header returns the header, i.e., the section with level 0 if it found as the first element of the document
 // For manpage documents, this also includes the first section (`Name` along with its first paragraph)
 func (d Document) Header() (Section, bool) {
@@ -712,7 +704,6 @@ func (s Section) SubstituteFootnotes(notes *Footnotes) interface{} {
 
 // NewDocumentHeader initializes a new Section with level 0 which can have authors and a revision, among other attributes
 func NewDocumentHeader(title []interface{}, authors interface{}, revision interface{}) (Section, error) {
-	// log.Debugf("new Section level 0 with authors '%v' and revision '%v'", authors, revision)
 	section, err := NewSection(0, title, nil, nil)
 	if err != nil {
 		return Section{}, err
@@ -2066,16 +2057,6 @@ func NewListingBlock(lines []interface{}, attributes interface{}) (ListingBlock,
 			AttrPositional2: AttrLanguage,
 			AttrPositional3: AttrLineNums,
 		})
-		// // positional attribute #2 is the "language" associated with the source block
-		// if lang, ok := attrs[AttrPositionalIndex+"2"]; ok {
-		// 	attrs[AttrLanguage] = lang
-		// }
-		// delete(attrs, AttrPositionalIndex+"2") // no-op if there is no such element
-		// // positional attribute #3 is the "linenums" flag
-		// if _, ok := attrs[AttrPositionalIndex+"3"]; ok {
-		// 	attrs[AttrLineNums] = true
-		// }
-		// delete(attrs, AttrPositionalIndex+"3") // no-op if there is no such element
 	}
 	return ListingBlock{
 		Attributes: attrs,
@@ -2524,11 +2505,6 @@ func NewVerbatimLine(elements []interface{}, callouts []interface{}) (VerbatimLi
 func (s VerbatimLine) IsEmpty() bool {
 	return len(s.Elements) == 0 // || emptyStringRE.MatchString(s.Content)
 }
-
-// // String return the content of this VerbatimLine
-// func (s VerbatimLine) String() string {
-// 	return s.Content
-// }
 
 // ------------------------------------------
 // Explicit line breaks

--- a/pkg/types/types_test.go
+++ b/pkg/types/types_test.go
@@ -30,11 +30,11 @@ var _ = Describe("line ranges", func() {
 
 	Context("multiple ranges", func() {
 
-		ranges := types.NewLineRanges(
+		ranges := types.NewLineRanges([]interface{}{
 			types.LineRange{StartLine: 1, EndLine: 1},
 			types.LineRange{StartLine: 3, EndLine: 4},
 			types.LineRange{StartLine: 6, EndLine: -1},
-		)
+		})
 
 		DescribeTable("match line range",
 			func(line int, expectation bool) {
@@ -56,7 +56,7 @@ var _ = Describe("tag ranges", func() {
 	DescribeTable("single range",
 		func(line int, c types.CurrentRanges, expectation bool) {
 			// given
-			ranges, _ := types.NewTagRanges(types.TagRange{
+			ranges := types.NewTagRanges(types.TagRange{
 				Name:     "foo",
 				Included: true,
 			})
@@ -94,12 +94,14 @@ var _ = Describe("tag ranges", func() {
 	DescribeTable("multiple ranges",
 		func(line int, c types.CurrentRanges, expectation bool) {
 			// given
-			ranges, _ := types.NewTagRanges(types.TagRange{
-				Name:     "foo",
-				Included: true,
-			}, types.TagRange{
-				Name:     "bar",
-				Included: true,
+			ranges := types.NewTagRanges([]interface{}{
+				types.TagRange{
+					Name:     "foo",
+					Included: true,
+				}, types.TagRange{
+					Name:     "bar",
+					Included: true,
+				},
 			})
 			// when
 			match := ranges.Match(line, c)
@@ -159,7 +161,7 @@ var _ = Describe("tag ranges", func() {
 		DescribeTable("** - all lines", // except lines containing a tag directive
 			func(line int, c types.CurrentRanges, expectation bool) {
 				// given
-				ranges, _ := types.NewTagRanges(types.TagRange{
+				ranges := types.NewTagRanges(types.TagRange{
 					Name:     "**",
 					Included: true,
 				})
@@ -193,7 +195,7 @@ var _ = Describe("tag ranges", func() {
 		DescribeTable("* - all tagged regions", // except lines containing a tag directive
 			func(line int, c types.CurrentRanges, expectation bool) {
 				// given
-				ranges, _ := types.NewTagRanges(types.TagRange{
+				ranges := types.NewTagRanges(types.TagRange{
 					Name:     "*",
 					Included: true,
 				})
@@ -228,12 +230,14 @@ var _ = Describe("tag ranges", func() {
 		DescribeTable("**;* - all the lines outside and inside of tagged regions", // except lines containing a tag directive
 			func(line int, c types.CurrentRanges, expectation bool) {
 				// given
-				ranges, _ := types.NewTagRanges(types.TagRange{
-					Name:     "**",
-					Included: true,
-				}, types.TagRange{
-					Name:     "*",
-					Included: true,
+				ranges := types.NewTagRanges([]interface{}{
+					types.TagRange{
+						Name:     "**",
+						Included: true,
+					}, types.TagRange{
+						Name:     "*",
+						Included: true,
+					},
 				})
 				// when
 				match := ranges.Match(line, c)
@@ -265,12 +269,13 @@ var _ = Describe("tag ranges", func() {
 		DescribeTable("foo;!bar - regions tagged foo, but not nested regions tagged bar",
 			func(line int, c types.CurrentRanges, expectation bool) {
 				// given
-				ranges, _ := types.NewTagRanges(types.TagRange{
+				ranges := types.NewTagRanges([]interface{}{types.TagRange{
 					Name:     "foo",
 					Included: true,
 				}, types.TagRange{
 					Name:     "bar",
 					Included: false,
+				},
 				})
 				// when
 				match := ranges.Match(line, c)
@@ -309,12 +314,14 @@ var _ = Describe("tag ranges", func() {
 		DescribeTable("*;!foo — all tagged regions, but excludes any regions tagged foo",
 			func(line int, c types.CurrentRanges, expectation bool) {
 				// given
-				ranges, _ := types.NewTagRanges(types.TagRange{
-					Name:     "*",
-					Included: true,
-				}, types.TagRange{
-					Name:     "foo",
-					Included: false,
+				ranges := types.NewTagRanges([]interface{}{
+					types.TagRange{
+						Name:     "*",
+						Included: true,
+					}, types.TagRange{
+						Name:     "foo",
+						Included: false,
+					},
 				})
 				// when
 				match := ranges.Match(line, c)
@@ -363,12 +370,14 @@ var _ = Describe("tag ranges", func() {
 		DescribeTable("**;!foo — selects all the lines of the document except for regions tagged foo",
 			func(line int, c types.CurrentRanges, expectation bool) {
 				// given
-				ranges, _ := types.NewTagRanges(types.TagRange{
-					Name:     "**",
-					Included: true,
-				}, types.TagRange{
-					Name:     "foo",
-					Included: false,
+				ranges := types.NewTagRanges([]interface{}{
+					types.TagRange{
+						Name:     "**",
+						Included: true,
+					}, types.TagRange{
+						Name:     "foo",
+						Included: false,
+					},
 				})
 				// when
 				match := ranges.Match(line, c)
@@ -417,12 +426,14 @@ var _ = Describe("tag ranges", func() {
 		DescribeTable("**;!* — selects only the regions of the document outside of tags (i.e., non-tagged regions).",
 			func(line int, c types.CurrentRanges, expectation bool) {
 				// given
-				ranges, _ := types.NewTagRanges(types.TagRange{
-					Name:     "**",
-					Included: true,
-				}, types.TagRange{
-					Name:     "*",
-					Included: false,
+				ranges := types.NewTagRanges([]interface{}{
+					types.TagRange{
+						Name:     "**",
+						Included: true,
+					}, types.TagRange{
+						Name:     "*",
+						Included: false,
+					},
 				})
 				// when
 				match := ranges.Match(line, c)
@@ -461,9 +472,9 @@ var _ = Describe("tag ranges", func() {
 
 	It("invalid tage ranges", func() {
 		// when
-		_, err := types.NewTagRanges("foo", "bar")
+		ranges := types.NewTagRanges([]interface{}{"foo", "bar"})
 		// then
-		Expect(err).To(HaveOccurred())
+		Expect(ranges).To(BeEmpty())
 	})
 
 })
@@ -724,8 +735,7 @@ var _ = Describe("element id resolution", func() {
 				section := types.Section{
 					Level: 0,
 					Attributes: types.Attributes{
-						types.AttrCustomID: true,
-						types.AttrID:       "bar",
+						types.AttrID: "bar",
 					},
 					Title: []interface{}{
 						types.StringElement{
@@ -751,8 +761,7 @@ var _ = Describe("element id resolution", func() {
 				section := types.Section{
 					Level: 0,
 					Attributes: types.Attributes{
-						types.AttrCustomID: true,
-						types.AttrID:       "bar",
+						types.AttrID: "bar",
 					},
 					Title: []interface{}{
 						types.StringElement{
@@ -1089,13 +1098,13 @@ var _ = DescribeTable("match for attribute with key and value",
 	func(key string, value interface{}, expected bool) {
 		// given
 		attributes := []interface{}{
-			types.Attribute{
-				Key:   types.AttrBlockKind,
+			types.Attribute{ // single attribute
+				Key:   types.AttrStyle,
 				Value: types.Quote,
 			},
-			types.Attributes{
-				types.AttrBlockKind: types.Verse,
-				types.AttrTitle:     "verse title",
+			types.Attributes{ // multiple attributes
+				types.AttrStyle: types.Verse,
+				types.AttrTitle: "verse title",
 			},
 		}
 		// when
@@ -1105,8 +1114,8 @@ var _ = DescribeTable("match for attribute with key and value",
 		Expect(result).To((Equal(expected)))
 
 	},
-	Entry("match for block-kind: verse", types.AttrBlockKind, types.Verse, true),
-	Entry("match for block-kind: quote", types.AttrBlockKind, types.Quote, true),
+	Entry("match for block-kind: verse", types.AttrStyle, types.Verse, true),
+	Entry("match for block-kind: quote", types.AttrStyle, types.Quote, true),
 	Entry("no match for block-kind: quote", types.AttrID, "unknown", false),
 )
 
@@ -1114,13 +1123,13 @@ var _ = DescribeTable("no match attribute with key",
 	func(key string, expected bool) {
 		// given
 		attributes := []interface{}{
-			types.Attribute{
-				Key:   types.AttrBlockKind,
+			types.Attribute{ // single attribute
+				Key:   types.AttrStyle,
 				Value: types.Quote,
 			},
-			types.Attributes{
-				types.AttrBlockKind: types.Verse,
-				types.AttrTitle:     "verse title",
+			types.Attributes{ // multiple attributes
+				types.AttrStyle: types.Verse,
+				types.AttrTitle: "verse title",
 			},
 		}
 		// when
@@ -1130,7 +1139,7 @@ var _ = DescribeTable("no match attribute with key",
 		Expect(result).To((Equal(expected)))
 
 	},
-	Entry("match for block-kind: verse", types.AttrBlockKind, false),
-	Entry("match for block-kind: quote", types.AttrBlockKind, false),
+	Entry("match for block-kind: verse", types.AttrStyle, false),
+	Entry("match for block-kind: quote", types.AttrStyle, false),
 	Entry("no match for block-kind: quote", types.AttrID, true),
 )

--- a/pkg/types/types_utils.go
+++ b/pkg/types/types_utils.go
@@ -54,7 +54,8 @@ type ReduceOption func(string) string
 // (ie, return its `Content`), otherwise return the given elements or empty string if the elements
 // is `nil` or an empty `[]interface{}`
 func Reduce(elements interface{}, opts ...ReduceOption) interface{} {
-	if e, ok := elements.([]interface{}); ok {
+	switch e := elements.(type) {
+	case []interface{}:
 		e = Merge(e...)
 		switch len(e) {
 		case 0: // if empty, return nil
@@ -68,12 +69,10 @@ func Reduce(elements interface{}, opts ...ReduceOption) interface{} {
 				elements = c
 			}
 		}
-	}
-	if s, ok := elements.(string); ok {
+	case string:
 		for _, apply := range opts {
-			s = apply(s)
+			e = apply(e)
 		}
-		return s
 	}
 	return elements
 }

--- a/pkg/types/types_utils.go
+++ b/pkg/types/types_utils.go
@@ -86,6 +86,5 @@ func Apply(source string, fs ...applyFunc) string {
 	for _, f := range fs {
 		result = f(result)
 	}
-	// log.Debugf("applied '%s' -> '%s' (%v characters)", source, result, len(result))
 	return result
 }


### PR DESCRIPTION
Process the attributes in a more generic way: positional values
are retained until the block is initialized, in which case they
are process accordingly, by mapping the position to an expected
attribute name.

Overall, the grammar for block and inline attributes is much simpler,
which means that adding support for new elements will require
less effort.

Also:
- no need to the `AdmonitionKind` and `BlockKind` types, whose
constant values are all `string` now and stored in the `style` key.
- for inline attributes, spaces after the opening square bracket (`[`)
are not tolerated (this was already the case for block attributes). This
allows for a better consistency and simpler grammar rules.

BREAKING CHANGE: for images and links, positional attributes are delimited
with commas, so if a link text should contain such a comma, it is necessary
that the text be wrapped in single or double quotes. This makes the syntax
(and thus, the parsing) consistent between block attributes and inline
attributes.
Eg: `link:http://example.com["a description, with comma"]`

BREAKING CHANGE: inline attributes content must not start with spaces, as
it is the case with block attributes.
Eg: `image::cookie.png[ cookie ]` is not valid.

Fixes #750

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>

