### PR TITLE
feat(renderer): support table ID

### DIFF
--- a/pkg/parser/ordered_list_test.go
+++ b/pkg/parser/ordered_list_test.go
@@ -281,7 +281,7 @@ var _ = Describe("ordered lists", func() {
 
 		Context("elements without numbers", func() {
 
-			It("ordered list with simple unnumbered elements", func() {
+			It("with simple unnumbered elements", func() {
 				source := `. a
 . b`
 
@@ -344,7 +344,7 @@ var _ = Describe("ordered lists", func() {
 				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
-			It("ordered list with unnumbered elements", func() {
+			It("with unnumbered elements", func() {
 				source := `. element 1
 . element 2`
 
@@ -380,7 +380,7 @@ var _ = Describe("ordered lists", func() {
 				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
-			It("ordered list with custom numbering on child elements with tabs ", func() {
+			It("with custom numbering on child elements with tabs ", func() {
 				// note: the [upperroman] attribute must be at the beginning of the line
 				source := `. element 1
 			.. element 1.1
@@ -491,7 +491,7 @@ var _ = Describe("ordered lists", func() {
 				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
-			It("ordered list with all default styles and blank lines", func() {
+			It("with all default styles and blank lines", func() {
 				source := `. level 1
 
 .. level 2
@@ -588,7 +588,7 @@ var _ = Describe("ordered lists", func() {
 				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
-			It("ordered list with all default styles and no blank line", func() {
+			It("with all default styles and no blank line", func() {
 				source := `. level 1
 .. level 2
 ... level 3
@@ -680,7 +680,7 @@ var _ = Describe("ordered lists", func() {
 
 		Context("numbered elements", func() {
 
-			It("ordered list with simple numbered elements", func() {
+			It("with simple numbered elements", func() {
 				source := `1. a
 2. b`
 				expected := &types.Document{
@@ -830,7 +830,7 @@ var _ = Describe("ordered lists", func() {
 				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
-			It("ordered list with numbered elements", func() {
+			It("with numbered elements", func() {
 				source := `1. element 1
 a. element 1.a
 2. element 2
@@ -900,7 +900,7 @@ b. element 2.a`
 
 		Context("list element continuation", func() {
 
-			It("ordered list with element continuation - case 1", func() {
+			It("case 1", func() {
 				source := `. foo
 +
 ----
@@ -960,7 +960,7 @@ another delimited block
 				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
-			It("ordered list with element continuation - case 2", func() {
+			It("case 2", func() {
 				source := `. {blank}
 +
 ----
@@ -1019,7 +1019,7 @@ print("two")
 				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
-			It("ordered list with element continuation - case 3", func() {
+			It("case 3", func() {
 				// continuation with "continued element" being a list element (ie, kinda invalid/empty continuation in the middle of a list)
 				source := `. element 1
 +
@@ -1071,6 +1071,68 @@ a paragraph
 											Elements: []interface{}{
 												&types.StringElement{
 													Content: "element 3",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
+			})
+
+			It("case 4", func() {
+				source := `. cookie
++
+image::cookie.png[]
++
+. chocolate
++
+image::chocolate.png[]`
+				expected := &types.Document{
+					Elements: []interface{}{
+						&types.List{
+							Kind: types.OrderedListKind,
+							Elements: []types.ListElement{
+								&types.OrderedListElement{
+									Style: types.Arabic,
+									Elements: []interface{}{
+										&types.Paragraph{
+											Elements: []interface{}{
+												&types.StringElement{
+													Content: "cookie",
+												},
+											},
+										},
+										&types.ImageBlock{
+											Location: &types.Location{
+												Path: []interface{}{
+													&types.StringElement{
+														"cookie.png",
+													},
+												},
+											},
+										},
+									},
+								},
+								&types.OrderedListElement{
+									Style: types.Arabic,
+									Elements: []interface{}{
+										&types.Paragraph{
+											Elements: []interface{}{
+												&types.StringElement{
+													Content: "chocolate",
+												},
+											},
+										},
+										&types.ImageBlock{
+											Location: &types.Location{
+												Path: []interface{}{
+													&types.StringElement{
+														"chocolate.png",
+													},
 												},
 											},
 										},

--- a/pkg/parser/ordered_list_test.go
+++ b/pkg/parser/ordered_list_test.go
@@ -1110,7 +1110,7 @@ image::chocolate.png[]`
 											Location: &types.Location{
 												Path: []interface{}{
 													&types.StringElement{
-														"cookie.png",
+														Content: "cookie.png",
 													},
 												},
 											},
@@ -1131,7 +1131,7 @@ image::chocolate.png[]`
 											Location: &types.Location{
 												Path: []interface{}{
 													&types.StringElement{
-														"chocolate.png",
+														Content: "chocolate.png",
 													},
 												},
 											},

--- a/pkg/parser/unordered_list_test.go
+++ b/pkg/parser/unordered_list_test.go
@@ -997,7 +997,7 @@ on 2 lines, too.`
 
 		Context("list element continuation", func() {
 
-			It("with item continuation - case 1", func() {
+			It("case 1", func() {
 				source := `* foo
 +
 ----
@@ -1063,7 +1063,7 @@ another delimited block
 				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
-			It("with item continuation - case 2", func() {
+			It("case 2", func() {
 				source := `.Unordered, complex
 * level 1
 ** level 2
@@ -1199,7 +1199,7 @@ The {plus} symbol is on a new line.
 				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
-			It("with list element continuation - case 3", func() {
+			It("case 3", func() {
 				source := `- here
 +
 _there_`
@@ -1239,76 +1239,6 @@ _there_`
 				}
 				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
-
-			It("without item continuation", func() {
-				source := `* foo
-
-----
-a delimited block
-----
-
-* bar
-
-----
-another delimited block
-----`
-				expected := &types.Document{
-					Elements: []interface{}{
-						&types.List{
-							Kind: types.UnorderedListKind,
-							Elements: []types.ListElement{
-								&types.UnorderedListElement{
-									BulletStyle: types.OneAsterisk,
-									CheckStyle:  types.NoCheck,
-									Elements: []interface{}{
-										&types.Paragraph{
-											Elements: []interface{}{
-												&types.StringElement{Content: "foo"},
-											},
-										},
-									},
-								},
-							},
-						},
-						&types.DelimitedBlock{
-							Kind: types.Listing,
-							Elements: []interface{}{
-								&types.StringElement{
-									Content: "a delimited block",
-								},
-							},
-						},
-						&types.List{
-							Kind: types.UnorderedListKind,
-							Elements: []types.ListElement{
-								&types.UnorderedListElement{
-									BulletStyle: types.OneAsterisk,
-									CheckStyle:  types.NoCheck,
-									Elements: []interface{}{
-										&types.Paragraph{
-											Elements: []interface{}{
-												&types.StringElement{Content: "bar"},
-											},
-										},
-									},
-								},
-							},
-						},
-						&types.DelimitedBlock{
-							Kind: types.Listing,
-							Elements: []interface{}{
-								&types.StringElement{
-									Content: "another delimited block",
-								},
-							},
-						},
-					},
-				}
-				Expect(ParseDocument(source)).To(MatchDocument(expected))
-			})
-		})
-
-		Context("attach to ancestor", func() {
 
 			It("attach to grandparent item", func() {
 				source := `* grandparent list element
@@ -1453,5 +1383,73 @@ paragraph attached to parent list element`
 				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 		})
+
+		It("without item continuation", func() {
+			source := `* foo
+
+----
+a delimited block
+----
+
+* bar
+
+----
+another delimited block
+----`
+			expected := &types.Document{
+				Elements: []interface{}{
+					&types.List{
+						Kind: types.UnorderedListKind,
+						Elements: []types.ListElement{
+							&types.UnorderedListElement{
+								BulletStyle: types.OneAsterisk,
+								CheckStyle:  types.NoCheck,
+								Elements: []interface{}{
+									&types.Paragraph{
+										Elements: []interface{}{
+											&types.StringElement{Content: "foo"},
+										},
+									},
+								},
+							},
+						},
+					},
+					&types.DelimitedBlock{
+						Kind: types.Listing,
+						Elements: []interface{}{
+							&types.StringElement{
+								Content: "a delimited block",
+							},
+						},
+					},
+					&types.List{
+						Kind: types.UnorderedListKind,
+						Elements: []types.ListElement{
+							&types.UnorderedListElement{
+								BulletStyle: types.OneAsterisk,
+								CheckStyle:  types.NoCheck,
+								Elements: []interface{}{
+									&types.Paragraph{
+										Elements: []interface{}{
+											&types.StringElement{Content: "bar"},
+										},
+									},
+								},
+							},
+						},
+					},
+					&types.DelimitedBlock{
+						Kind: types.Listing,
+						Elements: []interface{}{
+							&types.StringElement{
+								Content: "another delimited block",
+							},
+						},
+					},
+				},
+			}
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
+		})
+
 	})
 })

--- a/pkg/renderer/sgml/html5/ordered_list_test.go
+++ b/pkg/renderer/sgml/html5/ordered_list_test.go
@@ -88,7 +88,7 @@ lines</p>
 		Expect(RenderHTML(source)).To(MatchHTML(expected))
 	})
 
-	It("ordered list item reversed with explicit quoted numbering and start", func() {
+	It("item reversed with explicit quoted numbering and start", func() {
 		source := `[lowerroman%reversed, start="5"]
 . item 1
 . item 2`
@@ -106,11 +106,13 @@ lines</p>
 		Expect(RenderHTML(source)).To(MatchHTML(expected))
 	})
 
-	It("with paragraph continuation", func() {
-		source := `. item 1
+	Context("with list element continuation", func() {
+
+		It("case 1", func() {
+			source := `. item 1
 +
 foo`
-		expected := `<div class="olist arabic">
+			expected := `<div class="olist arabic">
 <ol class="arabic">
 <li>
 <p>item 1</p>
@@ -121,16 +123,16 @@ foo`
 </ol>
 </div>
 `
-		Expect(RenderHTML(source)).To(MatchHTML(expected))
-	})
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+		})
 
-	It("with delimited block continuation", func() {
-		source := `. item 1
+		It("case 2", func() {
+			source := `. item 1
 +
 ----
 foo
 ----`
-		expected := `<div class="olist arabic">
+			expected := `<div class="olist arabic">
 <ol class="arabic">
 <li>
 <p>item 1</p>
@@ -143,7 +145,106 @@ foo
 </ol>
 </div>
 `
-		Expect(RenderHTML(source)).To(MatchHTML(expected))
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+		})
+
+		It("case 3", func() {
+			source := `. cookie
++
+image::cookie.png[]
++
+. chocolate
++
+image::chocolate.png[]`
+			expected := `<div class="olist arabic">
+<ol class="arabic">
+<li>
+<p>cookie</p>
+<div class="imageblock">
+<div class="content">
+<img src="cookie.png" alt="cookie">
+</div>
+</div>
+</li>
+<li>
+<p>chocolate</p>
+<div class="imageblock">
+<div class="content">
+<img src="chocolate.png" alt="chocolate">
+</div>
+</div>
+</li>
+</ol>
+</div>
+`
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+		})
+
+		It("case 4", func() {
+			source := `. In the table, enter the data shown in <<non-uniform-mesh>>
++
+[#non-uniform-mesh]
+.Non-Uniform Mesh Parameters
+[cols="3*^",options="header"]
+|===
+|Dir (X,Y,Z) |Num Cells |Size
+|X |10 |0.1
+|Y |10 |0.1
+|Y |5  |0.2
+|Z |10 |0.1
+|===
++
+. Click *OK*`
+			expected := `<div class="olist arabic">
+<ol class="arabic">
+<li>
+<p>In the table, enter the data shown in <a href="#non-uniform-mesh">Non-Uniform Mesh Parameters</a></p>
+<table id="non-uniform-mesh" class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 1. Non-Uniform Mesh Parameters</caption>
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-center valign-top">Dir (X,Y,Z)</th>
+<th class="tableblock halign-center valign-top">Num Cells</th>
+<th class="tableblock halign-center valign-top">Size</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-center valign-top"><p class="tableblock">X</p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock">10</p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock">0.1</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-center valign-top"><p class="tableblock">Y</p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock">10</p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock">0.1</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-center valign-top"><p class="tableblock">Y</p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock">5</p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock">0.2</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-center valign-top"><p class="tableblock">Z</p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock">10</p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock">0.1</p></td>
+</tr>
+</tbody>
+</table>
+</li>
+<li>
+<p>Click <strong>OK</strong></p>
+</li>
+</ol>
+</div>
+`
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+		})
 	})
 
 	It("with unnumbered items", func() {
@@ -195,7 +296,7 @@ foo
 		Expect(RenderHTML(source)).To(MatchHTML(expected))
 	})
 
-	It("ordered list mixed with unordered list - simple case", func() {
+	It("mixed with unordered list - simple case", func() {
 		source := `. Linux
 * Fedora
 * Ubuntu
@@ -240,7 +341,7 @@ foo
 		Expect(RenderHTML(source)).To(MatchHTML(expected))
 	})
 
-	It("ordered list mixed with unordered list - complex case", func() {
+	It("mixed with unordered list - complex case", func() {
 		source := `- unordered 1
 1. ordered 1.1
 	a. ordered 1.1.a

--- a/pkg/renderer/sgml/html5/table.go
+++ b/pkg/renderer/sgml/html5/table.go
@@ -1,7 +1,7 @@
 package html5
 
 const (
-	tableTmpl = "<table class=\"tableblock" +
+	tableTmpl = "<table {{ if .ID }}id=\"{{ .ID }}\" {{ end }}class=\"tableblock" +
 		" frame-{{ .Frame }} grid-{{ .Grid }}" +
 		"{{ if .Stripes }} stripes-{{ .Stripes }}{{ end }}" +
 		"{{ if .Fit }} {{ .Fit }}{{ end }}" +

--- a/pkg/renderer/sgml/html5/unordered_list_test.go
+++ b/pkg/renderer/sgml/html5/unordered_list_test.go
@@ -134,13 +134,15 @@ short) breaks</p>
 		Expect(RenderHTML(source)).To(MatchHTML(expected))
 	})
 
-	It("simple unordered list with continuation", func() {
-		source := `* item 1
+	Context("with list element continuation", func() {
+
+		It("case 1", func() {
+			source := `* item 1
 +
 foo
 
 * item 2`
-		expected := `<div class="ulist">
+			expected := `<div class="ulist">
 <ul>
 <li>
 <p>item 1</p>
@@ -154,7 +156,63 @@ foo
 </ul>
 </div>
 `
-		Expect(RenderHTML(source)).To(MatchHTML(expected))
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+		})
+
+		It("case 2", func() {
+			source := `* foo
++
+----
+a delimited block
+----
++
+----
+another delimited block
+----
+* bar
+`
+			expected := `<div class="ulist">
+<ul>
+<li>
+<p>foo</p>
+<div class="listingblock">
+<div class="content">
+<pre>a delimited block</pre>
+</div>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>another delimited block</pre>
+</div>
+</div>
+</li>
+<li>
+<p>bar</p>
+</li>
+</ul>
+</div>
+`
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+		})
+
+		It("case 3", func() {
+			source := `- here
++
+_there_
+`
+			expected := `<div class="ulist">
+<ul>
+<li>
+<p>here</p>
+<div class="paragraph">
+<p><em>there</em></p>
+</div>
+</li>
+</ul>
+</div>
+`
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+		})
 	})
 
 	It("nested unordered lists without a title", func() {
@@ -209,61 +267,6 @@ foo
 </li>
 <li>
 <p>item 2</p>
-</li>
-</ul>
-</div>
-`
-		Expect(RenderHTML(source)).To(MatchHTML(expected))
-	})
-
-	It("unordered list with item continuation - case 1", func() {
-		source := `* foo
-+
-----
-a delimited block
-----
-+
-----
-another delimited block
-----
-* bar
-`
-		expected := `<div class="ulist">
-<ul>
-<li>
-<p>foo</p>
-<div class="listingblock">
-<div class="content">
-<pre>a delimited block</pre>
-</div>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre>another delimited block</pre>
-</div>
-</div>
-</li>
-<li>
-<p>bar</p>
-</li>
-</ul>
-</div>
-`
-		Expect(RenderHTML(source)).To(MatchHTML(expected))
-	})
-
-	It("unordered list with item continuation - case 2", func() {
-		source := `- here
-+
-_there_
-`
-		expected := `<div class="ulist">
-<ul>
-<li>
-<p>here</p>
-<div class="paragraph">
-<p><em>there</em></p>
-</div>
 </li>
 </ul>
 </div>

--- a/pkg/renderer/sgml/table.go
+++ b/pkg/renderer/sgml/table.go
@@ -7,9 +7,7 @@ import (
 
 	"github.com/bytesparadise/libasciidoc/pkg/renderer"
 	"github.com/bytesparadise/libasciidoc/pkg/types"
-	"github.com/davecgh/go-spew/spew"
 	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
 )
 
 func (r *sgmlRenderer) renderTable(ctx *renderer.Context, t *types.Table) (string, error) {
@@ -94,6 +92,7 @@ func (r *sgmlRenderer) renderTable(ctx *renderer.Context, t *types.Table) (strin
 	}
 	err = r.table.Execute(result, struct {
 		Context     *renderer.Context
+		ID          string
 		Title       string
 		Columns     []*types.TableColumn
 		TableNumber int
@@ -110,6 +109,7 @@ func (r *sgmlRenderer) renderTable(ctx *renderer.Context, t *types.Table) (strin
 		Footer      string
 	}{
 		Context:     ctx,
+		ID:          r.renderElementID(t.Attributes),
 		Title:       title,
 		Columns:     columns,
 		TableNumber: number,
@@ -186,11 +186,11 @@ func (r *sgmlRenderer) renderTableFooter(ctx *renderer.Context, f *types.TableRo
 }
 
 func (r *sgmlRenderer) renderTableBody(ctx *renderer.Context, rows []*types.TableRow, columns []*types.TableColumn) (string, error) {
-	if log.IsLevelEnabled(log.DebugLevel) {
-		log.Debug("rendering table body")
-		log.Debugf("columns:\n%s", spew.Sdump(columns))
-		log.Debugf("rows:\n%s", spew.Sdump(rows))
-	}
+	// if log.IsLevelEnabled(log.DebugLevel) {
+	// 	log.Debug("rendering table body")
+	// 	log.Debugf("columns:\n%s", spew.Sdump(columns))
+	// 	log.Debugf("rows:\n%s", spew.Sdump(rows))
+	// }
 	result := &strings.Builder{}
 	content := &strings.Builder{}
 	for _, row := range rows {
@@ -242,9 +242,9 @@ func (r *sgmlRenderer) renderTableCell(ctx *renderer.Context, tmpl *template.Tem
 	if err != nil {
 		return "", errors.Wrap(err, "unable to render cell")
 	}
-	if log.IsLevelEnabled(log.DebugLevel) {
-		log.Debugf("rendering cell with content '%s' and def %s", content, spew.Sdump(col))
-	}
+	// if log.IsLevelEnabled(log.DebugLevel) {
+	// 	log.Debugf("rendering cell with content '%s' and def %s", content, spew.Sdump(col))
+	// }
 	err = tmpl.Execute(result, struct {
 		Context *renderer.Context
 		Content string

--- a/pkg/renderer/sgml/xhtml5/table.go
+++ b/pkg/renderer/sgml/xhtml5/table.go
@@ -1,7 +1,7 @@
 package xhtml5
 
 const (
-	tableTmpl = "<table class=\"tableblock" +
+	tableTmpl = "<table {{ if .ID }}id=\"{{ .ID }}\" {{ end }}class=\"tableblock" +
 		" frame-{{ .Frame }} grid-{{ .Grid }}" +
 		"{{ if .Stripes }} stripes-{{ .Stripes }}{{ end }}" +
 		"{{ if .Fit }} {{ .Fit }}{{ end }}" +

--- a/pkg/renderer/sgml/xhtml5/table_test.go
+++ b/pkg/renderer/sgml/xhtml5/table_test.go
@@ -498,8 +498,6 @@ var _ = Describe("tables", func() {
 	})
 
 	It("columns with alignment changes", func() {
-		// source := "[cols=\"2*^.^,<,.>,>\"]\n|===\n|==="
-
 		source := "[cols=\"2*^.^,<,.>,>\"]\n|===\n|h1|h2|h3|h4|h5\n\n|one|two|three|four|five\n|==="
 		expected := `<table class="tableblock frame-all grid-all stretch">
 <colgroup>
@@ -617,6 +615,59 @@ var _ = Describe("tables", func() {
 <td class="tableblock halign-left valign-top"><p class="tableblock">Column 3, footer row</p></td>
 </tr>
 </tfoot>
+</table>
+`
+		Expect(RenderHTML(source)).To(MatchHTML(expected))
+	})
+
+	It("with id and title", func() {
+		source := `[#non-uniform-mesh]
+.Non-Uniform Mesh Parameters
+[cols="3*^",options="header"]
+|===
+|Dir (X,Y,Z) |Num Cells |Size
+|X |10 |0.1
+|Y |10 |0.1
+|Y |5  |0.2
+|Z |10 |0.1
+|===`
+
+		expected := `<table id="non-uniform-mesh" class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 1. Non-Uniform Mesh Parameters</caption>
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-center valign-top">Dir (X,Y,Z)</th>
+<th class="tableblock halign-center valign-top">Num Cells</th>
+<th class="tableblock halign-center valign-top">Size</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-center valign-top"><p class="tableblock">X</p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock">10</p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock">0.1</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-center valign-top"><p class="tableblock">Y</p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock">10</p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock">0.1</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-center valign-top"><p class="tableblock">Y</p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock">5</p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock">0.2</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-center valign-top"><p class="tableblock">Z</p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock">10</p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock">0.1</p></td>
+</tr>
+</tbody>
 </table>
 `
 		Expect(RenderHTML(source)).To(MatchHTML(expected))


### PR DESCRIPTION
also, verifies that cross references work in list element continuations
(#837)

Fixes #867
Fixes #837

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
