### PR TITLE
fix(parser/renderer): support cross references in elements defined later

### DIFF
--- a/pkg/parser/delimited_block_literal_test.go
+++ b/pkg/parser/delimited_block_literal_test.go
@@ -108,6 +108,9 @@ a normal paragraph.`
 							},
 						},
 					},
+					ElementReferences: types.ElementReferences{
+						"ID": "title",
+					},
 				}
 				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
@@ -165,6 +168,9 @@ a normal paragraph.`
 								},
 							},
 						},
+					},
+					ElementReferences: types.ElementReferences{
+						"ID": "title",
 					},
 				}
 				Expect(ParseDocument(source)).To(MatchDocument(expected))
@@ -233,6 +239,9 @@ a normal paragraph.`
 								},
 							},
 						},
+					},
+					ElementReferences: types.ElementReferences{
+						"ID": "title",
 					},
 				}
 				Expect(ParseDocument(source)).To(MatchDocument(expected))

--- a/pkg/parser/delimited_block_source_test.go
+++ b/pkg/parser/delimited_block_source_test.go
@@ -110,6 +110,9 @@ end`,
 						},
 					},
 				},
+				ElementReferences: types.ElementReferences{
+					"id-for-source-block": "app.rb",
+				},
 			}
 			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})

--- a/pkg/parser/document_processing_aggregate.go
+++ b/pkg/parser/document_processing_aggregate.go
@@ -92,6 +92,12 @@ func aggregate(ctx *ParseContext, fragmentStream <-chan types.DocumentFragment) 
 					return nil, nil, err
 				}
 			}
+			// also, check if the element has refs
+			if e, ok := element.(types.Referencable); ok {
+				if id, title := e.Ref(); id != "" && title != nil {
+					refs[id] = title
+				}
+			}
 		}
 	}
 

--- a/pkg/parser/paragraph_test.go
+++ b/pkg/parser/paragraph_test.go
@@ -1530,6 +1530,9 @@ NOTE: this is a note.`
 							},
 						},
 					},
+					ElementReferences: types.ElementReferences{
+						"cookie": "chocolate",
+					},
 				}
 				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
@@ -1586,6 +1589,9 @@ this is a
 								},
 							},
 						},
+					},
+					ElementReferences: types.ElementReferences{
+						"cookie": "chocolate",
 					},
 				}
 				Expect(ParseDocument(source)).To(MatchDocument(expected))
@@ -1721,6 +1727,9 @@ I am a verse paragraph.`
 								},
 							},
 						},
+					},
+					ElementReferences: types.ElementReferences{
+						"universal": "universe",
 					},
 				}
 				Expect(ParseDocument(source)).To(MatchDocument(expected))

--- a/pkg/parser/table_test.go
+++ b/pkg/parser/table_test.go
@@ -348,6 +348,9 @@ var _ = Describe("tables", func() {
 						},
 					},
 				},
+				ElementReferences: types.ElementReferences{
+					"anchor": "table title",
+				},
 			}
 			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})

--- a/pkg/renderer/sgml/cross_reference.go
+++ b/pkg/renderer/sgml/cross_reference.go
@@ -20,13 +20,16 @@ func (r *sgmlRenderer) renderInternalCrossReference(ctx *renderer.Context, xref 
 	if xrefLabel, ok := xref.Label.(string); ok {
 		label = xrefLabel
 	} else if target, found := ctx.ElementReferences[xrefID]; found {
-		if t, ok := target.([]interface{}); ok {
-			renderedContent, err := r.renderElement(ctx, t)
+		switch t := target.(type) {
+		case string:
+			label = t
+		case []interface{}:
+			renderedContent, err := r.renderPlainText(ctx, t)
 			if err != nil {
 				return "", errors.Wrap(err, "error while rendering internal cross reference")
 			}
 			label = renderedContent
-		} else {
+		default:
 			return "", errors.Errorf("unable to process internal cross reference to element of type %T", target)
 		}
 	} else {

--- a/pkg/renderer/sgml/html5/cross_reference_test.go
+++ b/pkg/renderer/sgml/html5/cross_reference_test.go
@@ -11,7 +11,7 @@ var _ = Describe("cross references", func() {
 
 	Context("internal references", func() {
 
-		It("cross reference with custom id", func() {
+		It("with custom id", func() {
 
 			source := `[[thetitle]]
 == a title
@@ -29,7 +29,7 @@ with some content linked to <<thetitle>>!`
 			Expect(RenderHTML(source)).To(MatchHTML(expected))
 		})
 
-		It("cross reference with custom id and label", func() {
+		It("custom id and label", func() {
 			source := `[[thetitle]]
 == a title
 
@@ -39,6 +39,45 @@ with some content linked to <<thetitle,a label to the title>>!`
 <div class="sectionbody">
 <div class="paragraph">
 <p>with some content linked to <a href="#thetitle">a label to the title</a>!</p>
+</div>
+</div>
+</div>
+`
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+		})
+
+		It("to paragraph defined later in the document", func() {
+			source := `a reference to <<a-paragraph>>
+
+[#a-paragraph]
+.another paragraph
+some content`
+			expected := `<div class="paragraph">
+<p>a reference to <a href="#a-paragraph">another paragraph</a></p>
+</div>
+<div id="a-paragraph" class="paragraph">
+<div class="title">another paragraph</div>
+<p>some content</p>
+</div>
+`
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+		})
+
+		It("to section defined later in the document", func() {
+			source := `a reference to <<section>>
+
+[#section]
+== A section with a link to https://example.com
+
+some content`
+			expected := `<div class="paragraph">
+<p>a reference to <a href="#section">A section with a link to https://example.com</a></p>
+</div>
+<div class="sect1">
+<h2 id="section">A section with a link to <a href="https://example.com" class="bare">https://example.com</a></h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>some content</p>
 </div>
 </div>
 </div>

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -64,6 +64,10 @@ type BlockWithLocation interface {
 	SetLocation(*Location) // TODO: unused?
 }
 
+type Referencable interface {
+	Ref() (string, interface{})
+}
+
 // ------------------------------------------
 // Substitution support
 // ------------------------------------------
@@ -1503,6 +1507,14 @@ func (p *Paragraph) mapAttributes() {
 	}
 }
 
+var _ Referencable = &Paragraph{}
+
+func (p *Paragraph) Ref() (string, interface{}) {
+	id := p.Attributes.GetAsStringWithDefault(AttrID, "")
+	title := p.Attributes[AttrTitle]
+	return id, title
+}
+
 var _ WithFootnotes = &Paragraph{}
 
 // SubstituteFootnotes replaces the footnotes in the paragraph lines
@@ -1968,6 +1980,14 @@ func (b *DelimitedBlock) mapAttributes() {
 	}
 }
 
+var _ Referencable = &DelimitedBlock{}
+
+func (b *DelimitedBlock) Ref() (string, interface{}) {
+	id := b.Attributes.GetAsStringWithDefault(AttrID, "")
+	title := b.Attributes[AttrTitle]
+	return id, title
+}
+
 // TODO: not needed?
 const (
 	// AttrLiteralBlockType the type of literal block, ie, how it was parsed
@@ -2040,7 +2060,6 @@ func (s *Section) ResolveID(attrs map[string]interface{}, refs ElementReferences
 			log.Debugf("updated section id to '%s' (to avoid duplicate refs)", s.Attributes[AttrID])
 		}
 		if _, exists := refs[id]; !exists {
-			refs[id] = s.Title
 			s.Attributes[AttrID] = id
 			break
 		}
@@ -2075,6 +2094,13 @@ func (s *Section) resolveID(attrs Attributes) (string, error) {
 	s.Attributes[AttrID] = id
 	log.Debugf("updated section id to '%s'", s.Attributes[AttrID])
 	return id, nil
+}
+
+var _ Referencable = &Section{}
+
+func (s *Section) Ref() (string, interface{}) {
+	id := s.Attributes.GetAsStringWithDefault(AttrID, "")
+	return id, s.Title
 }
 
 var _ WithElementAddition = &Section{}
@@ -3019,6 +3045,14 @@ func (t *Table) SetAttributes(attributes Attributes) {
 		t.Footer = t.Rows[len(t.Rows)-1]
 		t.Rows = t.Rows[:len(t.Rows)-1]
 	}
+}
+
+var _ Referencable = &Table{}
+
+func (t *Table) Ref() (string, interface{}) {
+	id := t.Attributes.GetAsStringWithDefault(AttrID, "")
+	title := t.Attributes[AttrTitle]
+	return id, title
 }
 
 type HAlign string


### PR DESCRIPTION
covers sections, tables, delimited blocks and paragraphs.

Fixes #863

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
