### PR TITLE
fix: ignore punctuation at the end of links

### DIFF
--- a/pkg/parser/link_test.go
+++ b/pkg/parser/link_test.go
@@ -203,6 +203,48 @@ a link to <{example}>.`
 				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
+			It("with trailing dot punctutation", func() {
+				source := "a link to https://example.com."
+				expected := &types.Document{
+					Elements: []interface{}{
+						&types.Paragraph{
+							Elements: []interface{}{
+								&types.StringElement{Content: "a link to "},
+								&types.InlineLink{
+									Location: &types.Location{
+										Scheme: "https://",
+										Path:   "example.com",
+									},
+								},
+								&types.StringElement{Content: "."},
+							},
+						},
+					},
+				}
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
+			})
+
+			It("with trailing question mark punctutation", func() {
+				source := "a link to https://example.com?"
+				expected := &types.Document{
+					Elements: []interface{}{
+						&types.Paragraph{
+							Elements: []interface{}{
+								&types.StringElement{Content: "a link to "},
+								&types.InlineLink{
+									Location: &types.Location{
+										Scheme: "https://",
+										Path:   "example.com",
+									},
+								},
+								&types.StringElement{Content: "?"},
+							},
+						},
+					},
+				}
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
+			})
+
 			It("with empty text", func() {
 				source := "a link to https://example.com[]"
 				expected := &types.Document{


### PR DESCRIPTION
add tests, was already fixed in #912

closes #911

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
