### PR TITLE
feat(parser/renderer): support quoted text in element attributes

### DIFF
--- a/cmd/libasciidoc/root_cmd.go
+++ b/cmd/libasciidoc/root_cmd.go
@@ -52,7 +52,7 @@ func NewRootCmd() *cobra.Command {
 			for _, sourcePath := range args {
 				out, close := getOut(cmd, sourcePath, outputName)
 				if out != nil {
-					defer close()
+					defer close() //nolint errcheck
 					// path, _ := filepath.Abs(sourcePath)
 					// log.Debugf("Starting to process file %v", path)
 					config := configuration.NewConfiguration(

--- a/libasciidoc.go
+++ b/libasciidoc.go
@@ -73,7 +73,10 @@ func Convert(r io.Reader, output io.Writer, config configuration.Configuration) 
 		return types.Metadata{}, err
 	}
 	// validate the document
-	problems := validator.Validate(&doc)
+	problems, err := validator.Validate(&doc)
+	if err != nil {
+		return types.Metadata{}, err
+	}
 	for _, problem := range problems {
 		switch problem.Severity {
 		case validator.Error:

--- a/pkg/parser/attributes_test.go
+++ b/pkg/parser/attributes_test.go
@@ -317,21 +317,21 @@ var _ = DescribeTable("valid block attributes",
 	},
 
 	// named attributes
-	Entry(`[foo1=bar1]`, `[foo1=bar1]`,
+	Entry(`[attr1=cookie]`, `[attr1=cookie]`,
 		types.Attributes{
-			`foo1`: `bar1`,
+			`attr1`: `cookie`,
 		},
 	),
-	Entry(`[foo1=bar1,foo2='bar2']`, `[foo1=bar1,foo2='bar2']`,
+	Entry(`[attr1=cookie,foo2='bar2']`, `[attr1=cookie,foo2='bar2']`,
 		types.Attributes{
-			`foo1`: `bar1`,
-			`foo2`: `bar2`,
+			`attr1`: `cookie`,
+			`foo2`:  `bar2`,
 		},
 	),
-	Entry(`[foo1=bar1,foo2=bar2]`, `[foo1=bar1,foo2="bar2"]`,
+	Entry(`[attr1=cookie,foo2=bar2]`, `[attr1=cookie,foo2="bar2"]`,
 		types.Attributes{
-			`foo1`: `bar1`,
-			`foo2`: `bar2`,
+			`attr1`: `cookie`,
+			`foo2`:  `bar2`,
 		},
 	),
 
@@ -572,6 +572,135 @@ var _ = DescribeTable("valid block attributes",
 	// TODO: attributes with substitutions
 )
 
+var _ = DescribeTable("valid inline attributes",
+
+	func(source string, expected types.Attributes) {
+		// given
+		log.Debugf("processing '%s'", source)
+		content := strings.NewReader(source + "\n")
+		// when parsing only (ie, no substitution applied)
+		result, err := parser.ParseReader("", content, parser.Entrypoint("InlineAttributes"))
+		// then
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(expected))
+	},
+
+	// ---------------------
+	// named attributes
+	// ---------------------
+	// named attributes with plain text value
+	Entry(`[attr1=cookie]`, `[attr1=cookie]`,
+		types.Attributes{
+			`attr1`: `cookie`,
+		},
+	),
+	Entry(`[attr1=cookie,attr2=chocolate]`, `[attr1=cookie,attr2=chocolate]`,
+		types.Attributes{
+			`attr1`: `cookie`,
+			"attr2": "chocolate",
+		},
+	),
+	// named attributes with single quoted values
+	Entry(`[attr1='cookie',attr2='chocolate']`, `[attr1='cookie',attr2='chocolate']`,
+		types.Attributes{
+			`attr1`: `cookie`,
+			"attr2": "chocolate",
+		},
+	),
+	// named attributes with double quoted values
+	Entry(`[attr1="cookie",attr2="chocolate"]`, `[attr1="cookie",attr2="chocolate"]`,
+		types.Attributes{
+			`attr1`: `cookie`,
+			"attr2": "chocolate",
+		},
+	),
+	// ---------------------
+	// positional attributes
+	// ---------------------
+	// unquoted positional attributes with plain text value
+	Entry(`[cookie,chocolate]`, `[cookie,chocolate]`,
+		types.Attributes{
+			types.AttrPositional1: "cookie",
+			types.AttrPositional2: "chocolate",
+		},
+	),
+	// unquoted positional attributes with quoted text value
+	Entry(`[*cookie*,_chocolate_]`, `[*cookie*,_chocolate_]`,
+		types.Attributes{
+			types.AttrPositional1: []interface{}{
+				types.QuotedText{
+					Kind: types.SingleQuoteBold,
+					Elements: []interface{}{
+						types.StringElement{
+							Content: "cookie",
+						},
+					},
+				},
+			},
+			types.AttrPositional2: []interface{}{
+				types.QuotedText{
+					Kind: types.SingleQuoteItalic,
+					Elements: []interface{}{
+						types.StringElement{
+							Content: "chocolate",
+						},
+					},
+				},
+			},
+		},
+	),
+	// single-quoted positional attributes with quoted text value
+	Entry(`[*cookie*,_chocolate_]`, `[*cookie*,_chocolate_]`,
+		types.Attributes{
+			types.AttrPositional1: []interface{}{
+				types.QuotedText{
+					Kind: types.SingleQuoteBold,
+					Elements: []interface{}{
+						types.StringElement{
+							Content: "cookie",
+						},
+					},
+				},
+			},
+			types.AttrPositional2: []interface{}{
+				types.QuotedText{
+					Kind: types.SingleQuoteItalic,
+					Elements: []interface{}{
+						types.StringElement{
+							Content: "chocolate",
+						},
+					},
+				},
+			},
+		},
+	),
+	// double-quoted positional attributes with quoted text value
+	Entry(`["*cookie*","_chocolate_"]`, `["*cookie*","_chocolate_"]`,
+		types.Attributes{
+			types.AttrPositional1: []interface{}{
+				types.QuotedText{
+					Kind: types.SingleQuoteBold,
+					Elements: []interface{}{
+						types.StringElement{
+							Content: "cookie",
+						},
+					},
+				},
+			},
+			types.AttrPositional2: []interface{}{
+				types.QuotedText{
+					Kind: types.SingleQuoteItalic,
+					Elements: []interface{}{
+						types.StringElement{
+							Content: "chocolate",
+						},
+					},
+				},
+			},
+		},
+	),
+)
+
 var _ = DescribeTable("invalid block attributes",
 
 	func(source string) {
@@ -584,7 +713,7 @@ var _ = DescribeTable("invalid block attributes",
 	},
 
 	// space after `[` is not allowed if more content exists
-	Entry(`[ foo1=bar1]`, `[ foo1=bar1]`),
+	Entry(`[ attr1=cookie]`, `[ attr1=cookie]`),
 
-	Entry(`[ foo1=bar1 ]`, `[ foo1=bar1 ]`),
+	Entry(`[ attr1=cookie ]`, `[ attr1=cookie ]`),
 )

--- a/pkg/parser/document_processing.go
+++ b/pkg/parser/document_processing.go
@@ -36,7 +36,10 @@ func ParseDocument(r io.Reader, config configuration.Configuration, options ...O
 
 	blocks, footnotes := processFootnotes(blocks)
 	// now, rearrange elements in a hierarchical manner
-	doc := rearrangeSections(blocks)
+	doc, err := rearrangeSections(blocks)
+	if err != nil {
+		return types.Document{}, err
+	}
 	// also, set the footnotes
 	doc.Footnotes = footnotes
 	// insert the preamble at the right location

--- a/pkg/parser/document_processing_apply_substitutions.go
+++ b/pkg/parser/document_processing_apply_substitutions.go
@@ -153,7 +153,11 @@ var substitutions = map[string]elementsSubstitution{
 
 func substitutionsFor(block types.WithCustomSubstitutions) ([]elementsSubstitution, error) {
 	subs := make(funcs, 0, len(substitutions))
-	for _, s := range block.SubstitutionsToApply() {
+	subsitutionsToApply, err := block.SubstitutionsToApply()
+	if err != nil {
+		return nil, err
+	}
+	for _, s := range subsitutionsToApply {
 		switch s {
 		case "normal":
 			subs = subs.append(

--- a/pkg/parser/document_processing_include_files.go
+++ b/pkg/parser/document_processing_include_files.go
@@ -170,7 +170,11 @@ func parseFileToInclude(ctx substitutionContext, incl types.FileInclusion, level
 		return content.Bytes(), nil
 	}
 	// parse the content, and returns the corresponding elements
-	if l, found := incl.Attributes.GetAsString(types.AttrLevelOffset); found {
+	l, found, err := incl.Attributes.GetAsString(types.AttrLevelOffset)
+	if err != nil {
+		return nil, err
+	}
+	if found {
 		offset, err := strconv.Atoi(l)
 		if err != nil {
 			return nil, errors.Wrap(err, "unable to read file to include")
@@ -196,7 +200,12 @@ func parseFileToInclude(ctx substitutionContext, incl types.FileInclusion, level
 // lineRanges parses the `lines` attribute if it exists in the given FileInclusion, and returns
 // a corresponding `LineRanges` (or `false` if parsing failed to invalid input)
 func lineRanges(incl types.FileInclusion, config configuration.Configuration) (types.LineRanges, bool) {
-	if lineRanges, exists := incl.Attributes.GetAsString(types.AttrLineRanges); exists {
+	lineRanges, exists, err := incl.Attributes.GetAsString(types.AttrLineRanges)
+	if err != nil {
+		log.Errorf("Unresolved directive in %s - %s", config.Filename, incl.RawText)
+		return types.LineRanges{}, false
+	}
+	if exists {
 		lr, err := Parse("", []byte(lineRanges), Entrypoint("LineRanges"))
 		if err != nil {
 			log.Errorf("Unresolved directive in %s - %s", config.Filename, incl.RawText)
@@ -210,7 +219,13 @@ func lineRanges(incl types.FileInclusion, config configuration.Configuration) (t
 // tagRanges parses the `tags` attribute if it exists in the given FileInclusion, and returns
 // a corresponding `TagRanges` (or `false` if parsing failed to invalid input)
 func tagRanges(incl types.FileInclusion, config configuration.Configuration) (types.TagRanges, bool) {
-	if tagRanges, exists := incl.Attributes.GetAsString(types.AttrTagRanges); exists {
+	tagRanges, exists, err := incl.Attributes.GetAsString(types.AttrTagRanges)
+	if err != nil {
+		log.Errorf("Unresolved directive in %s - %s", config.Filename, incl.RawText)
+		return types.TagRanges{}, false
+	}
+	log.Debugf("tag ranges to include: %v", spew.Sdump(tagRanges))
+	if exists {
 		tr, err := Parse("", []byte(tagRanges), Entrypoint("TagRanges"))
 		if err != nil {
 			log.Errorf("Unresolved directive in %s - %s", config.Filename, incl.RawText)

--- a/pkg/parser/generate.go
+++ b/pkg/parser/generate.go
@@ -1,3 +1,3 @@
 package parser
 
-//go:generate pigeon -optimize-parser -optimize-grammar -alternate-entrypoints RawSource,RawDocument,DocumentBlock,FileLocation,IncludedFileLine,LabeledListItemTerm,SpecialCharacterSubs,MarkdownQuoteAttribution,QuotedTextSubs,NoneSubs,AttributeSubs,ReplacementSubs,PostReplacementSubs,InlinePassthroughSubs,CalloutSubs,InlineMacroSubs,MarkdownQuoteMacroSubs,BlockAttributes,LineRanges,TagRanges -o parser.go parser.peg
+//go:generate pigeon -optimize-parser -optimize-grammar -alternate-entrypoints RawSource,RawDocument,DocumentBlock,FileLocation,IncludedFileLine,LabeledListItemTerm,SpecialCharacterSubs,MarkdownQuoteAttribution,QuotedTextSubs,NoneSubs,AttributeSubs,ReplacementSubs,PostReplacementSubs,InlinePassthroughSubs,CalloutSubs,InlineMacroSubs,MarkdownQuoteMacroSubs,BlockAttributes,InlineAttributes,LineRanges,TagRanges -o parser.go parser.peg

--- a/pkg/parser/image_test.go
+++ b/pkg/parser/image_test.go
@@ -92,6 +92,34 @@ image::images/foo.png[{alt}]`
 			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
 		})
 
+		It("with quoted text in attribute alt", func() {
+			source := `image::images/foo.png[*alt text*]`
+			expected := types.DraftDocument{
+				Elements: []interface{}{
+					types.ImageBlock{
+						Attributes: types.Attributes{
+							types.AttrImageAlt: []interface{}{
+								types.QuotedText{
+									Kind: types.SingleQuoteBold,
+									Elements: []interface{}{
+										types.StringElement{
+											Content: "alt text",
+										},
+									},
+								},
+							},
+						},
+						Location: types.Location{
+							Path: []interface{}{
+								types.StringElement{Content: "images/foo.png"},
+							},
+						},
+					},
+				},
+			}
+			Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
+		})
+
 		It("with dimensions and id link title meta", func() {
 			source := `[#img-foobar]
 .A title to foobar

--- a/pkg/parser/link_test.go
+++ b/pkg/parser/link_test.go
@@ -14,7 +14,7 @@ var _ = Describe("links", func() {
 
 		Context("external link", func() {
 
-			It("with special characters", func() {
+			It("with special characters in URL", func() {
 				source := `a link to https://example.com?a=1&b=2`
 				expected := types.DraftDocument{
 					Elements: []interface{}{
@@ -33,6 +33,43 @@ var _ = Describe("links", func() {
 												},
 												types.StringElement{
 													Content: "b=2",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+				Expect(ParseDraftDocument(source)).To(MatchDraftDocument(expected))
+			})
+
+			It("with quoted text in attributes", func() {
+				source := `a link to https://example.com[*alt text*]`
+				expected := types.DraftDocument{
+					Elements: []interface{}{
+						types.Paragraph{
+							Lines: [][]interface{}{
+								{types.StringElement{Content: "a link to "},
+									types.InlineLink{
+										Attributes: types.Attributes{
+											types.AttrInlineLinkText: []interface{}{
+												types.QuotedText{
+													Kind: types.SingleQuoteBold,
+													Elements: []interface{}{
+														types.StringElement{
+															Content: "alt text",
+														},
+													},
+												},
+											},
+										},
+										Location: types.Location{
+											Scheme: "https://",
+											Path: []interface{}{
+												types.StringElement{
+													Content: "example.com",
 												},
 											},
 										},

--- a/pkg/parser/parser.peg
+++ b/pkg/parser/parser.peg
@@ -425,7 +425,8 @@ AttributeValue <-
 SingleQuotedAttributeValue <- 
     "'" 
     elements:(
-        ([^'\r\n\uFFFD\\{]+ { // = and , signs are allowed within ' quotes 
+        QuotedText 
+        / ([^'\r\n\uFFFD\\{]+ { // = and , signs are allowed within ' quotes 
             return types.NewStringElement(string(c.text))
         })
         / ElementPlaceHolder
@@ -444,7 +445,8 @@ SingleQuotedAttributeValue <-
 DoubleQuotedAttributeValue <- 
     "\"" 
     elements:(
-        ([^\r\n\uFFFD"\\{]+ { // = and , signs are allowed within " quotes
+        QuotedText 
+        / ([^\r\n\uFFFD"\\{]+ { // = and , signs are allowed within " quotes
             return types.NewStringElement(string(c.text))
         }) 
         / ElementPlaceHolder
@@ -464,7 +466,8 @@ DoubleQuotedAttributeValue <-
 UnquotedAttributeValue <- 
     !Space
     elements:(
-        ([^,=\r\n\uFFFD{\]]+ {
+        QuotedText
+        / ([^,=\r\n\uFFFD{\]]+ {
             return types.NewStringElement(string(c.text))
         }) 
         / ElementPlaceHolder

--- a/pkg/renderer/sgml/attribution.go
+++ b/pkg/renderer/sgml/attribution.go
@@ -10,37 +10,43 @@ type Attribution struct { // TODO: unexport this type?
 
 // paragraphAttribution return a new attribution for the given Paragraph.
 // Can be empty if no attribution was specified.
-func paragraphAttribution(p types.Paragraph) Attribution {
+func paragraphAttribution(p types.Paragraph) (Attribution, error) {
 	return newAttribution(p.Attributes)
 }
 
 // quoteBlockAttribution return a new attribution for the given QuoteBlock.
 // Can be empty if no attribution was specified.
-func quoteBlockAttribution(b types.QuoteBlock) Attribution {
+func quoteBlockAttribution(b types.QuoteBlock) (Attribution, error) {
 	return newAttribution(b.Attributes)
 }
 
 // verseBlockAttribution return a new attribution for the given VerseBlock.
 // Can be empty if no attribution was specified.
-func verseBlockAttribution(b types.VerseBlock) Attribution {
+func verseBlockAttribution(b types.VerseBlock) (Attribution, error) {
 	return newAttribution(b.Attributes)
 }
 
 // markdownQuoteBlockAttribution return a new attribution for the given MarkdownQuoteBlock.
 // Can be empty if no attribution was specified.
-func markdownQuoteBlockAttribution(b types.MarkdownQuoteBlock) Attribution {
+func markdownQuoteBlockAttribution(b types.MarkdownQuoteBlock) (Attribution, error) {
 	return newAttribution(b.Attributes)
 }
 
-func newAttribution(attrs types.Attributes) Attribution {
+func newAttribution(attrs types.Attributes) (Attribution, error) {
 	result := Attribution{}
-	if author, found := attrs.GetAsString(types.AttrQuoteAuthor); found {
+	if author, found, err := attrs.GetAsString(types.AttrQuoteAuthor); err != nil {
+		return Attribution{}, err
+	} else if found {
 		result.First = author
-		if title, found := attrs.GetAsString(types.AttrQuoteTitle); found {
+		if title, found, err := attrs.GetAsString(types.AttrQuoteTitle); err != nil {
+			return Attribution{}, err
+		} else if found {
 			result.Second = title
 		}
-	} else if title, found := attrs.GetAsString(types.AttrQuoteTitle); found {
+	} else if title, found, err := attrs.GetAsString(types.AttrQuoteTitle); err != nil {
+		return Attribution{}, err
+	} else if found {
 		result.First = title
 	}
-	return result
+	return result, nil
 }

--- a/pkg/renderer/sgml/callout_list.go
+++ b/pkg/renderer/sgml/callout_list.go
@@ -24,6 +24,11 @@ func (r *sgmlRenderer) renderCalloutList(ctx *renderer.Context, l types.CalloutL
 	if err != nil {
 		return "", errors.Wrap(err, "unable to render callout list roles")
 	}
+	title, err := r.renderElementTitle(l.Attributes)
+	if err != nil {
+		return "", errors.Wrap(err, "unable to render callout list roles")
+	}
+
 	err = r.calloutList.Execute(result, struct {
 		Context *renderer.Context
 		ID      string
@@ -34,7 +39,7 @@ func (r *sgmlRenderer) renderCalloutList(ctx *renderer.Context, l types.CalloutL
 	}{
 		Context: ctx,
 		ID:      r.renderElementID(l.Attributes),
-		Title:   r.renderElementTitle(l.Attributes),
+		Title:   title,
 		Roles:   roles,
 		Content: string(content.String()),
 		Items:   l.Items,

--- a/pkg/renderer/sgml/delimited_block_admonition.go
+++ b/pkg/renderer/sgml/delimited_block_admonition.go
@@ -10,7 +10,10 @@ import (
 )
 
 func (r *sgmlRenderer) renderAdmonitionBlock(ctx *renderer.Context, b types.ExampleBlock) (string, error) {
-	kind, _ := b.Attributes.GetAsString(types.AttrStyle)
+	kind, _, err := b.Attributes.GetAsString(types.AttrStyle)
+	if err != nil {
+		return "", err
+	}
 	kind = strings.ToLower(kind)
 	icon, err := r.renderIcon(ctx, types.Icon{Class: strings.ToLower(kind), Attributes: b.Attributes}, true)
 	if err != nil {
@@ -26,6 +29,11 @@ func (r *sgmlRenderer) renderAdmonitionBlock(ctx *renderer.Context, b types.Exam
 	if err != nil {
 		return "", errors.Wrap(err, "unable to render fenced block content")
 	}
+	title, err := r.renderElementTitle(b.Attributes)
+	if err != nil {
+		return "", errors.Wrap(err, "unable to render callout list roles")
+	}
+
 	err = r.admonitionBlock.Execute(result, struct {
 		Context *renderer.Context
 		ID      string
@@ -39,7 +47,7 @@ func (r *sgmlRenderer) renderAdmonitionBlock(ctx *renderer.Context, b types.Exam
 		ID:      r.renderElementID(b.Attributes),
 		Kind:    kind,
 		Roles:   roles,
-		Title:   r.renderElementTitle(b.Attributes),
+		Title:   title,
 		Icon:    icon,
 		Content: content,
 	})
@@ -49,7 +57,10 @@ func (r *sgmlRenderer) renderAdmonitionBlock(ctx *renderer.Context, b types.Exam
 func (r *sgmlRenderer) renderAdmonitionParagraph(ctx *renderer.Context, p types.Paragraph) (string, error) {
 	log.Debug("rendering admonition paragraph...")
 	result := &strings.Builder{}
-	kind, ok := p.Attributes.GetAsString(types.AttrStyle)
+	kind, ok, err := p.Attributes.GetAsString(types.AttrStyle)
+	if err != nil {
+		return "", err
+	}
 	if !ok {
 		return "", errors.Errorf("failed to render admonition with unknown kind: %T", p.Attributes[types.AttrStyle])
 	}
@@ -66,6 +77,11 @@ func (r *sgmlRenderer) renderAdmonitionParagraph(ctx *renderer.Context, p types.
 	if err != nil {
 		return "", errors.Wrap(err, "unable to render fenced block content")
 	}
+	title, err := r.renderElementTitle(p.Attributes)
+	if err != nil {
+		return "", errors.Wrap(err, "unable to render callout list roles")
+	}
+
 	err = r.admonitionParagraph.Execute(result, struct {
 		Context *renderer.Context
 		ID      string
@@ -78,7 +94,7 @@ func (r *sgmlRenderer) renderAdmonitionParagraph(ctx *renderer.Context, p types.
 	}{
 		Context: ctx,
 		ID:      r.renderElementID(p.Attributes),
-		Title:   r.renderElementTitle(p.Attributes),
+		Title:   title,
 		Kind:    kind,
 		Roles:   roles,
 		Icon:    icon,

--- a/pkg/renderer/sgml/delimited_block_example.go
+++ b/pkg/renderer/sgml/delimited_block_example.go
@@ -27,7 +27,10 @@ func (r *sgmlRenderer) renderExampleBlock(ctx *renderer.Context, b types.Example
 	if err != nil {
 		return "", errors.Wrap(err, "unable to render fenced block content")
 	}
-	c, ok := b.Attributes.GetAsString(types.AttrCaption)
+	c, ok, err := b.Attributes.GetAsString(types.AttrCaption)
+	if err != nil {
+		return "", errors.Wrap(err, "unable to render fenced block content")
+	}
 	if !ok {
 		c = ctx.Attributes.GetAsStringWithDefault(types.AttrExampleCaption, "Example")
 		if c != "" {
@@ -38,6 +41,10 @@ func (r *sgmlRenderer) renderExampleBlock(ctx *renderer.Context, b types.Example
 	if strings.Contains(c, "{counter:example-number}") {
 		number = ctx.GetAndIncrementExampleBlockCounter()
 		c = strings.ReplaceAll(c, "{counter:example-number}", strconv.Itoa(number))
+	}
+	title, err := r.renderElementTitle(b.Attributes)
+	if err != nil {
+		return "", errors.Wrap(err, "unable to render callout list roles")
 	}
 	caption.WriteString(c)
 	err = r.exampleBlock.Execute(result, struct {
@@ -51,7 +58,7 @@ func (r *sgmlRenderer) renderExampleBlock(ctx *renderer.Context, b types.Example
 	}{
 		Context:       ctx,
 		ID:            r.renderElementID(b.Attributes),
-		Title:         r.renderElementTitle(b.Attributes),
+		Title:         title,
 		Caption:       caption.String(),
 		Roles:         roles,
 		ExampleNumber: number,
@@ -71,6 +78,10 @@ func (r *sgmlRenderer) renderExampleParagraph(ctx *renderer.Context, p types.Par
 	if err != nil {
 		return "", errors.Wrap(err, "unable to render fenced block content")
 	}
+	title, err := r.renderElementTitle(p.Attributes)
+	if err != nil {
+		return "", errors.Wrap(err, "unable to render callout list roles")
+	}
 	err = r.exampleBlock.Execute(result, struct {
 		Context       *renderer.Context
 		ID            string
@@ -83,7 +94,7 @@ func (r *sgmlRenderer) renderExampleParagraph(ctx *renderer.Context, p types.Par
 		Context: ctx,
 		Roles:   roles,
 		ID:      r.renderElementID(p.Attributes),
-		Title:   r.renderElementTitle(p.Attributes),
+		Title:   title,
 		Content: string(content) + "\n",
 	})
 

--- a/pkg/renderer/sgml/delimited_block_fenced.go
+++ b/pkg/renderer/sgml/delimited_block_fenced.go
@@ -24,6 +24,10 @@ func (r *sgmlRenderer) renderFencedBlock(ctx *renderer.Context, b types.FencedBl
 	if err != nil {
 		return "", errors.Wrap(err, "unable to render fenced block roles")
 	}
+	title, err := r.renderElementTitle(b.Attributes)
+	if err != nil {
+		return "", errors.Wrap(err, "unable to render callout list roles")
+	}
 
 	err = r.fencedBlock.Execute(result, struct {
 		Context *renderer.Context
@@ -34,7 +38,7 @@ func (r *sgmlRenderer) renderFencedBlock(ctx *renderer.Context, b types.FencedBl
 	}{
 		Context: ctx,
 		ID:      r.renderElementID(b.Attributes),
-		Title:   r.renderElementTitle(b.Attributes),
+		Title:   title,
 		Roles:   roles,
 		Content: content,
 	})

--- a/pkg/renderer/sgml/delimited_block_listing.go
+++ b/pkg/renderer/sgml/delimited_block_listing.go
@@ -27,6 +27,10 @@ func (r *sgmlRenderer) renderListingBlock(ctx *renderer.Context, b types.Listing
 	if err != nil {
 		return "", errors.Wrap(err, "unable to render listing block roles")
 	}
+	title, err := r.renderElementTitle(b.Attributes)
+	if err != nil {
+		return "", errors.Wrap(err, "unable to render callout list roles")
+	}
 
 	err = r.listingBlock.Execute(result, struct {
 		Context *renderer.Context
@@ -37,7 +41,7 @@ func (r *sgmlRenderer) renderListingBlock(ctx *renderer.Context, b types.Listing
 	}{
 		Context: ctx,
 		ID:      r.renderElementID(b.Attributes),
-		Title:   r.renderElementTitle(b.Attributes),
+		Title:   title,
 		Roles:   roles,
 		Content: content,
 	})
@@ -54,6 +58,10 @@ func (r *sgmlRenderer) renderListingParagraph(ctx *renderer.Context, p types.Par
 	if err != nil {
 		return "", errors.Wrap(err, "unable to render listing block roles")
 	}
+	title, err := r.renderElementTitle(p.Attributes)
+	if err != nil {
+		return "", errors.Wrap(err, "unable to render callout list roles")
+	}
 
 	err = r.listingBlock.Execute(result, struct {
 		Context *renderer.Context
@@ -64,7 +72,7 @@ func (r *sgmlRenderer) renderListingParagraph(ctx *renderer.Context, p types.Par
 	}{
 		Context: ctx,
 		ID:      r.renderElementID(p.Attributes),
-		Title:   r.renderElementTitle(p.Attributes),
+		Title:   title,
 		Roles:   roles,
 		Content: content,
 	})

--- a/pkg/renderer/sgml/delimited_block_markdown_quote.go
+++ b/pkg/renderer/sgml/delimited_block_markdown_quote.go
@@ -18,6 +18,15 @@ func (r *sgmlRenderer) renderMarkdownQuoteBlock(ctx *renderer.Context, b types.M
 	if err != nil {
 		return "", errors.Wrap(err, "unable to render fenced block content")
 	}
+	attribution, err := markdownQuoteBlockAttribution(b)
+	if err != nil {
+		return "", errors.Wrap(err, "unable to render fenced block content")
+	}
+	title, err := r.renderElementTitle(b.Attributes)
+	if err != nil {
+		return "", errors.Wrap(err, "unable to render callout list roles")
+	}
+
 	err = r.markdownQuoteBlock.Execute(result, struct {
 		Context     *renderer.Context
 		ID          string
@@ -28,9 +37,9 @@ func (r *sgmlRenderer) renderMarkdownQuoteBlock(ctx *renderer.Context, b types.M
 	}{
 		Context:     ctx,
 		ID:          r.renderElementID(b.Attributes),
-		Title:       r.renderElementTitle(b.Attributes),
+		Title:       title,
 		Roles:       roles,
-		Attribution: markdownQuoteBlockAttribution(b),
+		Attribution: attribution,
 		Content:     content,
 	})
 	return result.String(), err

--- a/pkg/renderer/sgml/delimited_block_quote.go
+++ b/pkg/renderer/sgml/delimited_block_quote.go
@@ -19,6 +19,15 @@ func (r *sgmlRenderer) renderQuoteBlock(ctx *renderer.Context, b types.QuoteBloc
 	if err != nil {
 		return "", errors.Wrap(err, "unable to render fenced block content")
 	}
+	attribution, err := quoteBlockAttribution(b)
+	if err != nil {
+		return "", errors.Wrap(err, "unable to render fenced block content")
+	}
+	title, err := r.renderElementTitle(b.Attributes)
+	if err != nil {
+		return "", errors.Wrap(err, "unable to render callout list roles")
+	}
+
 	err = r.quoteBlock.Execute(result, struct {
 		Context     *renderer.Context
 		ID          string
@@ -29,9 +38,9 @@ func (r *sgmlRenderer) renderQuoteBlock(ctx *renderer.Context, b types.QuoteBloc
 	}{
 		Context:     ctx,
 		ID:          r.renderElementID(b.Attributes),
-		Title:       r.renderElementTitle(b.Attributes),
+		Title:       title,
 		Roles:       roles,
-		Attribution: quoteBlockAttribution(b),
+		Attribution: attribution,
 		Content:     content,
 	})
 	return result.String(), err
@@ -45,6 +54,15 @@ func (r *sgmlRenderer) renderQuoteParagraph(ctx *renderer.Context, p types.Parag
 	if err != nil {
 		return "", errors.Wrap(err, "unable to render quote paragraph lines")
 	}
+	attribution, err := paragraphAttribution(p)
+	if err != nil {
+		return "", errors.Wrap(err, "unable to render quote paragraph lines")
+	}
+	title, err := r.renderElementTitle(p.Attributes)
+	if err != nil {
+		return "", errors.Wrap(err, "unable to render callout list roles")
+	}
+
 	err = r.quoteParagraph.Execute(result, struct {
 		Context     *renderer.Context
 		ID          string
@@ -55,8 +73,8 @@ func (r *sgmlRenderer) renderQuoteParagraph(ctx *renderer.Context, p types.Parag
 	}{
 		Context:     ctx,
 		ID:          r.renderElementID(p.Attributes),
-		Title:       r.renderElementTitle(p.Attributes),
-		Attribution: paragraphAttribution(p),
+		Title:       title,
+		Attribution: attribution,
 		Content:     string(content),
 		Lines:       p.Lines,
 	})

--- a/pkg/renderer/sgml/delimited_block_sidebar.go
+++ b/pkg/renderer/sgml/delimited_block_sidebar.go
@@ -20,6 +20,11 @@ func (r *sgmlRenderer) renderSidebarBlock(ctx *renderer.Context, b types.Sidebar
 	if err != nil {
 		return "", errors.Wrap(err, "unable to render fenced block content")
 	}
+	title, err := r.renderElementTitle(b.Attributes)
+	if err != nil {
+		return "", errors.Wrap(err, "unable to render callout list roles")
+	}
+
 	err = r.sidebarBlock.Execute(result, struct {
 		Context *renderer.Context
 		ID      string
@@ -29,7 +34,7 @@ func (r *sgmlRenderer) renderSidebarBlock(ctx *renderer.Context, b types.Sidebar
 	}{
 		Context: ctx,
 		ID:      r.renderElementID(b.Attributes),
-		Title:   r.renderElementTitle(b.Attributes),
+		Title:   title,
 		Roles:   roles,
 		Content: content,
 	})

--- a/pkg/renderer/sgml/delimited_block_verse.go
+++ b/pkg/renderer/sgml/delimited_block_verse.go
@@ -24,6 +24,14 @@ func (r *sgmlRenderer) renderVerseBlock(ctx *renderer.Context, b types.VerseBloc
 	if err != nil {
 		return "", errors.Wrap(err, "unable to render verse block")
 	}
+	attribution, err := verseBlockAttribution(b)
+	if err != nil {
+		return "", errors.Wrap(err, "unable to render verse block")
+	}
+	title, err := r.renderElementTitle(b.Attributes)
+	if err != nil {
+		return "", errors.Wrap(err, "unable to render callout list roles")
+	}
 
 	err = r.verseBlock.Execute(result, struct {
 		Context     *renderer.Context
@@ -35,9 +43,9 @@ func (r *sgmlRenderer) renderVerseBlock(ctx *renderer.Context, b types.VerseBloc
 	}{
 		Context:     ctx,
 		ID:          r.renderElementID(b.Attributes),
-		Title:       r.renderElementTitle(b.Attributes),
+		Title:       title,
 		Roles:       roles,
-		Attribution: verseBlockAttribution(b),
+		Attribution: attribution,
 		Content:     string(content),
 	})
 	return result.String(), err
@@ -51,6 +59,15 @@ func (r *sgmlRenderer) renderVerseParagraph(ctx *renderer.Context, p types.Parag
 	if err != nil {
 		return "", errors.Wrap(err, "unable to render verse paragraph lines")
 	}
+	attribution, err := paragraphAttribution(p)
+	if err != nil {
+		return "", errors.Wrap(err, "unable to render verse block")
+	}
+	title, err := r.renderElementTitle(p.Attributes)
+	if err != nil {
+		return "", errors.Wrap(err, "unable to render callout list roles")
+	}
+
 	err = r.verseParagraph.Execute(result, struct {
 		Context     *renderer.Context
 		ID          string
@@ -61,8 +78,8 @@ func (r *sgmlRenderer) renderVerseParagraph(ctx *renderer.Context, p types.Parag
 	}{
 		Context:     ctx,
 		ID:          r.renderElementID(p.Attributes),
-		Title:       r.renderElementTitle(p.Attributes),
-		Attribution: paragraphAttribution(p),
+		Title:       title,
+		Attribution: attribution,
 		Content:     string(content),
 		Lines:       p.Lines,
 	})

--- a/pkg/renderer/sgml/document_details.go
+++ b/pkg/renderer/sgml/document_details.go
@@ -18,9 +18,18 @@ func (r *sgmlRenderer) renderDocumentDetails(ctx *renderer.Context) (*string, er
 		}
 		documentDetailsBuff := &bytes.Buffer{}
 		revLabel := ctx.Attributes.GetAsStringWithDefault("version-label", "version")
-		revNumber, _ := ctx.Attributes.GetAsString("revnumber")
-		revDate, _ := ctx.Attributes.GetAsString("revdate")
-		revRemark, _ := ctx.Attributes.GetAsString("revremark")
+		revNumber, _, err := ctx.Attributes.GetAsString("revnumber")
+		if err != nil {
+			return nil, errors.Wrap(err, "error while rendering the document details")
+		}
+		revDate, _, err := ctx.Attributes.GetAsString("revdate")
+		if err != nil {
+			return nil, errors.Wrap(err, "error while rendering the document details")
+		}
+		revRemark, _, err := ctx.Attributes.GetAsString("revremark")
+		if err != nil {
+			return nil, errors.Wrap(err, "error while rendering the document details")
+		}
 		err = r.documentDetails.Execute(documentDetailsBuff, struct {
 			Authors   string
 			RevLabel  string
@@ -60,12 +69,17 @@ func (r *sgmlRenderer) renderDocumentAuthorsDetails(ctx *renderer.Context) (*str
 			emailKey = "email_" + index
 		}
 		// having at least one author is the minimal requirement for document details
-		if author, ok := ctx.Attributes.GetAsString(authorKey); ok {
+		if author, ok, err := ctx.Attributes.GetAsString(authorKey); err != nil {
+			return nil, errors.Wrap(err, "error while rendering the document details")
+		} else if ok {
 			if i > 1 {
 				authorsDetailsBuff.WriteString("\n")
 			}
-			email, _ := ctx.Attributes.GetAsString(emailKey)
-			err := r.documentAuthorDetails.Execute(authorsDetailsBuff, struct {
+			email, _, err := ctx.Attributes.GetAsString(emailKey)
+			if err != nil {
+				return nil, errors.Wrap(err, "error while rendering the document details")
+			}
+			err = r.documentAuthorDetails.Execute(authorsDetailsBuff, struct {
 				Index string
 				Name  string
 				Email string

--- a/pkg/renderer/sgml/element_role.go
+++ b/pkg/renderer/sgml/element_role.go
@@ -25,10 +25,14 @@ func (r *sgmlRenderer) renderElementRoles(ctx *Context, attrs types.Attributes) 
 // Image roles add float and alignment attributes -- we turn these into roles.
 func (r *sgmlRenderer) renderImageRoles(ctx *Context, attrs types.Attributes) (string, error) {
 	var result []string
-	if val, ok := attrs.GetAsString(types.AttrFloat); ok {
+	if val, ok, err := attrs.GetAsString(types.AttrFloat); err != nil {
+		return "", err
+	} else if ok {
 		result = append(result, val)
 	}
-	if val, ok := attrs.GetAsString(types.AttrImageAlign); ok {
+	if val, ok, err := attrs.GetAsString(types.AttrImageAlign); err != nil {
+		return "", err
+	} else if ok {
 		result = append(result, "text-"+val)
 	}
 	if roles, ok := attrs[types.AttrRoles].([]interface{}); ok {

--- a/pkg/renderer/sgml/html5/image_test.go
+++ b/pkg/renderer/sgml/html5/image_test.go
@@ -59,6 +59,17 @@ var _ = Describe("images", func() {
 			Expect(RenderHTML(source)).To(MatchHTML(expected))
 		})
 
+		It("with quoted text in attribute alt", func() {
+			// alt text is rendered as-is, even if it's rich
+			source := `image::images/foo.png[*alt text*, 600, 400]`
+			expected := `<div class="imageblock">
+<div class="content">
+<img src="images/foo.png" alt="*alt text*" width="600" height="400">
+</div>
+</div>
+`
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+		})
 		It("with custom caption", func() {
 			// TODO: split on multiple lines for readability
 			source := ".Image Title\nimage::foo.png[foo image, 600, 400,caption=\"Bar A. \"]"

--- a/pkg/renderer/sgml/image.go
+++ b/pkg/renderer/sgml/image.go
@@ -13,25 +13,29 @@ import (
 
 func (r *sgmlRenderer) renderImageBlock(ctx *renderer.Context, img types.ImageBlock) (string, error) {
 	result := &strings.Builder{}
-	caption := &strings.Builder{}
-	number := 0
-	title := r.renderElementTitle(img.Attributes)
+	title, err := r.renderElementTitle(img.Attributes)
+	if err != nil {
+		return "", errors.Wrap(err, "unable to render image")
+	}
 
 	// Matching asciidoctor behavior, we increment the counter if we have a title,
 	// regardless if we have a number or not. This will probably lead to confusion
 	// if mixed custom and stock captioning is used.
-	if _, found := img.Attributes.GetAsString(types.AttrTitle); found {
-		c, ok := img.Attributes.GetAsString(types.AttrCaption)
-		if !ok {
-			c = ctx.Attributes.GetAsStringWithDefault(types.AttrFigureCaption, "Figure")
-			if c != "" {
+	caption := &strings.Builder{}
+	number := 0
+	if title != "" {
+		c, found, err := img.Attributes.GetAsString(types.AttrCaption)
+		if err != nil {
+			return "", errors.Wrap(err, "unable to render image")
+		} else if !found {
+			if c = ctx.Attributes.GetAsStringWithDefault(types.AttrFigureCaption, "Figure"); c != "" {
 				// We always append the figure number, unless the caption is disabled.
 				// This is for asciidoctor compatibility.
 				c += " {counter:figure-number}. "
 			}
 		}
-		// TODO: Replace this hack when we have attribute substitution fully working
 		if strings.Contains(c, "{counter:figure-number}") {
+			// TODO: Replace this hack when we have attribute substitution fully working
 			number = ctx.GetAndIncrementImageCounter()
 			c = strings.ReplaceAll(c, "{counter:figure-number}", strconv.Itoa(number))
 		}
@@ -87,6 +91,11 @@ func (r *sgmlRenderer) renderInlineImage(ctx *Context, img types.InlineImage) (s
 	if err != nil {
 		return "", errors.Wrap(err, "unable to render image")
 	}
+	title, err := r.renderElementTitle(img.Attributes)
+	if err != nil {
+		return "", errors.Wrap(err, "unable to render callout list roles")
+	}
+
 	err = r.inlineImage.Execute(result, struct {
 		Roles  string
 		Title  string
@@ -96,7 +105,7 @@ func (r *sgmlRenderer) renderInlineImage(ctx *Context, img types.InlineImage) (s
 		Height string
 		Path   string
 	}{
-		Title:  r.renderElementTitle(img.Attributes),
+		Title:  title,
 		Roles:  roles,
 		Href:   img.Attributes.GetAsStringWithDefault(types.AttrInlineLink, ""),
 		Alt:    alt,
@@ -113,7 +122,9 @@ func (r *sgmlRenderer) renderInlineImage(ctx *Context, img types.InlineImage) (s
 }
 
 func (r *sgmlRenderer) renderImageAlt(attrs types.Attributes, path string) (string, error) {
-	if alt, found := attrs.GetAsString(types.AttrImageAlt); found {
+	if alt, found, err := attrs.GetAsString(types.AttrImageAlt); err != nil {
+		return "", errors.Wrap(err, "unable to render image")
+	} else if found {
 		return alt, nil
 	}
 	u, err := url.Parse(path)

--- a/pkg/renderer/sgml/labeled_list.go
+++ b/pkg/renderer/sgml/labeled_list.go
@@ -26,6 +26,10 @@ func (r *sgmlRenderer) renderLabeledList(ctx *renderer.Context, l types.LabeledL
 	if err != nil {
 		return "", errors.Wrap(err, "unable to render labeled list roles")
 	}
+	title, err := r.renderElementTitle(l.Attributes)
+	if err != nil {
+		return "", errors.Wrap(err, "unable to render callout list roles")
+	}
 	result := &strings.Builder{}
 	// here we must preserve the HTML tags
 	err = tmpl.Execute(result, struct {
@@ -38,7 +42,7 @@ func (r *sgmlRenderer) renderLabeledList(ctx *renderer.Context, l types.LabeledL
 	}{
 		Context: ctx,
 		ID:      r.renderElementID(l.Attributes),
-		Title:   r.renderElementTitle(l.Attributes),
+		Title:   title,
 		Roles:   roles,
 		Content: string(content.String()),
 		Items:   l.Items,

--- a/pkg/renderer/sgml/literal_blocks.go
+++ b/pkg/renderer/sgml/literal_blocks.go
@@ -45,6 +45,11 @@ func (r *sgmlRenderer) renderLiteralBlock(ctx *renderer.Context, b types.Literal
 	if err != nil {
 		return "", errors.Wrap(err, "unable to render literal block roles")
 	}
+	title, err := r.renderElementTitle(b.Attributes)
+	if err != nil {
+		return "", errors.Wrap(err, "unable to render callout list roles")
+	}
+
 	result := &strings.Builder{}
 	err = r.literalBlock.Execute(result, struct {
 		Context *renderer.Context
@@ -55,7 +60,7 @@ func (r *sgmlRenderer) renderLiteralBlock(ctx *renderer.Context, b types.Literal
 	}{
 		Context: ctx,
 		ID:      r.renderElementID(b.Attributes),
-		Title:   r.renderElementTitle(b.Attributes),
+		Title:   title,
 		Roles:   roles,
 		Content: strings.Join(lines, "\n"),
 	})

--- a/pkg/renderer/sgml/table.go
+++ b/pkg/renderer/sgml/table.go
@@ -41,8 +41,10 @@ func (r *sgmlRenderer) renderTable(ctx *renderer.Context, t types.Table) (string
 	}
 
 	if t.Attributes.Has(types.AttrTitle) {
-		c, ok := t.Attributes.GetAsString(types.AttrCaption)
-		if !ok {
+		c, ok, err := t.Attributes.GetAsString(types.AttrCaption)
+		if err != nil {
+			return "", err
+		} else if !ok {
 			c = ctx.Attributes.GetAsStringWithDefault(types.AttrTableCaption, "Table")
 			if c != "" {
 				// We always append the figure number, unless the caption is disabled.
@@ -50,7 +52,6 @@ func (r *sgmlRenderer) renderTable(ctx *renderer.Context, t types.Table) (string
 				c += " {counter:table-number}. "
 			}
 		}
-
 		// TODO: This is a very primitive and incomplete replacement of the counter attribute only.
 		// This should be removed when attribute values are allowed to contain attributes.
 		// Also this expansion should be limited to just singly quoted strings in the Attribute list,
@@ -75,6 +76,10 @@ func (r *sgmlRenderer) renderTable(ctx *renderer.Context, t types.Table) (string
 	if err != nil {
 		return "", errors.Wrap(err, "unable to render table roles")
 	}
+	title, err := r.renderElementTitle(t.Attributes)
+	if err != nil {
+		return "", errors.Wrap(err, "unable to render callout list roles")
+	}
 
 	err = r.table.Execute(result, struct {
 		Context     *renderer.Context
@@ -93,7 +98,7 @@ func (r *sgmlRenderer) renderTable(ctx *renderer.Context, t types.Table) (string
 		Body        string
 	}{
 		Context:     ctx,
-		Title:       r.renderElementTitle(t.Attributes),
+		Title:       title,
 		Columns:     t.Columns,
 		TableNumber: number,
 		Caption:     caption.String(),

--- a/pkg/renderer/sgml/table_of_contents.go
+++ b/pkg/renderer/sgml/table_of_contents.go
@@ -148,7 +148,9 @@ func (r *sgmlRenderer) visitSection(ctx *renderer.Context, section types.Section
 
 func getTableOfContentsLevels(ctx *renderer.Context) (int, error) {
 	// log.Debugf("doc attributes: %v", ctx.Attributes)
-	if l, found := ctx.Attributes.GetAsString(types.AttrTableOfContentsLevels); found {
+	if l, found, err := ctx.Attributes.GetAsString(types.AttrTableOfContentsLevels); err != nil {
+		return -1, err
+	} else if found {
 		// log.Debugf("ToC levels: '%s'", l)
 		return strconv.Atoi(l)
 	}

--- a/pkg/renderer/sgml/unordered_list.go
+++ b/pkg/renderer/sgml/unordered_list.go
@@ -29,6 +29,10 @@ func (r *sgmlRenderer) renderUnorderedList(ctx *renderer.Context, l types.Unorde
 	if err != nil {
 		return "", errors.Wrap(err, "unable to render unordered list roles")
 	}
+	title, err := r.renderElementTitle(l.Attributes)
+	if err != nil {
+		return "", errors.Wrap(err, "unable to render callout list roles")
+	}
 
 	// here we must preserve the HTML tags
 	err = r.unorderedList.Execute(result, struct {
@@ -43,7 +47,7 @@ func (r *sgmlRenderer) renderUnorderedList(ctx *renderer.Context, l types.Unorde
 	}{
 		Context:   ctx,
 		ID:        r.renderElementID(l.Attributes),
-		Title:     r.renderElementTitle(l.Attributes),
+		Title:     title,
 		Checklist: checkList,
 		Items:     l.Items,
 		Content:   string(content.String()),

--- a/pkg/types/table.go
+++ b/pkg/types/table.go
@@ -48,7 +48,10 @@ func (t Table) parseNum(c string) (int, string) {
 }
 
 func (t Table) parseColumnsAttr() ([]TableColumn, error) {
-	attr, ok := t.Attributes.GetAsString(AttrCols)
+	attr, ok, err := t.Attributes.GetAsString(AttrCols)
+	if err != nil {
+		return nil, err
+	}
 	if !ok {
 		return nil, nil
 	}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -143,7 +143,7 @@ type RawText interface {
 
 // WithCustomSubstitutions base interface for types on which custom substitutions apply
 type WithCustomSubstitutions interface {
-	SubstitutionsToApply() []string
+	SubstitutionsToApply() ([]string, error)
 	DefaultSubstitutions() []string
 }
 
@@ -1422,11 +1422,13 @@ func (p Paragraph) ReplaceAttributes(attributes Attributes) interface{} {
 var _ WithLineSubstitution = Paragraph{}
 
 // SubstitutionsToApply returns the name of the substitutions to apply
-func (p Paragraph) SubstitutionsToApply() []string {
-	if subs, found := p.Attributes.GetAsString(AttrSubstitutions); found {
-		return strings.Split(subs, ",")
+func (p Paragraph) SubstitutionsToApply() ([]string, error) {
+	if subs, found, err := p.Attributes.GetAsString(AttrSubstitutions); err != nil {
+		return nil, err
+	} else if found {
+		return strings.Split(subs, ","), nil
 	}
-	return p.DefaultSubstitutions()
+	return p.DefaultSubstitutions(), nil
 }
 
 // DefaultSubstitutions the default substitutions for the paragraph
@@ -1875,11 +1877,13 @@ func NewExampleBlock(elements []interface{}, attributes interface{}) (ExampleBlo
 var _ WithNestedElementSubstitution = ExampleBlock{}
 
 // SubstitutionsToApply returns the name of the substitutions to apply
-func (b ExampleBlock) SubstitutionsToApply() []string {
-	if subs, found := b.Attributes.GetAsString(AttrSubstitutions); found {
-		return strings.Split(subs, ",")
+func (b ExampleBlock) SubstitutionsToApply() ([]string, error) {
+	if subs, found, err := b.Attributes.GetAsString(AttrSubstitutions); err != nil {
+		return nil, err
+	} else if found {
+		return strings.Split(subs, ","), nil
 	}
-	return b.DefaultSubstitutions()
+	return b.DefaultSubstitutions(), nil
 }
 
 // DefaultSubstitutions the default substitutions for the paragraph
@@ -1934,11 +1938,13 @@ func NewQuoteBlock(elements []interface{}, attributes interface{}) (QuoteBlock, 
 var _ WithNestedElementSubstitution = QuoteBlock{}
 
 // SubstitutionsToApply returns the name of the substitutions to apply
-func (b QuoteBlock) SubstitutionsToApply() []string {
-	if subs, found := b.Attributes.GetAsString(AttrSubstitutions); found {
-		return strings.Split(subs, ",")
+func (b QuoteBlock) SubstitutionsToApply() ([]string, error) {
+	if subs, found, err := b.Attributes.GetAsString(AttrSubstitutions); err != nil {
+		return nil, err
+	} else if found {
+		return strings.Split(subs, ","), nil
 	}
-	return b.DefaultSubstitutions()
+	return b.DefaultSubstitutions(), nil
 }
 
 // DefaultSubstitutions the default substitutions for the paragraph
@@ -1991,11 +1997,13 @@ func NewSidebarBlock(elements []interface{}, attributes interface{}) (SidebarBlo
 var _ WithNestedElementSubstitution = SidebarBlock{}
 
 // SubstitutionsToApply returns the name of the substitutions to apply
-func (b SidebarBlock) SubstitutionsToApply() []string {
-	if subs, found := b.Attributes.GetAsString(AttrSubstitutions); found {
-		return strings.Split(subs, ",")
+func (b SidebarBlock) SubstitutionsToApply() ([]string, error) {
+	if subs, found, err := b.Attributes.GetAsString(AttrSubstitutions); err != nil {
+		return nil, err
+	} else if found {
+		return strings.Split(subs, ","), nil
 	}
-	return b.DefaultSubstitutions()
+	return b.DefaultSubstitutions(), nil
 }
 
 // DefaultSubstitutions the default substitutions for the paragraph
@@ -2052,11 +2060,13 @@ func NewFencedBlock(lines []interface{}, attributes interface{}) (FencedBlock, e
 var _ WithLineSubstitution = FencedBlock{}
 
 // SubstitutionsToApply returns the name of the substitutions to apply
-func (b FencedBlock) SubstitutionsToApply() []string {
-	if subs, found := b.Attributes.GetAsString(AttrSubstitutions); found {
-		return strings.Split(subs, ",")
+func (b FencedBlock) SubstitutionsToApply() ([]string, error) {
+	if subs, found, err := b.Attributes.GetAsString(AttrSubstitutions); err != nil {
+		return nil, err
+	} else if found {
+		return strings.Split(subs, ","), nil
 	}
-	return b.DefaultSubstitutions()
+	return b.DefaultSubstitutions(), nil
 }
 
 // DefaultSubstitutions the default substitutions for the paragraph
@@ -2104,7 +2114,9 @@ func NewListingBlock(lines []interface{}, attributes interface{}) (ListingBlock,
 	attrs := toAttributesWithMapping(attributes, map[string]string{
 		AttrPositional1: AttrStyle,
 	})
-	if style, ok := attrs.GetAsString(AttrStyle); ok && style == AttrSource {
+	if style, ok, err := attrs.GetAsString(AttrStyle); err != nil {
+		return ListingBlock{}, errors.Wrapf(err, "failed to initialize a new listing block")
+	} else if ok && style == AttrSource {
 		attrs = toAttributesWithMapping(attributes, map[string]string{
 			AttrPositional1: AttrStyle,
 			AttrPositional2: AttrLanguage,
@@ -2120,11 +2132,13 @@ func NewListingBlock(lines []interface{}, attributes interface{}) (ListingBlock,
 var _ WithLineSubstitution = ListingBlock{}
 
 // SubstitutionsToApply returns the name of the substitutions to apply
-func (b ListingBlock) SubstitutionsToApply() []string {
-	if subs, found := b.Attributes.GetAsString(AttrSubstitutions); found {
-		return strings.Split(subs, ",")
+func (b ListingBlock) SubstitutionsToApply() ([]string, error) {
+	if subs, found, err := b.Attributes.GetAsString(AttrSubstitutions); err != nil {
+		return nil, err
+	} else if found {
+		return strings.Split(subs, ","), nil
 	}
-	return b.DefaultSubstitutions()
+	return b.DefaultSubstitutions(), nil
 }
 
 // DefaultSubstitutions the default substitutions for the paragraph
@@ -2183,11 +2197,13 @@ func NewVerseBlock(lines []interface{}, attributes interface{}) (VerseBlock, err
 var _ WithLineSubstitution = VerseBlock{}
 
 // SubstitutionsToApply returns the name of the substitutions to apply
-func (b VerseBlock) SubstitutionsToApply() []string {
-	if subs, found := b.Attributes.GetAsString(AttrSubstitutions); found {
-		return strings.Split(subs, ",")
+func (b VerseBlock) SubstitutionsToApply() ([]string, error) {
+	if subs, found, err := b.Attributes.GetAsString(AttrSubstitutions); err != nil {
+		return nil, err
+	} else if found {
+		return strings.Split(subs, ","), nil
 	}
-	return b.DefaultSubstitutions()
+	return b.DefaultSubstitutions(), nil
 }
 
 // DefaultSubstitutions the default substitutions for the paragraph
@@ -2266,11 +2282,13 @@ func NewPassthroughBlock(lines []interface{}, attributes interface{}) (Passthrou
 var _ WithLineSubstitution = PassthroughBlock{}
 
 // SubstitutionsToApply returns the name of the substitutions to apply
-func (b PassthroughBlock) SubstitutionsToApply() []string {
-	if subs, found := b.Attributes.GetAsString(AttrSubstitutions); found {
-		return strings.Split(subs, ",")
+func (b PassthroughBlock) SubstitutionsToApply() ([]string, error) {
+	if subs, found, err := b.Attributes.GetAsString(AttrSubstitutions); err != nil {
+		return nil, err
+	} else if found {
+		return strings.Split(subs, ","), nil
 	}
-	return b.DefaultSubstitutions()
+	return b.DefaultSubstitutions(), nil
 }
 
 // DefaultSubstitutions the default substitutions for the paragraph
@@ -2364,11 +2382,13 @@ func NewLiteralBlock(origin string, lines []interface{}, attributes interface{})
 var _ WithLineSubstitution = LiteralBlock{}
 
 // SubstitutionsToApply returns the name of the substitutions to apply
-func (b LiteralBlock) SubstitutionsToApply() []string {
-	if subs, found := b.Attributes.GetAsString(AttrSubstitutions); found {
-		return strings.Split(subs, ",")
+func (b LiteralBlock) SubstitutionsToApply() ([]string, error) {
+	if subs, found, err := b.Attributes.GetAsString(AttrSubstitutions); err != nil {
+		return nil, err
+	} else if found {
+		return strings.Split(subs, ","), nil
 	}
-	return b.DefaultSubstitutions()
+	return b.DefaultSubstitutions(), nil
 }
 
 // DefaultSubstitutions the default substitutions for the paragraph

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -8,12 +8,13 @@ import (
 
 // Validate validates the given document
 // May also alter some attributes (eg: doctype from `manpage` to `article`)
-func Validate(doc *types.Document) []Problem {
-	problems := []Problem{}
-	if doctype, found := doc.Attributes.GetAsString(types.AttrDocType); found && doctype == "manpage" {
-		problems = append(problems, validateManpage(doc)...)
+func Validate(doc *types.Document) ([]Problem, error) {
+	if doctype, found, err := doc.Attributes.GetAsString(types.AttrDocType); err != nil {
+		return nil, err
+	} else if found && doctype == "manpage" {
+		return validateManpage(doc), nil
 	}
-	return problems
+	return nil, nil
 }
 
 // Problem a problem detected during validation

--- a/pkg/validator/validator_test.go
+++ b/pkg/validator/validator_test.go
@@ -31,9 +31,10 @@ var _ = Describe("document validator", func() {
 			}
 
 			// when
-			problems := Validate(&doc)
+			problems, err := Validate(&doc)
 
 			// then
+			Expect(err).NotTo(HaveOccurred())
 			Expect(problems).To(BeEmpty()) // no problem found
 		})
 	})
@@ -95,9 +96,10 @@ var _ = Describe("document validator", func() {
 			}
 
 			// when
-			problems := Validate(&doc)
+			problems, err := Validate(&doc)
 
 			// then
+			Expect(err).NotTo(HaveOccurred())
 			Expect(problems).To(BeEmpty())                                                            // no problem found
 			Expect(doc.Attributes.GetAsStringWithDefault(types.AttrDocType, "")).To(Equal("manpage")) // unchanged
 		})
@@ -159,9 +161,10 @@ var _ = Describe("document validator", func() {
 				}
 
 				// when
-				problems := Validate(&doc)
+				problems, err := Validate(&doc)
 
 				// then
+				Expect(err).NotTo(HaveOccurred())
 				Expect(problems).To(ContainElement(Problem{
 					Severity: Error,
 					Message:  "manpage document is missing a header",
@@ -224,9 +227,10 @@ var _ = Describe("document validator", func() {
 				}
 
 				// when
-				problems := Validate(&doc)
+				problems, err := Validate(&doc)
 
 				// then
+				Expect(err).NotTo(HaveOccurred())
 				Expect(problems).To(ContainElement(Problem{
 					Severity: Error,
 					Message:  "manpage document is missing the 'Name' section'",
@@ -289,9 +293,10 @@ var _ = Describe("document validator", func() {
 				}
 
 				// when
-				problems := Validate(&doc)
+				problems, err := Validate(&doc)
 
 				// then
+				Expect(err).NotTo(HaveOccurred())
 				Expect(problems).To(ContainElement(Problem{
 					Severity: Error,
 					Message:  "manpage document is missing the 'Name' section'",
@@ -343,9 +348,10 @@ var _ = Describe("document validator", func() {
 				}
 
 				// when
-				problems := Validate(&doc)
+				problems, err := Validate(&doc)
 
 				// then
+				Expect(err).NotTo(HaveOccurred())
 				Expect(problems).To(ContainElement(Problem{
 					Severity: Error,
 					Message:  "'Name' section' should contain a single paragraph",
@@ -408,9 +414,10 @@ var _ = Describe("document validator", func() {
 				}
 
 				// when
-				problems := Validate(&doc)
+				problems, err := Validate(&doc)
 
 				// then
+				Expect(err).NotTo(HaveOccurred())
 				Expect(problems).To(ContainElement(Problem{
 					Severity: Error,
 					Message:  "manpage document is missing the 'Synopsis' section'",
@@ -473,9 +480,10 @@ var _ = Describe("document validator", func() {
 				}
 
 				// when
-				problems := Validate(&doc)
+				problems, err := Validate(&doc)
 
 				// then
+				Expect(err).NotTo(HaveOccurred())
 				Expect(problems).To(ContainElement(Problem{
 					Severity: Error,
 					Message:  "manpage document is missing the 'Synopsis' section'",


### PR DESCRIPTION
except for image 'alt' which has to be renderer as plain text
(use the new `RawText` func)

Fixes #829

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
