### PR TITLE
refactor(parser/renderer): allocate slices with expected capacity

### DIFF
--- a/pkg/parser/document_processing_filter_blocks.go
+++ b/pkg/parser/document_processing_filter_blocks.go
@@ -49,26 +49,26 @@ elements:
 			e.Elements = filter(e.Elements, matchers...)
 			result = append(result, e)
 		case types.OrderedList:
-			items := make([]types.OrderedListItem, 0, len(e.Items))
-			for _, i := range e.Items {
-				i.Elements = filter(i.Elements, matchers...)
-				items = append(items, i)
+			items := make([]types.OrderedListItem, len(e.Items))
+			for i, item := range e.Items {
+				item.Elements = filter(item.Elements, matchers...)
+				items[i] = item
 			}
 			e.Items = items
 			result = append(result, e)
 		case types.UnorderedList:
-			items := make([]types.UnorderedListItem, 0, len(e.Items))
-			for _, i := range e.Items {
-				i.Elements = filter(i.Elements, matchers...)
-				items = append(items, i)
+			items := make([]types.UnorderedListItem, len(e.Items))
+			for i, item := range e.Items {
+				item.Elements = filter(item.Elements, matchers...)
+				items[i] = item
 			}
 			e.Items = items
 			result = append(result, e)
 		case types.LabeledList:
-			items := make([]types.LabeledListItem, 0, len(e.Items))
-			for _, i := range e.Items {
-				i.Elements = filter(i.Elements, matchers...)
-				items = append(items, i)
+			items := make([]types.LabeledListItem, len(e.Items))
+			for i, item := range e.Items {
+				item.Elements = filter(item.Elements, matchers...)
+				items[i] = item
 			}
 			e.Items = items
 			result = append(result, e)

--- a/pkg/parser/document_processing_rearrange_lists.go
+++ b/pkg/parser/document_processing_rearrange_lists.go
@@ -15,7 +15,7 @@ func rearrangeListItems(blocks []interface{}, withinDelimitedBlock bool) ([]inte
 	log.Debug("rearranging list items...")
 	a := &listArranger{
 		blocks:               make([]interface{}, 0, len(blocks)),
-		lists:                []types.List{},
+		lists:                make([]types.List, 0, len(blocks)),
 		blanklineCounter:     0,
 		withinDelimitedBlock: withinDelimitedBlock,
 	}
@@ -252,14 +252,12 @@ func (a *listArranger) appendLabeledListItem(item types.LabeledListItem) error {
 
 // a labeled list item term may contain links, images, quoted text, footnotes, etc.
 func parseLabeledListItemTerm(term string) ([]interface{}, error) {
-	result := []interface{}{}
+	// result := []interface{}{}
 	elements, err := ParseReader("", strings.NewReader(term), Entrypoint("LabeledListItemTerm"))
 	if err != nil {
 		return []interface{}{}, errors.Wrap(err, "error while parsing content for inline links")
 	}
-	// log.Debugf("parsed labeled list item term: '%+v'", elements)
-	result = append(result, elements.([]interface{})...)
-	return result, nil
+	return elements.([]interface{}), nil
 }
 
 func (a *listArranger) pruneLists(level int) {

--- a/pkg/renderer/sgml/element_role.go
+++ b/pkg/renderer/sgml/element_role.go
@@ -8,18 +8,18 @@ import (
 )
 
 func (r *sgmlRenderer) renderElementRoles(ctx *Context, attrs types.Attributes) (string, error) {
-	var result []string
 	if roles, ok := attrs[types.AttrRoles].([]interface{}); ok {
-		for _, e := range roles {
+		result := make([]string, len(roles))
+		for i, e := range roles {
 			s, err := r.renderElementRole(ctx, e)
 			if err != nil {
 				return "", err
 			}
-			result = append(result, s)
+			result[i] = s
 		}
+		return strings.Join(result, " "), nil
 	}
-	// log.Debugf("rendered roles: '%s'", result)
-	return strings.Join(result, " "), nil
+	return "", nil
 }
 
 // Image roles add float and alignment attributes -- we turn these into roles.

--- a/pkg/renderer/sgml/renderer.go
+++ b/pkg/renderer/sgml/renderer.go
@@ -388,7 +388,7 @@ func (r *sgmlRenderer) renderManpageHeader(ctx *renderer.Context, header types.S
 // renderDocumentElements renders all document elements, including the footnotes,
 // but not the HEAD and BODY containers
 func (r *sgmlRenderer) renderDocumentElements(ctx *renderer.Context, source []interface{}, footnotes []types.Footnote) (string, error) {
-	elements := []interface{}{}
+	elements := make([]interface{}, 0, len(source))
 	for i, e := range source {
 		switch e := e.(type) {
 		case types.Preamble:

--- a/pkg/types/non_alphanumerics_replacement.go
+++ b/pkg/types/non_alphanumerics_replacement.go
@@ -1,7 +1,6 @@
 package types
 
 import (
-	"bytes"
 	"strings"
 	"unicode"
 
@@ -10,7 +9,7 @@ import (
 
 // ReplaceNonAlphanumerics replace all non alpha numeric characters with the given `replacement`
 func ReplaceNonAlphanumerics(elements []interface{}, replacement string) (string, error) {
-	buf := bytes.NewBuffer(nil)
+	buf := &strings.Builder{}
 	for _, element := range elements {
 		switch element := element.(type) {
 		case QuotedText:
@@ -60,7 +59,7 @@ func ReplaceNonAlphanumerics(elements []interface{}, replacement string) (string
 }
 
 func replaceNonAlphanumerics(content, replacement string) (string, error) {
-	buf := bytes.NewBuffer(nil)
+	buf := &strings.Builder{}
 	lastCharIsSpace := false
 
 	// Drop the :// from links.

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -1,7 +1,6 @@
 package types
 
 import (
-	"bytes"
 	"fmt"
 	"net/url"
 	"sort"
@@ -726,7 +725,7 @@ func NewDocumentHeader(title []interface{}, authors interface{}, revision interf
 // those attributes can be used in attribute substitutions in the document
 func expandAuthors(authors []DocumentAuthor) Attributes {
 	result := make(map[string]interface{}, 1+6*len(authors)) // each author may add up to 6 fields in the result map
-	s := make([]DocumentAuthor, 0, len(authors))
+	s := make([]DocumentAuthor, len(authors))
 	for i, author := range authors {
 		var part1, part2, part3, email string
 		author.FullName = strings.ReplaceAll(author.FullName, "  ", " ")
@@ -784,10 +783,10 @@ func expandAuthors(authors []DocumentAuthor) Attributes {
 			result[key("email", i)] = email
 		}
 		// also include a "string" version of the given author
-		s = append(s, DocumentAuthor{
+		s[i] = DocumentAuthor{
 			FullName: result[key("author", i)].(string),
 			Email:    email,
-		})
+		}
 	}
 	result[AttrAuthors] = s
 	// log.Debugf("authors: %v", result)
@@ -1217,7 +1216,7 @@ func NewUnorderedListItemPrefix(s BulletStyle, l int) (UnorderedListItemPrefix, 
 // NewListItemContent initializes a new `UnorderedListItemContent`
 func NewListItemContent(content []interface{}) ([]interface{}, error) {
 	// log.Debugf("new ListItemContent with %d line(s)", len(content))
-	elements := make([]interface{}, 0)
+	elements := make([]interface{}, 0, len(content))
 	for _, element := range content {
 		// log.Debugf("Processing line element of type %T", element)
 		switch element := element.(type) {
@@ -3136,7 +3135,7 @@ func (l Location) WithPathPrefix(p interface{}) Location {
 
 // Stringify returns a string representation of the location
 func (l Location) Stringify() string {
-	result := bytes.NewBuffer(nil)
+	result := &strings.Builder{}
 	result.WriteString(l.Scheme)
 	for _, e := range l.Path {
 		if s, ok := e.(StringElement); ok {
@@ -3198,7 +3197,7 @@ func NewString(v interface{}) (string, error) {
 	case string:
 		return v, nil
 	case []interface{}:
-		res := &strings.Builder{}
+		res := strings.Builder{}
 		for _, item := range v {
 			s, e := NewString(item)
 			if e != nil {

--- a/pkg/types/types_utils.go
+++ b/pkg/types/types_utils.go
@@ -1,13 +1,13 @@
 package types
 
 import (
-	"bytes"
+	"strings"
 )
 
 // Merge merge string elements together
 func Merge(elements ...interface{}) []interface{} {
 	result := make([]interface{}, 0, len(elements))
-	buf := bytes.NewBuffer(nil)
+	buf := &strings.Builder{}
 	for _, element := range elements {
 		if element == nil {
 			continue
@@ -18,8 +18,7 @@ func Merge(elements ...interface{}) []interface{} {
 		case []byte:
 			buf.Write(element)
 		case StringElement:
-			content := element.Content
-			buf.WriteString(content)
+			buf.WriteString(element.Content)
 		case []interface{}:
 			if len(element) > 0 {
 				f := Merge(element...)
@@ -39,10 +38,10 @@ func Merge(elements ...interface{}) []interface{} {
 
 // appendBuffer appends the content of the given buffer to the given array of elements,
 // and returns a new buffer, or returns the given arguments if the buffer was empty
-func appendBuffer(elements []interface{}, buf *bytes.Buffer) ([]interface{}, *bytes.Buffer) {
+func appendBuffer(elements []interface{}, buf *strings.Builder) ([]interface{}, *strings.Builder) {
 	if buf.Len() > 0 {
 		s, _ := NewStringElement(buf.String())
-		return append(elements, s), bytes.NewBuffer(nil)
+		return append(elements, s), &strings.Builder{}
 	}
 	return elements, buf
 }


### PR DESCRIPTION
and use index to set value

also, replace remaining `bytes.Buffer` with `strings.Builder`

fixes #815

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
