### PR TITLE
refactor(parser): merge 'LiteralParagraph' and 'Paragraph' rules

### DIFF
--- a/pkg/parser/attributes_test.go
+++ b/pkg/parser/attributes_test.go
@@ -253,7 +253,7 @@ var _ = Describe("attributes", func() {
 						&types.ImageBlock{
 							Attributes: types.Attributes{
 								types.AttrImageAlt: `Quoted, Here`,
-								types.AttrHeight:   "100", // last one wins
+								types.AttrHeight:   "100", // named attribute one wins
 								types.AttrWidth:    "1",
 							},
 							Location: &types.Location{

--- a/pkg/parser/comment_test.go
+++ b/pkg/parser/comment_test.go
@@ -26,12 +26,11 @@ var _ = Describe("comments", func() {
 					Elements: []interface{}{
 						&types.Paragraph{
 							Attributes: types.Attributes{
-								types.AttrStyle:            types.Literal,
-								types.AttrLiteralBlockType: types.LiteralBlockWithSpacesOnFirstLine,
+								types.AttrStyle: types.LiteralParagraph,
 							},
 							Elements: []interface{}{
 								&types.StringElement{
-									Content: "  // A single-line comment.",
+									Content: "  // A single-line comment.", // spaces on first line of literal paragraphs are NOT trimmed by parser
 								},
 							},
 						},
@@ -46,12 +45,11 @@ var _ = Describe("comments", func() {
 					Elements: []interface{}{
 						&types.Paragraph{
 							Attributes: types.Attributes{
-								types.AttrStyle:            types.Literal,
-								types.AttrLiteralBlockType: types.LiteralBlockWithSpacesOnFirstLine,
+								types.AttrStyle: types.LiteralParagraph,
 							},
 							Elements: []interface{}{
 								&types.StringElement{
-									Content: "\t\t// A single-line comment.",
+									Content: "\t\t// A single-line comment.", // spaces on first line of literal paragraphs are NOT trimmed by parser
 								},
 							},
 						},

--- a/pkg/parser/delimited_block_literal_test.go
+++ b/pkg/parser/delimited_block_literal_test.go
@@ -20,12 +20,11 @@ var _ = Describe("literal blocks", func() {
 					Elements: []interface{}{
 						&types.Paragraph{
 							Attributes: types.Attributes{
-								types.AttrStyle:            types.Literal,
-								types.AttrLiteralBlockType: types.LiteralBlockWithSpacesOnFirstLine,
+								types.AttrStyle: types.LiteralParagraph,
 							},
 							Elements: []interface{}{
 								&types.StringElement{
-									Content: " some literal content",
+									Content: " some literal content", // spaces on first line of literal paragraphs are NOT trimmed by parser
 								},
 							},
 						},
@@ -42,12 +41,11 @@ lines.`
 					Elements: []interface{}{
 						&types.Paragraph{
 							Attributes: types.Attributes{
-								types.AttrStyle:            types.Literal,
-								types.AttrLiteralBlockType: types.LiteralBlockWithSpacesOnFirstLine,
+								types.AttrStyle: types.LiteralParagraph,
 							},
 							Elements: []interface{}{
 								&types.StringElement{
-									Content: " some literal content\non 3\nlines.",
+									Content: " some literal content\non 3\nlines.", // spaces on first line of literal paragraphs are NOT trimmed by parser
 								},
 							},
 						},
@@ -65,12 +63,11 @@ lines.`
 					Elements: []interface{}{
 						&types.Paragraph{
 							Attributes: types.Attributes{
-								types.AttrStyle:            types.Literal,
-								types.AttrLiteralBlockType: types.LiteralBlockWithSpacesOnFirstLine,
+								types.AttrStyle: types.LiteralParagraph,
 							},
 							Elements: []interface{}{
 								&types.StringElement{
-									Content: " some literal content\n  on 3\n   lines.",
+									Content: " some literal content\n  on 3\n   lines.", // spaces on first line of literal paragraphs are NOT trimmed by parser
 								},
 							},
 						},
@@ -89,14 +86,13 @@ a normal paragraph.`
 					Elements: []interface{}{
 						&types.Paragraph{
 							Attributes: types.Attributes{
-								types.AttrStyle:            types.Literal,
-								types.AttrLiteralBlockType: types.LiteralBlockWithSpacesOnFirstLine,
-								types.AttrID:               "ID",
-								types.AttrTitle:            "title",
+								types.AttrStyle: types.LiteralParagraph,
+								types.AttrID:    "ID",
+								types.AttrTitle: "title",
 							},
 							Elements: []interface{}{
 								&types.StringElement{
-									Content: "  some literal content",
+									Content: "  some literal content", // spaces on first line of literal paragraphs are NOT trimmed by parser
 								},
 							},
 						},
@@ -286,8 +282,7 @@ a normal paragraph.`
 					Elements: []interface{}{
 						&types.Paragraph{
 							Attributes: types.Attributes{
-								types.AttrStyle:            types.Literal,
-								types.AttrLiteralBlockType: types.LiteralBlockWithAttribute,
+								types.AttrStyle: types.Literal,
 							},
 							Elements: []interface{}{
 								&types.StringElement{
@@ -319,10 +314,9 @@ a normal paragraph.`
 					Elements: []interface{}{
 						&types.Paragraph{
 							Attributes: types.Attributes{
-								types.AttrStyle:            types.Literal,
-								types.AttrID:               "ID",
-								types.AttrTitle:            "title",
-								types.AttrLiteralBlockType: types.LiteralBlockWithAttribute,
+								types.AttrStyle: types.Literal,
+								types.AttrID:    "ID",
+								types.AttrTitle: "title",
 							},
 							Elements: []interface{}{
 								&types.StringElement{
@@ -340,6 +334,26 @@ a normal paragraph.`
 					},
 					ElementReferences: types.ElementReferences{
 						"ID": "title",
+					},
+				}
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
+			})
+
+			It("not an admonition", func() {
+				source := `[literal]   
+TIP: not an admonition`
+				expected := &types.Document{
+					Elements: []interface{}{
+						&types.Paragraph{
+							Attributes: types.Attributes{
+								types.AttrStyle: types.Literal,
+							},
+							Elements: []interface{}{
+								&types.StringElement{
+									Content: "TIP: not an admonition",
+								},
+							},
+						},
 					},
 				}
 				Expect(ParseDocument(source)).To(MatchDocument(expected))
@@ -633,13 +647,12 @@ and <more text> on the +
 						},
 						&types.Paragraph{
 							Attributes: types.Attributes{
-								types.AttrStyle:            types.Literal,
-								types.AttrLiteralBlockType: types.LiteralBlockWithSpacesOnFirstLine,
-								types.AttrSubstitutions:    "quotes,macros",
+								types.AttrStyle:         types.LiteralParagraph,
+								types.AttrSubstitutions: "quotes,macros",
 							},
 							Elements: []interface{}{
 								&types.StringElement{
-									Content: "  a link to ",
+									Content: "  a link to ", // spaces on first line of literal paragraphs are NOT trimmed by parser
 								},
 								&types.InlineLink{
 									Location: &types.Location{
@@ -708,9 +721,8 @@ and <more text> on the +
 						},
 						&types.Paragraph{
 							Attributes: types.Attributes{
-								types.AttrStyle:            types.Literal,
-								types.AttrLiteralBlockType: types.LiteralBlockWithAttribute,
-								types.AttrSubstitutions:    "quotes,macros",
+								types.AttrStyle:         types.Literal,
+								types.AttrSubstitutions: "quotes,macros",
 							},
 							Elements: []interface{}{
 								&types.StringElement{

--- a/pkg/parser/delimited_block_passthrough_test.go
+++ b/pkg/parser/delimited_block_passthrough_test.go
@@ -29,7 +29,7 @@ another paragraph`
 						Elements: []interface{}{
 							&types.Paragraph{
 								Attributes: types.Attributes{
-									types.AttrStyle: "pass",
+									types.AttrStyle: types.Passthrough,
 								},
 								Elements: []interface{}{
 									types.RawLine("_foo_\n"),

--- a/pkg/parser/document_preprocessing.go
+++ b/pkg/parser/document_preprocessing.go
@@ -60,7 +60,7 @@ func preprocess(ctx *ParseContext, source io.Reader) (string, error) {
 				}
 				b.WriteString(f)
 			case *types.BlockDelimiter:
-				t.push(types.BlockDelimiterKind(e.Kind), e.Length)
+				t.push(e.Kind, e.Length)
 				ctx.opts = append(ctx.opts, withinDelimitedBlock(t.withinDelimitedBlock()))
 				b.WriteString(e.RawText())
 			case types.ConditionalInclusion:

--- a/pkg/parser/document_processing_apply_substitutions.go
+++ b/pkg/parser/document_processing_apply_substitutions.go
@@ -166,7 +166,7 @@ func applySubstitutionsOnWithElements(ctx *ParseContext, b types.WithElements, o
 	if err := applySubstitutionsOnAttributes(ctx, b, headerSubstitutions()); err != nil {
 		return err
 	}
-	if s := b.GetAttributes().GetAsStringWithDefault(types.AttrStyle, ""); s == types.Passthrough {
+	if style, found := b.GetAttributes()[types.AttrStyle]; found && style == types.Passthrough {
 		log.Debugf("skipping substitutions on passthrough block of type '%T'", b)
 		content, _ := serialize(b.GetElements())
 		return b.SetElements([]interface{}{

--- a/pkg/parser/document_processing_parse_fragments.go
+++ b/pkg/parser/document_processing_parse_fragments.go
@@ -223,3 +223,21 @@ func (c *current) isDocumentHeaderAllowed() bool {
 func (c *current) disableDocumentHeaderRule() {
 	c.globalStore[documentHeaderKey] = false
 }
+
+const blockAttributesKey = "block_attributes"
+
+func (c *current) storeBlockAttributes(attributes types.Attributes) {
+	if log.IsLevelEnabled(log.DebugLevel) {
+		log.Debugf("storing block attributes in global store: %s", spew.Sdump(attributes))
+	}
+	c.globalStore[blockAttributesKey] = attributes
+}
+
+func (c *current) isWithinLiteralParagraph() bool {
+	if attrs, ok := c.globalStore[blockAttributesKey].(types.Attributes); ok {
+		log.Debugf("within literal paragraph: %t", attrs[types.AttrStyle] == types.Literal)
+		return attrs[types.AttrPositional1] == types.Literal || attrs[types.AttrStyle] == types.Literal
+	}
+	log.Debug("not within literal paragraph")
+	return false
+}

--- a/pkg/parser/mixed_lists_test.go
+++ b/pkg/parser/mixed_lists_test.go
@@ -499,7 +499,7 @@ ii) ordered 1.2.ii
 																	Elements: []interface{}{
 																		&types.Paragraph{
 																			Elements: []interface{}{
-																				&types.StringElement{Content: "unordered 2.1.1\nwith some\nextra lines."}, // leading tabs are trimmed
+																				&types.StringElement{Content: "unordered 2.1.1\n\twith some\n\textra lines."},
 																			},
 																		},
 																	},

--- a/pkg/parser/ordered_list_test.go
+++ b/pkg/parser/ordered_list_test.go
@@ -69,7 +69,7 @@ var _ = Describe("ordered lists", func() {
 										&types.Paragraph{
 											Elements: []interface{}{
 												&types.StringElement{
-													Content: "element\non\nmultiple\nlines", // spaces are trimmed
+													Content: "element\n\ton\n\tmultiple\n\tlines",
 												},
 											},
 										},

--- a/pkg/parser/parser.peg
+++ b/pkg/parser/parser.peg
@@ -226,7 +226,13 @@ IncludedFileEndTag <- "end::" tag:(Alphanums {return string(c.text), nil}) "[]" 
 // -------------------------------------------------------------------------------------
 DocumentFragment <-
     !EOF
-    attributes:(BlockAttributes)?
+    attributes:(BlockAttributes)? 
+    #{
+        if attributes, ok := attributes.(types.Attributes); ok {
+            c.storeBlockAttributes(attributes)
+        }
+        return nil
+    }
     element:(
         ImageBlock // must appear before ShortcutParagraph
         / UserMacroBlock // must appear before ShortcutParagraph
@@ -241,7 +247,6 @@ DocumentFragment <-
         / ListElements
         / Table
         / SinglelineComment
-        / LiteralParagraph
         / FrontMatter
         / Paragraph // must be the last one... 
     )? // allow attribute on empty/no element
@@ -286,21 +291,6 @@ FrontMatterFragmentElement <-
     // if no match, parser will return an error and content will be store in a RawLine
 
 // -------------------------------------------------------------------------------------
-// Admonitions
-// -------------------------------------------------------------------------------------
-AdmonitionKind <- "TIP: " {
-    return types.Tip, nil
-} / "NOTE: " {
-    return types.Note, nil
-} / "IMPORTANT: " {
-    return types.Important, nil
-} / "WARNING: " {
-    return types.Warning, nil
-} / "CAUTION: " {
-    return types.Caution, nil
-}
-
-// -------------------------------------------------------------------------------------
 // Attribute Declarations and Resets
 // -------------------------------------------------------------------------------------
 AttributeDeclaration <- 
@@ -313,7 +303,7 @@ AttributeDeclaration <-
     )? 
     EOL
     {
-        return types.NewAttributeDeclaration(name.(string), types.Reduce(value, strings.TrimSpace), string(c.text))
+        return types.NewAttributeDeclaration(name.(string), value, string(c.text))
     }
 
 // AttributeName must be at least one character long, 
@@ -333,6 +323,7 @@ AttributeDeclarationValue <-
         }
     )*
     {
+        // TODO: do not call `types.Reduce(..., strings.TrimSpace)` each time?
         if otherElements, ok := otherElements.([]interface{}); ok {
             return types.Reduce(append(elements.([]interface{}), otherElements...), strings.TrimSpace), nil
         }
@@ -428,7 +419,7 @@ ShortHandTitle <- `.`
         InlineWord
         / Space
         / AttributeReferenceValue
-        / ([^\r\n] { return string(c.text), nil })
+        / ([^\r\n] { return string(c.text), nil }) // TODO: create a rule for this (used multiple times)
     )+ {
         return types.NewTitleAttribute(types.Reduce(elements, strings.TrimSpace))
     }
@@ -548,7 +539,7 @@ NamedAttribute <-
 
 // The spec says attributes have be alphanumeric but does not consider foreign letters.  We are more generous.
 NamedAttributeKey <- !Space [^\r\n=,\]]+ Space* {
-        return strings.TrimSpace(string(c.text)), nil
+        return strings.TrimSpace(string(c.text)), nil // TODO: call `strings.TrimSpace` within `types.NewNamedAttribute()`
     }
 
 AttributeValue <- 
@@ -1482,6 +1473,7 @@ RelativeLink <-
 
 ExternalLink <- 
     // escaped
+    // TODO: do not attempt to parse url and attributes here, and support escaped element once for all at a higher level     
     `\` url:(LocationWithScheme) attributes:(InlineAttributes)? {
         return types.NewStringElement(strings.TrimPrefix(string(c.text), `\`))
     }
@@ -1548,20 +1540,6 @@ ExtraListElement <- // other elements can be separated by blankline WITHOUT attr
                 return append(attributes.([]interface{}), element), nil
             })
         / SinglelineComment
-        / ( BlankLine+
-            attributes:(BlockAttributes)* 
-            element:LiteralParagraph {
-                if e, ok := element.(types.WithAttributes); ok {
-                    for _, a := range attributes.([]interface{}) {
-                        if a, ok := a.(types.Attributes); ok {
-                            e.AddAttributes(a)
-                        }
-                    }
-                }
-                // implicit attachment to list element
-                // by wrapping into a ListContinuation
-                return types.NewListContinuation(0, element)
-            })
         / ( element:ListElementParagraphLine {
                 return element, nil
             }) // must follow directly a list element
@@ -1583,7 +1561,7 @@ ListElementParagraphLine <-
         !(LabeledListElementTerm LabeledListElementSeparator)
         !BlockDelimiter
         content:([^\r\n]+ {
-            return strings.TrimSpace(string(c.text)), nil
+            return string(c.text), nil
         })
         EOL { // do not retain the EOL chars
             return types.NewRawLine(content.(string))
@@ -1624,7 +1602,6 @@ ListContinuationElement <- // TODO: same as DelimitedBlockElement?
         / ImageBlock
         / Table
         / SinglelineComment
-        / LiteralParagraph
         / ListContinuationParagraph // must be the last one... 
     ) {
         if element,ok := element.(types.WithAttributes); ok && attributes != nil {
@@ -1638,9 +1615,9 @@ ListContinuationElement <- // TODO: same as DelimitedBlockElement?
 
 // new paragraph with single line (other lines will be appended afterwards)
 ListContinuationParagraph <- 
-    kind:(AdmonitionKind)? 
+    style:(ParagraphStyle)? 
     content:(ListElementParagraphLine) {
-        return types.NewParagraph(kind, content)
+        return types.NewParagraph(style, content)
     }
 
 // ------------------------
@@ -1817,11 +1794,32 @@ CalloutListElementPrefix <-
 // -----------------------------------------------------------------------------------------------------------------------
 // Paragraphs
 // -----------------------------------------------------------------------------------------------------------------------
+
+ParagraphStyle <- 
+    &{
+        return !c.isWithinLiteralParagraph(), nil
+    }
+    style:("TIP: " {
+            return types.Tip, nil
+        } / "NOTE: " {
+            return types.Note, nil
+        } / "IMPORTANT: " {
+            return types.Important, nil
+        } / "WARNING: " {
+            return types.Warning, nil
+        } / "CAUTION: " {
+            return types.Caution, nil
+        } / &(Spaces) { // check 
+            return types.LiteralParagraph, nil
+        }) {
+            return style, nil
+        }
+
 ShortcutParagraph <- 
     &(Alphanum) // make sure that the line starts with an alphanum and it's not an ordered list element prefix
     &(!OrderedListElementPrefix)
     &(!UnorderedListElementPrefix)
-    kind:(AdmonitionKind)?
+    style:(ParagraphStyle)?
     firstLine:(ParagraphRawLine) 
     &{
         // also, make sure that there is no LabeledListElement delimiter (`::` - `::::`) 
@@ -1840,11 +1838,11 @@ ShortcutParagraph <-
             return line, nil
         })* 
     {
-        return types.NewParagraph(kind, append([]interface{}{firstLine}, otherLines.([]interface{})...)...)
+        return types.NewParagraph(style, append([]interface{}{firstLine}, otherLines.([]interface{})...)...)
     }
 
 Paragraph <- 
-    kind:(AdmonitionKind)? 
+    style:(ParagraphStyle)? 
     firstLine:(ParagraphRawLine) 
     otherLines:(
         !EOF
@@ -1855,33 +1853,15 @@ Paragraph <-
             return line, nil
         })* 
     {
-        return types.NewParagraph(kind, append([]interface{}{firstLine}, otherLines.([]interface{})...)...)
+        return types.NewParagraph(style, append([]interface{}{firstLine}, otherLines.([]interface{})...)...)
     }
 
 ParagraphRawLine <- 
     content:([^\r\n]+ {
-        return strings.TrimRight(string(c.text), " \t"), nil // trim spaces and tabs
-    })
-    &{
-        return len(strings.TrimSpace(content.(string))) > 0, nil
-    }
-    EOL {
-        return types.NewRawLine(content.(string))
-    }
-
-LiteralParagraph <- // TODO: merge with paragraph?
-    firstLine:(LiteralParagraphRawLine) 
-    otherLines:(SinglelineComment / ParagraphRawLine)*
-    { 
-        return types.NewLiteralParagraph(types.LiteralBlockWithSpacesOnFirstLine, append([]interface{}{firstLine}, otherLines.([]interface{})...))
-    }
-
-LiteralParagraphRawLine <- 
-    content:(Spaces [^\r\n]+ {
         return string(c.text), nil
     })
     &{
-        return len(strings.TrimSpace(string(c.text))) > 0, nil
+        return len(strings.TrimSpace(content.(string))) > 0, nil // stop if blank line
     }
     EOL {
         return types.NewRawLine(content.(string))

--- a/pkg/parser/parser_ext.go
+++ b/pkg/parser/parser_ext.go
@@ -213,7 +213,7 @@ type blockDelimiterTracker struct {
 }
 
 type blockDelimiter struct {
-	kind   types.BlockDelimiterKind
+	kind   string
 	length int
 }
 
@@ -223,7 +223,7 @@ func newBlockDelimiterTracker() *blockDelimiterTracker {
 	}
 }
 
-func (t *blockDelimiterTracker) push(kind types.BlockDelimiterKind, length int) {
+func (t *blockDelimiterTracker) push(kind string, length int) {
 	switch {
 	case len(t.stack) > 0 && t.stack[len(t.stack)-1].kind == kind && t.stack[len(t.stack)-1].length == length:
 		// trim

--- a/pkg/parser/parser_ext_test.go
+++ b/pkg/parser/parser_ext_test.go
@@ -20,7 +20,7 @@ var _ = Describe("block delimiter tracker", func() {
 		// given
 		t := newBlockDelimiterTracker()
 		// when
-		t.push(types.BlockDelimiterKind(types.Listing), 4) // entered block
+		t.push(types.Listing, 4) // entered block
 		// then
 		Expect(t.withinDelimitedBlock()).To(BeTrue())
 	})
@@ -29,8 +29,8 @@ var _ = Describe("block delimiter tracker", func() {
 		// given
 		t := newBlockDelimiterTracker()
 		// when
-		t.push(types.BlockDelimiterKind(types.Listing), 4) // entered block
-		t.push(types.BlockDelimiterKind(types.Comment), 4) // entered another block
+		t.push(types.Listing, 4) // entered block
+		t.push(types.Comment, 4) // entered another block
 		// then
 		Expect(t.withinDelimitedBlock()).To(BeTrue())
 	})
@@ -39,8 +39,8 @@ var _ = Describe("block delimiter tracker", func() {
 		// given
 		t := newBlockDelimiterTracker()
 		// when
-		t.push(types.BlockDelimiterKind(types.Listing), 5) // entered first block
-		t.push(types.BlockDelimiterKind(types.Listing), 4) // entered second block
+		t.push(types.Listing, 5) // entered first block
+		t.push(types.Listing, 4) // entered second block
 		// then
 		Expect(t.withinDelimitedBlock()).To(BeTrue())
 	})
@@ -49,8 +49,8 @@ var _ = Describe("block delimiter tracker", func() {
 		// given
 		t := newBlockDelimiterTracker()
 		// when
-		t.push(types.BlockDelimiterKind(types.Listing), 4) // entered block
-		t.push(types.BlockDelimiterKind(types.Listing), 4) // exited block
+		t.push(types.Listing, 4) // entered block
+		t.push(types.Listing, 4) // exited block
 		// then
 		Expect(t.withinDelimitedBlock()).To(BeFalse())
 	})
@@ -59,10 +59,10 @@ var _ = Describe("block delimiter tracker", func() {
 		// given
 		t := newBlockDelimiterTracker()
 		// when
-		t.push(types.BlockDelimiterKind(types.Listing), 4) // entered first block
-		t.push(types.BlockDelimiterKind(types.Comment), 4) // entered second block
-		t.push(types.BlockDelimiterKind(types.Comment), 4) // existed second block
-		t.push(types.BlockDelimiterKind(types.Listing), 4) // exited first block
+		t.push(types.Listing, 4) // entered first block
+		t.push(types.Comment, 4) // entered second block
+		t.push(types.Comment, 4) // existed second block
+		t.push(types.Listing, 4) // exited first block
 		// then
 		Expect(t.withinDelimitedBlock()).To(BeFalse())
 	})
@@ -71,10 +71,10 @@ var _ = Describe("block delimiter tracker", func() {
 		// given
 		t := newBlockDelimiterTracker()
 		// when
-		t.push(types.BlockDelimiterKind(types.Listing), 5) // entered first block
-		t.push(types.BlockDelimiterKind(types.Listing), 4) // entered second block
-		t.push(types.BlockDelimiterKind(types.Listing), 4) // exited second block
-		t.push(types.BlockDelimiterKind(types.Listing), 5) // exited first block
+		t.push(types.Listing, 5) // entered first block
+		t.push(types.Listing, 4) // entered second block
+		t.push(types.Listing, 4) // exited second block
+		t.push(types.Listing, 5) // exited first block
 		// then
 		Expect(t.withinDelimitedBlock()).To(BeFalse())
 	})
@@ -83,10 +83,10 @@ var _ = Describe("block delimiter tracker", func() {
 		// given
 		t := newBlockDelimiterTracker()
 		// when
-		t.push(types.BlockDelimiterKind(types.Listing), 4) // entered first block
-		t.push(types.BlockDelimiterKind(types.Listing), 5) // entered second block
-		t.push(types.BlockDelimiterKind(types.Listing), 5) // exited second block
-		t.push(types.BlockDelimiterKind(types.Listing), 4) // exited first block
+		t.push(types.Listing, 4) // entered first block
+		t.push(types.Listing, 5) // entered second block
+		t.push(types.Listing, 5) // exited second block
+		t.push(types.Listing, 4) // exited first block
 		// then
 		Expect(t.withinDelimitedBlock()).To(BeFalse())
 	})

--- a/pkg/parser/q_a_list_test.go
+++ b/pkg/parser/q_a_list_test.go
@@ -41,8 +41,7 @@ What is the answer to the Ultimate Question?:: 42`
 								&types.Paragraph{
 									Elements: []interface{}{
 										&types.StringElement{
-											// leading spaces are trimmed
-											Content: "An implementation of the AsciiDoc processor in Golang.",
+											Content: "\tAn implementation of the AsciiDoc processor in Golang.",
 										},
 									},
 								},
@@ -106,7 +105,7 @@ What is the answer to the Ultimate Question?:: 42`
 								&types.Paragraph{
 									Elements: []interface{}{
 										&types.StringElement{
-											Content: "An implementation of the AsciiDoc processor in Golang.", // leading spaces are trimmed
+											Content: "\tAn implementation of the AsciiDoc processor in Golang.",
 										},
 									},
 								},

--- a/pkg/parser/section_test.go
+++ b/pkg/parser/section_test.go
@@ -948,11 +948,10 @@ a short preamble
 						Elements: []interface{}{
 							&types.Paragraph{
 								Attributes: types.Attributes{
-									types.AttrStyle:            types.Literal,
-									types.AttrLiteralBlockType: types.LiteralBlockWithSpacesOnFirstLine,
+									types.AttrStyle: types.LiteralParagraph,
 								},
 								Elements: []interface{}{
-									types.RawLine(" = a header with a prefix space"),
+									types.RawLine(" = a header with a prefix space"), // spaces on first line of literal paragraphs are NOT trimmed by parser
 								},
 							},
 						},
@@ -991,11 +990,10 @@ a short preamble
 						Elements: []interface{}{
 							&types.Paragraph{
 								Attributes: types.Attributes{
-									types.AttrStyle:            types.Literal,
-									types.AttrLiteralBlockType: types.LiteralBlockWithSpacesOnFirstLine,
+									types.AttrStyle: types.LiteralParagraph,
 								},
 								Elements: []interface{}{
-									types.RawLine("   == section with prefix space"),
+									types.RawLine("   == section with prefix space"), // spaces on first line of literal paragraphs are NOT trimmed by parser
 								},
 							},
 						},
@@ -2407,12 +2405,11 @@ a short preamble
 					Elements: []interface{}{
 						&types.Paragraph{
 							Attributes: types.Attributes{
-								types.AttrStyle:            types.Literal,
-								types.AttrLiteralBlockType: types.LiteralBlockWithSpacesOnFirstLine,
+								types.AttrStyle: types.LiteralParagraph,
 							},
 							Elements: []interface{}{
 								&types.StringElement{
-									Content: " = a header with a prefix space",
+									Content: " = a header with a prefix space", // spaces on first line of literal paragraphs are NOT trimmed by parser
 								},
 							},
 						},
@@ -2435,12 +2432,11 @@ a short preamble
 						},
 						&types.Paragraph{
 							Attributes: types.Attributes{
-								types.AttrStyle:            types.Literal,
-								types.AttrLiteralBlockType: types.LiteralBlockWithSpacesOnFirstLine,
+								types.AttrStyle: types.LiteralParagraph,
 							},
 							Elements: []interface{}{
 								&types.StringElement{
-									Content: " == section with prefix space",
+									Content: " == section with prefix space", // spaces on first line of literal paragraphs are NOT trimmed by parser
 								},
 							},
 						},

--- a/pkg/parser/unordered_list_test.go
+++ b/pkg/parser/unordered_list_test.go
@@ -466,7 +466,7 @@ on 2 lines, too.`
 									Elements: []interface{}{
 										&types.Paragraph{
 											Elements: []interface{}{
-												&types.StringElement{Content: "item 1\non 2 lines."}, // leading spaces are trimmed
+												&types.StringElement{Content: "item 1\n  on 2 lines."},
 											},
 										},
 									},
@@ -1464,10 +1464,11 @@ another delimited block
 			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
-		It("with implicit continuation for literal paragraph without attributes", func() {
+		It("with continuation for literal paragraph without attributes", func() {
 			source := `* first level
-
++
  with more literal text
+  on multiple lines
 
 ** second level
 `
@@ -1487,12 +1488,11 @@ another delimited block
 									},
 									&types.Paragraph{
 										Attributes: types.Attributes{
-											types.AttrStyle:            types.Literal,
-											types.AttrLiteralBlockType: types.LiteralBlockWithSpacesOnFirstLine,
+											types.AttrStyle: types.LiteralParagraph,
 										},
 										Elements: []interface{}{
 											&types.StringElement{
-												Content: " with more literal text",
+												Content: " with more literal text\n  on multiple lines", // spaces on first line of literal paragraphs are NOT trimmed by parser
 											},
 										},
 									},
@@ -1520,11 +1520,12 @@ another delimited block
 			}
 			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
-		It("with implicit continuation for literal paragraph with attributes", func() {
+		It("with continuation for literal paragraph with attributes", func() {
 			source := `* first level
-
++
 [role="a_role"]
  with more literal text
+  on multiple lines
 
 ** second level
 `
@@ -1544,13 +1545,12 @@ another delimited block
 									},
 									&types.Paragraph{
 										Attributes: types.Attributes{
-											types.AttrStyle:            types.Literal,
-											types.AttrLiteralBlockType: types.LiteralBlockWithSpacesOnFirstLine,
-											types.AttrRoles:            types.Roles{"a_role"},
+											types.AttrStyle: types.LiteralParagraph,
+											types.AttrRoles: types.Roles{"a_role"},
 										},
 										Elements: []interface{}{
 											&types.StringElement{
-												Content: " with more literal text",
+												Content: " with more literal text\n  on multiple lines", // spaces on first line of literal paragraphs are NOT trimmed by parser
 											},
 										},
 									},
@@ -1590,8 +1590,8 @@ with this literal text
 ....
 
 * first level
-
- with more literal text
++
+ with more literal text on a single line
 
 ** second level
 *** third level
@@ -1647,12 +1647,11 @@ first level`
 									},
 									&types.Paragraph{
 										Attributes: types.Attributes{
-											types.AttrStyle:            types.Literal,
-											types.AttrLiteralBlockType: types.LiteralBlockWithSpacesOnFirstLine,
+											types.AttrStyle: types.LiteralParagraph,
 										},
 										Elements: []interface{}{
 											&types.StringElement{
-												Content: " with more literal text",
+												Content: " with more literal text on a single line", // spaces on first line of literal paragraphs are NOT trimmed by parser
 											},
 										},
 									},

--- a/pkg/renderer/sgml/literal_blocks.go
+++ b/pkg/renderer/sgml/literal_blocks.go
@@ -1,7 +1,6 @@
 package sgml
 
 import (
-	"math"
 	"strings"
 
 	"github.com/bytesparadise/libasciidoc/pkg/renderer"
@@ -43,64 +42,4 @@ func (r *sgmlRenderer) renderLiteralBlock(ctx *renderer.Context, b *types.Delimi
 		return "", errors.Wrap(err, "unable to render literal block")
 	}
 	return result.String(), nil
-}
-
-func (r *sgmlRenderer) renderLiteralParagraph(ctx *renderer.Context, b *types.Paragraph) (string, error) {
-	log.Debugf("rendering literal paragraph")
-	content, err := r.renderElements(ctx, b.Elements)
-	if err != nil {
-		return "", err
-	}
-	if b.Attributes.GetAsStringWithDefault(types.AttrLiteralBlockType, "") == types.LiteralBlockWithSpacesOnFirstLine {
-		content = trimHeadingSpaces(content)
-	}
-	roles, err := r.renderElementRoles(ctx, b.Attributes)
-	if err != nil {
-		return "", errors.Wrap(err, "unable to render literal block roles")
-	}
-	title, err := r.renderElementTitle(ctx, b.Attributes)
-	if err != nil {
-		return "", errors.Wrap(err, "unable to render callout list roles")
-	}
-	result := &strings.Builder{}
-	err = r.literalBlock.Execute(result, struct {
-		Context *renderer.Context
-		ID      string
-		Title   string
-		Roles   string
-		Content string
-	}{
-		Context: ctx,
-		ID:      r.renderElementID(b.Attributes),
-		Title:   title,
-		Roles:   roles,
-		Content: content,
-	})
-	return result.String(), err
-}
-
-func trimHeadingSpaces(content string) string {
-	lines := strings.Split(content, "\n")
-	if len(lines) == 1 {
-		lines = []string{strings.TrimLeft(lines[0], " ")}
-	} else {
-		// remove as many spaces as needed on each line
-		spaceCount := 0
-		// first pass to determine the minimum number of spaces to remove
-		for i, line := range lines {
-			l := strings.TrimLeft(line, " ")
-			if i == 0 {
-				spaceCount = len(line) - len(l)
-			} else {
-				spaceCount = int(math.Min(float64(spaceCount), float64(len(line)-len(l))))
-			}
-		}
-		// log.Debugf("trimming %d space(s) on each line", int(spaceCount))
-		// then remove the same number of spaces on each line
-		spaces := strings.Repeat(" ", spaceCount)
-		for i, line := range lines {
-			lines[i] = strings.TrimPrefix(line, spaces)
-		}
-	}
-	return strings.Join(lines, "\n")
 }

--- a/pkg/types/attributes.go
+++ b/pkg/types/attributes.go
@@ -109,7 +109,7 @@ const (
 	AttrUnicode = "unicode"
 	// AttrCaption is the caption for block images, tables, and so forth
 	AttrCaption = "caption"
-	// AttrStyle block or list style
+	// AttrStyle paragraph, block or list style
 	AttrStyle = "style"
 	// AttrInlineLinkText the text attribute (first positional) of links
 	AttrInlineLinkText = "text"

--- a/test/compat/demo.adoc
+++ b/test/compat/demo.adoc
@@ -116,7 +116,7 @@ with this literal text
 ....
 
 * first level
-
++
  with more literal text
 
 ** second level


### PR DESCRIPTION
Also, removed obsolete constants for attributes.
Also, remove support for _implicit_ continuation of
literal paragraph: `+` character is required.
