### PR TITLE
refactor(project): make slices with capacity

### DIFF
--- a/make/profile.mk
+++ b/make/profile.mk
@@ -5,7 +5,7 @@ profile: generate-optimized
 	@go test -cpuprofile=tmp/bench/reports/$(GIT_BRANCH_NAME)-$(GIT_COMMIT_ID_SHORT).cpu.prof \
 		-memprofile tmp/bench/reports/$(GIT_BRANCH_NAME)-$(GIT_COMMIT_ID_SHORT).mem.prof \
 		-bench=. \
-		-benchtime=1x \
+		-benchtime=10x \
 		github.com/bytesparadise/libasciidoc \
 		-run=XXX
 	@echo "generate CPU reports..."

--- a/pkg/parser/document_processing_insert_preamble.go
+++ b/pkg/parser/document_processing_insert_preamble.go
@@ -21,7 +21,7 @@ func includePreamble(doc types.Document) types.Document {
 func doInsertPreamble(blocks []interface{}) []interface{} {
 	log.Debugf("generating preamble from %d blocks", len(blocks))
 	preamble := types.Preamble{
-		Elements: make([]interface{}, 0),
+		Elements: make([]interface{}, 0, len(blocks)),
 	}
 	for _, block := range blocks {
 		switch block.(type) {

--- a/pkg/types/table.go
+++ b/pkg/types/table.go
@@ -213,7 +213,7 @@ func NewTable(header interface{}, lines []interface{}, attributes interface{}) (
 		}
 	}
 	// need to regroup columns of all lines, they dispatch on lines
-	cells := make([][]interface{}, 0)
+	cells := make([][]interface{}, 0, len(lines))
 	for _, l := range lines {
 		if l, ok := l.(TableLine); ok {
 			// if no header line was set, inspect the first line to determine the number of columns per line
@@ -260,7 +260,7 @@ type TableLine struct {
 
 // NewTableLine initializes a new TableLine with the given columns
 func NewTableLine(columns []interface{}) (TableLine, error) {
-	c := make([][]interface{}, 0)
+	c := make([][]interface{}, 0, len(columns))
 	for _, column := range columns {
 		if e, ok := column.([]interface{}); ok {
 			c = append(c, e)

--- a/pkg/types/types_utils.go
+++ b/pkg/types/types_utils.go
@@ -6,7 +6,7 @@ import (
 
 // Merge merge string elements together
 func Merge(elements ...interface{}) []interface{} {
-	result := make([]interface{}, 0)
+	result := make([]interface{}, 0, len(elements))
 	buf := bytes.NewBuffer(nil)
 	for _, element := range elements {
 		if element == nil {


### PR DESCRIPTION
improves memory consumption by ~1.6%, based on
`make profile` results compared to `master`

also, `make profile` now runs 10 iterations

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
