### PR TITLE
fix(parser): delimited block immediately after paragraph

### DIFF
--- a/pkg/parser/delimited_block_listing_test.go
+++ b/pkg/parser/delimited_block_listing_test.go
@@ -149,6 +149,33 @@ some listing code
 				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
+			It("immediately after a paragraph", func() {
+				source := `a paragraph.
+----
+some listing code
+----`
+				expected := &types.Document{
+					Elements: []interface{}{
+						&types.Paragraph{
+							Elements: []interface{}{
+								&types.StringElement{
+									Content: "a paragraph.",
+								},
+							},
+						},
+						&types.DelimitedBlock{
+							Kind: types.Listing,
+							Elements: []interface{}{
+								&types.StringElement{
+									Content: "some listing code",
+								},
+							},
+						},
+					},
+				}
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
+			})
+
 			It("with unclosed delimiter", func() {
 				source := `----
 End of file here.`

--- a/pkg/parser/delimited_block_literal_test.go
+++ b/pkg/parser/delimited_block_literal_test.go
@@ -176,6 +176,61 @@ a normal paragraph.`
 				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
+			It("after a paragraph", func() {
+				source := `a normal paragraph.
+
+....
+some delimited content
+....`
+				expected := &types.Document{
+					Elements: []interface{}{
+						&types.Paragraph{
+							Elements: []interface{}{
+								&types.StringElement{
+									Content: "a normal paragraph.",
+								},
+							},
+						},
+						&types.DelimitedBlock{
+							Kind: types.Literal,
+							Elements: []interface{}{
+								&types.StringElement{
+									Content: "some delimited content",
+								},
+							},
+						},
+					},
+				}
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
+			})
+
+			It("immediately after a paragraph", func() {
+				source := `a normal paragraph.
+....
+some delimited content
+....`
+				expected := &types.Document{
+					Elements: []interface{}{
+						&types.Paragraph{
+							Elements: []interface{}{
+								&types.StringElement{
+									Content: "a normal paragraph.",
+								},
+							},
+						},
+						&types.DelimitedBlock{
+							Kind: types.Literal,
+							Elements: []interface{}{
+								&types.StringElement{
+									Content: "some delimited content",
+								},
+							},
+						},
+					},
+				}
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
+			})
+
 			Context("with variable delimiter length", func() {
 
 				It("with 5 chars", func() {

--- a/pkg/parser/parser.peg
+++ b/pkg/parser/parser.peg
@@ -1811,6 +1811,7 @@ ShortcutParagraph <-
         !EOF 
         !BlankLine
         !BlockAttributes
+        !BlockDelimiter
         !ListElementContinuationMarker
         line:(SingleLineComment / ParagraphRawLine) {
             return line, nil

--- a/pkg/parser/section_test.go
+++ b/pkg/parser/section_test.go
@@ -2453,7 +2453,7 @@ a short preamble
 
 		Context("unsupported section syntax", func() {
 
-			It("should not fail with underlined title", func() {
+			It("match unclosed example section", func() {
 				source := `Document Title
 ==============
 Doc Writer <thedoc@asciidoctor.org>`
@@ -2462,16 +2462,28 @@ Doc Writer <thedoc@asciidoctor.org>`
 						&types.Paragraph{
 							Elements: []interface{}{
 								&types.StringElement{
-									Content: "Document Title\n==============\nDoc Writer ",
+									Content: "Document Title",
 								},
-								&types.SpecialCharacter{
-									Name: "<",
-								},
-								&types.StringElement{
-									Content: "thedoc@asciidoctor.org",
-								},
-								&types.SpecialCharacter{
-									Name: ">",
+							},
+						},
+						&types.DelimitedBlock{
+							Kind: types.Example,
+							Elements: []interface{}{
+								&types.Paragraph{
+									Elements: []interface{}{
+										&types.StringElement{
+											Content: "Doc Writer ",
+										},
+										&types.SpecialCharacter{
+											Name: "<",
+										},
+										&types.StringElement{
+											Content: "thedoc@asciidoctor.org",
+										},
+										&types.SpecialCharacter{
+											Name: ">",
+										},
+									},
 								},
 							},
 						},


### PR DESCRIPTION
do not include raw content within paragraph.

Fixes #1008

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
