### PR TITLE
feat(parser/renderer): always include non-empty ToC in metadata

### DIFF
--- a/libasciidoc_bench_test.go
+++ b/libasciidoc_bench_test.go
@@ -129,6 +129,15 @@ Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit `,
 				},
 			},
 		},
+		TableOfContents: &types.TableOfContents{
+			MaxDepth: 2,
+			Sections: []*types.ToCSection{
+				{
+					ID:    "_lorem_ipsum",
+					Level: 1,
+				},
+			},
+		},
 		ElementReferences: types.ElementReferences{
 			"_lorem_ipsum": title,
 		},

--- a/libasciidoc_test.go
+++ b/libasciidoc_test.go
@@ -54,7 +54,7 @@ var _ = Describe("documents", func() {
 				Expect(MetadataTitle(source)).To(Equal(expectedTitle))
 			})
 
-			It("section levels 0 and 1", func() {
+			It("sections with level 0 and 1", func() {
 				source := `= a document title
 
 == Section A
@@ -92,7 +92,7 @@ a paragraph with *bold content*`
 				Expect(MetadataTitle(source)).To(Equal(expectedTitle))
 			})
 
-			It("section levels 0, 1 and 3", func() {
+			It("sections with level 0, 1 and 3", func() {
 				source := `= a document title
 
 == Section A
@@ -102,7 +102,6 @@ a paragraph with *bold content*
 ==== Section A.a.a
 
 a paragraph`
-				expectedTitle := "a document title"
 				expectedContent := `<div class="sect1">
 <h2 id="_section_a">Section A</h2>
 <div class="sectionbody">
@@ -119,32 +118,23 @@ a paragraph`
 </div>
 `
 				Expect(RenderHTML(source)).To(Equal(expectedContent))
-				Expect(MetadataTitle(source)).To(Equal(expectedTitle))
 				Expect(DocumentMetadata(source, lastUpdated)).To(Equal(types.Metadata{
 					Title:       "a document title",
 					LastUpdated: lastUpdated.Format(configuration.LastUpdatedFormat),
-					// see https://github.com/bytesparadise/libasciidoc/issues/939
-					// TableOfContents: types.TableOfContents{
-					// 	Sections: []*types.ToCSection{
-					// 		{
-					// 			ID:    "_section_a",
-					// 			Level: 1,
-					// 			Title: "Section A",
-					// 			Children: []*types.ToCSection{
-					// 				{
-					// 					ID:       "_section_a_a_a",
-					// 					Level:    3,
-					// 					Title:    "Section A.a.a",
-					// 					Children: []*types.ToCSection{},
-					// 				},
-					// 			},
-					// 		},
-					// 	},
-					// },
+					TableOfContents: &types.TableOfContents{
+						MaxDepth: 2,
+						Sections: []*types.ToCSection{
+							{
+								ID:    "_section_a",
+								Level: 1,
+								Title: "Section A",
+							},
+						},
+					},
 				}))
 			})
 
-			It("section levels 0, 1, 2 and 1", func() {
+			It("sections with level 0, 1, 2 and 1", func() {
 				source := `= a document title
 
 == Section A
@@ -187,30 +177,28 @@ a paragraph with _italic content_`
 				Expect(DocumentMetadata(source, lastUpdated)).To(Equal(types.Metadata{
 					Title:       "a document title",
 					LastUpdated: lastUpdated.Format(configuration.LastUpdatedFormat),
-					// see https://github.com/bytesparadise/libasciidoc/issues/939
-					// TableOfContents: types.TableOfContents{
-					// 	Sections: []*types.ToCSection{
-					// 		{
-					// 			ID:    "_section_a",
-					// 			Level: 1,
-					// 			Title: "Section A",
-					// 			Children: []*types.ToCSection{
-					// 				{
-					// 					ID:       "_section_a_a",
-					// 					Level:    2,
-					// 					Title:    "Section A.a",
-					// 					Children: []*types.ToCSection{},
-					// 				},
-					// 			},
-					// 		},
-					// 		{
-					// 			ID:       "_section_b",
-					// 			Level:    1,
-					// 			Title:    "Section B",
-					// 			Children: []*types.ToCSection{},
-					// 		},
-					// 	},
-					// },
+					TableOfContents: &types.TableOfContents{
+						MaxDepth: 2,
+						Sections: []*types.ToCSection{
+							{
+								ID:    "_section_a",
+								Level: 1,
+								Title: "Section A",
+								Children: []*types.ToCSection{
+									{
+										ID:    "_section_a_a",
+										Level: 2,
+										Title: "Section A.a",
+									},
+								},
+							},
+							{
+								ID:    "_section_b",
+								Level: 1,
+								Title: "Section B",
+							},
+						},
+					},
 				}))
 			})
 
@@ -232,17 +220,16 @@ a paragraph with _italic content_`
 				Expect(DocumentMetadata(source, lastUpdated)).To(Equal(types.Metadata{
 					Title:       "",
 					LastUpdated: lastUpdated.Format(configuration.LastUpdatedFormat),
-					// see https://github.com/bytesparadise/libasciidoc/issues/939
-					// TableOfContents: types.TableOfContents{
-					// 	Sections: []*types.ToCSection{
-					// 		{
-					// 			ID:       "_grandchild_title",
-					// 			Level:    1,
-					// 			Title:    "grandchild title",
-					// 			Children: []*types.ToCSection{},
-					// 		},
-					// 	},
-					// },
+					TableOfContents: &types.TableOfContents{
+						MaxDepth: 2,
+						Sections: []*types.ToCSection{
+							{
+								ID:    "_grandchild_title",
+								Level: 1,
+								Title: "grandchild title",
+							},
+						},
+					},
 				}))
 			})
 		})

--- a/pkg/parser/attribute_substitution_test.go
+++ b/pkg/parser/attribute_substitution_test.go
@@ -132,9 +132,6 @@ This journey continues`
 						},
 					},
 				},
-				TableOfContents: &types.TableOfContents{
-					MaxDepth: 2,
-				},
 			}
 			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})

--- a/pkg/parser/comment_test.go
+++ b/pkg/parser/comment_test.go
@@ -176,9 +176,6 @@ a second paragraph`
 				},
 			}
 			expected := &types.Document{
-				ElementReferences: types.ElementReferences{
-					"_section_1": section1Title,
-				},
 				Elements: []interface{}{
 					&types.Section{
 						Attributes: types.Attributes{
@@ -201,6 +198,18 @@ a second paragraph`
 									},
 								},
 							},
+						},
+					},
+				},
+				ElementReferences: types.ElementReferences{
+					"_section_1": section1Title,
+				},
+				TableOfContents: &types.TableOfContents{
+					MaxDepth: 2,
+					Sections: []*types.ToCSection{
+						{
+							ID:    "_section_1",
+							Level: 1,
 						},
 					},
 				},
@@ -232,9 +241,6 @@ a second paragraph`
 				},
 			}
 			expected := &types.Document{
-				ElementReferences: types.ElementReferences{
-					"_section_1": section1Title,
-				},
 				Elements: []interface{}{
 					&types.DocumentHeader{
 						Title: headerTitle,
@@ -260,6 +266,18 @@ a second paragraph`
 									},
 								},
 							},
+						},
+					},
+				},
+				ElementReferences: types.ElementReferences{
+					"_section_1": section1Title,
+				},
+				TableOfContents: &types.TableOfContents{
+					MaxDepth: 2,
+					Sections: []*types.ToCSection{
+						{
+							ID:    "_section_1",
+							Level: 1,
 						},
 					},
 				},

--- a/pkg/parser/context.go
+++ b/pkg/parser/context.go
@@ -80,15 +80,6 @@ func (a *contextAttributes) clone() *contextAttributes {
 	}
 }
 
-func (a *contextAttributes) has(k string) bool {
-	_, found := a.immutableAttributes[k]
-	if found {
-		return true
-	}
-	_, found = a.attributes[k]
-	return found
-}
-
 func (a *contextAttributes) allAttributes() map[string]interface{} {
 	result := make(map[string]interface{}, len(a.attributes)+len(a.immutableAttributes))
 	for k, v := range a.attributes {

--- a/pkg/parser/cross_reference_test.go
+++ b/pkg/parser/cross_reference_test.go
@@ -53,6 +53,15 @@ with some content linked to <<thetitle>>!`
 							},
 						},
 					},
+					TableOfContents: &types.TableOfContents{
+						MaxDepth: 2,
+						Sections: []*types.ToCSection{
+							{
+								ID:    "thetitle",
+								Level: 1,
+							},
+						},
+					},
 				}
 				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
@@ -96,6 +105,15 @@ with some content linked to <<thetitle,a label to the title>>!`
 					},
 					ElementReferences: types.ElementReferences{
 						"thetitle": title,
+					},
+					TableOfContents: &types.TableOfContents{
+						MaxDepth: 2,
+						Sections: []*types.ToCSection{
+							{
+								ID:    "thetitle",
+								Level: 1,
+							},
+						},
 					},
 				}
 				Expect(ParseDocument(source)).To(MatchDocument(expected))
@@ -151,6 +169,15 @@ some content`
 					},
 					ElementReferences: types.ElementReferences{
 						"section": title,
+					},
+					TableOfContents: &types.TableOfContents{
+						MaxDepth: 2,
+						Sections: []*types.ToCSection{
+							{
+								ID:    "section",
+								Level: 1,
+							},
+						},
 					},
 				}
 				Expect(ParseDocument(source)).To(MatchDocument(expected))

--- a/pkg/parser/document_fragment_processing_test.go
+++ b/pkg/parser/document_fragment_processing_test.go
@@ -241,6 +241,19 @@ eve - analyzes an image to determine if it's a picture of a life form
 					"_name":     nameSectionTitle,
 					"_synopsis": synopisSectionTitle,
 				},
+				TableOfContents: &types.TableOfContents{
+					MaxDepth: 2,
+					Sections: []*types.ToCSection{
+						{
+							ID:    "_name",
+							Level: 1,
+						},
+						{
+							ID:    "_synopsis",
+							Level: 1,
+						},
+					},
+				},
 			}
 			Expect(ParseDocument(source,
 				configuration.WithAttributes(map[string]interface{}{

--- a/pkg/parser/document_header_test.go
+++ b/pkg/parser/document_header_test.go
@@ -1111,9 +1111,6 @@ a paragraph`
 							},
 						},
 					},
-					TableOfContents: &types.TableOfContents{
-						MaxDepth: 2,
-					},
 				}
 				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
@@ -1146,9 +1143,6 @@ a paragraph`
 								&types.StringElement{Content: "a paragraph"},
 							},
 						},
-					},
-					TableOfContents: &types.TableOfContents{
-						MaxDepth: 2,
 					},
 				}
 				Expect(ParseDocument(source)).To(MatchDocument(expected))
@@ -1189,9 +1183,6 @@ a paragraph`
 							},
 						},
 					},
-					TableOfContents: &types.TableOfContents{
-						MaxDepth: 2,
-					},
 				}
 				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
@@ -1220,9 +1211,6 @@ a paragraph`
 							Name:  "author",
 							Value: "Xavier",
 						},
-					},
-					TableOfContents: &types.TableOfContents{
-						MaxDepth: 2,
 					},
 				}
 				Expect(ParseDocument(source)).To(MatchDocument(expected))

--- a/pkg/parser/document_preprocessing_include_files_test.go
+++ b/pkg/parser/document_preprocessing_include_files_test.go
@@ -823,6 +823,15 @@ package includes
 				ElementReferences: types.ElementReferences{
 					"_chapter_a": title,
 				},
+				TableOfContents: &types.TableOfContents{
+					MaxDepth: 2,
+					Sections: []*types.ToCSection{
+						{
+							ID:    "_chapter_a",
+							Level: 1,
+						},
+					},
+				},
 			}
 			Expect(ParseDocument(source)).To(MatchDocument(expected))
 			// verify no error/warning in logs
@@ -937,6 +946,15 @@ include::{includedir}/include.foo[]`
 				ElementReferences: types.ElementReferences{
 					"_grandchild_title": title,
 				},
+				TableOfContents: &types.TableOfContents{
+					MaxDepth: 2,
+					Sections: []*types.ToCSection{
+						{
+							ID:    "_grandchild_title",
+							Level: 1,
+						},
+					},
+				},
 			}
 			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
@@ -976,6 +994,15 @@ include::{includedir}/include.foo[]`
 				},
 				ElementReferences: types.ElementReferences{
 					"_grandchild_title": title,
+				},
+				TableOfContents: &types.TableOfContents{
+					MaxDepth: 2,
+					Sections: []*types.ToCSection{
+						{
+							ID:    "_grandchild_title",
+							Level: 2,
+						},
+					},
 				},
 			}
 			Expect(ParseDocument(source)).To(MatchDocument(expected))
@@ -1128,6 +1155,15 @@ include::{includedir}/include.foo[]`
 					"_child_section_2":  childSection2Title,
 					"_grandchild_title": grandchildTitle,
 				},
+				TableOfContents: &types.TableOfContents{
+					MaxDepth: 2,
+					Sections: []*types.ToCSection{
+						{
+							ID:    "_parent_title",
+							Level: 1,
+						},
+					},
+				},
 			}
 			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
@@ -1247,6 +1283,15 @@ include::{includedir}/include.foo[]`
 					"_child_section_1":  childSection1Title,
 					"_child_section_2":  childSection2Title,
 					"_grandchild_title": grandchildTitle,
+				},
+				TableOfContents: &types.TableOfContents{
+					MaxDepth: 2,
+					Sections: []*types.ToCSection{
+						{
+							ID:    "_parent_title",
+							Level: 1,
+						},
+					},
 				},
 			}
 			Expect(ParseDocument(source)).To(MatchDocument(expected))
@@ -1721,6 +1766,15 @@ ____`
 						ElementReferences: types.ElementReferences{
 							"_section_1": title,
 						},
+						TableOfContents: &types.TableOfContents{
+							MaxDepth: 2,
+							Sections: []*types.ToCSection{
+								{
+									ID:    "_section_1",
+									Level: 1,
+								},
+							},
+						},
 					}
 					Expect(ParseDocument(source)).To(MatchDocument(expected))
 				})
@@ -1750,6 +1804,15 @@ ____`
 					},
 					ElementReferences: types.ElementReferences{
 						"_section_1": title,
+					},
+					TableOfContents: &types.TableOfContents{
+						MaxDepth: 2,
+						Sections: []*types.ToCSection{
+							{
+								ID:    "_section_1",
+								Level: 1,
+							},
+						},
 					},
 				}
 				Expect(ParseDocument(source)).To(MatchDocument(expected))
@@ -1787,6 +1850,15 @@ ____`
 					},
 					ElementReferences: types.ElementReferences{
 						"_section_1": title,
+					},
+					TableOfContents: &types.TableOfContents{
+						MaxDepth: 2,
+						Sections: []*types.ToCSection{
+							{
+								ID:    "_section_1",
+								Level: 1,
+							},
+						},
 					},
 				}
 				Expect(ParseDocument(source)).To(MatchDocument(expected))
@@ -1867,6 +1939,15 @@ ____`
 					ElementReferences: types.ElementReferences{
 						"_section_1": title,
 					},
+					TableOfContents: &types.TableOfContents{
+						MaxDepth: 2,
+						Sections: []*types.ToCSection{
+							{
+								ID:    "_section_1",
+								Level: 1,
+							},
+						},
+					},
 				}
 				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
@@ -1909,6 +1990,15 @@ ____`
 						ElementReferences: types.ElementReferences{
 							"_section_1": title,
 						},
+						TableOfContents: &types.TableOfContents{
+							MaxDepth: 2,
+							Sections: []*types.ToCSection{
+								{
+									ID:    "_section_1",
+									Level: 1,
+								},
+							},
+						},
 					}
 					Expect(ParseDocument(source)).To(MatchDocument(expected))
 				})
@@ -1941,6 +2031,15 @@ ____`
 						},
 						ElementReferences: types.ElementReferences{
 							"_section_1": title,
+						},
+						TableOfContents: &types.TableOfContents{
+							MaxDepth: 2,
+							Sections: []*types.ToCSection{
+								{
+									ID:    "_section_1",
+									Level: 1,
+								},
+							},
 						},
 					}
 					Expect(ParseDocument(source)).To(MatchDocument(expected))
@@ -1982,6 +2081,15 @@ ____`
 						ElementReferences: types.ElementReferences{
 							"_section_1": title,
 						},
+						TableOfContents: &types.TableOfContents{
+							MaxDepth: 2,
+							Sections: []*types.ToCSection{
+								{
+									ID:    "_section_1",
+									Level: 1,
+								},
+							},
+						},
 					}
 					Expect(ParseDocument(source)).To(MatchDocument(expected))
 				})
@@ -2006,6 +2114,15 @@ ____`
 						ElementReferences: types.ElementReferences{
 							"_section_1": title,
 						},
+						TableOfContents: &types.TableOfContents{
+							MaxDepth: 2,
+							Sections: []*types.ToCSection{
+								{
+									ID:    "_section_1",
+									Level: 1,
+								},
+							},
+						},
 					}
 					Expect(ParseDocument(source)).To(MatchDocument(expected))
 				})
@@ -2029,6 +2146,15 @@ ____`
 						},
 						ElementReferences: types.ElementReferences{
 							"_section_1": title,
+						},
+						TableOfContents: &types.TableOfContents{
+							MaxDepth: 2,
+							Sections: []*types.ToCSection{
+								{
+									ID:    "_section_1",
+									Level: 1,
+								},
+							},
 						},
 					}
 					Expect(ParseDocument(source)).To(MatchDocument(expected))
@@ -2062,6 +2188,15 @@ ____`
 						},
 						ElementReferences: types.ElementReferences{
 							"_section_1": title,
+						},
+						TableOfContents: &types.TableOfContents{
+							MaxDepth: 2,
+							Sections: []*types.ToCSection{
+								{
+									ID:    "_section_1",
+									Level: 1,
+								},
+							},
 						},
 					}
 					Expect(ParseDocument(source)).To(MatchDocument(expected))
@@ -2186,6 +2321,15 @@ include::{includedir}/grandchild-include.adoc[]`
 					},
 					ElementReferences: types.ElementReferences{
 						"_grandchild_title": title,
+					},
+					TableOfContents: &types.TableOfContents{
+						MaxDepth: 2,
+						Sections: []*types.ToCSection{
+							{
+								ID:    "_grandchild_title",
+								Level: 1,
+							},
+						},
 					},
 				}
 				// Expect(ParseDocument(source, WithFilename("foo.adoc"))).To(MatchDocument(expected))

--- a/pkg/parser/document_processing_aggregate_test.go
+++ b/pkg/parser/document_processing_aggregate_test.go
@@ -173,9 +173,6 @@ var _ = Describe("aggregate fragments", func() {
 				},
 				paragraph, // not wrapped in a preamble since there is nothing afterwards
 			},
-			TableOfContents: &types.TableOfContents{
-				MaxDepth: 2,
-			},
 		}
 		doc, err := parser.Aggregate(ctx, c)
 		Expect(err).NotTo(HaveOccurred())
@@ -334,9 +331,6 @@ var _ = Describe("aggregate fragments", func() {
 					},
 				},
 				paragraph,
-			},
-			TableOfContents: &types.TableOfContents{
-				MaxDepth: 2,
 			},
 		}
 		doc, err := parser.Aggregate(ctx, c)

--- a/pkg/parser/document_test.go
+++ b/pkg/parser/document_test.go
@@ -179,6 +179,15 @@ Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit `,
 						&types.StringElement{Content: "Lorem Ipsum"},
 					},
 				},
+				TableOfContents: &types.TableOfContents{
+					MaxDepth: 2,
+					Sections: []*types.ToCSection{
+						{
+							ID:    "_lorem_ipsum",
+							Level: 1,
+						},
+					},
+				},
 			}
 			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})

--- a/pkg/parser/footnote_test.go
+++ b/pkg/parser/footnote_test.go
@@ -205,35 +205,6 @@ a paragraph with another footnote.footnote:[baz]`
 				},
 			}
 			expected := &types.Document{
-				ElementReferences: types.ElementReferences{
-					"_section_1": section1Title,
-				},
-				Footnotes: []*types.Footnote{
-					{
-						ID: 1,
-						Elements: []interface{}{
-							&types.StringElement{
-								Content: "foo",
-							},
-						},
-					},
-					{
-						ID: 2,
-						Elements: []interface{}{
-							&types.StringElement{
-								Content: "bar",
-							},
-						},
-					},
-					{
-						ID: 3,
-						Elements: []interface{}{
-							&types.StringElement{
-								Content: "baz",
-							},
-						},
-					},
-				},
 				Elements: []interface{}{
 					&types.DocumentHeader{
 						Title: []interface{}{
@@ -273,6 +244,44 @@ a paragraph with another footnote.footnote:[baz]`
 									},
 								},
 							},
+						},
+					},
+				},
+				ElementReferences: types.ElementReferences{
+					"_section_1": section1Title,
+				},
+				Footnotes: []*types.Footnote{
+					{
+						ID: 1,
+						Elements: []interface{}{
+							&types.StringElement{
+								Content: "foo",
+							},
+						},
+					},
+					{
+						ID: 2,
+						Elements: []interface{}{
+							&types.StringElement{
+								Content: "bar",
+							},
+						},
+					},
+					{
+						ID: 3,
+						Elements: []interface{}{
+							&types.StringElement{
+								Content: "baz",
+							},
+						},
+					},
+				},
+				TableOfContents: &types.TableOfContents{
+					MaxDepth: 2,
+					Sections: []*types.ToCSection{
+						{
+							ID:    "_section_1",
+							Level: 1,
 						},
 					},
 				},

--- a/pkg/parser/icon_test.go
+++ b/pkg/parser/icon_test.go
@@ -207,6 +207,15 @@ var _ = Describe("icons", func() {
 					ElementReferences: types.ElementReferences{
 						"_a_note_from_me": title,
 					},
+					TableOfContents: &types.TableOfContents{
+						MaxDepth: 2,
+						Sections: []*types.ToCSection{
+							{
+								ID:    "_a_note_from_me",
+								Level: 1,
+							},
+						},
+					},
 				}
 				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})

--- a/pkg/parser/link_test.go
+++ b/pkg/parser/link_test.go
@@ -1017,9 +1017,6 @@ a link to {scheme}://{path} and https://foo.com`
 						},
 					}
 					expected := &types.Document{
-						ElementReferences: types.ElementReferences{
-							"_a_title_to_httpsexample_com_and_httpsfoo_com": title,
-						},
 						Elements: []interface{}{
 							&types.DocumentHeader{
 								Elements: []interface{}{
@@ -1039,6 +1036,18 @@ a link to {scheme}://{path} and https://foo.com`
 									types.AttrID: "_a_title_to_httpsexample_com_and_httpsfoo_com",
 								},
 								Title: title,
+							},
+						},
+						ElementReferences: types.ElementReferences{
+							"_a_title_to_httpsexample_com_and_httpsfoo_com": title,
+						},
+						TableOfContents: &types.TableOfContents{
+							MaxDepth: 2,
+							Sections: []*types.ToCSection{
+								{
+									ID:    "_a_title_to_httpsexample_com_and_httpsfoo_com",
+									Level: 1,
+								},
 							},
 						},
 					}

--- a/pkg/parser/quoted_string_test.go
+++ b/pkg/parser/quoted_string_test.go
@@ -1005,6 +1005,15 @@ var _ = Describe("quoted strings", func() {
 			ElementReferences: types.ElementReferences{
 				"_a_curly_episode": title,
 			},
+			TableOfContents: &types.TableOfContents{
+				MaxDepth: 2,
+				Sections: []*types.ToCSection{
+					{
+						ID:    "_a_curly_episode",
+						Level: 1,
+					},
+				},
+			},
 		}
 		Expect(ParseDocument(source)).To(MatchDocument(expected))
 	})
@@ -1103,6 +1112,15 @@ var _ = Describe("quoted strings", func() {
 			},
 			ElementReferences: types.ElementReferences{
 				"_a_curly_episode": title,
+			},
+			TableOfContents: &types.TableOfContents{
+				MaxDepth: 2,
+				Sections: []*types.ToCSection{
+					{
+						ID:    "_a_curly_episode",
+						Level: 1,
+					},
+				},
 			},
 		}
 		Expect(ParseDocument(source)).To(MatchDocument(expected))

--- a/pkg/parser/section_test.go
+++ b/pkg/parser/section_test.go
@@ -1077,9 +1077,6 @@ and a paragraph`
 					},
 				}
 				expected := &types.Document{
-					ElementReferences: types.ElementReferences{
-						"_link_to_httpsfoo_bar": section1aTitle,
-					},
 					Elements: []interface{}{
 						&types.Section{
 							Attributes: types.Attributes{
@@ -1087,6 +1084,18 @@ and a paragraph`
 							},
 							Level: 1,
 							Title: section1aTitle,
+						},
+					},
+					ElementReferences: types.ElementReferences{
+						"_link_to_httpsfoo_bar": section1aTitle,
+					},
+					TableOfContents: &types.TableOfContents{
+						MaxDepth: 2,
+						Sections: []*types.ToCSection{
+							{
+								ID:    "_link_to_httpsfoo_bar",
+								Level: 1,
+							},
 						},
 					},
 				}
@@ -1104,9 +1113,6 @@ a paragraph with *bold content*`
 					&types.StringElement{Content: "section 1"},
 				}
 				expected := &types.Document{
-					ElementReferences: types.ElementReferences{
-						"_section_1": section1Title,
-					},
 					Elements: []interface{}{
 						&types.DocumentHeader{
 							Title: []interface{}{
@@ -1134,6 +1140,18 @@ a paragraph with *bold content*`
 							},
 						},
 					},
+					ElementReferences: types.ElementReferences{
+						"_section_1": section1Title,
+					},
+					TableOfContents: &types.TableOfContents{
+						MaxDepth: 2,
+						Sections: []*types.ToCSection{
+							{
+								ID:    "_section_1",
+								Level: 1,
+							},
+						},
+					},
 				}
 				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
@@ -1147,9 +1165,6 @@ a paragraph with *bold content*`
 				}
 
 				expected := &types.Document{
-					ElementReferences: types.ElementReferences{
-						"_a_second_header": otherDoctitle,
-					},
 					Elements: []interface{}{
 						&types.DocumentHeader{
 							Title: []interface{}{
@@ -1164,6 +1179,18 @@ a paragraph with *bold content*`
 							Title: otherDoctitle,
 						},
 					},
+					ElementReferences: types.ElementReferences{
+						"_a_second_header": otherDoctitle,
+					},
+					TableOfContents: &types.TableOfContents{
+						MaxDepth: 2,
+						Sections: []*types.ToCSection{
+							{
+								ID:    "_a_second_header",
+								Level: 0,
+							},
+						},
+					},
 				}
 				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
@@ -1174,9 +1201,6 @@ a paragraph with *bold content*`
 					&types.StringElement{Content: "section 1"},
 				}
 				expected := &types.Document{
-					ElementReferences: types.ElementReferences{
-						"_section_1": section1Title,
-					},
 					Elements: []interface{}{
 						&types.Section{
 							Attributes: types.Attributes{
@@ -1184,6 +1208,18 @@ a paragraph with *bold content*`
 							},
 							Level: 1,
 							Title: section1Title,
+						},
+					},
+					ElementReferences: types.ElementReferences{
+						"_section_1": section1Title,
+					},
+					TableOfContents: &types.TableOfContents{
+						MaxDepth: 2,
+						Sections: []*types.ToCSection{
+							{
+								ID:    "_section_1",
+								Level: 1,
+							},
 						},
 					},
 				}
@@ -1201,9 +1237,6 @@ a paragraph with *bold content*`
 					},
 				}
 				expected := &types.Document{
-					ElementReferences: types.ElementReferences{
-						"_2_spaces_and_bold_content": sectionTitle,
-					},
 					Elements: []interface{}{
 						&types.Section{
 							Attributes: types.Attributes{
@@ -1211,6 +1244,18 @@ a paragraph with *bold content*`
 							},
 							Level: 1,
 							Title: sectionTitle,
+						},
+					},
+					ElementReferences: types.ElementReferences{
+						"_2_spaces_and_bold_content": sectionTitle,
+					},
+					TableOfContents: &types.TableOfContents{
+						MaxDepth: 2,
+						Sections: []*types.ToCSection{
+							{
+								ID:    "_2_spaces_and_bold_content",
+								Level: 1,
+							},
 						},
 					},
 				}
@@ -1225,9 +1270,6 @@ a paragraph with *bold content*`
 					&types.StringElement{Content: "section 1"},
 				}
 				expected := &types.Document{
-					ElementReferences: types.ElementReferences{
-						"_section_1": section1Title,
-					},
 					Elements: []interface{}{
 						&types.DocumentHeader{
 							Title: []interface{}{
@@ -1242,6 +1284,18 @@ a paragraph with *bold content*`
 							Title: section1Title,
 						},
 					},
+					ElementReferences: types.ElementReferences{
+						"_section_1": section1Title,
+					},
+					TableOfContents: &types.TableOfContents{
+						MaxDepth: 2,
+						Sections: []*types.ToCSection{
+							{
+								ID:    "_section_1",
+								Level: 1,
+							},
+						},
+					},
 				}
 				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
@@ -1254,9 +1308,6 @@ a paragraph with *bold content*`
 					&types.StringElement{Content: "section 2"},
 				}
 				expected := &types.Document{
-					ElementReferences: types.ElementReferences{
-						"_section_2": section2Title,
-					},
 					Elements: []interface{}{
 						&types.DocumentHeader{
 							Title: []interface{}{
@@ -1271,6 +1322,18 @@ a paragraph with *bold content*`
 							Title: section2Title,
 						},
 					},
+					ElementReferences: types.ElementReferences{
+						"_section_2": section2Title,
+					},
+					TableOfContents: &types.TableOfContents{
+						MaxDepth: 2,
+						Sections: []*types.ToCSection{
+							{
+								ID:    "_section_2",
+								Level: 2,
+							},
+						},
+					},
 				}
 				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
@@ -1282,9 +1345,6 @@ and a paragraph`
 					&types.StringElement{Content: "a title"},
 				}
 				expected := &types.Document{
-					ElementReferences: types.ElementReferences{
-						"_a_title": section1Title,
-					},
 					Elements: []interface{}{
 						&types.Section{
 							Attributes: types.Attributes{
@@ -1298,6 +1358,18 @@ and a paragraph`
 										&types.StringElement{Content: "and a paragraph"},
 									},
 								},
+							},
+						},
+					},
+					ElementReferences: types.ElementReferences{
+						"_a_title": section1Title,
+					},
+					TableOfContents: &types.TableOfContents{
+						MaxDepth: 2,
+						Sections: []*types.ToCSection{
+							{
+								ID:    "_a_title",
+								Level: 1,
 							},
 						},
 					},
@@ -1313,9 +1385,6 @@ and a paragraph`
 					&types.StringElement{Content: "a title"},
 				}
 				expected := &types.Document{
-					ElementReferences: types.ElementReferences{
-						"_a_title": section1Title,
-					},
 					Elements: []interface{}{
 						&types.Section{
 							Attributes: types.Attributes{
@@ -1332,6 +1401,18 @@ and a paragraph`
 							},
 						},
 					},
+					ElementReferences: types.ElementReferences{
+						"_a_title": section1Title,
+					},
+					TableOfContents: &types.TableOfContents{
+						MaxDepth: 2,
+						Sections: []*types.ToCSection{
+							{
+								ID:    "_a_title",
+								Level: 1,
+							},
+						},
+					},
 				}
 				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
@@ -1342,9 +1423,6 @@ and a paragraph`
 					&types.StringElement{Content: "a title"},
 				}
 				expected := &types.Document{
-					ElementReferences: types.ElementReferences{
-						"_a_title": section1Title,
-					},
 					Elements: []interface{}{
 						&types.Section{
 							Attributes: types.Attributes{
@@ -1358,6 +1436,18 @@ and a paragraph`
 										&types.StringElement{Content: "and a paragraph"},
 									},
 								},
+							},
+						},
+					},
+					ElementReferences: types.ElementReferences{
+						"_a_title": section1Title,
+					},
+					TableOfContents: &types.TableOfContents{
+						MaxDepth: 2,
+						Sections: []*types.ToCSection{
+							{
+								ID:    "_a_title",
+								Level: 1,
 							},
 						},
 					},
@@ -1386,11 +1476,6 @@ a paragraph`
 					&types.StringElement{Content: "Section B"},
 				}
 				expected := &types.Document{
-					ElementReferences: types.ElementReferences{
-						"_section_a":   sectionATitle,
-						"_section_a_a": sectionAaTitle,
-						"_section_b":   sectionBTitle,
-					},
 					Elements: []interface{}{
 						&types.DocumentHeader{
 							Title: []interface{}{
@@ -1440,6 +1525,30 @@ a paragraph`
 							},
 						},
 					},
+					ElementReferences: types.ElementReferences{
+						"_section_a":   sectionATitle,
+						"_section_a_a": sectionAaTitle,
+						"_section_b":   sectionBTitle,
+					},
+					TableOfContents: &types.TableOfContents{
+						MaxDepth: 2,
+						Sections: []*types.ToCSection{
+							{
+								ID:    "_section_a",
+								Level: 1,
+								Children: []*types.ToCSection{
+									{
+										ID:    "_section_a_a",
+										Level: 2,
+									},
+								},
+							},
+							{
+								ID:    "_section_b",
+								Level: 1,
+							},
+						},
+					},
 				}
 				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
@@ -1465,11 +1574,6 @@ a paragraph`
 					&types.StringElement{Content: "Section A.b"},
 				}
 				expected := &types.Document{
-					ElementReferences: types.ElementReferences{
-						"_section_a":   sectionATitle,
-						"_section_a_a": sectionAaTitle,
-						"_section_a_b": sectionBTitle,
-					},
 					Elements: []interface{}{
 						&types.DocumentHeader{
 							Title: []interface{}{
@@ -1519,6 +1623,30 @@ a paragraph`
 							},
 						},
 					},
+					ElementReferences: types.ElementReferences{
+						"_section_a":   sectionATitle,
+						"_section_a_a": sectionAaTitle,
+						"_section_a_b": sectionBTitle,
+					},
+					TableOfContents: &types.TableOfContents{
+						MaxDepth: 2,
+						Sections: []*types.ToCSection{
+							{
+								ID:    "_section_a",
+								Level: 1,
+								Children: []*types.ToCSection{
+									{
+										ID:    "_section_a_a",
+										Level: 2,
+									},
+									{
+										ID:    "_section_a_b",
+										Level: 2,
+									},
+								},
+							},
+						},
+					},
 				}
 				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
@@ -1544,11 +1672,6 @@ a paragraph`
 					&types.StringElement{Content: "Section A.b"},
 				}
 				expected := &types.Document{
-					ElementReferences: types.ElementReferences{
-						"_section_a":   sectionATitle,
-						"_section_a_a": sectionAaTitle,
-						"_section_a_b": sectionAbTitle,
-					},
 					Elements: []interface{}{
 						&types.DocumentHeader{
 							Title: []interface{}{
@@ -1598,6 +1721,20 @@ a paragraph`
 							},
 						},
 					},
+					ElementReferences: types.ElementReferences{
+						"_section_a":   sectionATitle,
+						"_section_a_a": sectionAaTitle,
+						"_section_a_b": sectionAbTitle,
+					},
+					TableOfContents: &types.TableOfContents{
+						MaxDepth: 2,
+						Sections: []*types.ToCSection{
+							{
+								ID:    "_section_a",
+								Level: 2,
+							},
+						},
+					},
 				}
 				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
@@ -1623,11 +1760,6 @@ a paragraph`
 					&types.StringElement{Content: "Section C"},
 				}
 				expected := &types.Document{
-					ElementReferences: types.ElementReferences{
-						"_section_a": sectionATitle,
-						"_section_b": sectionBTitle,
-						"_section_c": sectionCTitle,
-					},
 					Elements: []interface{}{
 						&types.DocumentHeader{
 							Title: []interface{}{
@@ -1677,6 +1809,28 @@ a paragraph`
 							},
 						},
 					},
+					ElementReferences: types.ElementReferences{
+						"_section_a": sectionATitle,
+						"_section_b": sectionBTitle,
+						"_section_c": sectionCTitle,
+					},
+					TableOfContents: &types.TableOfContents{
+						MaxDepth: 2,
+						Sections: []*types.ToCSection{
+							{
+								ID:    "_section_a",
+								Level: 2,
+							},
+							{
+								ID:    "_section_b",
+								Level: 2,
+							},
+							{
+								ID:    "_section_c",
+								Level: 2,
+							},
+						},
+					},
 				}
 				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
@@ -1688,9 +1842,6 @@ a paragraph`
 					&types.StringElement{Content: "a header"},
 				}
 				expected := &types.Document{
-					ElementReferences: types.ElementReferences{
-						"custom_header": sectionTitle,
-					},
 					Elements: []interface{}{
 						&types.Section{
 							Attributes: types.Attributes{
@@ -1699,6 +1850,18 @@ a paragraph`
 							},
 							Level: 1,
 							Title: sectionTitle,
+						},
+					},
+					ElementReferences: types.ElementReferences{
+						"custom_header": sectionTitle,
+					},
+					TableOfContents: &types.TableOfContents{
+						MaxDepth: 2,
+						Sections: []*types.ToCSection{
+							{
+								ID:    "custom_header",
+								Level: 1,
+							},
 						},
 					},
 				}
@@ -1711,9 +1874,6 @@ a paragraph`
 					&types.StringElement{Content: "a header"},
 				}
 				expected := &types.Document{
-					ElementReferences: types.ElementReferences{
-						"custom_header": sectionTitle,
-					},
 					Elements: []interface{}{
 						&types.Section{
 							Attributes: types.Attributes{
@@ -1722,6 +1882,18 @@ a paragraph`
 							},
 							Level: 1,
 							Title: sectionTitle,
+						},
+					},
+					ElementReferences: types.ElementReferences{
+						"custom_header": sectionTitle,
+					},
+					TableOfContents: &types.TableOfContents{
+						MaxDepth: 2,
+						Sections: []*types.ToCSection{
+							{
+								ID:    "custom_header",
+								Level: 1,
+							},
 						},
 					},
 				}
@@ -1739,9 +1911,6 @@ a paragraph`
 					},
 				}
 				expected := &types.Document{
-					ElementReferences: types.ElementReferences{
-						"_a_header": sectionTitle,
-					},
 					Elements: []interface{}{
 						&types.Section{
 							Attributes: types.Attributes{
@@ -1749,6 +1918,18 @@ a paragraph`
 							},
 							Level: 1,
 							Title: sectionTitle,
+						},
+					},
+					ElementReferences: types.ElementReferences{
+						"_a_header": sectionTitle,
+					},
+					TableOfContents: &types.TableOfContents{
+						MaxDepth: 2,
+						Sections: []*types.ToCSection{
+							{
+								ID:    "_a_header",
+								Level: 1,
+							},
 						},
 					},
 				}
@@ -1766,9 +1947,6 @@ a paragraph`
 					},
 				}
 				expected := &types.Document{
-					ElementReferences: types.ElementReferences{
-						"custom_header": sectionTitle,
-					},
 					Elements: []interface{}{
 						&types.Section{
 							Attributes: types.Attributes{
@@ -1777,6 +1955,18 @@ a paragraph`
 							},
 							Level: 1,
 							Title: sectionTitle,
+						},
+					},
+					ElementReferences: types.ElementReferences{
+						"custom_header": sectionTitle,
+					},
+					TableOfContents: &types.TableOfContents{
+						MaxDepth: 2,
+						Sections: []*types.ToCSection{
+							{
+								ID:    "custom_header",
+								Level: 1,
+							},
 						},
 					},
 				}
@@ -1794,9 +1984,6 @@ a paragraph`
 					},
 				}
 				expected := &types.Document{
-					ElementReferences: types.ElementReferences{
-						"custom_header": sectionTitle,
-					},
 					Elements: []interface{}{
 						&types.Section{
 							Attributes: types.Attributes{
@@ -1805,6 +1992,18 @@ a paragraph`
 							},
 							Level: 1,
 							Title: sectionTitle,
+						},
+					},
+					ElementReferences: types.ElementReferences{
+						"custom_header": sectionTitle,
+					},
+					TableOfContents: &types.TableOfContents{
+						MaxDepth: 2,
+						Sections: []*types.ToCSection{
+							{
+								ID:    "custom_header",
+								Level: 1,
+							},
 						},
 					},
 				}
@@ -1832,10 +2031,6 @@ a paragraph`
 					&types.StringElement{Content: "Section B"},
 				}
 				expected := &types.Document{
-					ElementReferences: types.ElementReferences{
-						"foo": fooTitle,
-						"bar": barTitle,
-					},
 					Elements: []interface{}{
 						&types.DocumentHeader{
 							Title: []interface{}{
@@ -1870,6 +2065,23 @@ a paragraph`
 							},
 						},
 					},
+					ElementReferences: types.ElementReferences{
+						"foo": fooTitle,
+						"bar": barTitle,
+					},
+					TableOfContents: &types.TableOfContents{
+						MaxDepth: 2,
+						Sections: []*types.ToCSection{
+							{
+								ID:    "foo",
+								Level: 1,
+							},
+							{
+								ID:    "bar",
+								Level: 1,
+							},
+						},
+					},
 				}
 				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
@@ -1886,10 +2098,6 @@ a paragraph`
 				}
 
 				expected := &types.Document{
-					ElementReferences: types.ElementReferences{
-						"_section_1":   section1aTitle,
-						"_section_1_2": section1bTitle,
-					},
 					Elements: []interface{}{
 						&types.Section{
 							Attributes: types.Attributes{
@@ -1906,6 +2114,23 @@ a paragraph`
 							Title: section1bTitle,
 						},
 					},
+					ElementReferences: types.ElementReferences{
+						"_section_1":   section1aTitle,
+						"_section_1_2": section1bTitle,
+					},
+					TableOfContents: &types.TableOfContents{
+						MaxDepth: 2,
+						Sections: []*types.ToCSection{
+							{
+								ID:    "_section_1",
+								Level: 1,
+							},
+							{
+								ID:    "_section_1_2",
+								Level: 1,
+							},
+						},
+					},
 				}
 				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
@@ -1919,9 +2144,6 @@ a paragraph`
 					&types.StringElement{Content: "section 1"},
 				}
 				expected := &types.Document{
-					ElementReferences: types.ElementReferences{
-						"custom_section_1": section1Title,
-					},
 					Elements: []interface{}{
 						&types.DocumentHeader{
 							Title: []interface{}{
@@ -1940,6 +2162,18 @@ a paragraph`
 							},
 							Level: 1,
 							Title: section1Title,
+						},
+					},
+					ElementReferences: types.ElementReferences{
+						"custom_section_1": section1Title,
+					},
+					TableOfContents: &types.TableOfContents{
+						MaxDepth: 2,
+						Sections: []*types.ToCSection{
+							{
+								ID:    "custom_section_1",
+								Level: 1,
+							},
 						},
 					},
 				}
@@ -1962,10 +2196,6 @@ a paragraph`
 					&types.StringElement{Content: "section 1b"},
 				}
 				expected := &types.Document{
-					ElementReferences: types.ElementReferences{
-						"custom1a_section_1a": section1aTitle,
-						"custom1b_section_1b": section1bTitle,
-					},
 					Elements: []interface{}{
 						&types.DocumentHeader{
 							Title: []interface{}{
@@ -1997,6 +2227,23 @@ a paragraph`
 							},
 							Level: 1,
 							Title: section1bTitle,
+						},
+					},
+					ElementReferences: types.ElementReferences{
+						"custom1a_section_1a": section1aTitle,
+						"custom1b_section_1b": section1bTitle,
+					},
+					TableOfContents: &types.TableOfContents{
+						MaxDepth: 2,
+						Sections: []*types.ToCSection{
+							{
+								ID:    "custom1a_section_1a",
+								Level: 1,
+							},
+							{
+								ID:    "custom1b_section_1b",
+								Level: 1,
+							},
 						},
 					},
 				}
@@ -2020,10 +2267,6 @@ a paragraph`
 					&types.StringElement{Content: "section 1b"},
 				}
 				expected := &types.Document{
-					ElementReferences: types.ElementReferences{
-						"custom1a_section_1a": section1aTitle,
-						"custom1b_section_1b": section1bTitle,
-					},
 					Elements: []interface{}{
 						&types.DocumentHeader{
 							Title: []interface{}{
@@ -2057,6 +2300,23 @@ a paragraph`
 							Title: section1bTitle,
 						},
 					},
+					ElementReferences: types.ElementReferences{
+						"custom1a_section_1a": section1aTitle,
+						"custom1b_section_1b": section1bTitle,
+					},
+					TableOfContents: &types.TableOfContents{
+						MaxDepth: 2,
+						Sections: []*types.ToCSection{
+							{
+								ID:    "custom1a_section_1a",
+								Level: 1,
+							},
+							{
+								ID:    "custom1b_section_1b",
+								Level: 1,
+							},
+						},
+					},
 				}
 				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
@@ -2068,11 +2328,6 @@ a short preamble
 
 == Section 1`
 				expected := &types.Document{
-					ElementReferences: types.ElementReferences{
-						"_section_1": []interface{}{
-							&types.StringElement{Content: "Section 1"},
-						},
-					},
 					Elements: []interface{}{
 						&types.DocumentHeader{
 							Title: []interface{}{
@@ -2095,6 +2350,20 @@ a short preamble
 							Level: 1,
 							Title: []interface{}{
 								&types.StringElement{Content: "Section 1"},
+							},
+						},
+					},
+					ElementReferences: types.ElementReferences{
+						"_section_1": []interface{}{
+							&types.StringElement{Content: "Section 1"},
+						},
+					},
+					TableOfContents: &types.TableOfContents{
+						MaxDepth: 2,
+						Sections: []*types.ToCSection{
+							{
+								ID:    "_section_1",
+								Level: 1,
 							},
 						},
 					},

--- a/pkg/renderer/sgml/html5/file_inclusion_test.go
+++ b/pkg/renderer/sgml/html5/file_inclusion_test.go
@@ -35,6 +35,18 @@ var _ = Describe("file inclusions", func() {
 		Expect(DocumentMetadata(source, lastUpdated)).To(Equal(types.Metadata{
 			Title:       "",
 			LastUpdated: lastUpdated.Format(configuration.LastUpdatedFormat),
+			TableOfContents: &types.TableOfContents{
+				MaxDepth: 2,
+				Sections: []*types.ToCSection{
+					{
+						ID:       "_grandchild_title",
+						Level:    1,
+						Title:    "grandchild title",
+						Number:   "",
+						Children: nil,
+					},
+				},
+			},
 		}))
 		// verify no error/warning in logs
 		Expect(logs).ToNot(ContainAnyMessageWithLevels(log.ErrorLevel, log.WarnLevel))

--- a/pkg/renderer/sgml/xhtml5/file_inclusion_test.go
+++ b/pkg/renderer/sgml/xhtml5/file_inclusion_test.go
@@ -34,17 +34,16 @@ var _ = Describe("file inclusions", func() {
 		Expect(RenderXHTML(source, configuration.WithLastUpdated(lastUpdated))).To(Equal(expected))
 		Expect(DocumentMetadata(source, lastUpdated)).To(Equal(types.Metadata{
 			LastUpdated: lastUpdated.Format(configuration.LastUpdatedFormat),
-			// See https://github.com/bytesparadise/libasciidoc/issues/939
-			// TableOfContents: &types.TableOfContents{
-			// 	Sections: []*types.ToCSection{
-			// 		{
-			// 			ID:       "_grandchild_title",
-			// 			Level:    1,
-			// 			Title:    "grandchild title",
-			// 			Children: []*types.ToCSection{},
-			// 		},
-			// 	},
-			// },
+			TableOfContents: &types.TableOfContents{
+				MaxDepth: 2,
+				Sections: []*types.ToCSection{
+					{
+						ID:    "_grandchild_title",
+						Level: 1,
+						Title: "grandchild title",
+					},
+				},
+			},
 		}))
 		// verify no error/warning in logs
 		Expect(logs).ToNot(ContainAnyMessageWithLevels(log.ErrorLevel, log.WarnLevel))

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -184,6 +184,7 @@ type ToCSection struct {
 	ID       string
 	Level    int
 	Title    string // the title as it was rendered in HTML
+	Number   string // the number assigned during rendering, if the `sectnums` attribute was set
 	Children []*ToCSection
 }
 


### PR DESCRIPTION
the `types.Metadata` value returned by the call to `libasciidoc.Convert(...)`
contains a TableOfContents (when non-empty), even if the ToC is not
rendered.

Fixes #939

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
