### PR TITLE
refactor(parser): simplify file inclusion rule

### DIFF
--- a/pkg/parser/document_preprocessing_include_files_test.go
+++ b/pkg/parser/document_preprocessing_include_files_test.go
@@ -65,7 +65,8 @@ include::{includedir}/include.foo[]`
 
 *some strong content*
 
-include::hello_world.go.txt[]`
+include::hello_world.go.txt[]
+`
 			Expect(PreparseDocument(source)).To(Equal(expected))
 		})
 

--- a/pkg/parser/document_processing_apply_substitutions.go
+++ b/pkg/parser/document_processing_apply_substitutions.go
@@ -1166,54 +1166,7 @@ func serialize(content interface{}) ([]byte, *placeholders) {
 	return result.Bytes(), placeholders
 }
 
-type grammarRule string
-
-const FileInclusion grammarRule = "FileInclusion"
-
-const disabledRules = "disabled_rules"
-
-func DisableRule(rule grammarRule) Option {
-	return func(p *parser) Option {
-		rules, ok := p.cur.globalStore[disabledRules].(map[grammarRule]bool)
-		if !ok { // 'rules' doesn't exist yet
-			rules = map[grammarRule]bool{}
-			p.cur.globalStore[disabledRules] = rules
-
-		}
-		rules[rule] = true // mark as disabled
-		return nil         // no need to provide an Option restore the setting
-	}
-}
-
-func (c *current) isRuleEnabled(rule grammarRule) (bool, error) {
-	if rules, ok := c.globalStore[disabledRules].(map[grammarRule]bool); ok {
-		if disabled, found := rules[rule]; found {
-			return !disabled, nil
-		}
-	}
-	return true, nil
-
-}
-
-// sets the new substitution plan in the golbal store, overriding any exist–ing one
-// NOTE: will override any existing substitution context
-func (c *current) setCurrentSubstitution(kind string) error {
-	// log.Debugf("setting current substitution kind to '%s'", kind)
-	p, err := newSubstitution(kind)
-	if err != nil {
-		return err
-	}
-	c.state[substitutionKey] = p
-	return nil
-}
-
 func (c *current) lookupCurrentSubstitution() (*substitution, bool) {
-	// look-up in the current state
-	if s, found := c.state[substitutionKey].(*substitution); found {
-		// log.Debug("found substitution in current state")
-		return s, found
-	}
-	// otherwise, lookup in the global-store
 	s, found := c.globalStore[substitutionKey].(*substitution)
 	return s, found
 }

--- a/pkg/parser/parser.peg
+++ b/pkg/parser/parser.peg
@@ -35,7 +35,7 @@ DocumentRawLine <-
     }
 
 // ----------------------------------------------------------
-// File inclusions
+// Raw Sections
 // ----------------------------------------------------------
 RawSection <- 
     &{
@@ -61,15 +61,6 @@ RawSection <-
 // File inclusions
 // ----------------------------------------------------------
 FileInclusion <- 
-    &{
-        // skip if disabled
-        return c.isRuleEnabled(FileInclusion)
-    }
-    #{
-        // force/enable attribute substitution // TODO: why? 
-        // log.Debug("entering FileInclusion rule")
-        return c.setCurrentSubstitution("attributes")
-    }
     incl:(
         "include::" 
         path:(FileLocation) 

--- a/pkg/parser/parser_ext.go
+++ b/pkg/parser/parser_ext.go
@@ -112,7 +112,7 @@ func (c *current) trackSpaceSuffix(element interface{}) {
 	case *types.StringElement:
 		c.globalStore[spaceSuffixTrackingKey] = strings.HasSuffix(e.Content, " ")
 	default:
-		delete(c.state, spaceSuffixTrackingKey)
+		delete(c.globalStore, spaceSuffixTrackingKey)
 	}
 	// if log.IsLevelEnabled(log.DebugLevel) {
 	// 	log.Debugf("space suffix detected: %t", c.globalStore[spaceSuffixTrackingKey])


### PR DESCRIPTION
remove unneeded conditions and simplify support for inclusion
of non-asciidoc files.

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
