### PR TITLE
refactor(types): add func to return raw text

### DIFF
--- a/pkg/parser/cross_reference_test.go
+++ b/pkg/parser/cross_reference_test.go
@@ -134,7 +134,7 @@ with some content linked to <<thetitle,a label to the title>>!`
 										},
 										Label: []interface{}{
 											types.QuotedText{
-												Kind: types.Bold,
+												Kind: types.SingleQuoteBold,
 												Elements: []interface{}{
 													types.StringElement{
 														Content: "another doc",

--- a/pkg/parser/delimited_block_example_test.go
+++ b/pkg/parser/delimited_block_example_test.go
@@ -29,7 +29,7 @@ some *example* content
 												Content: "some ",
 											},
 											types.QuotedText{
-												Kind: types.Bold,
+												Kind: types.SingleQuoteBold,
 												Elements: []interface{}{
 													types.StringElement{
 														Content: "example",
@@ -90,7 +90,7 @@ with _italic content_
 												Content: "some listing ",
 											},
 											types.QuotedText{
-												Kind: types.Bold,
+												Kind: types.SingleQuoteBold,
 												Elements: []interface{}{
 													types.StringElement{
 														Content: "bold code",
@@ -103,7 +103,7 @@ with _italic content_
 												Content: "with ",
 											},
 											types.QuotedText{
-												Kind: types.Italic,
+												Kind: types.SingleQuoteItalic,
 												Elements: []interface{}{
 													types.StringElement{
 														Content: "italic content",
@@ -244,7 +244,7 @@ some *example* content`
 										Content: "some ",
 									},
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.SingleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{
 												Content: "example",
@@ -283,7 +283,7 @@ some *example* content
 												Content: "some ",
 											},
 											types.QuotedText{
-												Kind: types.Bold,
+												Kind: types.SingleQuoteBold,
 												Elements: []interface{}{
 													types.StringElement{
 														Content: "example",
@@ -344,7 +344,7 @@ with *bold content*
 												Content: "with ",
 											},
 											types.QuotedText{
-												Kind: types.Bold,
+												Kind: types.SingleQuoteBold,
 												Elements: []interface{}{
 													types.StringElement{
 														Content: "bold content",
@@ -463,7 +463,7 @@ some *example* content`
 										Content: "some ",
 									},
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.SingleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{
 												Content: "example",

--- a/pkg/parser/delimited_block_literal_test.go
+++ b/pkg/parser/delimited_block_literal_test.go
@@ -428,7 +428,7 @@ and <more text> on the +
 								},
 								{
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.SingleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{
 												Content: "next",
@@ -533,7 +533,7 @@ and <more text> on the +
 								},
 								{
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.SingleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{
 												Content: "next",
@@ -627,7 +627,7 @@ and <more text> on the +
 										Content: "  ",
 									},
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.SingleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{
 												Content: "next",
@@ -713,7 +713,7 @@ and <more text> on the +
 								},
 								{
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.SingleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{
 												Content: "next",

--- a/pkg/parser/delimited_block_markdown_quote_test.go
+++ b/pkg/parser/delimited_block_markdown_quote_test.go
@@ -33,7 +33,7 @@ with a link to https://example.com[]`
 										Content: "on ",
 									},
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.SingleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{
 												Content: "multiple lines",
@@ -83,7 +83,7 @@ with a link to https://example.com[]`
 										Content: "on ",
 									},
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.SingleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{
 												Content: "multiple lines",
@@ -121,7 +121,7 @@ with a link to https://example.com[]`
 										Content: "on ",
 									},
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.SingleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{
 												Content: "multiple lines",
@@ -159,7 +159,7 @@ with a link to https://example.com[]`
 										Content: "on ",
 									},
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.SingleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{
 												Content: "multiple lines",
@@ -212,7 +212,7 @@ on *multiple lines*`
 										Content: "on ",
 									},
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.SingleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{
 												Content: "multiple lines",
@@ -244,7 +244,7 @@ on *multiple lines*`
 										Content: "on ",
 									},
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.SingleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{
 												Content: "multiple lines",
@@ -280,7 +280,7 @@ on *multiple lines*`
 										Content: "on ",
 									},
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.SingleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{
 												Content: "multiple lines",
@@ -318,7 +318,7 @@ on *multiple lines*`
 										Content: "on ",
 									},
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.SingleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{
 												Content: "multiple lines",

--- a/pkg/parser/delimited_block_quote_test.go
+++ b/pkg/parser/delimited_block_quote_test.go
@@ -35,7 +35,7 @@ ____`
 												Content: "some ",
 											},
 											types.QuotedText{
-												Kind: types.Bold,
+												Kind: types.SingleQuoteBold,
 												Elements: []interface{}{
 													types.StringElement{
 														Content: "quote",
@@ -306,7 +306,7 @@ ____`
 												Content: "some ",
 											},
 											types.QuotedText{
-												Kind: types.Bold,
+												Kind: types.SingleQuoteBold,
 												Elements: []interface{}{
 													types.StringElement{
 														Content: "quote",

--- a/pkg/parser/delimited_block_sidebar_test.go
+++ b/pkg/parser/delimited_block_sidebar_test.go
@@ -29,7 +29,7 @@ some *bold* content
 												Content: "some ",
 											},
 											types.QuotedText{
-												Kind: types.Bold,
+												Kind: types.SingleQuoteBold,
 												Elements: []interface{}{
 													types.StringElement{
 														Content: "bold",
@@ -73,7 +73,7 @@ bar
 												Content: "some ",
 											},
 											types.QuotedText{
-												Kind: types.Bold,
+												Kind: types.SingleQuoteBold,
 												Elements: []interface{}{
 													types.StringElement{
 														Content: "bold",
@@ -136,7 +136,7 @@ bar
 												Content: "some ",
 											},
 											types.QuotedText{
-												Kind: types.Bold,
+												Kind: types.SingleQuoteBold,
 												Elements: []interface{}{
 													types.StringElement{
 														Content: "bold",
@@ -192,7 +192,7 @@ some *verse* content
 												Content: "some ",
 											},
 											types.QuotedText{
-												Kind: types.Bold,
+												Kind: types.SingleQuoteBold,
 												Elements: []interface{}{
 													types.StringElement{
 														Content: "verse",
@@ -236,7 +236,7 @@ bar
 												Content: "some ",
 											},
 											types.QuotedText{
-												Kind: types.Bold,
+												Kind: types.SingleQuoteBold,
 												Elements: []interface{}{
 													types.StringElement{
 														Content: "verse",
@@ -306,7 +306,7 @@ some *verse* content
 												Content: "some ",
 											},
 											types.QuotedText{
-												Kind: types.Bold,
+												Kind: types.SingleQuoteBold,
 												Elements: []interface{}{
 													types.StringElement{
 														Content: "verse",
@@ -350,7 +350,7 @@ bar
 												Content: "some ",
 											},
 											types.QuotedText{
-												Kind: types.Bold,
+												Kind: types.SingleQuoteBold,
 												Elements: []interface{}{
 													types.StringElement{
 														Content: "verse",

--- a/pkg/parser/delimited_block_verse_test.go
+++ b/pkg/parser/delimited_block_verse_test.go
@@ -35,7 +35,7 @@ ____`
 										Content: "some ",
 									},
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.SingleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{
 												Content: "verse",
@@ -327,7 +327,7 @@ ____
 									},
 									{
 										types.QuotedText{
-											Kind: types.Bold,
+											Kind: types.SingleQuoteBold,
 											Elements: []interface{}{
 												types.StringElement{
 													Content: "next",
@@ -443,7 +443,7 @@ ____
 									},
 									{
 										types.QuotedText{
-											Kind: types.Bold,
+											Kind: types.SingleQuoteBold,
 											Elements: []interface{}{
 												types.StringElement{
 													Content: "next",
@@ -524,7 +524,7 @@ ____
 									},
 									{
 										types.QuotedText{
-											Kind: types.Bold,
+											Kind: types.SingleQuoteBold,
 											Elements: []interface{}{
 												types.StringElement{
 													Content: "next",
@@ -1044,7 +1044,7 @@ ____
 									},
 									{
 										types.QuotedText{
-											Kind: types.Bold,
+											Kind: types.SingleQuoteBold,
 											Elements: []interface{}{
 												types.StringElement{
 													Content: "next",
@@ -1128,7 +1128,7 @@ ____
 									},
 									{
 										types.QuotedText{
-											Kind: types.Bold,
+											Kind: types.SingleQuoteBold,
 											Elements: []interface{}{
 												types.StringElement{
 													Content: "next",
@@ -1256,7 +1256,7 @@ ____`
 										Content: "some ",
 									},
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.SingleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{
 												Content: "verse",

--- a/pkg/parser/document_processing_apply_custom_substitutions_test.go
+++ b/pkg/parser/document_processing_apply_custom_substitutions_test.go
@@ -101,7 +101,7 @@ and <more text> on the +
 										},
 										{
 											types.QuotedText{
-												Kind: types.Bold,
+												Kind: types.SingleQuoteBold,
 												Elements: []interface{}{
 													types.StringElement{
 														Content: "next",
@@ -229,7 +229,7 @@ and <more text> on the +
 										},
 										{
 											types.QuotedText{
-												Kind: types.Bold,
+												Kind: types.SingleQuoteBold,
 												Elements: []interface{}{
 													types.StringElement{
 														Content: "next",
@@ -322,7 +322,7 @@ and <more text> on the +
 										},
 										{
 											types.QuotedText{
-												Kind: types.Bold,
+												Kind: types.SingleQuoteBold,
 												Elements: []interface{}{
 													types.StringElement{
 														Content: "next",
@@ -926,7 +926,7 @@ and <more text> on the +
 										},
 										{
 											types.QuotedText{
-												Kind: types.Bold,
+												Kind: types.SingleQuoteBold,
 												Elements: []interface{}{
 													types.StringElement{
 														Content: "next",
@@ -1022,7 +1022,7 @@ and <more text> on the +
 										},
 										{
 											types.QuotedText{
-												Kind: types.Bold,
+												Kind: types.SingleQuoteBold,
 												Elements: []interface{}{
 													types.StringElement{
 														Content: "next",
@@ -1308,7 +1308,7 @@ and <more text> on the +
 								},
 								{
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.SingleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{
 												Content: "next",
@@ -1386,7 +1386,7 @@ and <more text> on the +
 								},
 								{
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.SingleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{
 												Content: "next",
@@ -1885,7 +1885,7 @@ and <more text> on the +
 								},
 								{
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.SingleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{
 												Content: "next",
@@ -1966,7 +1966,7 @@ and <more text> on the +
 								},
 								{
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.SingleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{
 												Content: "next",
@@ -2083,7 +2083,7 @@ _foo_
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Italic,
+										Kind: types.SingleQuoteItalic,
 										Elements: []interface{}{
 											types.StringElement{
 												Content: "foo",
@@ -2094,7 +2094,7 @@ _foo_
 								{},
 								{
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.SingleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{
 												Content: "bar",
@@ -2154,7 +2154,7 @@ _foo_
 								},
 								{
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.SingleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{
 												Content: "next",
@@ -2403,7 +2403,7 @@ _foo_
 								},
 								{
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.SingleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{
 												Content: "next",
@@ -2635,7 +2635,7 @@ and <more text> on the +
 								},
 								{
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.SingleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{
 												Content: "next",
@@ -2713,7 +2713,7 @@ and <more text> on the +
 								},
 								{
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.SingleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{
 												Content: "next",

--- a/pkg/parser/document_processing_rearrange_lists_test.go
+++ b/pkg/parser/document_processing_rearrange_lists_test.go
@@ -427,7 +427,7 @@ var _ = Describe("rearrange lists", func() {
 						Level: 1,
 						Term: []interface{}{
 							types.QuotedText{
-								Kind: types.Monospace,
+								Kind: types.SingleQuoteMonospace,
 								Elements: []interface{}{
 									types.StringElement{
 										Content: "foo",
@@ -452,7 +452,7 @@ var _ = Describe("rearrange lists", func() {
 										Level: 2,
 										Term: []interface{}{
 											types.QuotedText{
-												Kind: types.Monospace,
+												Kind: types.SingleQuoteMonospace,
 												Elements: []interface{}{
 													types.StringElement{
 														Content: "bar",

--- a/pkg/parser/footnote_test.go
+++ b/pkg/parser/footnote_test.go
@@ -54,7 +54,7 @@ var _ = Describe("footnotes - document", func() {
 						Content: "some ",
 					},
 					types.QuotedText{
-						Kind: types.Bold,
+						Kind: types.SingleQuoteBold,
 						Elements: []interface{}{
 							types.StringElement{
 								Content: "rich",

--- a/pkg/parser/icon_test.go
+++ b/pkg/parser/icon_test.go
@@ -310,7 +310,7 @@ item 2:: two`
 										Content: "an ",
 									},
 									types.QuotedText{
-										Kind: types.Italic,
+										Kind: types.SingleQuoteItalic,
 										Elements: []interface{}{
 											types.StringElement{Content: "italicized "},
 											types.Icon{Class: "warning"},
@@ -332,7 +332,7 @@ item 2:: two`
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Marked,
+										Kind: types.SingleQuoteMarked,
 										Elements: []interface{}{
 											types.StringElement{Content: "marked "},
 											types.Icon{Class: "warning"},
@@ -355,7 +355,7 @@ item 2:: two`
 								{
 									types.StringElement{Content: "in "},
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.SingleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{Content: "bold "},
 											types.Icon{Class: "warning"},
@@ -378,7 +378,7 @@ item 2:: two`
 								{
 									types.StringElement{Content: "in "},
 									types.QuotedText{
-										Kind: types.Monospace,
+										Kind: types.SingleQuoteMonospace,
 										Elements: []interface{}{
 											types.StringElement{Content: "monospace "},
 											types.Icon{Class: "warning"},

--- a/pkg/parser/index_terms_test.go
+++ b/pkg/parser/index_terms_test.go
@@ -53,7 +53,7 @@ a paragraph with an index term.`
 											Content: "foo_bar_baz ",
 										},
 										types.QuotedText{
-											Kind: types.Italic,
+											Kind: types.SingleQuoteItalic,
 											Elements: []interface{}{
 												types.StringElement{
 													Content: "italic",

--- a/pkg/parser/inline_elements_test.go
+++ b/pkg/parser/inline_elements_test.go
@@ -20,7 +20,7 @@ var _ = Describe("inline elements", func() {
 						Lines: [][]interface{}{
 							{
 								types.QuotedText{
-									Kind: types.Bold,
+									Kind: types.SingleQuoteBold,
 									Elements: []interface{}{
 										types.StringElement{Content: "some bold content"},
 									},
@@ -42,7 +42,7 @@ var _ = Describe("inline elements", func() {
 							{
 								types.StringElement{Content: "("},
 								types.QuotedText{
-									Kind: types.Bold,
+									Kind: types.SingleQuoteBold,
 									Elements: []interface{}{
 										types.StringElement{Content: "some bold content"},
 									},
@@ -127,7 +127,7 @@ var _ = Describe("inline elements", func() {
 						Lines: [][]interface{}{
 							{
 								types.QuotedText{
-									Kind: types.Bold,
+									Kind: types.DoubleQuoteBold,
 									Elements: []interface{}{
 										types.StringElement{Content: "foo"},
 									},

--- a/pkg/parser/labeled_list_test.go
+++ b/pkg/parser/labeled_list_test.go
@@ -81,7 +81,7 @@ on 2 lines`
 											Content: "This function is ",
 										},
 										types.QuotedText{
-											Kind: types.Italic,
+											Kind: types.SingleQuoteItalic,
 											Elements: []interface{}{
 												types.StringElement{
 													Content: "untyped",
@@ -893,7 +893,7 @@ on 2 lines`
 							{
 								Term: []interface{}{
 									types.QuotedText{
-										Kind: types.Monospace,
+										Kind: types.SingleQuoteMonospace,
 										Elements: []interface{}{
 											types.StringElement{
 												Content: "foo()",
@@ -910,7 +910,7 @@ on 2 lines`
 													Content: "This function is ",
 												},
 												types.QuotedText{
-													Kind: types.Italic,
+													Kind: types.SingleQuoteItalic,
 													Elements: []interface{}{
 														types.StringElement{
 															Content: "untyped",
@@ -943,7 +943,7 @@ on 2 lines`
 									types.IndexTerm{
 										Term: []interface{}{
 											types.QuotedText{
-												Kind: types.Monospace,
+												Kind: types.SingleQuoteMonospace,
 												Elements: []interface{}{
 													types.StringElement{
 														Content: "foo",
@@ -962,7 +962,7 @@ on 2 lines`
 													Content: "This function is ",
 												},
 												types.QuotedText{
-													Kind: types.Italic,
+													Kind: types.SingleQuoteItalic,
 													Elements: []interface{}{
 														types.StringElement{
 															Content: "untyped",
@@ -1007,7 +1007,7 @@ on 2 lines`
 													Content: "This function is ",
 												},
 												types.QuotedText{
-													Kind: types.Italic,
+													Kind: types.SingleQuoteItalic,
 													Elements: []interface{}{
 														types.StringElement{
 															Content: "untyped",

--- a/pkg/parser/link_test.go
+++ b/pkg/parser/link_test.go
@@ -462,7 +462,7 @@ next lines`
 										Attributes: types.Attributes{
 											types.AttrInlineLinkText: []interface{}{
 												types.QuotedText{
-													Kind: types.Italic,
+													Kind: types.SingleQuoteItalic,
 													Elements: []interface{}{
 														types.StringElement{
 															Content: "a",
@@ -473,7 +473,7 @@ next lines`
 													Content: " ",
 												},
 												types.QuotedText{
-													Kind: types.Bold,
+													Kind: types.SingleQuoteBold,
 													Elements: []interface{}{
 														types.StringElement{
 															Content: "b",
@@ -484,7 +484,7 @@ next lines`
 													Content: " ",
 												},
 												types.QuotedText{
-													Kind: types.Monospace,
+													Kind: types.SingleQuoteMonospace,
 													Elements: []interface{}{
 														types.StringElement{
 															Content: "c",
@@ -519,7 +519,7 @@ next lines`
 							Lines: [][]interface{}{
 								{types.StringElement{Content: "a link to "},
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.SingleQuoteBold,
 										Elements: []interface{}{
 											types.InlineLink{
 												Location: types.Location{
@@ -575,7 +575,7 @@ next lines`
 							Lines: [][]interface{}{
 								{types.StringElement{Content: "a link to "},
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.SingleQuoteBold,
 										Elements: []interface{}{
 											types.InlineLink{
 												Location: types.Location{
@@ -606,7 +606,7 @@ next lines`
 							Lines: [][]interface{}{
 								{types.StringElement{Content: "a link to "},
 									types.QuotedText{
-										Kind: types.Italic,
+										Kind: types.SingleQuoteItalic,
 										Elements: []interface{}{
 											types.InlineLink{
 												Location: types.Location{
@@ -730,7 +730,7 @@ a link to *{scheme}://{path}[] and https://foo.com[]*`
 									{
 										types.StringElement{Content: "a link to "},
 										types.QuotedText{
-											Kind: types.Bold,
+											Kind: types.SingleQuoteBold,
 											Elements: []interface{}{
 												types.InlineLink{
 													Location: types.Location{
@@ -1096,7 +1096,7 @@ a link to {scheme}://{path} and https://foo.com`
 												Content: "a ",
 											},
 											types.QuotedText{
-												Kind: types.Italic,
+												Kind: types.SingleQuoteItalic,
 												Elements: []interface{}{
 													types.StringElement{
 														Content: "a",
@@ -1107,7 +1107,7 @@ a link to {scheme}://{path} and https://foo.com`
 												Content: " b ",
 											},
 											types.QuotedText{
-												Kind: types.Bold,
+												Kind: types.SingleQuoteBold,
 												Elements: []interface{}{
 													types.StringElement{
 														Content: "b",
@@ -1118,7 +1118,7 @@ a link to {scheme}://{path} and https://foo.com`
 												Content: " c ",
 											},
 											types.QuotedText{
-												Kind: types.Monospace,
+												Kind: types.SingleQuoteMonospace,
 												Elements: []interface{}{
 													types.StringElement{
 														Content: "c",
@@ -1263,7 +1263,7 @@ a link to {scheme}:{path}[] and https://foo.com`
 						types.Paragraph{
 							Lines: [][]interface{}{
 								{types.QuotedText{
-									Kind: types.Bold,
+									Kind: types.SingleQuoteBold,
 									Elements: []interface{}{
 										types.InlineLink{
 											Location: types.Location{

--- a/pkg/parser/paragraph_test.go
+++ b/pkg/parser/paragraph_test.go
@@ -473,7 +473,7 @@ another one using attribute substitution: {github-url}[]...
 											Content: "using the ",
 										},
 										types.QuotedText{
-											Kind: types.Bold,
+											Kind: types.SingleQuoteBold,
 											Elements: []interface{}{
 												types.StringElement{
 													Content: "inline link macro",
@@ -556,7 +556,7 @@ another one using attribute substitution: {github-url}[]...
 											Content: "using the ",
 										},
 										types.QuotedText{
-											Kind: types.Bold,
+											Kind: types.SingleQuoteBold,
 											Elements: []interface{}{
 												types.StringElement{
 													Content: "inline link macro",
@@ -620,7 +620,7 @@ another one using attribute substitution: {github-url}[]...
 											Content: "a link to https://github.com[] <using the ",
 										},
 										types.QuotedText{
-											Kind: types.Bold,
+											Kind: types.SingleQuoteBold,
 											Elements: []interface{}{
 												types.StringElement{
 													Content: "inline link macro",
@@ -906,7 +906,7 @@ another one using attribute substitution: {github-url}[]...
 											Content: " <using the ",
 										},
 										types.QuotedText{
-											Kind: types.Bold,
+											Kind: types.SingleQuoteBold,
 											Elements: []interface{}{
 												types.StringElement{
 													Content: "inline link macro",
@@ -969,7 +969,7 @@ another one using attribute substitution: {github-url}[]...
 											Content: " <using the ",
 										},
 										types.QuotedText{
-											Kind: types.Bold,
+											Kind: types.SingleQuoteBold,
 											Elements: []interface{}{
 												types.StringElement{
 													Content: "inline link macro",
@@ -1139,7 +1139,7 @@ this is a
 								},
 								{
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.SingleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{
 												Content: "caution",
@@ -1726,7 +1726,7 @@ another one using attribute substitution: {github-url}[]...
 											Content: "a link to https://github.com[] <using the ",
 										},
 										types.QuotedText{
-											Kind: types.Bold,
+											Kind: types.SingleQuoteBold,
 											Elements: []interface{}{
 												types.StringElement{
 													Content: "inline link macro",
@@ -1952,7 +1952,7 @@ another one using attribute substitution: {github-url}[]...
 											Content: " <using the ",
 										},
 										types.QuotedText{
-											Kind: types.Bold,
+											Kind: types.SingleQuoteBold,
 											Elements: []interface{}{
 												types.StringElement{
 													Content: "inline link macro",
@@ -2005,7 +2005,7 @@ another one using attribute substitution: {github-url}[]...
 											Content: " <using the ",
 										},
 										types.QuotedText{
-											Kind: types.Bold,
+											Kind: types.SingleQuoteBold,
 											Elements: []interface{}{
 												types.StringElement{
 													Content: "inline link macro",

--- a/pkg/parser/parser.peg
+++ b/pkg/parser/parser.peg
@@ -1049,7 +1049,7 @@ TwoOrMoreBackslashes <- `\\` `\`* {
 BoldText <- DoubleQuoteBoldText / SingleQuoteBoldText // double punctuation must be evaluated first
 
 DoubleQuoteBoldText <- "**" elements:(DoubleQuoteBoldTextElements) "**" {
-    return types.NewQuotedText(types.Bold, elements.([]interface{}))
+    return types.NewQuotedText(types.DoubleQuoteBold, elements.([]interface{}))
 } 
 
 DoubleQuoteBoldTextElements <- DoubleQuoteBoldTextElement*  
@@ -1083,9 +1083,9 @@ DoubleQuoteBoldTextFallbackCharacter <-
 
 SingleQuoteBoldText <- 
     ("*" !"*") elements:(SingleQuoteBoldTextElements) "*" &(!Alphanum) { // single punctuation cannot be followed by a character (needs '**' to emphazise a portion of a word)
-        return types.NewQuotedText(types.Bold, elements.([]interface{}))
+        return types.NewQuotedText(types.SingleQuoteBold, elements.([]interface{}))
     } / "*" elements:("*" SingleQuoteBoldTextElements) "*" { // unbalanced `**` vs `*` punctuation.
-        return types.NewQuotedText(types.Bold, elements.([]interface{})) // include the second heading `*` as a regular StringElement in the bold content
+        return types.NewQuotedText(types.SingleQuoteBold, elements.([]interface{})) // include the second heading `*` as a regular StringElement in the bold content
     } 
 
 SingleQuoteBoldTextElements <- !Space SingleQuoteBoldTextElement+
@@ -1132,7 +1132,7 @@ EscapedBoldText <-
 ItalicText <- DoubleQuoteItalicText / SingleQuoteItalicText
 
 DoubleQuoteItalicText <- "__" elements:(DoubleQuoteItalicTextElements) "__" { // double punctuation must be evaluated first
-    return types.NewQuotedText(types.Italic, elements.([]interface{}))
+    return types.NewQuotedText(types.DoubleQuoteItalic, elements.([]interface{}))
 }
 
 DoubleQuoteItalicTextElements <- DoubleQuoteItalicTextElement* 
@@ -1167,9 +1167,9 @@ DoubleQuoteItalicTextFallbackCharacter <-
 
 SingleQuoteItalicText <- 
     ("_" !"_") elements:(SingleQuoteItalicTextElements) "_" { // single punctuation cannot be followed by a character (needs '__' to emphazise a portion of a word)
-        return types.NewQuotedText(types.Italic, elements.([]interface{}))
+        return types.NewQuotedText(types.SingleQuoteItalic, elements.([]interface{}))
     } / "_" elements:("_" SingleQuoteItalicTextElements) "_" { // unbalanced `__` vs `_` punctuation.
-        return types.NewQuotedText(types.Italic, elements.([]interface{})) // include the second heading `_` as a regular StringElement in the italic content
+        return types.NewQuotedText(types.SingleQuoteItalic, elements.([]interface{})) // include the second heading `_` as a regular StringElement in the italic content
     } 
 
 SingleQuoteItalicTextElements <- !Space SingleQuoteItalicTextElement+
@@ -1216,7 +1216,7 @@ EscapedItalicText <-
 MonospaceText <- DoubleQuoteMonospaceText / SingleQuoteMonospaceText
 
 DoubleQuoteMonospaceText <- "``" elements:(DoubleQuoteMonospaceTextElements) "``" { // double punctuation must be evaluated first
-    return types.NewQuotedText(types.Monospace, elements.([]interface{}))
+    return types.NewQuotedText(types.DoubleQuoteMonospace, elements.([]interface{}))
 }
 
 DoubleQuoteMonospaceTextElements <- DoubleQuoteMonospaceTextElement* // may start and end with spaces
@@ -1252,9 +1252,9 @@ DoubleQuoteMonospaceTextFallbackCharacter <-
 
 SingleQuoteMonospaceText <- 
     ("`" !"`") elements:(SingleQuoteMonospaceTextElements) "`" { // single punctuation cannot be followed by a character (needs "``" to emphazise a portion of a word)
-        return types.NewQuotedText(types.Monospace, elements.([]interface{}))
+        return types.NewQuotedText(types.SingleQuoteMonospace, elements.([]interface{}))
     } / "`" elements:("`" SingleQuoteMonospaceTextElements) "`" { // unbalanced "``" vs "`" punctuation.
-       return types.NewQuotedText(types.Monospace, elements.([]interface{})) // include the second heading "`" as a regular StringElement in the monospace content
+       return types.NewQuotedText(types.SingleQuoteMonospace, elements.([]interface{})) // include the second heading "`" as a regular StringElement in the monospace content
     }
 
 SingleQuoteMonospaceTextElements <- !Space SingleQuoteMonospaceTextElement+
@@ -1387,7 +1387,7 @@ DoubleQuotedStringFallbackCharacter <-  ([^\r\n\t `] / "`" !"\"") {
 MarkedText <- DoubleQuoteMarkedText / SingleQuoteMarkedText
 
 DoubleQuoteMarkedText <- "##" elements:(DoubleQuoteMarkedTextElements) "##" { // double punctuation must be evaluated first
-    return types.NewQuotedText(types.Marked, elements.([]interface{}))
+    return types.NewQuotedText(types.DoubleQuoteMarked, elements.([]interface{}))
 }
 
 DoubleQuoteMarkedTextElements <- DoubleQuoteMarkedTextElement (!("##") (Space / DoubleQuoteMarkedTextElement))*  // may start and end with spaces
@@ -1417,9 +1417,9 @@ DoubleQuoteMarkedTextFallbackCharacter <-
 }
 
 SingleQuoteMarkedText <- ("#" !"#") elements:(SingleQuoteMarkedTextElements) "#" { // single punctuation cannot be followed by a character (needs '##' to emphazise a portion of a word)
-    return types.NewQuotedText(types.Marked, elements.([]interface{}))
+    return types.NewQuotedText(types.SingleQuoteMarked, elements.([]interface{}))
 } / "#" elements:("#" SingleQuoteMarkedTextElements) "#" { // unbalanced `##` vs `#` punctuation.
-    return types.NewQuotedText(types.Marked, elements.([]interface{})) // include the second heading `_` as a regular StringElement in the italic content
+    return types.NewQuotedText(types.SingleQuoteMarked, elements.([]interface{})) // include the second heading `_` as a regular StringElement in the italic content
 }
 
 SingleQuoteMarkedTextElements <- !Space SingleQuoteMarkedTextElement+
@@ -1460,7 +1460,7 @@ EscapedMarkedText <-
 
 
 SubscriptText <- "~" element:(SubscriptTextElement) "~" { // wraps a single word
-    return types.NewQuotedText(types.Subscript, element)
+    return types.NewQuotedText(types.SingleQuoteSubscript, element)
 }
 
 SubscriptTextElement <- QuotedText / NonSubscriptText 
@@ -1474,7 +1474,7 @@ EscapedSubscriptText <- backslashes:(OneOrMoreBackslashes) "~" element:(Subscrip
 } 
 
 SuperscriptText <- "^" element:(SuperscriptTextElement) "^" { // wraps a single word
-    return types.NewQuotedText(types.Superscript, element)
+    return types.NewQuotedText(types.SingleQuoteSuperscript, element)
 }
 
 SuperscriptTextElement <- QuotedText / NonSuperscriptText 

--- a/pkg/parser/passthrough_test.go
+++ b/pkg/parser/passthrough_test.go
@@ -280,7 +280,7 @@ var _ = Describe("passthroughs", func() {
 										Content: "+",
 									},
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.SingleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{
 												Content: "hello",
@@ -310,7 +310,7 @@ var _ = Describe("passthroughs", func() {
 										Content: "+ ",
 									},
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.SingleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{
 												Content: "hello",
@@ -339,7 +339,7 @@ var _ = Describe("passthroughs", func() {
 										Content: "+ ",
 									},
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.SingleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{
 												Content: "hello",
@@ -393,7 +393,7 @@ var _ = Describe("passthroughs", func() {
 											Content: "The text + ",
 										},
 										types.QuotedText{
-											Kind: types.Bold,
+											Kind: types.SingleQuoteBold,
 											Elements: []interface{}{
 												types.StringElement{
 													Content: "hello",
@@ -539,7 +539,7 @@ var _ = Describe("passthroughs", func() {
 										Kind: types.PassthroughMacro,
 										Elements: []interface{}{
 											types.QuotedText{
-												Kind: types.Bold,
+												Kind: types.SingleQuoteBold,
 												Elements: []interface{}{
 													types.StringElement{
 														Content: "hello",
@@ -569,7 +569,7 @@ var _ = Describe("passthroughs", func() {
 												Content: " a ",
 											},
 											types.QuotedText{
-												Kind: types.Bold,
+												Kind: types.SingleQuoteBold,
 												Elements: []interface{}{
 													types.StringElement{
 														Content: "hello",

--- a/pkg/parser/quoted_string_test.go
+++ b/pkg/parser/quoted_string_test.go
@@ -92,7 +92,7 @@ var _ = Describe("quoted strings", func() {
 									Elements: []interface{}{
 										types.StringElement{Content: "curly "},
 										types.QuotedText{
-											Kind: types.Bold,
+											Kind: types.SingleQuoteBold,
 											Elements: []interface{}{
 												types.StringElement{Content: "was"},
 											},
@@ -120,7 +120,7 @@ var _ = Describe("quoted strings", func() {
 									Elements: []interface{}{
 										types.StringElement{Content: "curly "},
 										types.QuotedText{
-											Kind: types.Italic,
+											Kind: types.SingleQuoteItalic,
 											Elements: []interface{}{
 												types.StringElement{Content: "was"},
 											},
@@ -149,7 +149,7 @@ var _ = Describe("quoted strings", func() {
 											Content: "curly ",
 										},
 										types.QuotedText{
-											Kind: types.Marked,
+											Kind: types.SingleQuoteMarked,
 											Attributes: types.Attributes{
 												types.AttrRoles: []interface{}{"strikeout"},
 											},
@@ -160,7 +160,7 @@ var _ = Describe("quoted strings", func() {
 											},
 										},
 										types.QuotedText{
-											Kind: types.Italic,
+											Kind: types.SingleQuoteItalic,
 											Elements: []interface{}{
 												types.StringElement{
 													Content: "is",
@@ -192,7 +192,7 @@ var _ = Describe("quoted strings", func() {
 									Elements: []interface{}{
 										types.StringElement{Content: "curly "},
 										types.QuotedText{
-											Kind: types.Monospace,
+											Kind: types.SingleQuoteMonospace,
 											Elements: []interface{}{
 												types.StringElement{Content: "is"},
 											},
@@ -218,7 +218,7 @@ var _ = Describe("quoted strings", func() {
 									Kind: types.SingleQuote,
 									Elements: []interface{}{
 										types.QuotedText{
-											Kind: types.Monospace,
+											Kind: types.SingleQuoteMonospace,
 											Elements: []interface{}{
 												types.StringElement{Content: "curly"},
 											},
@@ -268,7 +268,7 @@ var _ = Describe("quoted strings", func() {
 						Lines: [][]interface{}{
 							{
 								types.QuotedText{
-									Kind: types.Monospace,
+									Kind: types.SingleQuoteMonospace,
 									Elements: []interface{}{
 										types.QuotedString{
 											Kind: types.SingleQuote,
@@ -293,7 +293,7 @@ var _ = Describe("quoted strings", func() {
 						Lines: [][]interface{}{
 							{
 								types.QuotedText{
-									Kind: types.Italic,
+									Kind: types.SingleQuoteItalic,
 									Elements: []interface{}{
 										types.QuotedString{
 											Kind: types.SingleQuote,
@@ -318,7 +318,7 @@ var _ = Describe("quoted strings", func() {
 						Lines: [][]interface{}{
 							{
 								types.QuotedText{
-									Kind: types.Bold,
+									Kind: types.SingleQuoteBold,
 									Elements: []interface{}{
 										types.QuotedString{
 											Kind: types.SingleQuote,
@@ -541,7 +541,7 @@ var _ = Describe("quoted strings", func() {
 									Elements: []interface{}{
 										types.StringElement{Content: "curly "},
 										types.QuotedText{
-											Kind: types.Bold,
+											Kind: types.SingleQuoteBold,
 											Elements: []interface{}{
 												types.StringElement{Content: "was"},
 											},
@@ -568,7 +568,7 @@ var _ = Describe("quoted strings", func() {
 									Elements: []interface{}{
 										types.StringElement{Content: "curly "},
 										types.QuotedText{
-											Kind: types.Italic,
+											Kind: types.SingleQuoteItalic,
 											Elements: []interface{}{
 												types.StringElement{Content: "was"},
 											},
@@ -598,7 +598,7 @@ var _ = Describe("quoted strings", func() {
 											Content: "curly ",
 										},
 										types.QuotedText{
-											Kind: types.Marked,
+											Kind: types.SingleQuoteMarked,
 											Attributes: types.Attributes{
 												types.AttrRoles: []interface{}{"strikeout"},
 											},
@@ -609,7 +609,7 @@ var _ = Describe("quoted strings", func() {
 											},
 										},
 										types.QuotedText{
-											Kind: types.Italic,
+											Kind: types.SingleQuoteItalic,
 											Elements: []interface{}{
 												types.StringElement{
 													Content: "is",
@@ -641,7 +641,7 @@ var _ = Describe("quoted strings", func() {
 									Elements: []interface{}{
 										types.StringElement{Content: "curly "},
 										types.QuotedText{
-											Kind: types.Monospace,
+											Kind: types.SingleQuoteMonospace,
 											Elements: []interface{}{
 												types.StringElement{Content: "is"},
 											},
@@ -667,7 +667,7 @@ var _ = Describe("quoted strings", func() {
 									Kind: types.DoubleQuote,
 									Elements: []interface{}{
 										types.QuotedText{
-											Kind: types.Monospace,
+											Kind: types.SingleQuoteMonospace,
 											Elements: []interface{}{
 												types.StringElement{Content: "curly"},
 											},
@@ -715,7 +715,7 @@ var _ = Describe("quoted strings", func() {
 						Lines: [][]interface{}{
 							{
 								types.QuotedText{
-									Kind: types.Monospace,
+									Kind: types.SingleQuoteMonospace,
 									Elements: []interface{}{
 										types.QuotedString{
 											Kind: types.DoubleQuote,
@@ -740,7 +740,7 @@ var _ = Describe("quoted strings", func() {
 						Lines: [][]interface{}{
 							{
 								types.QuotedText{
-									Kind: types.Italic,
+									Kind: types.SingleQuoteItalic,
 									Elements: []interface{}{
 										types.QuotedString{
 											Kind: types.DoubleQuote,
@@ -765,7 +765,7 @@ var _ = Describe("quoted strings", func() {
 						Lines: [][]interface{}{
 							{
 								types.QuotedText{
-									Kind: types.Bold,
+									Kind: types.SingleQuoteBold,
 									Elements: []interface{}{
 										types.QuotedString{
 											Kind: types.DoubleQuote,

--- a/pkg/parser/quoted_text_test.go
+++ b/pkg/parser/quoted_text_test.go
@@ -22,7 +22,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.SingleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{
 												Content: "some bold\ncontent",
@@ -45,7 +45,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Italic,
+										Kind: types.SingleQuoteItalic,
 										Elements: []interface{}{
 											types.StringElement{
 												Content: "some italic content",
@@ -68,7 +68,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Italic,
+										Kind: types.SingleQuoteItalic,
 										Elements: []interface{}{
 											types.StringElement{
 												Content: "some italic\ncontent",
@@ -91,7 +91,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Monospace,
+										Kind: types.SingleQuoteMonospace,
 										Elements: []interface{}{
 											types.StringElement{
 												Content: "some monospace content",
@@ -114,7 +114,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Monospace,
+										Kind: types.SingleQuoteMonospace,
 										Elements: []interface{}{
 											types.StringElement{
 												Content: "some monospace\ncontent",
@@ -173,11 +173,11 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Italic,
+										Kind: types.SingleQuoteItalic,
 										Elements: []interface{}{
 											types.StringElement{Content: "some "},
 											types.QuotedText{
-												Kind: types.Bold,
+												Kind: types.SingleQuoteBold,
 												Elements: []interface{}{
 													types.StringElement{Content: "bold"},
 												},
@@ -201,15 +201,15 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.SingleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{Content: "some "},
 											types.QuotedText{
-												Kind: types.Italic,
+												Kind: types.SingleQuoteItalic,
 												Elements: []interface{}{
 													types.StringElement{Content: "italic and "},
 													types.QuotedText{
-														Kind: types.Monospace,
+														Kind: types.SingleQuoteMonospace,
 														Elements: []interface{}{
 															types.StringElement{
 																Content: "monospaced content",
@@ -236,7 +236,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Italic,
+										Kind: types.SingleQuoteItalic,
 										Elements: []interface{}{
 											types.StringElement{Content: "some _very italic"},
 										},
@@ -258,7 +258,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.SingleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{Content: "bold*content"},
 										},
@@ -279,7 +279,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Italic,
+										Kind: types.SingleQuoteItalic,
 										Elements: []interface{}{
 											types.StringElement{Content: "italic_content"},
 										},
@@ -300,7 +300,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Monospace,
+										Kind: types.SingleQuoteMonospace,
 										Elements: []interface{}{
 											types.StringElement{Content: "monospace`content"},
 										},
@@ -324,7 +324,7 @@ var _ = Describe("quoted texts", func() {
 										Content: "non*bold*content ",
 									},
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.SingleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{Content: "bold content"},
 										},
@@ -347,7 +347,7 @@ var _ = Describe("quoted texts", func() {
 										Content: "non_italic_content ",
 									},
 									types.QuotedText{
-										Kind: types.Italic,
+										Kind: types.SingleQuoteItalic,
 										Elements: []interface{}{
 											types.StringElement{Content: "italic content"},
 										},
@@ -371,7 +371,7 @@ var _ = Describe("quoted texts", func() {
 										Content: "non`monospace`content ",
 									},
 									types.QuotedText{
-										Kind: types.Monospace,
+										Kind: types.SingleQuoteMonospace,
 										Elements: []interface{}{
 											types.StringElement{Content: "monospace content"},
 										},
@@ -393,7 +393,7 @@ var _ = Describe("quoted texts", func() {
 								{
 									types.StringElement{Content: "O"},
 									types.QuotedText{
-										Kind: types.Subscript,
+										Kind: types.SingleQuoteSubscript,
 										Elements: []interface{}{
 											types.StringElement{Content: "2"},
 										},
@@ -416,7 +416,7 @@ var _ = Describe("quoted texts", func() {
 								{
 									types.StringElement{Content: "M"},
 									types.QuotedText{
-										Kind: types.Superscript,
+										Kind: types.SingleQuoteSuperscript,
 										Elements: []interface{}{
 											types.StringElement{Content: "me"},
 										},
@@ -457,7 +457,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.DoubleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{Content: "hello"},
 										},
@@ -478,7 +478,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.DoubleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{Content: "some bold\ncontent"},
 										},
@@ -499,7 +499,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Italic,
+										Kind: types.DoubleQuoteItalic,
 										Elements: []interface{}{
 											types.StringElement{Content: "some italic content"},
 										},
@@ -520,7 +520,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Italic,
+										Kind: types.DoubleQuoteItalic,
 										Elements: []interface{}{
 											types.StringElement{Content: "some italic\ncontent"},
 										},
@@ -541,7 +541,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Monospace,
+										Kind: types.DoubleQuoteMonospace,
 										Elements: []interface{}{
 											types.StringElement{Content: " some monospace content "},
 										},
@@ -562,7 +562,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Monospace,
+										Kind: types.DoubleQuoteMonospace,
 										Elements: []interface{}{
 											types.StringElement{Content: "some monospace\ncontent"},
 										},
@@ -583,11 +583,11 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Italic,
+										Kind: types.DoubleQuoteItalic,
 										Elements: []interface{}{
 											types.StringElement{Content: "some "},
 											types.QuotedText{
-												Kind: types.Superscript,
+												Kind: types.SingleQuoteSuperscript,
 												Elements: []interface{}{
 													types.StringElement{Content: "superscript"},
 												},
@@ -611,15 +611,15 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.DoubleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{Content: "some "},
 											types.QuotedText{
-												Kind: types.Italic,
+												Kind: types.SingleQuoteItalic,
 												Elements: []interface{}{
 													types.StringElement{Content: "italic and "},
 													types.QuotedText{
-														Kind: types.Superscript,
+														Kind: types.SingleQuoteSuperscript,
 														Elements: []interface{}{
 															types.StringElement{Content: "superscriptcontent"},
 														},
@@ -648,7 +648,7 @@ var _ = Describe("quoted texts", func() {
 								{
 									types.StringElement{Content: "a paragraph with "},
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.SingleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{Content: "some bold content"},
 										},
@@ -718,7 +718,7 @@ var _ = Describe("quoted texts", func() {
 								{
 									types.StringElement{Content: "some "},
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.SingleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{Content: "bold and _italic content _ together"},
 										},
@@ -741,7 +741,7 @@ var _ = Describe("quoted texts", func() {
 								{
 									types.StringElement{Content: "some *bold and "},
 									types.QuotedText{
-										Kind: types.Italic,
+										Kind: types.SingleQuoteItalic,
 										Elements: []interface{}{
 											types.StringElement{Content: "italic content"},
 										},
@@ -859,7 +859,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Marked,
+										Kind: types.SingleQuoteMarked,
 										Elements: []interface{}{
 											types.StringElement{Content: "some marked\ncontent"},
 										},
@@ -880,7 +880,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Marked,
+										Kind: types.DoubleQuoteMarked,
 										Elements: []interface{}{
 											types.StringElement{Content: "some marked\ncontent"},
 										},
@@ -905,7 +905,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Italic,
+										Kind: types.SingleQuoteItalic,
 										Elements: []interface{}{
 											types.StringElement{Content: "italics"},
 										},
@@ -932,7 +932,7 @@ var _ = Describe("quoted texts", func() {
 										Content: "it",
 									},
 									types.QuotedText{
-										Kind: types.Italic,
+										Kind: types.DoubleQuoteItalic,
 										Elements: []interface{}{
 											types.StringElement{Content: "al"},
 										},
@@ -959,7 +959,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.SingleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{Content: "bold"},
 										},
@@ -986,7 +986,7 @@ var _ = Describe("quoted texts", func() {
 										Content: "it",
 									},
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.DoubleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{Content: "al"},
 										},
@@ -1013,7 +1013,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Monospace,
+										Kind: types.SingleQuoteMonospace,
 										Elements: []interface{}{
 											types.StringElement{Content: "true"},
 										},
@@ -1040,7 +1040,7 @@ var _ = Describe("quoted texts", func() {
 										Content: "int",
 									},
 									types.QuotedText{
-										Kind: types.Monospace,
+										Kind: types.DoubleQuoteMonospace,
 										Elements: []interface{}{
 											types.StringElement{Content: "eg"},
 										},
@@ -1067,7 +1067,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Italic,
+										Kind: types.SingleQuoteItalic,
 										Attributes: types.Attributes{
 											types.AttrRoles: []interface{}{"myrole"},
 											"and":           "nothing",
@@ -1092,7 +1092,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Italic,
+										Kind: types.SingleQuoteItalic,
 										Attributes: types.Attributes{
 											types.AttrRoles: []interface{}{"myrole"},
 											"and":           "nothing",
@@ -1117,7 +1117,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.SingleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{Content: "bold"},
 										},
@@ -1141,7 +1141,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.DoubleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{Content: "bold"},
 										},
@@ -1165,7 +1165,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.DoubleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{Content: "bold"},
 										},
@@ -1189,7 +1189,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.DoubleQuoteBold,
 										Attributes: types.Attributes{
 											types.AttrRoles: []interface{}{
 												[]interface{}{
@@ -1228,7 +1228,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.DoubleQuoteBold,
 										Attributes: types.Attributes{
 											types.AttrRoles: []interface{}{
 												[]interface{}{
@@ -1267,7 +1267,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Marked,
+										Kind: types.DoubleQuoteMarked,
 										Elements: []interface{}{
 											types.StringElement{Content: "the builder"},
 										},
@@ -1291,7 +1291,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.DoubleQuoteBold,
 										Attributes: types.Attributes{
 											types.AttrRoles: []interface{}{"role1", "role2", "role3"},
 											types.AttrID:    "anchor",
@@ -1301,7 +1301,7 @@ var _ = Describe("quoted texts", func() {
 										},
 									},
 									types.QuotedText{
-										Kind: types.Italic,
+										Kind: types.SingleQuoteItalic,
 										Attributes: types.Attributes{
 											types.AttrRoles: []interface{}{"second", "class"},
 											types.AttrID:    "here",
@@ -1326,7 +1326,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.DoubleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{Content: "bold"},
 										},
@@ -1347,7 +1347,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.DoubleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{Content: "bold"},
 										},
@@ -1372,7 +1372,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.DoubleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{Content: "bold"},
 										},
@@ -1429,7 +1429,7 @@ var _ = Describe("quoted texts", func() {
 										Content: "]",
 									},
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.DoubleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{Content: "bold"},
 										},
@@ -1457,11 +1457,11 @@ var _ = Describe("quoted texts", func() {
 								{
 									types.StringElement{Content: "some "},
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.SingleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{Content: "bold and "},
 											types.QuotedText{
-												Kind: types.Italic,
+												Kind: types.SingleQuoteItalic,
 												Elements: []interface{}{
 													types.StringElement{Content: "italic content"},
 												},
@@ -1487,7 +1487,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.SingleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{Content: "some *nested bold"},
 										},
@@ -1510,14 +1510,14 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.DoubleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{Content: "some "},
 										},
 									},
 									types.StringElement{Content: "nested bold"},
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.DoubleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{Content: " content"},
 										},
@@ -1539,11 +1539,11 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.DoubleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{Content: "some "},
 											types.QuotedText{
-												Kind: types.Bold,
+												Kind: types.SingleQuoteBold,
 												Elements: []interface{}{
 													types.StringElement{Content: "nested bold"},
 												},
@@ -1568,11 +1568,11 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.SingleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{Content: "some "},
 											types.QuotedText{
-												Kind: types.Bold,
+												Kind: types.DoubleQuoteBold,
 												Elements: []interface{}{
 													types.StringElement{Content: "nested bold"},
 												},
@@ -1597,7 +1597,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Italic,
+										Kind: types.SingleQuoteItalic,
 										Elements: []interface{}{
 											types.StringElement{Content: "some _nested italic"},
 										},
@@ -1620,14 +1620,14 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Italic,
+										Kind: types.DoubleQuoteItalic,
 										Elements: []interface{}{
 											types.StringElement{Content: "some "},
 										},
 									},
 									types.StringElement{Content: "nested italic"},
 									types.QuotedText{
-										Kind: types.Italic,
+										Kind: types.DoubleQuoteItalic,
 										Elements: []interface{}{
 											types.StringElement{Content: " content"},
 										},
@@ -1649,11 +1649,11 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Italic,
+										Kind: types.SingleQuoteItalic,
 										Elements: []interface{}{
 											types.StringElement{Content: "some "},
 											types.QuotedText{
-												Kind: types.Italic,
+												Kind: types.DoubleQuoteItalic,
 												Elements: []interface{}{
 													types.StringElement{Content: "nested italic"},
 												},
@@ -1678,11 +1678,11 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Italic,
+										Kind: types.SingleQuoteItalic,
 										Elements: []interface{}{
 											types.StringElement{Content: "some "},
 											types.QuotedText{
-												Kind: types.Italic,
+												Kind: types.DoubleQuoteItalic,
 												Elements: []interface{}{
 													types.StringElement{Content: "nested italic"},
 												},
@@ -1707,7 +1707,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Monospace,
+										Kind: types.SingleQuoteMonospace,
 										Elements: []interface{}{
 											types.StringElement{Content: "some `nested monospace"},
 										},
@@ -1730,14 +1730,14 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Monospace,
+										Kind: types.DoubleQuoteMonospace,
 										Elements: []interface{}{
 											types.StringElement{Content: "some "},
 										},
 									},
 									types.StringElement{Content: "nested monospace"},
 									types.QuotedText{
-										Kind: types.Monospace,
+										Kind: types.DoubleQuoteMonospace,
 										Elements: []interface{}{
 											types.StringElement{Content: " content"},
 										},
@@ -1759,11 +1759,11 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Monospace,
+										Kind: types.SingleQuoteMonospace,
 										Elements: []interface{}{
 											types.StringElement{Content: "some "},
 											types.QuotedText{
-												Kind: types.Monospace,
+												Kind: types.DoubleQuoteMonospace,
 												Elements: []interface{}{
 													types.StringElement{Content: "nested monospace"},
 												},
@@ -1788,11 +1788,11 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Monospace,
+										Kind: types.SingleQuoteMonospace,
 										Elements: []interface{}{
 											types.StringElement{Content: "some "},
 											types.QuotedText{
-												Kind: types.Monospace,
+												Kind: types.DoubleQuoteMonospace,
 												Elements: []interface{}{
 													types.StringElement{Content: "nested monospace"},
 												},
@@ -1817,25 +1817,25 @@ var _ = Describe("quoted texts", func() {
 								{
 									types.StringElement{Content: "some "},
 									types.QuotedText{
-										Kind: types.Marked,
+										Kind: types.SingleQuoteMarked,
 										Elements: []interface{}{
 											types.StringElement{Content: "marked and "},
 											types.QuotedText{
-												Kind: types.Italic,
+												Kind: types.SingleQuoteItalic,
 												Elements: []interface{}{
 													types.StringElement{Content: "italic"},
 												},
 											},
 											types.StringElement{Content: " and "},
 											types.QuotedText{
-												Kind: types.Bold,
+												Kind: types.SingleQuoteBold,
 												Elements: []interface{}{
 													types.StringElement{Content: "bold"},
 												},
 											},
 											types.StringElement{Content: " and "},
 											types.QuotedText{
-												Kind: types.Monospace,
+												Kind: types.SingleQuoteMonospace,
 												Elements: []interface{}{
 													types.StringElement{Content: "monospaced"},
 												},
@@ -1860,7 +1860,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Monospace,
+										Kind: types.SingleQuoteMonospace,
 										Elements: []interface{}{
 											types.StringElement{Content: "*a"},
 										},
@@ -1881,7 +1881,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Monospace,
+										Kind: types.SingleQuoteMonospace,
 										Elements: []interface{}{
 											types.StringElement{Content: "a*b"},
 										},
@@ -1902,10 +1902,10 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Monospace,
+										Kind: types.SingleQuoteMonospace,
 										Elements: []interface{}{
 											types.QuotedText{
-												Kind: types.Italic,
+												Kind: types.SingleQuoteItalic,
 												Elements: []interface{}{
 													types.StringElement{Content: "a"},
 												},
@@ -1928,7 +1928,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Monospace,
+										Kind: types.SingleQuoteMonospace,
 										Elements: []interface{}{
 											types.StringElement{Content: "a_b"},
 										},
@@ -1949,7 +1949,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Monospace,
+										Kind: types.SingleQuoteMonospace,
 										Elements: []interface{}{
 											types.StringElement{Content: "a*b*"},
 										},
@@ -1970,11 +1970,11 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Monospace,
+										Kind: types.SingleQuoteMonospace,
 										Elements: []interface{}{
 											types.StringElement{Content: "a"},
 											types.QuotedText{
-												Kind: types.Subscript,
+												Kind: types.SingleQuoteSubscript,
 												Elements: []interface{}{
 													types.StringElement{Content: "b"},
 												},
@@ -1997,7 +1997,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Monospace,
+										Kind: types.SingleQuoteMonospace,
 										Elements: []interface{}{
 											types.StringElement{Content: "a\nb"},
 										},
@@ -2018,7 +2018,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Monospace,
+										Kind: types.SingleQuoteMonospace,
 										Elements: []interface{}{
 											types.StringElement{Content: "a\nb"},
 										},
@@ -2039,11 +2039,11 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Monospace,
+										Kind: types.SingleQuoteMonospace,
 										Elements: []interface{}{
 											types.StringElement{Content: "a\n"},
 											types.QuotedText{
-												Kind: types.Bold,
+												Kind: types.SingleQuoteBold,
 												Elements: []interface{}{
 													types.StringElement{Content: "b"},
 												},
@@ -2066,11 +2066,11 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Monospace,
+										Kind: types.SingleQuoteMonospace,
 										Elements: []interface{}{
 											types.StringElement{Content: "a\n"},
 											types.QuotedText{
-												Kind: types.Bold,
+												Kind: types.SingleQuoteBold,
 												Elements: []interface{}{
 													types.StringElement{Content: "b"},
 												},
@@ -2093,7 +2093,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.SingleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{Content: "a "},
 											types.InlineLink{
@@ -2126,7 +2126,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.SingleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{Content: "a "},
 											types.InlineImage{
@@ -2156,7 +2156,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.SingleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{Content: "a "},
 											types.InlinePassthrough{
@@ -2183,7 +2183,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.SingleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{Content: "a "},
 											types.InlinePassthrough{
@@ -2210,7 +2210,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Italic,
+										Kind: types.SingleQuoteItalic,
 										Elements: []interface{}{
 											types.StringElement{Content: "a "},
 											types.InlineLink{
@@ -2243,7 +2243,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Italic,
+										Kind: types.SingleQuoteItalic,
 										Elements: []interface{}{
 											types.StringElement{Content: "a "},
 											types.InlineImage{
@@ -2273,7 +2273,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Italic,
+										Kind: types.SingleQuoteItalic,
 										Elements: []interface{}{
 											types.StringElement{Content: "a "},
 											types.InlinePassthrough{
@@ -2300,7 +2300,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Italic,
+										Kind: types.SingleQuoteItalic,
 										Elements: []interface{}{
 											types.StringElement{Content: "a "},
 											types.InlinePassthrough{
@@ -2327,7 +2327,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Monospace,
+										Kind: types.SingleQuoteMonospace,
 										Elements: []interface{}{
 											types.StringElement{Content: "a "},
 											types.InlineLink{
@@ -2360,7 +2360,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Monospace,
+										Kind: types.SingleQuoteMonospace,
 										Elements: []interface{}{
 											types.StringElement{Content: "a "},
 											types.InlineImage{
@@ -2390,7 +2390,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Monospace,
+										Kind: types.SingleQuoteMonospace,
 										Elements: []interface{}{
 											types.StringElement{Content: "a "},
 											types.InlinePassthrough{
@@ -2417,7 +2417,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Monospace,
+										Kind: types.SingleQuoteMonospace,
 										Elements: []interface{}{
 											types.StringElement{Content: "a "},
 											types.InlinePassthrough{
@@ -2450,7 +2450,7 @@ var _ = Describe("quoted texts", func() {
 								Lines: [][]interface{}{
 									{
 										types.QuotedText{
-											Kind: types.Bold,
+											Kind: types.SingleQuoteBold,
 											Elements: []interface{}{
 												types.StringElement{Content: "*some bold content"},
 											},
@@ -2471,7 +2471,7 @@ var _ = Describe("quoted texts", func() {
 								Lines: [][]interface{}{
 									{
 										types.QuotedText{
-											Kind: types.Bold,
+											Kind: types.SingleQuoteBold,
 											Elements: []interface{}{
 												types.StringElement{Content: "some bold content"},
 											},
@@ -2496,7 +2496,7 @@ var _ = Describe("quoted texts", func() {
 								Lines: [][]interface{}{
 									{
 										types.QuotedText{
-											Kind: types.Italic,
+											Kind: types.SingleQuoteItalic,
 											Elements: []interface{}{
 												types.StringElement{Content: "_some italic content"},
 											},
@@ -2517,7 +2517,7 @@ var _ = Describe("quoted texts", func() {
 								Lines: [][]interface{}{
 									{
 										types.QuotedText{
-											Kind: types.Italic,
+											Kind: types.SingleQuoteItalic,
 											Elements: []interface{}{
 												types.StringElement{Content: "some italic content"},
 											},
@@ -2542,7 +2542,7 @@ var _ = Describe("quoted texts", func() {
 								Lines: [][]interface{}{
 									{
 										types.QuotedText{
-											Kind: types.Monospace,
+											Kind: types.SingleQuoteMonospace,
 											Elements: []interface{}{
 												types.StringElement{Content: "`some monospace content"},
 											},
@@ -2563,7 +2563,7 @@ var _ = Describe("quoted texts", func() {
 								Lines: [][]interface{}{
 									{
 										types.QuotedText{
-											Kind: types.Monospace,
+											Kind: types.SingleQuoteMonospace,
 											Elements: []interface{}{
 												types.StringElement{Content: "some monospace content"},
 											},
@@ -2710,7 +2710,7 @@ var _ = Describe("quoted texts", func() {
 										{
 											types.StringElement{Content: "*"},
 											types.QuotedText{
-												Kind: types.Italic,
+												Kind: types.SingleQuoteItalic,
 												Elements: []interface{}{
 													types.StringElement{Content: "italic content"},
 												},
@@ -2733,7 +2733,7 @@ var _ = Describe("quoted texts", func() {
 										{
 											types.StringElement{Content: "**"},
 											types.QuotedText{
-												Kind: types.Italic,
+												Kind: types.SingleQuoteItalic,
 												Elements: []interface{}{
 													types.StringElement{Content: "italic content"},
 												},
@@ -2756,7 +2756,7 @@ var _ = Describe("quoted texts", func() {
 										{
 											types.StringElement{Content: "*bold "},
 											types.QuotedText{
-												Kind: types.Italic,
+												Kind: types.SingleQuoteItalic,
 												Elements: []interface{}{
 													types.StringElement{Content: "and italic"},
 												},
@@ -2885,7 +2885,7 @@ var _ = Describe("quoted texts", func() {
 										{
 											types.StringElement{Content: "_"},
 											types.QuotedText{
-												Kind: types.Monospace,
+												Kind: types.SingleQuoteMonospace,
 												Elements: []interface{}{
 													types.StringElement{Content: "monospace content"},
 												},
@@ -2908,7 +2908,7 @@ var _ = Describe("quoted texts", func() {
 										{
 											types.StringElement{Content: "__"},
 											types.QuotedText{
-												Kind: types.Bold,
+												Kind: types.SingleQuoteBold,
 												Elements: []interface{}{
 													types.StringElement{Content: "bold content"},
 												},
@@ -2931,7 +2931,7 @@ var _ = Describe("quoted texts", func() {
 										{
 											types.StringElement{Content: "_italic "},
 											types.QuotedText{
-												Kind: types.Bold,
+												Kind: types.SingleQuoteBold,
 												Elements: []interface{}{
 													types.StringElement{Content: "and bold"},
 												},
@@ -3059,7 +3059,7 @@ var _ = Describe("quoted texts", func() {
 										{
 											types.StringElement{Content: "`"},
 											types.QuotedText{
-												Kind: types.Bold,
+												Kind: types.SingleQuoteBold,
 												Elements: []interface{}{
 													types.StringElement{Content: "bold content"},
 												},
@@ -3082,7 +3082,7 @@ var _ = Describe("quoted texts", func() {
 										{
 											types.StringElement{Content: "``"},
 											types.QuotedText{
-												Kind: types.Bold,
+												Kind: types.SingleQuoteBold,
 												Elements: []interface{}{
 													types.StringElement{Content: "bold content"},
 												},
@@ -3105,7 +3105,7 @@ var _ = Describe("quoted texts", func() {
 										{
 											types.StringElement{Content: "`monospace "},
 											types.QuotedText{
-												Kind: types.Bold,
+												Kind: types.SingleQuoteBold,
 												Elements: []interface{}{
 													types.StringElement{Content: "and bold"},
 												},
@@ -3170,7 +3170,7 @@ var _ = Describe("quoted texts", func() {
 										{
 											types.StringElement{Content: "~"},
 											types.QuotedText{
-												Kind: types.Bold,
+												Kind: types.SingleQuoteBold,
 												Elements: []interface{}{
 													types.StringElement{Content: "boldcontent"},
 												},
@@ -3193,7 +3193,7 @@ var _ = Describe("quoted texts", func() {
 										{
 											types.StringElement{Content: `\~subscript `},
 											types.QuotedText{
-												Kind: types.Bold,
+												Kind: types.SingleQuoteBold,
 												Elements: []interface{}{
 													types.StringElement{Content: "and bold"},
 												},
@@ -3258,7 +3258,7 @@ var _ = Describe("quoted texts", func() {
 										{
 											types.StringElement{Content: `^`},
 											types.QuotedText{
-												Kind: types.Bold,
+												Kind: types.SingleQuoteBold,
 												Elements: []interface{}{
 													types.StringElement{Content: "bold content"},
 												},
@@ -3281,7 +3281,7 @@ var _ = Describe("quoted texts", func() {
 										{
 											types.StringElement{Content: "^"},
 											types.QuotedText{
-												Kind: types.Bold,
+												Kind: types.SingleQuoteBold,
 												Elements: []interface{}{
 													types.StringElement{Content: "bold content"},
 												},
@@ -3304,7 +3304,7 @@ var _ = Describe("quoted texts", func() {
 										{
 											types.StringElement{Content: `\^superscript `},
 											types.QuotedText{
-												Kind: types.Bold,
+												Kind: types.SingleQuoteBold,
 												Elements: []interface{}{
 													types.StringElement{Content: "and bold"},
 												},
@@ -3332,7 +3332,7 @@ var _ = Describe("quoted texts", func() {
 								{
 									types.StringElement{Content: "this "},
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.SingleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{
 												Content: "mother\u2019s mothers' mothers\u2019",
@@ -3356,7 +3356,7 @@ var _ = Describe("quoted texts", func() {
 								{
 									types.StringElement{Content: "this "},
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.DoubleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{
 												Content: "mother\u2019s mothers' mothers\u2019",
@@ -3380,7 +3380,7 @@ var _ = Describe("quoted texts", func() {
 								{
 									types.StringElement{Content: "this "},
 									types.QuotedText{
-										Kind: types.Italic,
+										Kind: types.SingleQuoteItalic,
 										Elements: []interface{}{
 											types.StringElement{
 												Content: "mother\u2019s mothers' mothers\u2019",
@@ -3404,7 +3404,7 @@ var _ = Describe("quoted texts", func() {
 								{
 									types.StringElement{Content: "this "},
 									types.QuotedText{
-										Kind: types.Italic,
+										Kind: types.DoubleQuoteItalic,
 										Elements: []interface{}{
 											types.StringElement{
 												Content: "mother\u2019s mothers' mothers\u2019",
@@ -3428,7 +3428,7 @@ var _ = Describe("quoted texts", func() {
 								{
 									types.StringElement{Content: "this "},
 									types.QuotedText{
-										Kind: types.Monospace,
+										Kind: types.SingleQuoteMonospace,
 										Elements: []interface{}{
 											types.StringElement{
 												Content: "mother\u2019s mothers\u2019 day",
@@ -3452,7 +3452,7 @@ var _ = Describe("quoted texts", func() {
 								{
 									types.StringElement{Content: "this "},
 									types.QuotedText{
-										Kind: types.Monospace,
+										Kind: types.DoubleQuoteMonospace,
 										Elements: []interface{}{
 											types.StringElement{
 												Content: "mother\u2019s mothers\u2019 day",
@@ -3476,7 +3476,7 @@ var _ = Describe("quoted texts", func() {
 								{
 									types.StringElement{Content: "this "},
 									types.QuotedText{
-										Kind: types.Marked,
+										Kind: types.SingleQuoteMarked,
 										Elements: []interface{}{
 											types.StringElement{
 												Content: "mother\u2019s mothers' mothers\u2019",
@@ -3500,7 +3500,7 @@ var _ = Describe("quoted texts", func() {
 								{
 									types.StringElement{Content: "this "},
 									types.QuotedText{
-										Kind: types.Marked,
+										Kind: types.DoubleQuoteMarked,
 										Elements: []interface{}{
 											types.StringElement{
 												Content: "mother\u2019s mothers' mothers\u2019",
@@ -3529,7 +3529,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.SingleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{Content: "hello"},
 										},
@@ -3550,7 +3550,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.SingleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{Content: "bold    content"},
 										},
@@ -3571,7 +3571,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.SingleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{Content: "some bold content"},
 										},
@@ -3592,7 +3592,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Italic,
+										Kind: types.SingleQuoteItalic,
 										Elements: []interface{}{
 											types.StringElement{Content: "some italic content"},
 										},
@@ -3613,7 +3613,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Monospace,
+										Kind: types.SingleQuoteMonospace,
 										Elements: []interface{}{
 											types.StringElement{Content: "some monospace content"},
 										},
@@ -3666,11 +3666,11 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Italic,
+										Kind: types.SingleQuoteItalic,
 										Elements: []interface{}{
 											types.StringElement{Content: "some "},
 											types.QuotedText{
-												Kind: types.Bold,
+												Kind: types.SingleQuoteBold,
 												Elements: []interface{}{
 													types.StringElement{Content: "bold"},
 												},
@@ -3694,15 +3694,15 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.SingleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{Content: "some "},
 											types.QuotedText{
-												Kind: types.Italic,
+												Kind: types.SingleQuoteItalic,
 												Elements: []interface{}{
 													types.StringElement{Content: "italic and "},
 													types.QuotedText{
-														Kind: types.Monospace,
+														Kind: types.SingleQuoteMonospace,
 														Elements: []interface{}{
 															types.StringElement{Content: "monospaced content"},
 														},
@@ -3727,7 +3727,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Italic,
+										Kind: types.SingleQuoteItalic,
 										Elements: []interface{}{
 											types.StringElement{Content: "some _very italic"},
 										},
@@ -3750,7 +3750,7 @@ var _ = Describe("quoted texts", func() {
 								{
 									types.StringElement{Content: "O"},
 									types.QuotedText{
-										Kind: types.Subscript,
+										Kind: types.SingleQuoteSubscript,
 										Elements: []interface{}{
 											types.StringElement{Content: "2"},
 										},
@@ -3773,7 +3773,7 @@ var _ = Describe("quoted texts", func() {
 								{
 									types.StringElement{Content: "M"},
 									types.QuotedText{
-										Kind: types.Superscript,
+										Kind: types.SingleQuoteSuperscript,
 										Elements: []interface{}{
 											types.StringElement{Content: "me"},
 										},
@@ -3911,7 +3911,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.DoubleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{Content: "hello"},
 										},
@@ -3932,7 +3932,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Italic,
+										Kind: types.DoubleQuoteItalic,
 										Elements: []interface{}{
 											types.StringElement{Content: "some italic content"},
 										},
@@ -3953,7 +3953,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Monospace,
+										Kind: types.DoubleQuoteMonospace,
 										Elements: []interface{}{
 											types.StringElement{Content: " some monospace content "},
 										},
@@ -3974,11 +3974,11 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Italic,
+										Kind: types.DoubleQuoteItalic,
 										Elements: []interface{}{
 											types.StringElement{Content: "some "},
 											types.QuotedText{
-												Kind: types.Superscript,
+												Kind: types.SingleQuoteSuperscript,
 												Elements: []interface{}{
 													types.StringElement{Content: "superscript"},
 												},
@@ -4002,15 +4002,15 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.DoubleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{Content: "some "},
 											types.QuotedText{
-												Kind: types.Italic,
+												Kind: types.SingleQuoteItalic,
 												Elements: []interface{}{
 													types.StringElement{Content: "italic and "},
 													types.QuotedText{
-														Kind: types.Superscript,
+														Kind: types.SingleQuoteSuperscript,
 														Elements: []interface{}{
 															types.StringElement{Content: "superscriptcontent"},
 														},
@@ -4140,7 +4140,7 @@ var _ = Describe("quoted texts", func() {
 								{
 									types.StringElement{Content: "a paragraph with "},
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.SingleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{Content: "some bold content"},
 										},
@@ -4210,7 +4210,7 @@ var _ = Describe("quoted texts", func() {
 								{
 									types.StringElement{Content: "some "},
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.SingleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{Content: "bold and _italic content _ together"},
 										},
@@ -4233,7 +4233,7 @@ var _ = Describe("quoted texts", func() {
 								{
 									types.StringElement{Content: "some *bold and "},
 									types.QuotedText{
-										Kind: types.Italic,
+										Kind: types.SingleQuoteItalic,
 										Elements: []interface{}{
 											types.StringElement{Content: "italic content"},
 										},
@@ -4355,11 +4355,11 @@ var _ = Describe("quoted texts", func() {
 								{
 									types.StringElement{Content: "some "},
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.SingleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{Content: "bold and "},
 											types.QuotedText{
-												Kind: types.Italic,
+												Kind: types.SingleQuoteItalic,
 												Elements: []interface{}{
 													types.StringElement{Content: "italic content"},
 												},
@@ -4385,7 +4385,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.SingleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{Content: "some *nested bold"},
 										},
@@ -4408,14 +4408,14 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.DoubleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{Content: "some "},
 										},
 									},
 									types.StringElement{Content: "nested bold"},
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.DoubleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{Content: " content"},
 										},
@@ -4437,11 +4437,11 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.DoubleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{Content: "some "},
 											types.QuotedText{
-												Kind: types.Bold,
+												Kind: types.SingleQuoteBold,
 												Elements: []interface{}{
 													types.StringElement{Content: "nested bold"},
 												},
@@ -4466,11 +4466,11 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.SingleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{Content: "some "},
 											types.QuotedText{
-												Kind: types.Bold,
+												Kind: types.DoubleQuoteBold,
 												Elements: []interface{}{
 													types.StringElement{Content: "nested bold"},
 												},
@@ -4495,7 +4495,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Italic,
+										Kind: types.SingleQuoteItalic,
 										Elements: []interface{}{
 											types.StringElement{Content: "some _nested italic"},
 										},
@@ -4518,14 +4518,14 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Italic,
+										Kind: types.DoubleQuoteItalic,
 										Elements: []interface{}{
 											types.StringElement{Content: "some "},
 										},
 									},
 									types.StringElement{Content: "nested italic"},
 									types.QuotedText{
-										Kind: types.Italic,
+										Kind: types.DoubleQuoteItalic,
 										Elements: []interface{}{
 											types.StringElement{Content: " content"},
 										},
@@ -4540,18 +4540,18 @@ var _ = Describe("quoted texts", func() {
 
 			It("single-quote italic within double-quote italic text", func() {
 				// here we allow for italic text within italic text, to comply with the existing implementations (asciidoc and asciidoctor)
-				source := "_some __nested italic__ content_"
+				source := "__some _nested italic_ content__"
 				expected := types.Document{
 					Elements: []interface{}{
 						types.Paragraph{
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Italic,
+										Kind: types.DoubleQuoteItalic,
 										Elements: []interface{}{
 											types.StringElement{Content: "some "},
 											types.QuotedText{
-												Kind: types.Italic,
+												Kind: types.SingleQuoteItalic,
 												Elements: []interface{}{
 													types.StringElement{Content: "nested italic"},
 												},
@@ -4576,11 +4576,11 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Italic,
+										Kind: types.SingleQuoteItalic,
 										Elements: []interface{}{
 											types.StringElement{Content: "some "},
 											types.QuotedText{
-												Kind: types.Italic,
+												Kind: types.DoubleQuoteItalic,
 												Elements: []interface{}{
 													types.StringElement{Content: "nested italic"},
 												},
@@ -4605,7 +4605,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Monospace,
+										Kind: types.SingleQuoteMonospace,
 										Elements: []interface{}{
 											types.StringElement{Content: "some `nested monospace"},
 										},
@@ -4628,14 +4628,14 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Monospace,
+										Kind: types.DoubleQuoteMonospace,
 										Elements: []interface{}{
 											types.StringElement{Content: "some "},
 										},
 									},
 									types.StringElement{Content: "nested monospace"},
 									types.QuotedText{
-										Kind: types.Monospace,
+										Kind: types.DoubleQuoteMonospace,
 										Elements: []interface{}{
 											types.StringElement{Content: " content"},
 										},
@@ -4657,11 +4657,11 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Monospace,
+										Kind: types.SingleQuoteMonospace,
 										Elements: []interface{}{
 											types.StringElement{Content: "some "},
 											types.QuotedText{
-												Kind: types.Monospace,
+												Kind: types.DoubleQuoteMonospace,
 												Elements: []interface{}{
 													types.StringElement{Content: "nested monospace"},
 												},
@@ -4686,11 +4686,11 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Monospace,
+										Kind: types.SingleQuoteMonospace,
 										Elements: []interface{}{
 											types.StringElement{Content: "some "},
 											types.QuotedText{
-												Kind: types.Monospace,
+												Kind: types.DoubleQuoteMonospace,
 												Elements: []interface{}{
 													types.StringElement{Content: "nested monospace"},
 												},
@@ -4714,7 +4714,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Monospace,
+										Kind: types.SingleQuoteMonospace,
 										Elements: []interface{}{
 											types.StringElement{Content: "*a"},
 										},
@@ -4735,7 +4735,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Monospace,
+										Kind: types.SingleQuoteMonospace,
 										Elements: []interface{}{
 											types.StringElement{Content: "a*b"},
 										},
@@ -4756,10 +4756,10 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Monospace,
+										Kind: types.SingleQuoteMonospace,
 										Elements: []interface{}{
 											types.QuotedText{
-												Kind: types.Italic,
+												Kind: types.SingleQuoteItalic,
 												Elements: []interface{}{
 													types.StringElement{Content: "a"},
 												},
@@ -4782,7 +4782,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Monospace,
+										Kind: types.SingleQuoteMonospace,
 										Elements: []interface{}{
 											types.StringElement{Content: "a_b"},
 										},
@@ -4803,7 +4803,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Monospace,
+										Kind: types.SingleQuoteMonospace,
 										Elements: []interface{}{
 											types.StringElement{Content: "a*b*"},
 										},
@@ -4824,11 +4824,11 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Monospace,
+										Kind: types.SingleQuoteMonospace,
 										Elements: []interface{}{
 											types.StringElement{Content: "a"},
 											types.QuotedText{
-												Kind: types.Subscript,
+												Kind: types.SingleQuoteSubscript,
 												Elements: []interface{}{
 													types.StringElement{Content: "b"},
 												},
@@ -4851,7 +4851,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Monospace,
+										Kind: types.SingleQuoteMonospace,
 										Elements: []interface{}{
 											types.StringElement{Content: "a\nb"},
 										},
@@ -4872,7 +4872,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Monospace,
+										Kind: types.SingleQuoteMonospace,
 										Elements: []interface{}{
 											types.StringElement{Content: "a\nb"},
 										},
@@ -4893,11 +4893,11 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Monospace,
+										Kind: types.SingleQuoteMonospace,
 										Elements: []interface{}{
 											types.StringElement{Content: "a\n"},
 											types.QuotedText{
-												Kind: types.Bold,
+												Kind: types.SingleQuoteBold,
 												Elements: []interface{}{
 													types.StringElement{Content: "b"},
 												},
@@ -4920,11 +4920,11 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Monospace,
+										Kind: types.SingleQuoteMonospace,
 										Elements: []interface{}{
 											types.StringElement{Content: "a\n"},
 											types.QuotedText{
-												Kind: types.Bold,
+												Kind: types.SingleQuoteBold,
 												Elements: []interface{}{
 													types.StringElement{Content: "b"},
 												},
@@ -4947,7 +4947,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.SingleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{Content: "a "},
 											types.InlineLink{
@@ -4980,7 +4980,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.SingleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{Content: "a "},
 											types.InlineImage{
@@ -5010,7 +5010,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.SingleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{Content: "a "},
 											types.InlinePassthrough{
@@ -5037,7 +5037,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.SingleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{Content: "a "},
 											types.InlinePassthrough{
@@ -5064,7 +5064,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Italic,
+										Kind: types.SingleQuoteItalic,
 										Elements: []interface{}{
 											types.StringElement{Content: "a "},
 											types.InlineLink{
@@ -5097,7 +5097,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Italic,
+										Kind: types.SingleQuoteItalic,
 										Elements: []interface{}{
 											types.StringElement{Content: "a "},
 											types.InlineImage{
@@ -5127,7 +5127,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Italic,
+										Kind: types.SingleQuoteItalic,
 										Elements: []interface{}{
 											types.StringElement{Content: "a "},
 											types.InlinePassthrough{
@@ -5154,7 +5154,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Italic,
+										Kind: types.SingleQuoteItalic,
 										Elements: []interface{}{
 											types.StringElement{Content: "a "},
 											types.InlinePassthrough{
@@ -5181,7 +5181,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Monospace,
+										Kind: types.SingleQuoteMonospace,
 										Elements: []interface{}{
 											types.StringElement{Content: "a "},
 											types.InlineLink{
@@ -5214,7 +5214,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Monospace,
+										Kind: types.SingleQuoteMonospace,
 										Elements: []interface{}{
 											types.StringElement{Content: "a "},
 											types.InlineImage{
@@ -5244,7 +5244,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Monospace,
+										Kind: types.SingleQuoteMonospace,
 										Elements: []interface{}{
 											types.StringElement{Content: "a "},
 											types.InlinePassthrough{
@@ -5271,7 +5271,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Monospace,
+										Kind: types.SingleQuoteMonospace,
 										Elements: []interface{}{
 											types.StringElement{Content: "a "},
 											types.InlinePassthrough{
@@ -5304,7 +5304,7 @@ var _ = Describe("quoted texts", func() {
 								Lines: [][]interface{}{
 									{
 										types.QuotedText{
-											Kind: types.Bold,
+											Kind: types.SingleQuoteBold,
 											Elements: []interface{}{
 												types.StringElement{Content: "*some bold content"},
 											},
@@ -5326,7 +5326,7 @@ var _ = Describe("quoted texts", func() {
 									{
 
 										types.QuotedText{
-											Kind: types.Bold,
+											Kind: types.SingleQuoteBold,
 											Elements: []interface{}{
 												types.StringElement{Content: "some bold content"},
 											},
@@ -5352,7 +5352,7 @@ var _ = Describe("quoted texts", func() {
 									{
 
 										types.QuotedText{
-											Kind: types.Italic,
+											Kind: types.SingleQuoteItalic,
 											Elements: []interface{}{
 												types.StringElement{Content: "_some italic content"},
 											},
@@ -5373,7 +5373,7 @@ var _ = Describe("quoted texts", func() {
 								Lines: [][]interface{}{
 									{
 										types.QuotedText{
-											Kind: types.Italic,
+											Kind: types.SingleQuoteItalic,
 											Elements: []interface{}{
 												types.StringElement{Content: "some italic content"},
 											},
@@ -5398,7 +5398,7 @@ var _ = Describe("quoted texts", func() {
 								Lines: [][]interface{}{
 									{
 										types.QuotedText{
-											Kind: types.Monospace,
+											Kind: types.SingleQuoteMonospace,
 											Elements: []interface{}{
 												types.StringElement{Content: "`some monospace content"},
 											},
@@ -5419,7 +5419,7 @@ var _ = Describe("quoted texts", func() {
 								Lines: [][]interface{}{
 									{
 										types.QuotedText{
-											Kind: types.Monospace,
+											Kind: types.SingleQuoteMonospace,
 											Elements: []interface{}{
 												types.StringElement{Content: "some monospace content"},
 											},
@@ -5566,7 +5566,7 @@ var _ = Describe("quoted texts", func() {
 										{
 											types.StringElement{Content: "*"},
 											types.QuotedText{
-												Kind: types.Italic,
+												Kind: types.SingleQuoteItalic,
 												Elements: []interface{}{
 													types.StringElement{Content: "italic content"},
 												},
@@ -5589,7 +5589,7 @@ var _ = Describe("quoted texts", func() {
 										{
 											types.StringElement{Content: "**"},
 											types.QuotedText{
-												Kind: types.Italic,
+												Kind: types.SingleQuoteItalic,
 												Elements: []interface{}{
 													types.StringElement{Content: "italic content"},
 												},
@@ -5612,7 +5612,7 @@ var _ = Describe("quoted texts", func() {
 										{
 											types.StringElement{Content: "*bold "},
 											types.QuotedText{
-												Kind: types.Italic,
+												Kind: types.SingleQuoteItalic,
 												Elements: []interface{}{
 													types.StringElement{Content: "and italic"},
 												},
@@ -5741,7 +5741,7 @@ var _ = Describe("quoted texts", func() {
 										{
 											types.StringElement{Content: "_"},
 											types.QuotedText{
-												Kind: types.Monospace,
+												Kind: types.SingleQuoteMonospace,
 												Elements: []interface{}{
 													types.StringElement{Content: "monospace content"},
 												},
@@ -5764,7 +5764,7 @@ var _ = Describe("quoted texts", func() {
 										{
 											types.StringElement{Content: "__"},
 											types.QuotedText{
-												Kind: types.Bold,
+												Kind: types.SingleQuoteBold,
 												Elements: []interface{}{
 													types.StringElement{Content: "bold content"},
 												},
@@ -5787,7 +5787,7 @@ var _ = Describe("quoted texts", func() {
 										{
 											types.StringElement{Content: "_italic "},
 											types.QuotedText{
-												Kind: types.Bold,
+												Kind: types.SingleQuoteBold,
 												Elements: []interface{}{
 													types.StringElement{Content: "and bold"},
 												},
@@ -5915,7 +5915,7 @@ var _ = Describe("quoted texts", func() {
 										{
 											types.StringElement{Content: "`"},
 											types.QuotedText{
-												Kind: types.Bold,
+												Kind: types.SingleQuoteBold,
 												Elements: []interface{}{
 													types.StringElement{Content: "bold content"},
 												},
@@ -5938,7 +5938,7 @@ var _ = Describe("quoted texts", func() {
 										{
 											types.StringElement{Content: "``"},
 											types.QuotedText{
-												Kind: types.Bold,
+												Kind: types.SingleQuoteBold,
 												Elements: []interface{}{
 													types.StringElement{Content: "bold content"},
 												},
@@ -5961,7 +5961,7 @@ var _ = Describe("quoted texts", func() {
 										{
 											types.StringElement{Content: "`monospace "},
 											types.QuotedText{
-												Kind: types.Bold,
+												Kind: types.SingleQuoteBold,
 												Elements: []interface{}{
 													types.StringElement{Content: "and bold"},
 												},
@@ -6026,7 +6026,7 @@ var _ = Describe("quoted texts", func() {
 										{
 											types.StringElement{Content: "~"},
 											types.QuotedText{
-												Kind: types.Bold,
+												Kind: types.SingleQuoteBold,
 												Elements: []interface{}{
 													types.StringElement{Content: "boldcontent"},
 												},
@@ -6049,7 +6049,7 @@ var _ = Describe("quoted texts", func() {
 										{
 											types.StringElement{Content: `\~subscript `},
 											types.QuotedText{
-												Kind: types.Bold,
+												Kind: types.SingleQuoteBold,
 												Elements: []interface{}{
 													types.StringElement{Content: "and bold"},
 												},
@@ -6114,7 +6114,7 @@ var _ = Describe("quoted texts", func() {
 										{
 											types.StringElement{Content: `^`},
 											types.QuotedText{
-												Kind: types.Bold,
+												Kind: types.SingleQuoteBold,
 												Elements: []interface{}{
 													types.StringElement{Content: "bold content"},
 												},
@@ -6137,7 +6137,7 @@ var _ = Describe("quoted texts", func() {
 										{
 											types.StringElement{Content: "^"},
 											types.QuotedText{
-												Kind: types.Bold,
+												Kind: types.SingleQuoteBold,
 												Elements: []interface{}{
 													types.StringElement{Content: "bold content"},
 												},
@@ -6160,7 +6160,7 @@ var _ = Describe("quoted texts", func() {
 										{
 											types.StringElement{Content: `\^superscript `},
 											types.QuotedText{
-												Kind: types.Bold,
+												Kind: types.SingleQuoteBold,
 												Elements: []interface{}{
 													types.StringElement{Content: "and bold"},
 												},
@@ -6187,7 +6187,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.SingleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{Content: "a "},
 											types.InlineImage{
@@ -6217,7 +6217,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Italic,
+										Kind: types.SingleQuoteItalic,
 										Elements: []interface{}{
 											types.StringElement{Content: "a "},
 											types.InlineImage{
@@ -6247,7 +6247,7 @@ var _ = Describe("quoted texts", func() {
 							Lines: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Monospace,
+										Kind: types.SingleQuoteMonospace,
 										Elements: []interface{}{
 											types.StringElement{Content: "a "},
 											types.InlineImage{

--- a/pkg/parser/section_test.go
+++ b/pkg/parser/section_test.go
@@ -178,7 +178,7 @@ and a paragraph`
 				source := `==  *2 spaces and bold content*`
 				sectionTitle := []interface{}{
 					types.QuotedText{
-						Kind: types.Bold,
+						Kind: types.SingleQuoteBold,
 						Elements: []interface{}{
 							types.StringElement{Content: "2 spaces and bold content"},
 						},
@@ -622,7 +622,7 @@ a paragraph with *bold content*`
 												{
 													types.StringElement{Content: "a paragraph with "},
 													types.QuotedText{
-														Kind: types.Bold,
+														Kind: types.SingleQuoteBold,
 														Elements: []interface{}{
 															types.StringElement{Content: "bold content"},
 														},
@@ -1033,7 +1033,7 @@ and a paragraph`
 				source := `==  *2 spaces and bold content*`
 				sectionTitle := []interface{}{
 					types.QuotedText{
-						Kind: types.Bold,
+						Kind: types.SingleQuoteBold,
 						Elements: []interface{}{
 							types.StringElement{Content: "2 spaces and bold content"},
 						},

--- a/pkg/parser/table_test.go
+++ b/pkg/parser/table_test.go
@@ -27,7 +27,7 @@ var _ = Describe("tables", func() {
 							Cells: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.SingleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{
 												Content: "foo",
@@ -40,7 +40,7 @@ var _ = Describe("tables", func() {
 								},
 								{
 									types.QuotedText{
-										Kind: types.Italic,
+										Kind: types.SingleQuoteItalic,
 										Elements: []interface{}{
 											types.StringElement{
 												Content: "bar",
@@ -77,7 +77,7 @@ var _ = Describe("tables", func() {
 							Cells: [][]interface{}{
 								{
 									types.QuotedText{
-										Kind: types.Bold,
+										Kind: types.SingleQuoteBold,
 										Elements: []interface{}{
 											types.StringElement{
 												Content: "foo",
@@ -90,7 +90,7 @@ var _ = Describe("tables", func() {
 								},
 								{
 									types.QuotedText{
-										Kind: types.Italic,
+										Kind: types.SingleQuoteItalic,
 										Elements: []interface{}{
 											types.StringElement{
 												Content: "bar",

--- a/pkg/parser/unordered_list_test.go
+++ b/pkg/parser/unordered_list_test.go
@@ -156,7 +156,7 @@ var _ = Describe("unordered lists", func() {
 										{
 											types.StringElement{Content: "a second item with "},
 											types.QuotedText{
-												Kind: types.Bold,
+												Kind: types.SingleQuoteBold,
 												Elements: []interface{}{
 													types.StringElement{Content: "bold content"},
 												},
@@ -332,7 +332,7 @@ var _ = Describe("unordered lists", func() {
 										{
 											types.StringElement{Content: "a second item with "},
 											types.QuotedText{
-												Kind: types.Bold,
+												Kind: types.SingleQuoteBold,
 												Elements: []interface{}{
 													types.StringElement{Content: "bold content"},
 												},
@@ -462,7 +462,7 @@ var _ = Describe("unordered lists", func() {
 										{
 											types.StringElement{Content: "a second item with "},
 											types.QuotedText{
-												Kind: types.Bold,
+												Kind: types.SingleQuoteBold,
 												Elements: []interface{}{
 													types.StringElement{Content: "bold content"},
 												},
@@ -1634,7 +1634,7 @@ paragraph attached to parent list item`
 												{
 													types.StringElement{Content: "a second item with "},
 													types.QuotedText{
-														Kind: types.Bold,
+														Kind: types.SingleQuoteBold,
 														Elements: []interface{}{
 															types.StringElement{Content: "bold content"},
 														},
@@ -1830,7 +1830,7 @@ paragraph attached to parent list item`
 												{
 													types.StringElement{Content: "a second item with "},
 													types.QuotedText{
-														Kind: types.Bold,
+														Kind: types.SingleQuoteBold,
 														Elements: []interface{}{
 															types.StringElement{Content: "bold content"},
 														},
@@ -1979,7 +1979,7 @@ paragraph attached to parent list item`
 												{
 													types.StringElement{Content: "a second item with "},
 													types.QuotedText{
-														Kind: types.Bold,
+														Kind: types.SingleQuoteBold,
 														Elements: []interface{}{
 															types.StringElement{Content: "bold content"},
 														},

--- a/pkg/renderer/sgml/quoted_text.go
+++ b/pkg/renderer/sgml/quoted_text.go
@@ -24,17 +24,17 @@ func (r *sgmlRenderer) renderQuotedText(ctx *renderer.Context, t types.QuotedTex
 	}
 	var tmpl *textTemplate
 	switch t.Kind {
-	case types.Bold:
+	case types.SingleQuoteBold, types.DoubleQuoteBold:
 		tmpl = r.boldText
-	case types.Italic:
+	case types.SingleQuoteItalic, types.DoubleQuoteItalic:
 		tmpl = r.italicText
-	case types.Marked:
+	case types.SingleQuoteMarked, types.DoubleQuoteMarked:
 		tmpl = r.markedText
-	case types.Monospace:
+	case types.SingleQuoteMonospace, types.DoubleQuoteMonospace:
 		tmpl = r.monospaceText
-	case types.Subscript:
+	case types.SingleQuoteSubscript:
 		tmpl = r.subscriptText
-	case types.Superscript:
+	case types.SingleQuoteSuperscript:
 		tmpl = r.superscriptText
 	default:
 		return "", errors.Errorf("unsupported quoted text kind: '%v'", t.Kind)

--- a/pkg/types/non_alphanumeric_replacement_test.go
+++ b/pkg/types/non_alphanumeric_replacement_test.go
@@ -49,7 +49,7 @@ var _ = Describe("normalizing string", func() {
 		source := []interface{}{
 			types.StringElement{Content: "a section title, with"},
 			types.QuotedText{
-				Kind: types.Bold,
+				Kind: types.SingleQuoteBold,
 				Elements: []interface{}{
 					types.StringElement{Content: "bold content"},
 				},

--- a/pkg/types/types_test.go
+++ b/pkg/types/types_test.go
@@ -1143,3 +1143,205 @@ var _ = DescribeTable("no match attribute with key",
 	Entry("match for block-kind: quote", types.AttrStyle, false),
 	Entry("no match for block-kind: quote", types.AttrID, true),
 )
+
+var _ = DescribeTable("rawtest",
+	func(element types.RawText, expected string) {
+		Expect(element.RawText()).To(Equal(expected))
+	},
+	// quoted text
+	Entry("single quote bold text",
+		types.QuotedText{
+			Kind: types.SingleQuoteBold,
+			Elements: []interface{}{
+				types.StringElement{
+					Content: "content",
+				},
+			},
+		},
+		"*content*"),
+	Entry("double quote bold text",
+		types.QuotedText{
+			Kind: types.DoubleQuoteBold,
+			Elements: []interface{}{
+				types.StringElement{
+					Content: "content",
+				},
+			},
+		},
+		"**content**"),
+	Entry("single quote italic text",
+		types.QuotedText{
+			Kind: types.SingleQuoteItalic,
+			Elements: []interface{}{
+				types.StringElement{
+					Content: "content",
+				},
+			},
+		},
+		"_content_"),
+	Entry("double quote italic text",
+		types.QuotedText{
+			Kind: types.DoubleQuoteItalic,
+			Elements: []interface{}{
+				types.StringElement{
+					Content: "content",
+				},
+			},
+		},
+		"__content__"),
+	Entry("single quote monospace text",
+		types.QuotedText{
+			Kind: types.SingleQuoteMonospace,
+			Elements: []interface{}{
+				types.StringElement{
+					Content: "content",
+				},
+			},
+		},
+		"`content`"),
+	Entry("double quote monospace text",
+		types.QuotedText{
+			Kind: types.DoubleQuoteMonospace,
+			Elements: []interface{}{
+				types.StringElement{
+					Content: "content",
+				},
+			},
+		},
+		"``content``"),
+	Entry("single quote marked text",
+		types.QuotedText{
+			Kind: types.SingleQuoteMarked,
+			Elements: []interface{}{
+				types.StringElement{
+					Content: "content",
+				},
+			},
+		},
+		"#content#"),
+	Entry("double quote marked text",
+		types.QuotedText{
+			Kind: types.DoubleQuoteMarked,
+			Elements: []interface{}{
+				types.StringElement{
+					Content: "content",
+				},
+			},
+		},
+		"##content##"),
+	Entry("single quote subscript text",
+		types.QuotedText{
+			Kind: types.SingleQuoteSubscript,
+			Elements: []interface{}{
+				types.StringElement{
+					Content: "content",
+				},
+			},
+		},
+		"~content~"),
+	Entry("single quote superscript text",
+		types.QuotedText{
+			Kind: types.SingleQuoteSuperscript,
+			Elements: []interface{}{
+				types.StringElement{
+					Content: "content",
+				},
+			},
+		},
+		"^content^"),
+	// quoted string
+	Entry("single quoted string",
+		types.QuotedString{
+			Kind: types.SingleQuote,
+			Elements: []interface{}{
+				types.StringElement{
+					Content: "content",
+				},
+			},
+		},
+		"`'content'`"),
+	Entry("double quoted string",
+		types.QuotedString{
+			Kind: types.DoubleQuote,
+			Elements: []interface{}{
+				types.StringElement{
+					Content: "content",
+				},
+			},
+		},
+		"`\"content\"`"),
+	// inline passthrough
+	Entry("singleplus inline passthrough",
+		types.InlinePassthrough{
+			Kind: types.SinglePlusPassthrough,
+			Elements: []interface{}{
+				types.StringElement{
+					Content: "content",
+				},
+			},
+		},
+		"+content+"),
+	Entry("tripleplus inline passthrough",
+		types.InlinePassthrough{
+			Kind: types.TriplePlusPassthrough,
+			Elements: []interface{}{
+				types.StringElement{
+					Content: "content",
+				},
+			},
+		},
+		"+++content+++"),
+	Entry("macro inline passthrough",
+		types.InlinePassthrough{
+			Kind: types.PassthroughMacro,
+			Elements: []interface{}{
+				types.StringElement{
+					Content: "content",
+				},
+			},
+		},
+		"pass:[content]"),
+	// special characters
+	Entry("special character",
+		types.SpecialCharacter{
+			Name: "<",
+		},
+		"<"),
+	// attribute substitution
+	Entry("attribute substitution",
+		types.AttributeSubstitution{
+			Name: "cookie",
+		},
+		"{cookie}"),
+	// mixins
+	Entry("mixins",
+		types.QuotedText{
+			Kind: types.SingleQuoteBold,
+			Elements: []interface{}{
+				types.StringElement{
+					Content: "some ",
+				},
+				types.QuotedString{
+					Kind: types.DoubleQuote,
+					Elements: []interface{}{
+						types.StringElement{
+							Content: "content",
+						},
+						types.SpecialCharacter{
+							Name: "<",
+						},
+						types.SpecialCharacter{
+							Name: ">",
+						},
+					},
+				},
+				types.StringElement{
+					Content: " ",
+				},
+				types.AttributeSubstitution{
+					Name: "here",
+				},
+			},
+		},
+		"*some `\"content<>\"` {here}*"),
+)


### PR DESCRIPTION
New interface for elements that can return their raw text representation
of as they were in the source document (supposedly)
For now, the following types implement this new interface:
- QuotedText
- QuotedString
- StringElement
- SpecialCharacter
- InlinePassthrough
- AttributeSubstitution

This is simpler than capturing the content that was parsed, because
in case where elements are embedded, we would need to process the
`ElementPlaceHolder`, which would add complexity.

Fixes #831

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
