### PR TITLE
refactor(parser): remove unnecessary grammar rules

### DIFF
--- a/pkg/parser/document_preprocessing_include_files.go
+++ b/pkg/parser/document_preprocessing_include_files.go
@@ -53,7 +53,7 @@ func processFileInclusions(ctx *ParseContext, source io.Reader) (string, error) 
 				content.WriteString(f)
 			case *types.BlockDelimiter:
 				t.push(types.BlockDelimiterKind(e.Kind))
-				ctx.Opts = append(ctx.Opts, GlobalStore(delimitedBlockScopeKey, t.withinDelimitedBlock()))
+				ctx.Opts = append(ctx.Opts, withinDelimitedBlock(t.withinDelimitedBlock()))
 				t, _ := e.RawText()
 				content.WriteString(t)
 			default:

--- a/pkg/parser/document_processing_parse_fragments.go
+++ b/pkg/parser/document_processing_parse_fragments.go
@@ -90,7 +90,7 @@ func parseDelimitedBlockElements(ctx *ParseContext, b *types.DelimitedBlock) ([]
 	log.Debugf("parsing content of delimited block of kind '%s'", b.Kind)
 	// TODO: use real Substitution?
 	content, placeholders := serialize(b.Elements)
-	opts := append(ctx.Opts, Entrypoint("DelimitedBlockElements"), GlobalStore(delimitedBlockScopeKey, true))
+	opts := append(ctx.Opts, Entrypoint("DelimitedBlockElements"), withinDelimitedBlock(true))
 	elements, err := Parse("", content, opts...)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to parse content") // ignore error (malformed content)

--- a/pkg/parser/parser.peg
+++ b/pkg/parser/parser.peg
@@ -690,16 +690,7 @@ DelimitedBlockRawLine <-
 // Comment Blocks
 // ----------------
 CommentBlock <-
-    &{
-        // only accept if not already in a delimited block of this kind
-        return !c.isWithinDelimitedBlockOfKind(types.Comment), nil
-    }
     CommentBlockStartDelimiter
-    &{
-        // only accept if the delimiter matches the current delimited block or if no kind is registered yet
-        c.setWithinDelimitedBlockOfKind(types.Comment)
-        return true, nil
-    }
     content:(CommentBlockContent)
     CommentBlockEndDelimiter? {
         c.unsetWithinDelimitedBlock()
@@ -720,18 +711,9 @@ CommentBlockContent <-
 // Example Blocks
 // ----------------------
 ExampleBlock <-
-    &{
-        // only accept if not already in a delimited block of this kind
-        return !c.isWithinDelimitedBlockOfKind(types.Example), nil
-    }
     ExampleBlockStartDelimiter
-    &{
-        // only accept if the delimiter matches the current delimited block or if no kind is registered yet
-        c.setWithinDelimitedBlockOfKind(types.Example)
-        return true, nil
-    }
     content:(ExampleBlockContent)
-    ExampleBlockEndDelimiter {
+    ExampleBlockEndDelimiter? {
         c.unsetWithinDelimitedBlock()
         return types.NewDelimitedBlock(types.Example, content.([]interface{}))
     }
@@ -750,18 +732,9 @@ ExampleBlockContent <-
 // Fenced Blocks
 // ----------------------
 FencedBlock <-
-    &{
-        // only accept if not already in a delimited block of this kind
-        return !c.isWithinDelimitedBlockOfKind(types.Fenced), nil
-    }
     FencedBlockStartDelimiter
-    &{
-        // only accept if the delimiter matches the current delimited block or if no kind is registered yet
-        c.setWithinDelimitedBlockOfKind(types.Fenced)
-        return true, nil
-    }
     content:(FencedBlockContent)
-    FencedBlockEndDelimiter {
+    FencedBlockEndDelimiter? {
         c.unsetWithinDelimitedBlock()
         return types.NewDelimitedBlock(types.Fenced, content.([]interface{}))
     }
@@ -780,18 +753,9 @@ FencedBlockContent <-
 // Listing Blocks
 // ----------------------
 ListingBlock <-
-    &{
-        // only accept if not already in a delimited block of this kind
-        return !c.isWithinDelimitedBlockOfKind(types.Listing), nil
-    }
     ListingBlockStartDelimiter
-    &{
-        // only accept if the delimiter matches the current delimited block or if no kind is registered yet
-        c.setWithinDelimitedBlockOfKind(types.Listing)
-        return true, nil
-    }
     content:(ListingBlockContent)
-    ListingBlockEndDelimiter {
+    ListingBlockEndDelimiter? {
         c.unsetWithinDelimitedBlock()
         return types.NewDelimitedBlock(types.Listing, content.([]interface{}))
     }
@@ -811,16 +775,7 @@ ListingBlockContent <-
 // ----------------------
 LiteralBlock <-
     LiteralBlockStartDelimiter
-    &{
-        // only accept if not already in a delimited block of this kind
-        return !c.isWithinDelimitedBlockOfKind(types.Literal), nil
-    }
     content:(LiteralBlockContent)
-    &{
-        // only accept if the delimiter matches the current delimited block or if no kind is registered yet
-        c.setWithinDelimitedBlockOfKind(types.Literal)
-        return true, nil
-    }
     LiteralBlockEndDelimiter? {
         c.unsetWithinDelimitedBlock()
         return types.NewDelimitedBlock(types.Literal, content.([]interface{}))
@@ -866,16 +821,7 @@ MarkdownQuoteAttribution <-
 // Passthrough Blocks
 // ----------------------
 PassthroughBlock <-
-    &{
-        // only accept if not already in a delimited block of this kind
-        return !c.isWithinDelimitedBlockOfKind(types.Passthrough), nil
-    }
     PassthroughBlockStartDelimiter
-    &{
-        // only accept if the delimiter matches the current delimited block or if no kind is registered yet
-        c.setWithinDelimitedBlockOfKind(types.Passthrough)
-        return true, nil
-    }
     content:(PassthroughBlockContent)
     PassthroughBlockEndDelimiter? {
         c.unsetWithinDelimitedBlock()
@@ -896,18 +842,9 @@ PassthroughBlockContent <-
 // Quote Blocks
 // ----------------------
 QuoteBlock <-
-    &{
-        // only accept if not already in a delimited block of this kind
-        return !c.isWithinDelimitedBlockOfKind(types.Quote), nil
-    }
     QuoteBlockStartDelimiter
-    &{
-        // only accept if the delimiter matches the current delimited block or if no kind is registered yet
-        c.setWithinDelimitedBlockOfKind(types.Quote)
-        return true, nil
-    }
     content:(QuoteBlockContent)
-    QuoteBlockEndDelimiter {
+    QuoteBlockEndDelimiter? {
         c.unsetWithinDelimitedBlock()
         return types.NewDelimitedBlock(types.Quote, content.([]interface{}))
     }
@@ -926,18 +863,9 @@ QuoteBlockContent <-
 // Sidebar Blocks
 // ----------------------
 SidebarBlock <-
-    &{
-        // only accept if not already in a delimited block of this kind
-        return !c.isWithinDelimitedBlockOfKind(types.Sidebar), nil
-    }
     SidebarBlockStartDelimiter
-    &{
-        // only accept if the delimiter matches the current delimited block or if no kind is registered yet
-        c.setWithinDelimitedBlockOfKind(types.Sidebar)
-        return true, nil
-    }
     content:(SidebarBlockContent)
-    SidebarBlockEndDelimiter {
+    SidebarBlockEndDelimiter? {
         c.unsetWithinDelimitedBlock()
         return types.NewDelimitedBlock(types.Sidebar, content.([]interface{}))
     }

--- a/pkg/parser/parser_ext.go
+++ b/pkg/parser/parser_ext.go
@@ -170,15 +170,10 @@ func (c *current) isSectionEnabled() bool {
 	return found && enabled
 }
 
-const delimitedBlockScopeKey = "delimited_block_scope"
+const withinDelimitedBlockKey = "within_delimited_block"
 
-// state info to indicate that parsing is happening within a delimited block of the given kind,
-// in which case some grammar rules may need to be disabled
-func (c *current) setWithinDelimitedBlockOfKind(kind string) {
-	// if log.IsLevelEnabled(log.DebugLevel) {
-	// 	log.Debugf("setting scope within block of kind '%s'", kind)
-	// }
-	c.globalStore[delimitedBlockScopeKey] = kind
+func withinDelimitedBlock(v bool) Option {
+	return GlobalStore(withinDelimitedBlockKey, v)
 }
 
 // state info to indicate that parsing is happening within a delimited block of the given kind,
@@ -187,32 +182,17 @@ func (c *current) unsetWithinDelimitedBlock() {
 	// if log.IsLevelEnabled(log.DebugLevel) {
 	// 	log.Debugf("unsetting scope within block of kind '%s'", kind)
 	// }
-	delete(c.globalStore, delimitedBlockScopeKey)
+	delete(c.globalStore, withinDelimitedBlockKey)
 }
 
 // state info to determine if parsing is happening within a delimited block (any kind),
 // in which case some grammar rules need to be disabled
 func (c *current) isWithinDelimitedBlock() bool {
-	w, found := c.globalStore[delimitedBlockScopeKey].(bool)
+	w, found := c.globalStore[withinDelimitedBlockKey].(bool)
 	if log.IsLevelEnabled(log.DebugLevel) {
 		log.Debugf("checking if within delimited block: %t/%t", found, w)
 	}
 	return found && w
-}
-
-// state info to determine if parsing is happening within a delimited block of the given kind,
-// in which case some grammar rules need to be disabled
-func (c *current) isWithinDelimitedBlockOfKind(kind string) bool {
-	if k, found := c.globalStore[delimitedBlockScopeKey].(string); found {
-		// if log.IsLevelEnabled(log.DebugLevel) {
-		// 	log.Debugf("checking if within block of kind '%s': %t (1)", kind, k == kind)
-		// }
-		return k == kind
-	}
-	// if log.IsLevelEnabled(log.DebugLevel) {
-	// 	log.Debugf("checking if within block of kind '%s': false (2)", kind)
-	// }
-	return false
 }
 
 type blockDelimiterTracker struct {


### PR DESCRIPTION
no need for checking if/what kind of delimited block is being parsed.

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
