### PR TITLE
refactor(parser): delete 'CalloutListElementContent' rule

### DIFF
--- a/pkg/parser/parser.peg
+++ b/pkg/parser/parser.peg
@@ -1786,21 +1786,13 @@ Callout <-
 
 CalloutListElement <- 
     ref:(CalloutListElementPrefix) 
-    description:(CalloutListElementContent) {
-        return types.NewCalloutListElement(ref.(int), description.(types.RawLine))
+    description:(ListElementContent) {
+        return types.NewCalloutListElement(ref.(int), description.(*types.Paragraph))
     }
 
 CalloutListElementPrefix <- 
     "<" ref:([0-9]+ { return strconv.Atoi(string(c.text)) }) ">" Spaces {
         return ref, nil
-    }
-
-CalloutListElementContent <- // TODO: remove in favor of `ListElementContent`
-    rawline:([^\r\n]+ {
-        return string(c.text), nil
-    })
-    EOL {
-        return types.NewRawLine(rawline.(string))
     }
 
 // -----------------------------------------------------------------------------------------------------------------------

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -1027,16 +1027,12 @@ var _ ListElement = &CalloutListElement{}
 var _ DocumentElement = &CalloutListElement{}
 
 // NewCalloutListElement returns a new CalloutListElement
-func NewCalloutListElement(ref int, content RawLine) (*CalloutListElement, error) {
+func NewCalloutListElement(ref int, content *Paragraph) (*CalloutListElement, error) {
 	return &CalloutListElement{
 		Attributes: nil,
 		Ref:        ref,
 		Elements: []interface{}{
-			&Paragraph{
-				Elements: []interface{}{
-					content,
-				},
-			},
+			content,
 		},
 	}, nil
 }


### PR DESCRIPTION
use 'ListElementContent' instead

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
