### PR TITLE
feat(renderer): support for description metadata

### DIFF
--- a/pkg/renderer/sgml/html5/document_details_test.go
+++ b/pkg/renderer/sgml/html5/document_details_test.go
@@ -100,6 +100,43 @@ Last updated {{.LastUpdated}}
 			Expect(RenderHTML(source, configuration.WithHeaderFooter(true), configuration.WithLastUpdated(now))).
 				To(MatchHTMLTemplate(expected, now))
 		})
+
+		It("header with description", func() {
+			source := `= Document Title
+:description: a description
+
+some content`
+			expected := `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="generator" content="libasciidoc">
+<meta name="description" content="a description">
+<title>Document Title</title>
+</head>
+<body class="article">
+<div id="header">
+<h1>Document Title</h1>
+</div>
+<div id="content">
+<div class="paragraph">
+<p>some content</p>
+</div>
+</div>
+<div id="footer">
+<div id="footer-text">
+Last updated {{.LastUpdated}}
+</div>
+</div>
+</body>
+</html>
+`
+			now := time.Now()
+			Expect(RenderHTML(source, configuration.WithHeaderFooter(true), configuration.WithLastUpdated(now))).
+				To(MatchHTMLTemplate(expected, now))
+		})
 	})
 
 	Context("custom header and footer", func() {

--- a/pkg/renderer/sgml/html5/html5.go
+++ b/pkg/renderer/sgml/html5/html5.go
@@ -8,6 +8,7 @@ const (
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 {{ if .Generator }}<meta name="generator" content="{{ .Generator }}">
+{{ end }}{{ if .Description }}<meta name="description" content="{{ .Description }}">
 {{ end }}{{ if .Authors }}<meta name="author" content="{{ .Authors }}">
 {{ end }}{{ if .CSS}}<link type="text/css" rel="stylesheet" href="{{ .CSS }}">
 {{ end }}<title>{{ .Title }}</title>

--- a/pkg/renderer/sgml/renderer.go
+++ b/pkg/renderer/sgml/renderer.go
@@ -202,11 +202,12 @@ func (r *sgmlRenderer) Render(ctx *renderer.Context, doc *types.Document, output
 	if ctx.Config.WrapInHTMLBodyElement {
 		log.Debugf("Rendering full document...")
 		err = r.article.Execute(output, struct {
-			Generator string
-			Doctype   string
-			Title     string
-			Authors   string
-			Header    string
+			Doctype     string
+			Generator   string
+			Description string
+			Title       string
+			Authors     string
+			Header      string
 			// Role                  string
 			ID                    string
 			Roles                 string
@@ -217,8 +218,9 @@ func (r *sgmlRenderer) Render(ctx *renderer.Context, doc *types.Document, output
 			IncludeHTMLBodyHeader bool
 			IncludeHTMLBodyFooter bool
 		}{
-			Generator:             "libasciidoc", // TODO: externalize this value and include the lib version ?
 			Doctype:               ctx.Attributes.GetAsStringWithDefault(types.AttrDocType, "article"),
+			Generator:             "libasciidoc", // TODO: externalize this value and include the lib version ?
+			Description:           ctx.Attributes.GetAsStringWithDefault(types.AttrDescription, ""),
 			Title:                 renderedTitle,
 			Authors:               r.renderAuthors(ctx, doc),
 			Header:                renderedHeader,

--- a/pkg/types/attributes.go
+++ b/pkg/types/attributes.go
@@ -15,6 +15,8 @@ import (
 const (
 	// AttrDocType the "doctype" attribute
 	AttrDocType = "doctype"
+	// AttrDocType the "description" attribute
+	AttrDescription = "description"
 	// AttrSyntaxHighlighter the attribute to define the syntax highlighter on code source blocks
 	AttrSyntaxHighlighter = "source-highlighter"
 	// AttrID the key to retrieve the ID


### PR DESCRIPTION
appears in HTML document as a `<meta name="description" content="...">`
tag

fixes #892

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
