### PR TITLE
fix(renderer): image alt without separators

### DIFF
--- a/pkg/renderer/sgml/html5/delimited_block_open_test.go
+++ b/pkg/renderer/sgml/html5/delimited_block_open_test.go
@@ -63,7 +63,7 @@ image::another-image.png[]
 </div></div></td>
 <td class="tableblock halign-center valign-top"><div class="content"><div id="another-id" class="imageblock">
 <div class="content">
-<img src="another-image.png" alt="another-image">
+<img src="another-image.png" alt="another image">
 </div>
 <div class="title">Figure 2. Another title</div>
 </div></div></td>

--- a/pkg/renderer/sgml/html5/image_test.go
+++ b/pkg/renderer/sgml/html5/image_test.go
@@ -11,12 +11,22 @@ var _ = Describe("images", func() {
 
 	Context("block images", func() {
 
-		It("alone", func() {
-
-			source := "image::foo.png[]"
+		It("alone with underscores in filename", func() {
+			source := "image::an_image_here.png[]"
 			expected := `<div class="imageblock">
 <div class="content">
-<img src="foo.png" alt="foo">
+<img src="an_image_here.png" alt="an image here">
+</div>
+</div>
+`
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+		})
+
+		It("alone with dashes in filename", func() {
+			source := "image::an-image-here.png[]"
+			expected := `<div class="imageblock">
+<div class="content">
+<img src="an-image-here.png" alt="an image here">
 </div>
 </div>
 `

--- a/pkg/renderer/sgml/html5/table_test.go
+++ b/pkg/renderer/sgml/html5/table_test.go
@@ -645,7 +645,7 @@ image::another-image.png[]
 </div></div></td>
 <td class="tableblock halign-center valign-top"><div class="content"><div class="imageblock">
 <div class="content">
-<img src="another-image.png" alt="another-image">
+<img src="another-image.png" alt="another image">
 </div>
 </div></div></td>
 </tr>
@@ -682,7 +682,7 @@ image::another-image.png[]
 </div></div></td>
 <td class="tableblock halign-center valign-top"><div class="content"><div id="another-id" class="imageblock">
 <div class="content">
-<img src="another-image.png" alt="another-image">
+<img src="another-image.png" alt="another image">
 </div>
 <div class="title">Figure 2. Another title</div>
 </div></div></td>

--- a/pkg/renderer/sgml/image.go
+++ b/pkg/renderer/sgml/image.go
@@ -164,5 +164,9 @@ func (r *sgmlRenderer) renderImageAlt(attrs types.Attributes, path string) (stri
 		return "", errors.Wrap(err, "unable to render image")
 	}
 	// return base path without its extension
-	return strings.TrimSuffix(filepath.Base(u.Path), filepath.Ext(u.Path)), nil
+	result := strings.TrimSuffix(filepath.Base(u.Path), filepath.Ext(u.Path))
+	// replace separators
+	result = strings.ReplaceAll(result, "-", " ")
+	result = strings.ReplaceAll(result, "_", " ")
+	return result, nil
 }


### PR DESCRIPTION
replace underscores and hyphens with spaces

Fixes #1019

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
