### PR TITLE
feat(parser/renderer): support 'header' and 'footer' options in tables

### DIFF
--- a/pkg/parser/attributes_test.go
+++ b/pkg/parser/attributes_test.go
@@ -522,10 +522,37 @@ var _ = DescribeTable("valid block attributes",
 		},
 	),
 
+	// options (explicit)
+	Entry(`[options=header]`, `[options=header]`,
+		types.Attributes{
+			types.AttrOptions: []interface{}{"header"},
+		},
+	),
+	Entry(`[options="header,footer"]`, `[options="header,footer"]`,
+		types.Attributes{
+			types.AttrOptions: []interface{}{"header", "footer"},
+		},
+	),
+
 	// option shorthand
 	Entry(`[%hardbreaks]`, `[%hardbreaks]`,
 		types.Attributes{
 			types.AttrOptions: []interface{}{"hardbreaks"},
+		},
+	),
+	Entry(`[%header]`, `[%header]`,
+		types.Attributes{
+			types.AttrOptions: []interface{}{"header"},
+		},
+	),
+	Entry(`[%footer]`, `[%footer]`,
+		types.Attributes{
+			types.AttrOptions: []interface{}{"footer"},
+		},
+	),
+	Entry(`[%header%footer]`, `[%header%footer]`,
+		types.Attributes{
+			types.AttrOptions: []interface{}{"header", "footer"},
 		},
 	),
 

--- a/pkg/parser/document_processing_apply_substitutions.go
+++ b/pkg/parser/document_processing_apply_substitutions.go
@@ -170,6 +170,11 @@ func applySubstitutionsOnBlockWithElements(ctx *ParseContext, block types.BlockW
 				return err
 			}
 		}
+		if b.Footer != nil {
+			if err = s.processBlockWithElements(ctx, b.Footer, opts...); err != nil {
+				return err
+			}
+		}
 	}
 	if err := s.processBlockWithElements(ctx, block, opts...); err != nil {
 		return err

--- a/pkg/parser/table_test.go
+++ b/pkg/parser/table_test.go
@@ -25,10 +25,6 @@ var _ = Describe("tables", func() {
 			expected := &types.Document{
 				Elements: []interface{}{
 					&types.Table{
-						// Columns: []*types.TableColumn{
-						// 	{Width: "50", VAlign: "top", HAlign: "left"},
-						// 	{Width: "50", VAlign: "top", HAlign: "left"},
-						// },
 						Rows: []*types.TableRow{
 							{
 								Cells: []*types.TableCell{
@@ -78,11 +74,6 @@ var _ = Describe("tables", func() {
 			expected := &types.Document{
 				Elements: []interface{}{
 					&types.Table{
-						// Columns: []*types.TableColumn{
-						// 	{Width: "33.3333", VAlign: "top", HAlign: "left"},
-						// 	{Width: "33.3333", VAlign: "top", HAlign: "left"},
-						// 	{Width: "33.3334", VAlign: "top", HAlign: "left"},
-						// },
 						Rows: []*types.TableRow{
 							{
 								Cells: []*types.TableCell{
@@ -140,11 +131,6 @@ var _ = Describe("tables", func() {
 			expected := &types.Document{
 				Elements: []interface{}{
 					&types.Table{
-						// Columns: []*types.TableColumn{
-						// 	{Width: "33.3333", VAlign: "top", HAlign: "left"},
-						// 	{Width: "33.3333", VAlign: "top", HAlign: "left"},
-						// 	{Width: "33.3334", VAlign: "top", HAlign: "left"},
-						// },
 						Rows: []*types.TableRow{
 							{
 								Cells: []*types.TableCell{
@@ -220,11 +206,6 @@ var _ = Describe("tables", func() {
 						Attributes: types.Attributes{
 							types.AttrTitle: "table title",
 						},
-						// Columns: []*types.TableColumn{
-						// 	{Width: "50", HAlign: "left", VAlign: "top"},
-						// 	{Width: "50", HAlign: "left", VAlign: "top"},
-						// },
-
 						Header: &types.TableRow{
 							Cells: []*types.TableCell{
 								{
@@ -327,11 +308,6 @@ var _ = Describe("tables", func() {
 								},
 							},
 						},
-						// Columns: []*types.TableColumn{
-						// 	// autowidth clears width
-						// 	{HAlign: "left", VAlign: "top"},
-						// 	{HAlign: "left", VAlign: "top"},
-						// },
 						Rows: []*types.TableRow{
 							{
 								Cells: []*types.TableCell{
@@ -381,10 +357,7 @@ var _ = Describe("tables", func() {
 |===`
 			expected := &types.Document{
 				Elements: []interface{}{
-					&types.Table{
-						// Columns: []*types.TableColumn{},
-						// Lines:   []*types.TableLine{},
-					},
+					&types.Table{},
 				},
 			}
 			Expect(ParseDocument(source)).To(MatchDocument(expected))
@@ -432,9 +405,6 @@ var _ = Describe("tables", func() {
 |===
 |===`
 			expected := &types.Document{
-				// Attributes: types.Attributes{
-				// 	"cols": "2*^.^d,<e,.>s",
-				// },
 				Elements: []interface{}{
 					&types.AttributeDeclaration{
 						Name:  "cols",
@@ -463,6 +433,260 @@ var _ = Describe("tables", func() {
 									VAlign:     types.VAlignBottom,
 									Style:      types.StrongStyle,
 									Weight:     1,
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
+		})
+
+		It("with header option", func() {
+			source := `[cols="3*^",options="header"]
+|===
+|Dir (X,Y,Z) |Num Cells |Size
+|X |10 |0.1
+|Y |5  |0.2
+|Z |10 |0.1
+|===`
+			expected := &types.Document{
+				Elements: []interface{}{
+					&types.Table{
+						Attributes: types.Attributes{
+							types.AttrCols: []interface{}{
+								&types.TableColumn{
+									Multiplier: 3,
+									HAlign:     types.HAlignCenter,
+									VAlign:     types.VAlignTop,
+									Weight:     1,
+								},
+							},
+							types.AttrOptions: []interface{}{"header"},
+						},
+						Header: &types.TableRow{
+							Cells: []*types.TableCell{
+								{
+									Elements: []interface{}{
+										&types.StringElement{
+											Content: "Dir (X,Y,Z) ",
+										},
+									},
+								},
+								{
+									Elements: []interface{}{
+										&types.StringElement{
+											Content: "Num Cells ",
+										},
+									},
+								},
+								{
+									Elements: []interface{}{
+										&types.StringElement{
+											Content: "Size",
+										},
+									},
+								},
+							},
+						},
+						Rows: []*types.TableRow{
+							{
+								Cells: []*types.TableCell{
+									{
+										Elements: []interface{}{
+											&types.StringElement{
+												Content: "X ",
+											},
+										},
+									},
+									{
+										Elements: []interface{}{
+											&types.StringElement{
+												Content: "10 ",
+											},
+										},
+									},
+									{
+										Elements: []interface{}{
+											&types.StringElement{
+												Content: "0.1",
+											},
+										},
+									},
+								},
+							},
+							{
+								Cells: []*types.TableCell{
+									{
+										Elements: []interface{}{
+											&types.StringElement{
+												Content: "Y ",
+											},
+										},
+									},
+									{
+										Elements: []interface{}{
+											&types.StringElement{
+												Content: "5  ",
+											},
+										},
+									},
+									{
+										Elements: []interface{}{
+											&types.StringElement{
+												Content: "0.2",
+											},
+										},
+									},
+								},
+							},
+							{
+								Cells: []*types.TableCell{
+									{
+										Elements: []interface{}{
+											&types.StringElement{
+												Content: "Z ",
+											},
+										},
+									},
+									{
+										Elements: []interface{}{
+											&types.StringElement{
+												Content: "10 ",
+											},
+										},
+									},
+									{
+										Elements: []interface{}{
+											&types.StringElement{
+												Content: "0.1",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
+		})
+
+		It("with header and footer options", func() {
+			source := `[%header%footer,cols="2,2,1"] 
+|===
+|Column 1, header row
+|Column 2, header row
+|Column 3, header row
+
+|Cell in column 1, row 2
+|Cell in column 2, row 2
+|Cell in column 3, row 2
+
+|Column 1, footer row
+|Column 2, footer row
+|Column 3, footer row
+|===`
+			expected := &types.Document{
+				Elements: []interface{}{
+					&types.Table{
+						Attributes: types.Attributes{
+							types.AttrCols: []interface{}{
+								&types.TableColumn{
+									Multiplier: 1,
+									HAlign:     types.HAlignLeft,
+									VAlign:     types.VAlignTop,
+									Weight:     2,
+								},
+								&types.TableColumn{
+									Multiplier: 1,
+									HAlign:     types.HAlignLeft,
+									VAlign:     types.VAlignTop,
+									Weight:     2,
+								},
+								&types.TableColumn{
+									Multiplier: 1,
+									HAlign:     types.HAlignLeft,
+									VAlign:     types.VAlignTop,
+									Weight:     1,
+								},
+							},
+							types.AttrOptions: []interface{}{"header", "footer"},
+						},
+						Header: &types.TableRow{
+							Cells: []*types.TableCell{
+								{
+									Elements: []interface{}{
+										&types.StringElement{
+											Content: "Column 1, header row",
+										},
+									},
+								},
+								{
+									Elements: []interface{}{
+										&types.StringElement{
+											Content: "Column 2, header row",
+										},
+									},
+								},
+								{
+									Elements: []interface{}{
+										&types.StringElement{
+											Content: "Column 3, header row",
+										},
+									},
+								},
+							},
+						},
+						Rows: []*types.TableRow{
+							{
+								Cells: []*types.TableCell{
+									{
+										Elements: []interface{}{
+											&types.StringElement{
+												Content: "Cell in column 1, row 2",
+											},
+										},
+									},
+									{
+										Elements: []interface{}{
+											&types.StringElement{
+												Content: "Cell in column 2, row 2",
+											},
+										},
+									},
+									{
+										Elements: []interface{}{
+											&types.StringElement{
+												Content: "Cell in column 3, row 2",
+											},
+										},
+									},
+								},
+							},
+						},
+						Footer: &types.TableRow{
+							Cells: []*types.TableCell{
+								{
+									Elements: []interface{}{
+										&types.StringElement{
+											Content: "Column 1, footer row",
+										},
+									},
+								},
+								{
+									Elements: []interface{}{
+										&types.StringElement{
+											Content: "Column 2, footer row",
+										},
+									},
+								},
+								{
+									Elements: []interface{}{
+										&types.StringElement{
+											Content: "Column 3, footer row",
+										},
+									},
 								},
 							},
 						},
@@ -509,6 +733,30 @@ var _ = Describe("table cols", func() {
 					VAlign:     types.VAlignTop,
 					Weight:     1,
 					Width:      "100",
+				},
+			}),
+		Entry(`3*^`, `3*^`,
+			[]*types.TableColumn{
+				{
+					Multiplier: 3,
+					HAlign:     types.HAlignCenter,
+					VAlign:     types.VAlignTop,
+					Weight:     1,
+					Width:      "33.3333",
+				},
+				{
+					Multiplier: 3,
+					HAlign:     types.HAlignCenter,
+					VAlign:     types.VAlignTop,
+					Weight:     1,
+					Width:      "33.3333",
+				},
+				{
+					Multiplier: 3,
+					HAlign:     types.HAlignCenter,
+					VAlign:     types.VAlignTop,
+					Weight:     1,
+					Width:      "33.3334",
 				},
 			}),
 		Entry(`20,~,~`, `20,~,~`,

--- a/pkg/renderer/sgml/html5/table.go
+++ b/pkg/renderer/sgml/html5/table.go
@@ -18,6 +18,7 @@ const (
 		"</colgroup>\n" +
 		"{{ .Header }}" +
 		"{{ .Body }}" +
+		"{{ .Footer }}" +
 		"{{ end }}" +
 		"</table>\n"
 
@@ -25,9 +26,13 @@ const (
 
 	tableHeaderTmpl = "{{ if .Content }}<thead>\n<tr>\n{{ .Content }}</tr>\n</thead>\n{{ end }}"
 
-	tableRowTmpl = "<tr>\n{{ .Content }}</tr>\n"
-
 	tableHeaderCellTmpl = "<th class=\"tableblock {{ halign .HAlign }} {{ valign .VAlign }}\">{{ .Content }}</th>\n"
+
+	tableFooterTmpl = "{{ if .Content }}<tfoot>\n<tr>\n{{ .Content }}</tr>\n</tfoot>\n{{ end }}"
+
+	tableFooterCellTmpl = "<td class=\"tableblock {{ halign .HAlign }} {{ valign .VAlign }}\"><p class=\"tableblock\">{{ .Content }}</p></td>\n"
+
+	tableRowTmpl = "<tr>\n{{ .Content }}</tr>\n"
 
 	tableCellTmpl = "<td class=\"tableblock {{ halign .HAlign }} {{ valign .VAlign }}\"><p class=\"tableblock\">{{ .Content }}</p></td>\n"
 )

--- a/pkg/renderer/sgml/html5/table_test.go
+++ b/pkg/renderer/sgml/html5/table_test.go
@@ -532,5 +532,94 @@ var _ = Describe("tables", func() {
 		Expect(RenderHTML(source)).To(MatchHTML(expected))
 	})
 
+	It("with header option", func() {
+		source := `[cols="3*^",options="header"]
+|===
+|Dir (X,Y,Z) |Num Cells |Size
+|X |10 |0.1
+|Y |5  |0.2
+|Z |10 |0.1
+|===`
+		expected := `<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-center valign-top">Dir (X,Y,Z)</th>
+<th class="tableblock halign-center valign-top">Num Cells</th>
+<th class="tableblock halign-center valign-top">Size</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-center valign-top"><p class="tableblock">X</p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock">10</p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock">0.1</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-center valign-top"><p class="tableblock">Y</p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock">5</p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock">0.2</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-center valign-top"><p class="tableblock">Z</p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock">10</p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock">0.1</p></td>
+</tr>
+</tbody>
+</table>
+`
+		Expect(RenderHTML(source)).To(MatchHTML(expected))
+	})
+
+	It("with header and footer options", func() {
+		source := `[%header%footer,cols="2,2,1"] 
+|===
+|Column 1, header row
+|Column 2, header row
+|Column 3, header row
+
+|Cell in column 1, row 2
+|Cell in column 2, row 2
+|Cell in column 3, row 2
+
+|Column 1, footer row
+|Column 2, footer row
+|Column 3, footer row
+|===`
+		expected := `<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 40%;">
+<col style="width: 40%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Column 1, header row</th>
+<th class="tableblock halign-left valign-top">Column 2, header row</th>
+<th class="tableblock halign-left valign-top">Column 3, header row</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Cell in column 1, row 2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Cell in column 2, row 2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Cell in column 3, row 2</p></td>
+</tr>
+</tbody>
+<tfoot>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Column 1, footer row</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Column 2, footer row</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Column 3, footer row</p></td>
+</tr>
+</tfoot>
+</table>
+`
+		Expect(RenderHTML(source)).To(MatchHTML(expected))
+	})
 	// TODO: Verify styles -- it's verified in the parser for now, but we still need to implement styles.
 })

--- a/pkg/renderer/sgml/html5/templates.go
+++ b/pkg/renderer/sgml/html5/templates.go
@@ -74,6 +74,8 @@ var templates = sgml.Templates{
 	TableCell:                 tableCellTmpl,
 	TableHeader:               tableHeaderTmpl,
 	TableHeaderCell:           tableHeaderCellTmpl,
+	TableFooter:               tableFooterTmpl,
+	TableFooterCell:           tableFooterCellTmpl,
 	TableRow:                  tableRowTmpl,
 	ThematicBreak:             thematicBreakTmpl,
 	TocRoot:                   tocRootTmpl,

--- a/pkg/renderer/sgml/sgml_renderer.go
+++ b/pkg/renderer/sgml/sgml_renderer.go
@@ -74,6 +74,8 @@ type sgmlRenderer struct {
 	tableCell                 *textTemplate
 	tableHeader               *textTemplate
 	tableHeaderCell           *textTemplate
+	tableFooter               *textTemplate
+	tableFooterCell           *textTemplate
 	tableRow                  *textTemplate
 	thematicBreak             *textTemplate
 	tocEntry                  *textTemplate
@@ -154,6 +156,8 @@ func (r *sgmlRenderer) prepareTemplates() error {
 		r.tableCell, err = r.newTemplate("table-cell", tmpls.TableCell, err)
 		r.tableHeader, err = r.newTemplate("table-header", tmpls.TableHeader, err)
 		r.tableHeaderCell, err = r.newTemplate("table-header-cell", tmpls.TableHeaderCell, err)
+		r.tableFooter, err = r.newTemplate("table-header", tmpls.TableFooter, err)
+		r.tableFooterCell, err = r.newTemplate("table-header-cell", tmpls.TableFooterCell, err)
 		r.tableRow, err = r.newTemplate("table-row", tmpls.TableRow, err)
 		r.thematicBreak, err = r.newTemplate("thematic-break", tmpls.ThematicBreak, err)
 		r.tocEntry, err = r.newTemplate("toc-entry", tmpls.TocEntry, err)

--- a/pkg/renderer/sgml/templates.go
+++ b/pkg/renderer/sgml/templates.go
@@ -67,6 +67,8 @@ type Templates struct {
 	TableCell                 string
 	TableHeader               string
 	TableHeaderCell           string
+	TableFooter               string
+	TableFooterCell           string
 	TableRow                  string
 	ThematicBreak             string
 	TocEntry                  string

--- a/pkg/renderer/sgml/xhtml5/table_test.go
+++ b/pkg/renderer/sgml/xhtml5/table_test.go
@@ -532,5 +532,94 @@ var _ = Describe("tables", func() {
 		Expect(RenderXHTML(source)).To(MatchHTML(expected))
 	})
 
+	It("with header option", func() {
+		source := `[cols="3*^",options="header"]
+|===
+|Dir (X,Y,Z) |Num Cells |Size
+|X |10 |0.1
+|Y |5  |0.2
+|Z |10 |0.1
+|===`
+		expected := `<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-center valign-top">Dir (X,Y,Z)</th>
+<th class="tableblock halign-center valign-top">Num Cells</th>
+<th class="tableblock halign-center valign-top">Size</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-center valign-top"><p class="tableblock">X</p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock">10</p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock">0.1</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-center valign-top"><p class="tableblock">Y</p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock">5</p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock">0.2</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-center valign-top"><p class="tableblock">Z</p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock">10</p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock">0.1</p></td>
+</tr>
+</tbody>
+</table>
+`
+		Expect(RenderHTML(source)).To(MatchHTML(expected))
+	})
+
+	It("with header and footer options", func() {
+		source := `[%header%footer,cols="2,2,1"] 
+|===
+|Column 1, header row
+|Column 2, header row
+|Column 3, header row
+
+|Cell in column 1, row 2
+|Cell in column 2, row 2
+|Cell in column 3, row 2
+
+|Column 1, footer row
+|Column 2, footer row
+|Column 3, footer row
+|===`
+		expected := `<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 40%;">
+<col style="width: 40%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Column 1, header row</th>
+<th class="tableblock halign-left valign-top">Column 2, header row</th>
+<th class="tableblock halign-left valign-top">Column 3, header row</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Cell in column 1, row 2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Cell in column 2, row 2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Cell in column 3, row 2</p></td>
+</tr>
+</tbody>
+<tfoot>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Column 1, footer row</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Column 2, footer row</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Column 3, footer row</p></td>
+</tr>
+</tfoot>
+</table>
+`
+		Expect(RenderHTML(source)).To(MatchHTML(expected))
+	})
 	// TODO: Verify styles -- it's verified in the parser for now, but we still need to implement styles.
 })

--- a/pkg/types/attributes.go
+++ b/pkg/types/attributes.go
@@ -117,8 +117,8 @@ const (
 	AttrFloat = "float"
 	// AttrCols the table columns attribute
 	AttrCols = "cols"
-	// AttrAutowidth the `autowidth` attribute on a table
-	AttrAutowidth = "autowidth"
+	// AttrAutoWidth the `autowidth` attribute on a table
+	AttrAutoWidth = "autowidth"
 	// AttrPositionalPrefix positional parameter prefix (DEPRECATED - use `AttrPositionalIndex`)
 	AttrPositionalPrefix = "@"
 	// AttrPositionalIndex positional parameter index
@@ -403,10 +403,24 @@ func (a Attributes) Set(key string, value interface{}) Attributes {
 				a[AttrRoles] = r
 			}
 		}
-	case AttrOption:
+	case AttrOption: // move into `options`
 		if options, ok := a[AttrOptions].([]interface{}); ok {
 			a[AttrOptions] = append(options, value)
 		} else {
+			a[AttrOptions] = []interface{}{value}
+		}
+	case AttrOptions: // make sure the value is wrapped into a []interface{}
+		switch v := value.(type) {
+		case []interface{}:
+			a[AttrOptions] = v
+		case string:
+			values := strings.Split(v, ",")
+			options := make([]interface{}, len(values))
+			for i, v := range values {
+				options[i] = v
+			}
+			a[AttrOptions] = options
+		default:
 			a[AttrOptions] = []interface{}{value}
 		}
 	default:


### PR DESCRIPTION
Supports the shorthand (`%header%footer`) syntax and the explicit
one (`options="header,footer"`)

also, fixes a bug in column settings when multiplier is used

Fixes #861

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
