### PR TITLE
Fallback symlink command doesn't work

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -60,7 +60,7 @@ To build libasciidoc and make it available on the command line, do this:
 
 If `$GOPATH/bin` is already in `$PATH`, then you should be good. Otherwise, for Linux and macOS users, you can run the following command:
  
-    $ sudo ln -s  ./bin/libasciidoc /usr/bin/libasciidoc
+    $ sudo ln -s "$PWD/bin/libasciidoc" /usr/bin/libasciidoc
 
 == Usage
 

--- a/README.adoc
+++ b/README.adoc
@@ -60,7 +60,7 @@ To build libasciidoc and make it available on the command line, do this:
 
 If `$GOPATH/bin` is already in `$PATH`, then you should be good. Otherwise, for Linux and macOS users, you can run the following command:
  
-    $ sudo ln -s "$PWD/bin/libasciidoc" /usr/bin/libasciidoc
+    $ sudo ln -s "$PWD/bin/libasciidoc" /usr/local/bin/libasciidoc
 
 == Usage
 


### PR DESCRIPTION
If run as-is, the current symlink command will create a broken link:

```
$ sudo ln -s  ./bin/libasciidoc /usr/bin/libasciidoc
$ file /usr/bin/libasciidoc
/usr/bin/libasciidoc: broken symbolic link to ./bin/libasciidoc
```

This command works and produces a working absolute link:

```console
$ sudo ln -s "$PWD/bin/libasciidoc" /usr/bin/libasciidoc
```