### PR TITLE
chore(build): update golangci-lint-action to v2.3.0

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -71,7 +71,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Lint
-      uses: golangci/golangci-lint-action@v1
+      uses: golangci/golangci-lint-action@v2.3.0
       with:
         version: v1.29
         args: -E gofmt,golint,megacheck,misspell


### PR DESCRIPTION
Fixes a problem where the lint job would fail without
any explanation. Also, a good opportunity to update to the latest version.

Fixes #806 

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
