### PR TITLE
feat(parser): support soft-wrapping of attribute values

### DIFF
--- a/pkg/parser/document_header_test.go
+++ b/pkg/parser/document_header_test.go
@@ -1161,6 +1161,75 @@ a paragraph`
 				}
 				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
+
+			Context("with soft-wrapping", func() {
+
+				It("alone without indentation", func() {
+					source := `:description: a long \
+description on \
+multiple \
+lines.`
+					expected := &types.Document{
+						Elements: []interface{}{
+							&types.AttributeDeclaration{
+								Name:  "description",
+								Value: "a long description on multiple lines.",
+							},
+						},
+					}
+					Expect(ParseDocument(source)).To(MatchDocument(expected))
+				})
+
+				It("with other attributes without indentation", func() {
+					source := `:hardbreaks:
+:description: a long \
+description on \
+multiple \
+lines.
+:author: Xavier`
+					expected := &types.Document{
+						Elements: []interface{}{
+							&types.AttributeDeclaration{
+								Name: "hardbreaks",
+							},
+							&types.AttributeDeclaration{
+								Name:  "description",
+								Value: "a long description on multiple lines.",
+							},
+							&types.AttributeDeclaration{
+								Name:  "author",
+								Value: "Xavier",
+							},
+						},
+					}
+					Expect(ParseDocument(source)).To(MatchDocument(expected))
+				})
+
+				It("with other attributes and with variable indentation", func() {
+					source := `:hardbreaks:
+:description: a long \
+    description on \
+      multiple \
+    lines.
+:author: Xavier`
+					expected := &types.Document{
+						Elements: []interface{}{
+							&types.AttributeDeclaration{
+								Name: "hardbreaks",
+							},
+							&types.AttributeDeclaration{
+								Name:  "description",
+								Value: "a long description on multiple lines.",
+							},
+							&types.AttributeDeclaration{
+								Name:  "author",
+								Value: "Xavier",
+							},
+						},
+					}
+					Expect(ParseDocument(source)).To(MatchDocument(expected))
+				})
+			})
 		})
 
 		Context("invalid cases", func() {

--- a/pkg/parser/parser.peg
+++ b/pkg/parser/parser.peg
@@ -315,8 +315,14 @@ AdmonitionKind <- "TIP" {
 // -------------------------------------------------------------------------------------
 AttributeDeclaration <- 
     ":" name:(AttributeName) ":" 
-    value:(AttributeDeclarationValue)? 
-    EOL {
+    value:(
+        Spaces // value is optional, but there must be a space between `:` and value itself
+        value:(AttributeDeclarationValue) {
+            return value, nil
+        }
+    )? 
+    EOL
+    {
         return types.NewAttributeDeclaration(name.(string), types.Reduce(value, strings.TrimSpace), string(c.text))
     }
 
@@ -328,15 +334,33 @@ AttributeName <- [\pL0-9_] ([\pL0-9-])* {
     }
 
 AttributeDeclarationValue <- 
-    Spaces elements:(AttributeDeclarationValueElement)* {
+    elements:(AttributeDeclarationValueElements) 
+    otherElements:(
+        "\\" Newline 
+        Space*
+        elements:(AttributeDeclarationValue) {
+           return elements, nil
+        }
+    )*
+    {
+        if otherElements, ok := otherElements.([]interface{}); ok {
+            return types.Reduce(append(elements.([]interface{}), otherElements...), strings.TrimSpace), nil
+        }
         return types.Reduce(elements.([]interface{}), strings.TrimSpace), nil
     }
 
-AttributeDeclarationValueElement <- !EOL 
+AttributeDeclarationValueElements <- 
+    elements:(AttributeDeclarationValueElement)* {
+        return elements.([]interface{}), nil
+    }
+
+AttributeDeclarationValueElement <- 
+    !("\\"? Space* EOL)
     element:(
-        ([^\r\n{]+ {
+        ([^\r\n{ ]+ {
                 return types.NewStringElement(string(c.text))
         })
+        / Space
         / AttributeSubstitution
         / ("{" { // standalone '{'
             return types.NewStringElement(string(c.text))

--- a/pkg/renderer/sgml/html5/document_details_test.go
+++ b/pkg/renderer/sgml/html5/document_details_test.go
@@ -137,6 +137,52 @@ Last updated {{.LastUpdated}}
 			Expect(RenderHTML(source, configuration.WithHeaderFooter(true), configuration.WithLastUpdated(now))).
 				To(MatchHTMLTemplate(expected, now))
 		})
+
+		It("header with sotf-wrapped description", func() {
+			source := `= Document Title
+:author: Xavier
+:description: a long \
+			description on \
+			multiple \
+			lines.
+
+{description}`
+
+			expected := `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="generator" content="libasciidoc">
+<meta name="description" content="a long description on multiple lines.">
+<meta name="author" content="Xavier">
+<title>Document Title</title>
+</head>
+<body class="article">
+<div id="header">
+<h1>Document Title</h1>
+<div class="details">
+<span id="author" class="author">Xavier</span><br>
+</div>
+</div>
+<div id="content">
+<div class="paragraph">
+<p>a long description on multiple lines.</p>
+</div>
+</div>
+<div id="footer">
+<div id="footer-text">
+Last updated {{.LastUpdated}}
+</div>
+</div>
+</body>
+</html>
+`
+			now := time.Now()
+			Expect(RenderHTML(source, configuration.WithHeaderFooter(true), configuration.WithLastUpdated(now))).
+				To(MatchHTMLTemplate(expected, now))
+		})
 	})
 
 	Context("custom header and footer", func() {


### PR DESCRIPTION
using recursive grammar rule to parse subsequent lines when
line ends with the `\` continuation character.

fixes #891

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
