### PR TITLE
fix(parser): links with underscores

### DIFF
--- a/pkg/parser/link_test.go
+++ b/pkg/parser/link_test.go
@@ -1310,6 +1310,46 @@ a link to {scheme}:{path}[] and https://foo.com`
 				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
+			It("links with underscores", func() {
+				source := "link:a_[A] link:a_[A]"
+				expected := &types.Document{
+					Elements: []interface{}{
+						&types.Paragraph{
+							Elements: []interface{}{
+								&types.InlineLink{
+									Attributes: types.Attributes{
+										types.AttrInlineLinkText: "A",
+									},
+									Location: &types.Location{
+										Path: []interface{}{
+											&types.StringElement{
+												Content: "a_",
+											},
+										},
+									},
+								},
+								&types.StringElement{
+									Content: " ",
+								},
+								&types.InlineLink{
+									Attributes: types.Attributes{
+										types.AttrInlineLinkText: "A",
+									},
+									Location: &types.Location{
+										Path: []interface{}{
+											&types.StringElement{
+												Content: "a_",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
+			})
+
 			Context("text attribute with comma", func() {
 
 				It("relative link only with text having comma", func() {

--- a/pkg/renderer/sgml/html5/link_test.go
+++ b/pkg/renderer/sgml/html5/link_test.go
@@ -331,6 +331,15 @@ a link to {scheme}:{path}[] and https://foo.baz`
 `
 				Expect(RenderHTML(source)).To(MatchHTML(expected))
 			})
+
+			It("links with underscores", func() {
+				source := "link:a_[A] link:a_[A]"
+				expected := `<div class="paragraph">
+<p><a href="a_">A</a> <a href="a_">A</a></p>
+</div>
+`
+				Expect(RenderHTML(source)).To(MatchHTML(expected))
+			})
 		})
 	})
 })


### PR DESCRIPTION
Add tests to verify that it now works, but was already fixed by #843

Closes #849

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
