### PR TITLE
feat(parser): default basebackend

### DIFF
--- a/libasciidoc.go
+++ b/libasciidoc.go
@@ -57,8 +57,10 @@ func Convert(r io.Reader, output io.Writer, config *configuration.Configuration)
 	switch config.BackEnd {
 	case "html", "html5", "":
 		render = html5.Render
+		config.Attributes.Set("basebackend-html", true)
 	case "xhtml", "xhtml5":
 		render = xhtml5.Render
+		config.Attributes.Set("basebackend-html", true)
 	default:
 		return types.Metadata{}, fmt.Errorf("backend '%s' not supported", config.BackEnd)
 	}

--- a/pkg/parser/document_preprocessing_conditionals_test.go
+++ b/pkg/parser/document_preprocessing_conditionals_test.go
@@ -132,8 +132,14 @@ ifdef::cookie[* conditional content]
 * more content`
 					Expect(PreparseDocument(source)).To(Equal(expected))
 				})
-			})
 
+				It("with backend attribute", func() {
+					source := `ifdef::basebackend-html[* to pass through +++<b>HTML</b>+++ directly, surround the text with triple plus]`
+					expected := `* to pass through +++<b>HTML</b>+++ directly, surround the text with triple plus`
+					Expect(PreparseDocument(source)).To(Equal(expected))
+				})
+
+			})
 		})
 
 		Context("ifndef", func() {

--- a/testsupport/preparse_document.go
+++ b/testsupport/preparse_document.go
@@ -13,6 +13,7 @@ import (
 func PreparseDocument(source string, options ...interface{}) (string, error) {
 	settings := []configuration.Setting{
 		configuration.WithFilename("test.adoc"),
+		configuration.WithAttribute("basebackend-html", true),
 	}
 	opts := []parser.Option{}
 	for _, o := range options {


### PR DESCRIPTION
when rendering in HTML or XHTML, set the 'basebackend-html' attribute so
the content of 'ifdef::basebackend-html' directives can be included in
the document to render.

Fixes #925

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
