### PR TITLE
chore(build): do not generate the parser if not needed

### DIFF
--- a/make/clean.mk
+++ b/make/clean.mk
@@ -1,0 +1,2 @@
+clean:
+	@rm pkg/parser/parser.go

--- a/make/go.mk
+++ b/make/go.mk
@@ -34,14 +34,23 @@ install-pigeon:
 .PHONY: generate
 ## generate the .go file based on the asciidoc grammar
 generate: install-pigeon
-	@echo "generating the parser..."
-	@pigeon ./pkg/parser/parser.peg > ./pkg/parser/parser.go
+	@if [ "pkg/parser/parser.go" -ot "pkg/parser/parser.peg" ]; then \
+		echo "generating the parser..."; \
+		pigeon ./pkg/parser/parser.peg > ./pkg/parser/parser.go; \
+	else \
+		echo "no need to regenerate the parser."; \
+	fi;
 
 .PHONY: generate-optimized
 ## generate the .go file based on the asciidoc grammar
 generate-optimized: install-pigeon
-	@echo "generating the parser (optimized)..."
-	@go generate ./...
+	@if [ "pkg/parser/parser.go" -ot "pkg/parser/parser.peg" ]; then \
+		echo "generating the parser (optimized)..."; \
+		go generate ./...; \
+	else \
+		echo "no need to regenerate the parser."; \
+	fi;
+
 
 .PHONY: build
 ## build the binary executable from CLI


### PR DESCRIPTION
Compare the date of pkg/parser/parser.peg vs pkg/parser/parser.go.
If the latter is newer, then assume that the generated parser is up-to-date.
In doubt, provide a make clean goal to force the generation.

Fixes #840

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
