### PR TITLE
feat(parser): support attribute name in 'endif' directive

### DIFF
--- a/pkg/parser/document_preprocessing_conditionals_test.go
+++ b/pkg/parser/document_preprocessing_conditionals_test.go
@@ -133,6 +133,7 @@ ifdef::cookie[* conditional content]
 					Expect(PreparseDocument(source)).To(Equal(expected))
 				})
 			})
+
 		})
 
 		Context("ifndef", func() {
@@ -331,6 +332,37 @@ closing content`
 
 closing content`
 				Expect(PreparseDocument(source, configuration.WithAttribute("sectnumlevels", "2"))).To(Equal(expected))
+			})
+		})
+
+		Context("endif with attribute name", func() {
+
+			It("should support attribute name in endif directive", func() {
+				source := `:cookie:
+
+intro content
+
+ifdef::cookie[]
+cookie content (1)
+
+ifdef::chocolate[]
+chocolate content
+
+endif::chocolate[]
+cookie content (2)
+endif::cookie[]
+
+closing content`
+				expected := `:cookie:
+
+intro content
+
+cookie content (1)
+
+cookie content (2)
+
+closing content`
+				Expect(PreparseDocument(source)).To(Equal(expected))
 			})
 		})
 	})

--- a/pkg/parser/parser.peg
+++ b/pkg/parser/parser.peg
@@ -126,8 +126,8 @@ IfevalExpressionValue <-
     / InlineWord
 
 
-EndIf <- "endif::" InlineAttributes Space* EOF {
-         return types.NewEndOfCondition() // attributes are parsed but ignored
+EndIf <- "endif::" name:(ConditionalVariableName)? "[" attr:(ConditionalInclusionAttribute)? "]" Space* EOF {
+         return types.NewEndOfCondition() // name and attributes are parsed but ignored
     }
 
 ConditionalVariableName <- [^\r\n []+ { 


### PR DESCRIPTION
name is parsed but no check is done with regards to current ifdef/ifnded
directives.

fixes #898

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
