### PR TITLE
fix: support multiple roles on blocks

### DIFF
--- a/pkg/parser/attributes_test.go
+++ b/pkg/parser/attributes_test.go
@@ -505,6 +505,11 @@ var _ = DescribeTable("valid block attributes",
 			types.AttrPositional2: `go.not_a_role`,
 		},
 	),
+	Entry("multiple roles", "[.role1]\n[.role2]",
+		types.Attributes{
+			types.AttrRoles: []interface{}{`role1`, `role2`},
+		},
+	),
 
 	// option shorthand
 	Entry(`[%hardbreaks]`, `[%hardbreaks]`,

--- a/pkg/parser/paragraph_test.go
+++ b/pkg/parser/paragraph_test.go
@@ -297,8 +297,38 @@ baz`
 				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 			})
 
-			It("with paragraph roles and attribute", func() {
+			It("with paragraph roles and attribute - case 1", func() {
 				source := `[.role1%hardbreaks.role2]
+foo
+bar
+baz`
+				expected := types.DraftDocument{
+					Elements: []interface{}{
+						types.Paragraph{
+							Attributes: types.Attributes{
+								types.AttrOptions: []interface{}{"hardbreaks"},
+								types.AttrRoles:   []interface{}{"role1", "role2"},
+							},
+							Lines: [][]interface{}{
+								{
+									types.StringElement{Content: "foo"},
+								},
+								{
+									types.StringElement{Content: "bar"},
+								},
+								{
+									types.StringElement{Content: "baz"},
+								},
+							},
+						},
+					},
+				}
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
+			})
+
+			It("with paragraph roles - case 2", func() {
+				source := `[.role1%hardbreaks]
+[.role2]
 foo
 bar
 baz`


### PR DESCRIPTION
support the following syntax:
```
[.role1]
[.role2]
a paragraph
```

Fixes #602

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
