### PR TITLE
chore(build): use latest version of golangci-lint

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -73,6 +73,6 @@ jobs:
     - name: Lint
       uses: golangci/golangci-lint-action@v2.3.0
       with:
-        version: v1.29
+        version: latest
         args: -c .golangci.yml
 

--- a/make/lint.mk
+++ b/make/lint.mk
@@ -1,7 +1,7 @@
 .PHONY: install-golangci-lint
 ## Install development tools.
 install-golangci-lint:
-	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin v1.29.0
+	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin
 
 .PHONY: lint
 ## run golangci-lint against project


### PR DESCRIPTION
applies to GH Workflow (using the golangci-lint-action) and
from CLI via `make lint`

Fixes #833

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
