### PR TITLE
fix(parser/renderer): inline anchors and custom ID in sections

### DIFF
--- a/pkg/parser/attributes_test.go
+++ b/pkg/parser/attributes_test.go
@@ -517,7 +517,6 @@ var _ = DescribeTable("valid block attributes",
 		types.Attributes{
 			types.AttrPositional1: nil,
 			types.AttrPositional2: nil,
-			// types.AttrPositional3: nil,
 		},
 	),
 	// quoted values

--- a/pkg/parser/document_processing_filter_elements_test.go
+++ b/pkg/parser/document_processing_filter_elements_test.go
@@ -56,7 +56,6 @@ var _ = Describe("element filters", func() {
 				Kind: types.Listing,
 				Elements: []interface{}{
 					&types.StringElement{},
-					// &types.BlankLine{},
 					&types.StringElement{},
 				},
 			},

--- a/pkg/parser/icon_test.go
+++ b/pkg/parser/icon_test.go
@@ -39,9 +39,6 @@ var _ = Describe("icons", func() {
 								&types.Icon{
 									Class: "note",
 								},
-								// &types.StringElement{
-								// 	Content: "  \t\t  ",
-								// },
 							},
 						},
 					},

--- a/pkg/parser/mixed_lists_test.go
+++ b/pkg/parser/mixed_lists_test.go
@@ -1281,9 +1281,6 @@ a paragraph
 												},
 											},
 										},
-										// &types.SingleLineComment{
-										// 	Content: " -",
-										// },
 									},
 								},
 								&types.OrderedListElement{
@@ -1326,15 +1323,6 @@ a paragraph
 												},
 											},
 										},
-										// &types.SingleLineComment{
-										// 	Content: " -",
-										// },
-										// &types.SingleLineComment{
-										// 	Content: " -",
-										// },
-										// &types.SingleLineComment{
-										// 	Content: " -",
-										// },
 									},
 								},
 								&types.OrderedListElement{
@@ -1380,9 +1368,6 @@ a paragraph
 								},
 							},
 						},
-						// &types.SingleLineComment{
-						// 	Content: " -",
-						// },
 						&types.List{
 							Kind: types.OrderedListKind,
 							Elements: []types.ListElement{
@@ -1431,15 +1416,6 @@ a paragraph
 								},
 							},
 						},
-						// &types.SingleLineComment{
-						// 	Content: " -",
-						// },
-						// &types.SingleLineComment{
-						// 	Content: " -",
-						// },
-						// &types.SingleLineComment{
-						// 	Content: " -",
-						// },
 						&types.List{
 							Kind: types.OrderedListKind,
 							Elements: []types.ListElement{

--- a/pkg/parser/parser.peg
+++ b/pkg/parser/parser.peg
@@ -385,7 +385,7 @@ AttributeReset <- ":!" name:(AttributeName) ":" Space* EOL {
 BlockAttributes <-
     attributes:(
         // shorthand syntax for anchors. Eg: `[[an_id]]`
-        (anchor:(ShortHandAnchor) Space* EOL {
+        (anchor:(LegacyElementID) Space* EOL {
             return anchor, nil
         })
         // shorthand syntax for titles. Eg: `.a title`
@@ -416,7 +416,7 @@ InlineAttributes <-
     }
 
 // shorthand syntax for anchors. Eg: `[[An ID]]`
-ShortHandAnchor <-
+LegacyElementID <-
    "[[" 
     id:(
         elements:(
@@ -1130,16 +1130,6 @@ FrontMatterLine <- (.)* {
 // -------------------------------------------------------------------------------------
 // Inline Elements
 // -------------------------------------------------------------------------------------
-InlineElements <- 
-    elements:(comment:(SingleLineComment) {
-        return types.NewInlineElements([]interface{}{comment})
-    } / elements:(InlineElement)+ EOL { 
-        return types.NewInlineElements(elements.([]interface{}))
-    }) {
-        c.resetSpaceSuffixTracking()
-        return elements, nil
-    }
-
 
 // TODO: group as below and enable based on substitution context.
 // Also, add Callouts
@@ -1169,9 +1159,9 @@ InlineElement <-
 }
 
 // -------------------------------------------------------------------------------------
-// InlineElement ID
+// InlineAnchor 
 // -------------------------------------------------------------------------------------
-InlineElementID <- "[[" id:(Id) "]]" Space* { // no EOL here since there can be multiple InlineElementID on the same line
+InlineAnchor <- "[[" id:(Id) "]]" { // no EOL here since there can be multiple InlineElementID on the same line
     return types.NewInlineAnchor(id.(string))
 }
 
@@ -2467,7 +2457,8 @@ HeaderGroup <-
 HeaderGroupElement <-
     !EOF
     element:(
-        InlineWord
+        Word
+        / (Space+ id:(LegacyElementID) Space* &EOF { return id, nil}) // (legacy) element ID
         / Space
         / InlinePassthrough
         / SpecialCharacter
@@ -2477,7 +2468,7 @@ HeaderGroupElement <-
         / AttributeSubstitution
         / ElementPlaceHolder // needed when parsing a second time, after first pass returned attribute substitutions
         / Replacement
-        / ShortHandAnchor
+        / InlineAnchor // must be after LegacyElementID
         / InlineFootnote
         / AnyChar) {
             return element, nil
@@ -2602,7 +2593,7 @@ InlineMacro <-
         / InlineFootnote 
         / CrossReference 
         / InlineUserMacro 
-        / InlineElementID
+        / InlineAnchor
         / ConcealedIndexTerm
         / IndexTerm
         / InlineUserMacro) {

--- a/pkg/parser/section_test.go
+++ b/pkg/parser/section_test.go
@@ -1669,7 +1669,7 @@ a paragraph`
 				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
-			It("single section with custom ID", func() {
+			It("single with custom block ID", func() {
 				source := `[[custom_header]]
 == a header`
 				sectionTitle := []interface{}{
@@ -1693,7 +1693,113 @@ a paragraph`
 				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
-			It("multiple sections with custom IDs", func() {
+			It("single with custom inline ID", func() {
+				source := `== a header [[custom_header]]`
+				sectionTitle := []interface{}{
+					&types.StringElement{Content: "a header"},
+				}
+				expected := &types.Document{
+					ElementReferences: types.ElementReferences{
+						"custom_header": sectionTitle,
+					},
+					Elements: []interface{}{
+						&types.Section{
+							Attributes: types.Attributes{
+								types.AttrID:       "custom_header",
+								types.AttrCustomID: true,
+							},
+							Level: 1,
+							Title: sectionTitle,
+						},
+					},
+				}
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
+			})
+
+			It("single with attached inline anchor", func() {
+				source := `== a header[[bookmark]]`
+				sectionTitle := []interface{}{
+					&types.StringElement{Content: "a header"},
+					&types.InlineLink{
+						Attributes: types.Attributes{
+							types.AttrID: "bookmark",
+						},
+					},
+				}
+				expected := &types.Document{
+					ElementReferences: types.ElementReferences{
+						"_a_header": sectionTitle,
+					},
+					Elements: []interface{}{
+						&types.Section{
+							Attributes: types.Attributes{
+								types.AttrID: "_a_header",
+							},
+							Level: 1,
+							Title: sectionTitle,
+						},
+					},
+				}
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
+			})
+
+			It("single with attached inline anchor and inline ID", func() {
+				source := `== a header[[bookmark]] [[custom_header]]`
+				sectionTitle := []interface{}{
+					&types.StringElement{Content: "a header"},
+					&types.InlineLink{
+						Attributes: types.Attributes{
+							types.AttrID: "bookmark",
+						},
+					},
+				}
+				expected := &types.Document{
+					ElementReferences: types.ElementReferences{
+						"custom_header": sectionTitle,
+					},
+					Elements: []interface{}{
+						&types.Section{
+							Attributes: types.Attributes{
+								types.AttrID:       "custom_header",
+								types.AttrCustomID: true,
+							},
+							Level: 1,
+							Title: sectionTitle,
+						},
+					},
+				}
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
+			})
+
+			It("single with detached inline anchor and inline ID", func() {
+				source := `== a header [[bookmark]] [[custom_header]]`
+				sectionTitle := []interface{}{
+					&types.StringElement{Content: "a header "},
+					&types.InlineLink{
+						Attributes: types.Attributes{
+							types.AttrID: "bookmark",
+						},
+					},
+				}
+				expected := &types.Document{
+					ElementReferences: types.ElementReferences{
+						"custom_header": sectionTitle,
+					},
+					Elements: []interface{}{
+						&types.Section{
+							Attributes: types.Attributes{
+								types.AttrID:       "custom_header",
+								types.AttrCustomID: true,
+							},
+							Level: 1,
+							Title: sectionTitle,
+						},
+					},
+				}
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
+			})
+
+			It("multiple sections with multiple inline custom IDs", func() {
 				source := `[[custom_header]]
 = a header
 
@@ -1704,16 +1810,10 @@ a paragraph`
 a paragraph`
 				fooTitle := []interface{}{
 					&types.StringElement{Content: "Section F "},
-					&types.Attribute{
-						Key:   "id",
-						Value: "ignored",
-					},
-					&types.StringElement{
-						Content: " ",
-					},
-					&types.Attribute{
-						Key:   "id",
-						Value: "foo",
+					&types.InlineLink{
+						Attributes: types.Attributes{
+							types.AttrID: "ignored",
+						},
 					},
 				}
 				barTitle := []interface{}{
@@ -1731,7 +1831,6 @@ a paragraph`
 							},
 							Attributes: types.Attributes{
 								types.AttrID: "custom_header",
-								// types.AttrCustomID: true,
 							},
 						},
 						&types.Section{

--- a/pkg/renderer/sgml/html5/link.go
+++ b/pkg/renderer/sgml/html5/link.go
@@ -1,5 +1,5 @@
 package html5
 
 const (
-	linkTmpl = `<a href="{{ .URL }}"{{if .Class}} class="{{ .Class }}"{{ end }}{{if .Target}} target="{{ .Target }}"{{ end }}>{{ .Text }}</a>`
+	linkTmpl = `<a{{ if .ID }} id="{{ .ID }}"{{ end }}{{ if .URL }} href="{{ .URL }}"{{ end }}{{if .Class}} class="{{ .Class }}"{{ end }}{{if .Target}} target="{{ .Target }}"{{ end }}>{{ .Text }}</a>`
 )

--- a/pkg/renderer/sgml/html5/section_test.go
+++ b/pkg/renderer/sgml/html5/section_test.go
@@ -287,6 +287,76 @@ Listing block content is commonly used to preserve code input.</pre>
 `
 			Expect(RenderHTML(source)).To(MatchHTML(expected))
 		})
+
+		It("single with custom inline ID", func() {
+			source := `== a header [[custom_header]]`
+			expected := `<div class="sect1">
+<h2 id="custom_header">a header</h2>
+<div class="sectionbody">
+</div>
+</div>
+`
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+		})
+
+		It("single with attached inline anchor", func() {
+			source := `== a header[[bookmark]]`
+			expected := `<div class="sect1">
+<h2 id="_a_header">a header<a id="bookmark"></a></h2>
+<div class="sectionbody">
+</div>
+</div>
+`
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+		})
+
+		It("single with attached inline anchor and inline ID", func() {
+			source := `== a header[[bookmark]] [[custom_header]]`
+			expected := `<div class="sect1">
+<h2 id="custom_header">a header<a id="bookmark"></a></h2>
+<div class="sectionbody">
+</div>
+</div>
+`
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+		})
+
+		It("single with detached inline anchor and inline ID", func() {
+			source := `== a header [[bookmark]] [[custom_header]]`
+			expected := `<div class="sect1">
+<h2 id="custom_header">a header <a id="bookmark"></a></h2>
+<div class="sectionbody">
+</div>
+</div>
+`
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+		})
+
+		It("multiple sections with multiple inline custom IDs", func() {
+			source := `[[custom_header]]
+= a header
+
+== Section F [[ignored]] [[foo]]
+
+[[bar]]
+== Section B
+a paragraph`
+			expected := `<div class="sect1">
+<h2 id="foo">Section F <a id="ignored"></a></h2>
+<div class="sectionbody">
+</div>
+</div>
+<div class="sect1">
+<h2 id="bar">Section B</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>a paragraph</p>
+</div>
+</div>
+</div>
+`
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+		})
 	})
 
 	Context("preambles", func() {

--- a/pkg/renderer/sgml/link.go
+++ b/pkg/renderer/sgml/link.go
@@ -15,6 +15,7 @@ func (r *sgmlRenderer) renderLink(ctx *renderer.Context, l *types.InlineLink) (s
 	location := l.Location.Stringify()
 	text := ""
 	class := ""
+	id := l.Attributes.GetAsStringWithDefault(types.AttrID, "")
 	roles, err := r.renderElementRoles(ctx, l.Attributes)
 	if err != nil {
 		return "", errors.Wrap(err, "unable to render link")
@@ -35,16 +36,18 @@ func (r *sgmlRenderer) renderLink(ctx *renderer.Context, l *types.InlineLink) (s
 		text = html.EscapeString(location)
 		if len(roles) > 0 {
 			class = "bare " + roles
-		} else {
+		} else if len(text) > 0 { // keep empty 'class' when there's no location
 			class = "bare"
 		}
 	}
 	err = r.link.Execute(result, struct {
+		ID     string
 		URL    string
 		Text   string
 		Class  string
 		Target string
 	}{
+		ID:     id,
 		URL:    location,
 		Text:   text,
 		Class:  class,

--- a/pkg/types/non_alphanumerics_replacement.go
+++ b/pkg/types/non_alphanumerics_replacement.go
@@ -31,14 +31,16 @@ func ReplaceNonAlphanumerics(elements []interface{}, replacement string) (string
 			}
 			buf.WriteString(r)
 		case *InlineLink:
-			r, err := replaceNonAlphanumerics(element.Location.Stringify(), replacement)
-			if err != nil {
-				return "", err
+			if element.Location != nil {
+				r, err := replaceNonAlphanumerics(element.Location.Stringify(), replacement)
+				if err != nil {
+					return "", err
+				}
+				if buf.Len() > 0 {
+					buf.WriteString(replacement)
+				}
+				buf.WriteString(r)
 			}
-			if buf.Len() > 0 {
-				buf.WriteString(replacement)
-			}
-			buf.WriteString(r)
 		case *Icon:
 			s := element.Attributes.GetAsStringWithDefault(AttrImageAlt, element.Class)
 			r, err := replaceNonAlphanumerics(s, replacement)


### PR DESCRIPTION
clarify the use of inline anchors vs custom IDs

fixes #903

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
