### PR TITLE
chore(project): run golangci-lint-action on Go 1.17 only

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.16.x, 1.17.x]
+        go-version: [1.17.x]
     steps:
     - name: Checkout code
       uses: actions/checkout@v2


### PR DESCRIPTION
Fixes #1003

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
