### PR TITLE
refactor(test): support multiple assertions

### DIFF
--- a/libasciidoc_test.go
+++ b/libasciidoc_test.go
@@ -316,6 +316,8 @@ Last updated {{.LastUpdated}}
 		Context("with body only", func() {
 
 			It("should render valid manpage", func() {
+				logs, reset := ConfigureLogger(log.WarnLevel)
+				defer reset()
 				source := `= eve(1)
 Andrew Stanton
 v1.0.0
@@ -364,12 +366,15 @@ Free use of this software is granted under the terms of the MIT License.</p>
 					))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(out.String()).To(MatchHTML(expectedContent))
+				Expect(logs).To(ContainJSONLog(log.WarnLevel, "unable to find attribute 'author'"))
 			})
 		})
 
 		Context("full", func() {
 
 			It("should render valid manpage", func() {
+				logs, reset := ConfigureLogger(log.WarnLevel)
+				defer reset()
 				source := `= eve(1)
 Andrew Stanton
 v1.0.0
@@ -446,9 +451,12 @@ Last updated {{.LastUpdated}}
 					))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(out.String()).To(MatchHTMLTemplate(expectedContent, lastUpdated))
+				Expect(logs).To(ContainJSONLog(log.WarnLevel, "unable to find attribute 'author'"))
 			})
 
 			It("should render invalid manpage as article", func() {
+				logs, reset := ConfigureLogger(log.WarnLevel)
+				defer reset()
 				source := `= eve(1)
 Andrew Stanton
 v1.0.0
@@ -533,6 +541,9 @@ Last updated {{.LastUpdated}}
 					))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(out.String()).To(MatchHTMLTemplate(expectedContent, lastUpdated))
+				Expect(logs).To(ContainJSONLog(log.WarnLevel, "unable to find attribute 'author'"))
+				Expect(logs).To(ContainJSONLog(log.WarnLevel, "changing doctype to 'article' because problems were found in the document"))
+				Expect(logs).To(ContainJSONLog(log.ErrorLevel, "manpage document is missing the 'Name' section"))
 			})
 
 			It("should render html", func() {
@@ -622,6 +633,8 @@ Last updated {{.LastUpdated}}
 			})
 
 			It("should fail given bogus backend", func() {
+				_, reset := ConfigureLogger(log.WarnLevel)
+				defer reset()
 				source := `= Story
 
 Our story begins.`

--- a/pkg/parser/delimited_block_listing_test.go
+++ b/pkg/parser/delimited_block_listing_test.go
@@ -1162,7 +1162,7 @@ and <more text> on the +
 				})
 
 				It("should fail when substitution is unknown", func() {
-					logs, reset := ConfigureLogger(log.DebugLevel) //, DiscardStdout)
+					logs, reset := ConfigureLogger(log.ErrorLevel)
 					defer reset()
 					s := strings.ReplaceAll(source, "$SUBS", "unknown")
 					expected := &types.Document{
@@ -1174,7 +1174,7 @@ and <more text> on the +
 						},
 					}
 					Expect(ParseDocument(s)).To(MatchDocument(expected))
-					Expect(logs).To(ContainJSONLog(log.ErrorLevel, 33, 183, "unsupported kind of substitution: 'unknown'"))
+					Expect(logs).To(ContainJSONLogWithOffset(log.ErrorLevel, 33, 183, "unsupported kind of substitution: 'unknown'"))
 				})
 			})
 		})

--- a/pkg/parser/document_processing_include_files_test.go
+++ b/pkg/parser/document_processing_include_files_test.go
@@ -786,7 +786,7 @@ last line of parent `,
 					source := `include::../../test/includes/chapter-a.adoc[lines=1;3..4;6..foo]` // not a number
 					expected := &types.Document{}
 					Expect(ParseDocument(source)).To(MatchDocument(expected))
-					Expect(logs).To(ContainJSONLog(log.ErrorLevel, 0, 64, "Unresolved directive in test.adoc - include::../../test/includes/chapter-a.adoc[lines=1;3..4;6..foo]"))
+					Expect(logs).To(ContainJSONLogWithOffset(log.ErrorLevel, 0, 64, "Unresolved directive in test.adoc - include::../../test/includes/chapter-a.adoc[lines=1;3..4;6..foo]"))
 				})
 
 				It("with invalid unquoted range - case 2", func() {
@@ -908,7 +908,7 @@ last line of parent `,
 					source := `include::../../test/includes/chapter-a.adoc[lines="1,3..4,6..foo"]` // not a number
 					_, err := ParseDocument(source)
 					Expect(err).NotTo(HaveOccurred()) // parsing does not fail, but an error is logged for the fragment with the `include` macro
-					Expect(logs).To(ContainJSONLog(log.ErrorLevel, 0, 66, "Unresolved directive in test.adoc - include::../../test/includes/chapter-a.adoc[lines=\"1,3..4,6..foo\"]"))
+					Expect(logs).To(ContainJSONLogWithOffset(log.ErrorLevel, 0, 66, "Unresolved directive in test.adoc - include::../../test/includes/chapter-a.adoc[lines=\"1,3..4,6..foo\"]"))
 				})
 
 				It("with ignored tags", func() {
@@ -1030,7 +1030,7 @@ last line of parent `,
 				}
 				Expect(ParseDocument(source)).To(MatchDocument(expected))
 				// verify error in logs
-				Expect(logs).To(ContainJSONLog(log.WarnLevel, -1, -1, "detected unclosed tag 'unclosed' starting at line 6 of include file: ../../test/includes/tag-include-unclosed.adoc"))
+				Expect(logs).To(ContainJSONLog(log.WarnLevel, "detected unclosed tag 'unclosed' starting at line 6 of include file: ../../test/includes/tag-include-unclosed.adoc"))
 			})
 
 			It("with unknown tag", func() {
@@ -1043,7 +1043,7 @@ last line of parent `,
 				_, err := ParseDocument(source)
 				// verify error in logs
 				Expect(err).NotTo(HaveOccurred()) // parsing does not fail, but an error is logged for the fragment with the `include` macro
-				Expect(logs).To(ContainJSONLog(log.ErrorLevel, 0, 58, "Unresolved directive in test.adoc - include::../../test/includes/tag-include.adoc[tag=unknown]: tag 'unknown' not found in file to include"))
+				Expect(logs).To(ContainJSONLogWithOffset(log.ErrorLevel, 0, 58, "Unresolved directive in test.adoc - include::../../test/includes/tag-include.adoc[tag=unknown]: tag 'unknown' not found in file to include"))
 			})
 
 			It("with no tag", func() {
@@ -1308,7 +1308,7 @@ last line of parent `,
 				source := `include::{unknown}/unknown.adoc[leveloffset=+1]`
 				expected := &types.Document{}
 				Expect(ParseDocument(source)).To(MatchDocument(expected))
-				Expect(logs).To(ContainJSONLog(log.ErrorLevel, 0, 47, "Unresolved directive in test.adoc - include::{unknown}/unknown.adoc[leveloffset=+1]"))
+				Expect(logs).To(ContainJSONLogWithOffset(log.ErrorLevel, 0, 47, "Unresolved directive in test.adoc - include::{unknown}/unknown.adoc[leveloffset=+1]"))
 			})
 
 			It("should fail if file is missing in standalone block", func() {
@@ -1317,7 +1317,7 @@ last line of parent `,
 				source := `include::{unknown}/unknown.adoc[leveloffset=+1]`
 				expected := &types.Document{}
 				Expect(ParseDocument(source)).To(MatchDocument(expected))
-				Expect(logs).To(ContainJSONLog(log.ErrorLevel, 0, 47, "Unresolved directive in test.adoc - include::{unknown}/unknown.adoc[leveloffset=+1]"))
+				Expect(logs).To(ContainJSONLogWithOffset(log.ErrorLevel, 0, 47, "Unresolved directive in test.adoc - include::{unknown}/unknown.adoc[leveloffset=+1]"))
 			})
 
 			It("should fail if file with attribute in path is not resolved in standalone block", func() {
@@ -1326,7 +1326,7 @@ last line of parent `,
 				source := `include::{includedir}/unknown.adoc[leveloffset=+1]`
 				expected := &types.Document{}
 				Expect(ParseDocument(source)).To(MatchDocument(expected))
-				Expect(logs).To(ContainJSONLog(log.ErrorLevel, 0, 50, "Unresolved directive in test.adoc - include::{includedir}/unknown.adoc[leveloffset=+1]"))
+				Expect(logs).To(ContainJSONLogWithOffset(log.ErrorLevel, 0, 50, "Unresolved directive in test.adoc - include::{includedir}/unknown.adoc[leveloffset=+1]"))
 			})
 
 			It("should fail if file is missing in delimited block", func() {
@@ -1337,7 +1337,7 @@ include::../../test/includes/unknown.adoc[leveloffset=+1]
 ----`
 				expected := &types.Document{}
 				Expect(ParseDocument(source)).To(MatchDocument(expected))
-				Expect(logs).To(ContainJSONLog(log.ErrorLevel, 0, 67, "Unresolved directive in test.adoc - include::../../test/includes/unknown.adoc[leveloffset=+1]"))
+				Expect(logs).To(ContainJSONLogWithOffset(log.ErrorLevel, 0, 67, "Unresolved directive in test.adoc - include::../../test/includes/unknown.adoc[leveloffset=+1]"))
 			})
 
 			It("should fail if file with attribute in path is not resolved in delimited block", func() {
@@ -1348,7 +1348,7 @@ include::{includedir}/unknown.adoc[leveloffset=+1]
 ----`
 				expected := &types.Document{}
 				Expect(ParseDocument(source)).To(MatchDocument(expected))
-				Expect(logs).To(ContainJSONLog(log.ErrorLevel, 0, 60, "Unresolved directive in test.adoc - include::{includedir}/unknown.adoc[leveloffset=+1]"))
+				Expect(logs).To(ContainJSONLogWithOffset(log.ErrorLevel, 0, 60, "Unresolved directive in test.adoc - include::{includedir}/unknown.adoc[leveloffset=+1]"))
 			})
 		})
 

--- a/pkg/renderer/sgml/html5/file_inclusion_test.go
+++ b/pkg/renderer/sgml/html5/file_inclusion_test.go
@@ -725,7 +725,7 @@ func helloworld() {
 `
 			Expect(RenderHTML(source)).To(MatchHTML(expected))
 			// verify error in logs
-			Expect(logs).To(ContainJSONLog(log.WarnLevel, -1, -1, "detected unclosed tag 'unclosed' starting at line 6 of include file: ../../../../test/includes/tag-include-unclosed.adoc"))
+			Expect(logs).To(ContainJSONLog(log.WarnLevel, "detected unclosed tag 'unclosed' starting at line 6 of include file: ../../../../test/includes/tag-include-unclosed.adoc"))
 		})
 
 		It("file inclusion with no tag", func() {

--- a/pkg/renderer/sgml/xhtml5/file_inclusion_test.go
+++ b/pkg/renderer/sgml/xhtml5/file_inclusion_test.go
@@ -723,7 +723,7 @@ func helloworld() {
 `
 			Expect(RenderXHTML(source)).To(MatchHTML(expected))
 			// verify error in logs
-			Expect(logs).To(ContainJSONLog(log.WarnLevel, -1, -1, "detected unclosed tag 'unclosed' starting at line 6 of include file: ../../../../test/includes/tag-include-unclosed.adoc"))
+			Expect(logs).To(ContainJSONLog(log.WarnLevel, "detected unclosed tag 'unclosed' starting at line 6 of include file: ../../../../test/includes/tag-include-unclosed.adoc"))
 		})
 
 		It("file inclusion with no tag", func() {


### PR DESCRIPTION
make sure that a test can call multiple times
assertions such as `ContainJSONLog` on a given
console output.

Also, provide the alternative `ContainJSONLogWithOffset func
to assert lines with `start_offset` and `end_offset` fields.

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
