### PR TITLE
fix(renderer): missing footer when rendering with XHTML5 backend

### DIFF
--- a/pkg/renderer/sgml/xhtml5/delimited_block_passthrough_test.go
+++ b/pkg/renderer/sgml/xhtml5/delimited_block_passthrough_test.go
@@ -35,7 +35,7 @@ _foo_
 
 <input>
 `
-			Expect(RenderHTML(source)).To(MatchHTML(expected))
+			Expect(RenderXHTML(source)).To(MatchHTML(expected))
 		})
 
 	})

--- a/pkg/renderer/sgml/xhtml5/paragraph_test.go
+++ b/pkg/renderer/sgml/xhtml5/paragraph_test.go
@@ -274,7 +274,7 @@ this is a note.
 </table>
 </div>
 `
-			Expect(RenderHTML(source)).To(MatchHTML(expected))
+			Expect(RenderXHTML(source)).To(MatchHTML(expected))
 		})
 
 		It("admonition warning default caption", func() {
@@ -293,7 +293,7 @@ Missiles inbound.
 </table>
 </div>
 `
-			Expect(RenderHTML(source)).To(MatchHTML(expected))
+			Expect(RenderXHTML(source)).To(MatchHTML(expected))
 		})
 	})
 

--- a/pkg/renderer/sgml/xhtml5/table.go
+++ b/pkg/renderer/sgml/xhtml5/table.go
@@ -18,6 +18,7 @@ const (
 		"</colgroup>\n" +
 		"{{ .Header }}" +
 		"{{ .Body }}" +
+		"{{ .Footer }}" +
 		"{{ end }}" +
 		"</table>\n"
 )

--- a/pkg/renderer/sgml/xhtml5/table_test.go
+++ b/pkg/renderer/sgml/xhtml5/table_test.go
@@ -540,9 +540,9 @@ var _ = Describe("tables", func() {
 |===`
 		expected := `<table class="tableblock frame-all grid-all stretch">
 <colgroup>
-<col style="width: 33.3333%;">
-<col style="width: 33.3333%;">
-<col style="width: 33.3334%;">
+<col style="width: 33.3333%;"/>
+<col style="width: 33.3333%;"/>
+<col style="width: 33.3334%;"/>
 </colgroup>
 <thead>
 <tr>
@@ -570,7 +570,7 @@ var _ = Describe("tables", func() {
 </tbody>
 </table>
 `
-		Expect(RenderHTML(source)).To(MatchHTML(expected))
+		Expect(RenderXHTML(source)).To(MatchHTML(expected))
 	})
 
 	It("with header and footer options", func() {
@@ -590,9 +590,9 @@ var _ = Describe("tables", func() {
 |===`
 		expected := `<table class="tableblock frame-all grid-all stretch">
 <colgroup>
-<col style="width: 40%;">
-<col style="width: 40%;">
-<col style="width: 20%;">
+<col style="width: 40%;"/>
+<col style="width: 40%;"/>
+<col style="width: 20%;"/>
 </colgroup>
 <thead>
 <tr>
@@ -617,7 +617,7 @@ var _ = Describe("tables", func() {
 </tfoot>
 </table>
 `
-		Expect(RenderHTML(source)).To(MatchHTML(expected))
+		Expect(RenderXHTML(source)).To(MatchHTML(expected))
 	})
 
 	It("with id and title", func() {
@@ -635,9 +635,9 @@ var _ = Describe("tables", func() {
 		expected := `<table id="non-uniform-mesh" class="tableblock frame-all grid-all stretch">
 <caption class="title">Table 1. Non-Uniform Mesh Parameters</caption>
 <colgroup>
-<col style="width: 33.3333%;">
-<col style="width: 33.3333%;">
-<col style="width: 33.3334%;">
+<col style="width: 33.3333%;"/>
+<col style="width: 33.3333%;"/>
+<col style="width: 33.3334%;"/>
 </colgroup>
 <thead>
 <tr>
@@ -670,7 +670,7 @@ var _ = Describe("tables", func() {
 </tbody>
 </table>
 `
-		Expect(RenderHTML(source)).To(MatchHTML(expected))
+		Expect(RenderXHTML(source)).To(MatchHTML(expected))
 	})
 	// TODO: Verify styles -- it's verified in the parser for now, but we still need to implement styles.
 })


### PR DESCRIPTION
Also, fix a few other tests in the `xhtml5_test` package which were
using the `HTML5` renderer intead of the `XHTML5` one :/

Fixes #870

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
