### PR TITLE
fix(renderer): support empty label in cross-references

### DIFF
--- a/pkg/renderer/sgml/cross_reference.go
+++ b/pkg/renderer/sgml/cross_reference.go
@@ -61,7 +61,7 @@ func (r *sgmlRenderer) renderExternalCrossReference(ctx *renderer.Context, xref 
 			return "", errors.Wrap(err, "unable to render external cross reference")
 		}
 	default:
-		return "", errors.Errorf("unable to render external cross reference label of type '%T'", xref.Attributes)
+		label = defaultXrefLabel(xref)
 	}
 	err = r.externalCrossReference.Execute(result, struct {
 		Href  string
@@ -76,9 +76,20 @@ func (r *sgmlRenderer) renderExternalCrossReference(ctx *renderer.Context, xref 
 	return result.String(), nil
 }
 
+func defaultXrefLabel(xref *types.ExternalCrossReference) string {
+	loc := xref.Location.Stringify()
+	ext := filepath.Ext(xref.Location.Stringify())
+	if ext == "" {
+		return "[" + loc + "]" // intenal references are within brackets
+	}
+	return loc[:len(loc)-len(ext)] + ".html"
+}
+
 func getCrossReferenceLocation(xref *types.ExternalCrossReference) string {
 	loc := xref.Location.Stringify()
 	ext := filepath.Ext(xref.Location.Stringify())
-	// log.Debugf("ext of '%s': '%s'", loc, ext)
+	if ext == "" { // internal reference
+		return "#" + loc
+	}
 	return loc[:len(loc)-len(ext)] + ".html" // TODO output extension
 }

--- a/pkg/renderer/sgml/html5/cross_reference_test.go
+++ b/pkg/renderer/sgml/html5/cross_reference_test.go
@@ -9,7 +9,7 @@ import (
 
 var _ = Describe("cross references", func() {
 
-	Context("internal references", func() {
+	Context("using shorthand syntax", func() {
 
 		It("with custom id", func() {
 
@@ -29,7 +29,7 @@ with some content linked to <<thetitle>>!`
 			Expect(RenderHTML(source)).To(MatchHTML(expected))
 		})
 
-		It("custom id and label", func() {
+		It("with custom id and label", func() {
 			source := `[[thetitle]]
 == a title
 
@@ -104,9 +104,9 @@ with some content linked to <<thewrongtitle>>!`
 		})
 	})
 
-	Context("external references", func() {
+	Context("using macro syntax", func() {
 
-		It("external cross reference to other doc with plain text location and rich label", func() {
+		It("to other doc with plain text location and rich label", func() {
 			source := `some content linked to xref:another-doc.adoc[*another doc*]!`
 			expected := `<div class="paragraph">
 <p>some content linked to <a href="another-doc.html"><strong>another doc</strong></a>!</p>
@@ -115,11 +115,29 @@ with some content linked to <<thewrongtitle>>!`
 			Expect(RenderHTML(source)).To(MatchHTML(expected))
 		})
 
-		It("external cross reference to other doc with document attribute in location and label with special chars", func() {
+		It("to other doc with document attribute in location and label", func() {
 			source := `:foo: foo-doc
 some content linked to xref:{foo}.adoc[another_doc()]!`
 			expected := `<div class="paragraph">
 <p>some content linked to <a href="foo-doc.html">another_doc()</a>!</p>
+</div>
+`
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+		})
+
+		It("to other section with empty label", func() {
+			source := `some content linked to xref:section_a[]!`
+			expected := `<div class="paragraph">
+<p>some content linked to <a href="#section_a">[section_a]</a>!</p>
+</div>
+`
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+		})
+
+		It("to other doc with empty label", func() {
+			source := `some content linked to xref:foo.adoc[]!`
+			expected := `<div class="paragraph">
+<p>some content linked to <a href="foo.html">foo.html</a>!</p>
 </div>
 `
 			Expect(RenderHTML(source)).To(MatchHTML(expected))


### PR DESCRIPTION
compute the default label from the xref's location

fixes #905

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
