### PR TITLE
refactor(parser): unexport 'opts' field in Context type

### DIFF
--- a/pkg/parser/context.go
+++ b/pkg/parser/context.go
@@ -11,25 +11,27 @@ import (
 
 type ParseContext struct {
 	filename     string
-	Opts         []Option // TODO: unexport this field?
+	opts         []Option
 	levelOffsets levelOffsets
 	attributes   *contextAttributes
 	userMacros   map[string]configuration.MacroTemplate
 	counters     map[string]interface{}
 }
 
-func NewParseContext(config *configuration.Configuration, opts ...Option) *ParseContext {
+func NewParseContext(config *configuration.Configuration, options ...Option) *ParseContext {
 	if log.IsLevelEnabled(log.DebugLevel) {
 		log.Debugf("new parser context with attributes: %s", spew.Sdump(config.Attributes))
 	}
-	opts = append(opts, Entrypoint("DocumentFragment"))
-	opts = append(opts, GlobalStore(frontMatterKey, true))
-	opts = append(opts, GlobalStore(documentHeaderKey, true))
-	opts = append(opts, GlobalStore(enabledSubstitutions, []string{AttributeRefs}))
-	opts = append(opts, GlobalStore(usermacrosKey, config.Macros))
+	opts := []Option{
+		Entrypoint("DocumentFragment"),
+		GlobalStore(frontMatterKey, true),
+		GlobalStore(documentHeaderKey, true),
+		GlobalStore(enabledSubstitutions, []string{AttributeRefs}),
+		GlobalStore(usermacrosKey, config.Macros)}
+	opts = append(opts, options...)
 	return &ParseContext{
 		filename:     config.Filename,
-		Opts:         opts,
+		opts:         opts,
 		levelOffsets: []*levelOffset{},
 		attributes:   newContextAttributes(config.Attributes),
 		userMacros:   config.Macros,
@@ -40,7 +42,7 @@ func NewParseContext(config *configuration.Configuration, opts ...Option) *Parse
 func (c *ParseContext) Clone() *ParseContext {
 	return &ParseContext{
 		filename:     c.filename,
-		Opts:         options(c.Opts).clone(),
+		opts:         options(c.opts).clone(),
 		levelOffsets: c.levelOffsets.clone(),
 		attributes:   c.attributes.clone(),
 		userMacros:   c.userMacros,

--- a/pkg/parser/document_preprocessing.go
+++ b/pkg/parser/document_preprocessing.go
@@ -35,7 +35,7 @@ func preprocess(ctx *ParseContext, source io.Reader) (string, error) {
 	t := newBlockDelimiterTracker()
 	for scanner.Scan() {
 		line := scanner.Bytes()
-		element, err := Parse("", line, append(ctx.Opts, Entrypoint("DocumentRawLine"))...)
+		element, err := Parse("", line, append(ctx.opts, Entrypoint("DocumentRawLine"))...)
 		if err != nil {
 			// log.Error(err)
 			// content of line was not relevant in the context of preparsing (ie, it's a regular line), so let's keep it as-is
@@ -61,7 +61,7 @@ func preprocess(ctx *ParseContext, source io.Reader) (string, error) {
 				b.WriteString(f)
 			case *types.BlockDelimiter:
 				t.push(types.BlockDelimiterKind(e.Kind), e.Length)
-				ctx.Opts = append(ctx.Opts, withinDelimitedBlock(t.withinDelimitedBlock()))
+				ctx.opts = append(ctx.opts, withinDelimitedBlock(t.withinDelimitedBlock()))
 				b.WriteString(e.RawText())
 			case types.ConditionalInclusion:
 				if content, ok := e.SingleLineContent(); ok {
@@ -86,7 +86,7 @@ func preprocess(ctx *ParseContext, source io.Reader) (string, error) {
 // fragment, making it potentially big, but at the same time we ensure that the context
 // of the inclusion (for example, within a delimited block) is not lost.
 func includeFile(ctx *ParseContext, incl *types.FileInclusion) (string, error) {
-	ctx.Opts = append(ctx.Opts, GlobalStore(documentHeaderKey, false))
+	ctx.opts = append(ctx.opts, GlobalStore(documentHeaderKey, false))
 	if l, ok := incl.GetLocation().Path.([]interface{}); ok {
 		l, _, err := replaceAttributeRefsInSlice(ctx, l, noneSubstitutions())
 		if err != nil {
@@ -101,7 +101,7 @@ func includeFile(ctx *ParseContext, incl *types.FileInclusion) (string, error) {
 	if !adoc {
 		return string(content), nil
 	}
-	ctx.Opts = append(ctx.Opts, sectionEnabled())
+	ctx.opts = append(ctx.opts, sectionEnabled())
 	return preprocess(ctx, bytes.NewReader(content))
 }
 

--- a/pkg/parser/document_processing_apply_substitutions.go
+++ b/pkg/parser/document_processing_apply_substitutions.go
@@ -35,7 +35,7 @@ func applySubstitutionsOnFragment(ctx *ParseContext, f types.DocumentFragment) t
 		return f
 	}
 	for i := range f.Elements {
-		if err := applySubstitutionsOnElement(ctx, f.Elements[i], ctx.Opts...); err != nil {
+		if err := applySubstitutionsOnElement(ctx, f.Elements[i], ctx.opts...); err != nil {
 			return types.NewErrorFragment(f.Position, err)
 		}
 	}
@@ -53,13 +53,13 @@ func applySubstitutionsOnElement(ctx *ParseContext, element interface{}, opts ..
 	case *types.AttributeDeclaration:
 		ctx.attributes.set(b.Name, b.Value)
 		if b.Name == types.AttrExperimental {
-			ctx.Opts = append(ctx.Opts, enableExperimentalMacros(true))
+			ctx.opts = append(ctx.opts, enableExperimentalMacros(true))
 		}
 		return nil
 	case *types.AttributeReset:
 		ctx.attributes.unset(b.Name)
 		if b.Name == types.AttrExperimental {
-			ctx.Opts = append(ctx.Opts, enableExperimentalMacros(false))
+			ctx.opts = append(ctx.opts, enableExperimentalMacros(false))
 		}
 		return nil
 	case *types.DocumentHeader:

--- a/pkg/parser/document_processing_parse_fragments.go
+++ b/pkg/parser/document_processing_parse_fragments.go
@@ -19,7 +19,7 @@ func ParseFragments(ctx *ParseContext, source io.Reader, done <-chan interface{}
 			resultStream <- types.NewErrorFragment(types.Position{}, err)
 			return
 		}
-		p := newParser(ctx.filename, b, ctx.Opts...) // we want to parse block attributes to detect AttributeReferences
+		p := newParser(ctx.filename, b, ctx.opts...) // we want to parse block attributes to detect AttributeReferences
 		if err := p.setup(g); err != nil {
 			resultStream <- types.NewErrorFragment(types.Position{}, err)
 			return
@@ -138,7 +138,7 @@ func reparseTableCell(ctx *ParseContext, c *types.TableCell) error {
 	log.Debugf("reparsing content of table cell")
 	switch c.Format {
 	case "a":
-		opts := append(ctx.Opts, Entrypoint("DelimitedBlockElements"))
+		opts := append(ctx.opts, Entrypoint("DelimitedBlockElements"))
 		elements, err := reparseElements(c.Elements, opts...)
 		if err != nil {
 			return err
@@ -160,7 +160,7 @@ func reparseDelimitedBlock(ctx *ParseContext, b *types.DelimitedBlock) error {
 	switch b.Kind {
 	case types.Example, types.Quote, types.Sidebar, types.Open:
 		log.Debugf("parsing elements of delimited block of kind '%s'", b.Kind)
-		opts := append(ctx.Opts, Entrypoint("DelimitedBlockElements"), withinDelimitedBlock(true))
+		opts := append(ctx.opts, Entrypoint("DelimitedBlockElements"), withinDelimitedBlock(true))
 		elements, err := reparseElements(b.Elements, opts...)
 		if err != nil {
 			return err

--- a/testsupport/parse_document_fragment_groups.go
+++ b/testsupport/parse_document_fragment_groups.go
@@ -11,8 +11,7 @@ import (
 // ParseDocumentFragments parses the actual source with the options
 func ParseDocumentFragments(actual string, options ...parser.Option) ([]types.DocumentFragment, error) {
 	r := strings.NewReader(actual)
-	ctx := parser.NewParseContext(configuration.NewConfiguration())
-	ctx.Opts = append(ctx.Opts, options...)
+	ctx := parser.NewParseContext(configuration.NewConfiguration(), options...)
 	done := make(chan interface{})
 	defer close(done)
 	// ctx.Opts = append(ctx.Opts, parser.Debug(true))


### PR DESCRIPTION
finally addressing this long-time TODO comment ;)

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
