### PR TITLE
refactor(parser): simplify QuotedText rule

### DIFF
--- a/pkg/parser/parser.peg
+++ b/pkg/parser/parser.peg
@@ -537,8 +537,8 @@ NamedAttribute <-
     }
 
 // The spec says attributes have be alphanumeric but does not consider foreign letters.  We are more generous.
-NamedAttributeKey <- !Space [^\r\n=,\]]+ Space* {
-        return strings.TrimSpace(string(c.text)), nil // TODO: call `strings.TrimSpace` within `types.NewNamedAttribute()`
+NamedAttributeKey <- !Space [^\r\n=,\]]+ {
+        return string(c.text), nil
     }
 
 AttributeValue <- 
@@ -610,7 +610,6 @@ UnquotedAttributeValue <-
     !Space // can't start with a space (eg: can't have `[ cookie ]`)
     elements:(
         ("[" UnquotedAttributeValue "]") // recursively within brackets (see comment above)
-        // / ElementPlaceHolder
         / ([^=,\uFFFD\]{'"` ]+ { // not within brackets and stop on space and quotation marks (`"')
             return string(c.text), nil
         }) 
@@ -1574,9 +1573,6 @@ ListContinuationElement <- // TODO: same as DelimitedBlockElement?
         if element,ok := element.(types.WithAttributes); ok && attributes != nil {
             element.AddAttributes(attributes.(types.Attributes))
         }
-        // if log.IsLevelEnabled(log.DebugLevel) {
-        //     log.Debugf("returning element '%s'\n", spew.Sdump(element))
-        // }
         return element, nil
     }
 
@@ -1798,7 +1794,6 @@ Paragraph <-
         !EOF
         !BlankLine
         !BlockAttributes
-        !ListContinuationMarker // TODO: needed?
         line:(SinglelineComment / ParagraphRawLine) {
             return line, nil
         })* 
@@ -1823,19 +1818,34 @@ ParagraphRawLine <-
 QuotedText <- 
     // TODO: do not check for attributes twice here?  
     // TODO: also, do not check for attributes on quoted text if we're already parsing an attribute value?
-    // escaped with optional attributes
-    attributes:(LongHandAttributes { 
-        return types.NewStringElement(string(c.text))
-    })?
-    text:EscapedQuotedText {
-        log.Debugf("matched escaped quoted text")
-        return append([]interface{}{attributes}, text.([]interface{})...), nil
+    attributes:(LongHandAttributes)?
+    #{
+        if attributes != nil { // otherwise, `c.text` matches the current character read by the parser
+            c.state["attrs"] = attributes
+            c.state["attrs_text"] = string(c.text)
+        } else {
+            // make sure that current state does not contain attributes of parent/surrounding quoted text
+            delete(c.state, "attrs")
+            delete(c.state, "attrs_text")
+        }
+        return nil
     }
-    / 
-    // unescaped 
-    attributes:(LongHandAttributes)? 
-    text:(UnconstrainedQuotedText / ConstrainedQuotedText) {
-        return text.(*types.QuotedText).WithAttributes(attributes)
+    element:(
+        // escaped
+        escaped:(EscapedQuotedText) {
+            attributes := c.state["attrs_text"]
+            log.Debugf("matched escaped quoted text (attrs='%v')", attributes)
+            return append([]interface{}{attributes}, escaped.([]interface{})...), nil
+        }
+        / 
+        // unescaped 
+        unescaped:(UnconstrainedQuotedText / ConstrainedQuotedText) {
+            attributes := c.state["attrs"]
+            log.Debugf("matched unescaped quoted text (attrs='%v')", attributes)
+            return unescaped.(*types.QuotedText).WithAttributes(attributes)
+        }
+    ) {
+        return element, nil
     }
 
 ConstrainedQuotedTextMarker <- "*" !"*" / "_" !"_" / "#" !"#" / "`" !"`"

--- a/pkg/parser/quoted_text_test.go
+++ b/pkg/parser/quoted_text_test.go
@@ -2048,6 +2048,20 @@ var _ = Describe("quoted texts", func() {
 						Expect(ParseDocument(source)).To(MatchDocument(expected))
 					})
 
+					It("escaped bold text with single backslash and attributes", func() {
+						source := `[k1=v1,k2=v2]\*bold content*`
+						expected := &types.Document{
+							Elements: []interface{}{
+								&types.Paragraph{
+									Elements: []interface{}{
+										&types.StringElement{Content: "[k1=v1,k2=v2]*bold content*"},
+									},
+								},
+							},
+						}
+						Expect(ParseDocument(source)).To(MatchDocument(expected))
+					})
+
 					It("escaped bold text with multiple backslashes", func() {
 						source := `\\*bold content*`
 						expected := &types.Document{
@@ -2128,6 +2142,27 @@ var _ = Describe("quoted texts", func() {
 								&types.Paragraph{
 									Elements: []interface{}{
 										&types.StringElement{Content: "*"},
+										&types.QuotedText{
+											Kind: types.SingleQuoteItalic,
+											Elements: []interface{}{
+												&types.StringElement{Content: "italic content"},
+											},
+										},
+										&types.StringElement{Content: "*"},
+									},
+								},
+							},
+						}
+						Expect(ParseDocument(source)).To(MatchDocument(expected))
+					})
+
+					It("escaped bold text with nested italic text and attributes", func() {
+						source := `[k1=v1,k2=v2]\*_italic content_*`
+						expected := &types.Document{
+							Elements: []interface{}{
+								&types.Paragraph{
+									Elements: []interface{}{
+										&types.StringElement{Content: "[k1=v1,k2=v2]*"},
 										&types.QuotedText{
 											Kind: types.SingleQuoteItalic,
 											Elements: []interface{}{
@@ -2535,8 +2570,8 @@ var _ = Describe("quoted texts", func() {
 
 				Context("with nested quoted text", func() {
 
-					It("escaped subscript text with nested bold text", func() {
-						source := `\~*boldcontent*~`
+					It("escaped subscript text with nested bold text - case 1", func() {
+						source := `\~*bold content*~`
 						expected := &types.Document{
 							Elements: []interface{}{
 								&types.Paragraph{
@@ -2545,7 +2580,7 @@ var _ = Describe("quoted texts", func() {
 										&types.QuotedText{
 											Kind: types.SingleQuoteBold,
 											Elements: []interface{}{
-												&types.StringElement{Content: "boldcontent"},
+												&types.StringElement{Content: "bold content"},
 											},
 										},
 										&types.StringElement{Content: "~"},
@@ -2556,7 +2591,7 @@ var _ = Describe("quoted texts", func() {
 						Expect(ParseDocument(source)).To(MatchDocument(expected))
 					})
 
-					It("escaped subscript text with nested bold text", func() {
+					It("escaped subscript text with nested bold text - case 2", func() {
 						source := `\~subscript *and bold* content~`
 						expected := &types.Document{
 							Elements: []interface{}{

--- a/pkg/types/attributes.go
+++ b/pkg/types/attributes.go
@@ -324,6 +324,7 @@ type PositionalAttribute struct {
 
 // NewPositionalAttribute returns a new attribute who key is the position in the group
 func NewPositionalAttribute(value interface{}) (*PositionalAttribute, error) {
+	value = Reduce(value, strings.TrimSpace)
 	// log.Debugf("new positional attribute: '%s'", value)
 	return &PositionalAttribute{
 		Value: value,
@@ -339,7 +340,7 @@ type Options []interface{} // more explicit than `[]interface{}`, and to bypass 
 
 // NewOptionAttribute sets a boolean option.
 func NewOptionAttribute(option interface{}) (*Attribute, error) {
-	option = Reduce(option)
+	option = Reduce(option, strings.TrimSpace)
 	if log.IsLevelEnabled(log.DebugLevel) {
 		log.Debugf("new option attribute: '%s'", spew.Sdump(option))
 	}
@@ -351,7 +352,8 @@ func NewOptionAttribute(option interface{}) (*Attribute, error) {
 
 // NewNamedAttribute a named (or positional) element
 func NewNamedAttribute(key string, value interface{}) (*Attribute, error) {
-	value = Reduce(value)
+	// value = Reduce(value, strings.TrimSpace)
+	key = strings.TrimSpace(key)
 	if key == AttrOpts { // Handle the alias
 		key = AttrOptions
 	}
@@ -362,36 +364,20 @@ func NewNamedAttribute(key string, value interface{}) (*Attribute, error) {
 }
 
 // NewTitleAttribute initializes a new attribute map with a single entry for the title using the given value
-func NewTitleAttribute(title interface{}) (*Attribute, error) {
-	if log.IsLevelEnabled(log.DebugLevel) {
-		log.Debugf("initializing a new Title attribute with %s", spew.Sdump(title))
-	}
-	return &Attribute{
-		Key:   AttrTitle,
-		Value: title,
-	}, nil
+func NewTitleAttribute(value interface{}) (*Attribute, error) {
+	return NewNamedAttribute(AttrTitle, value)
 }
 
 // NewRoleAttribute initializes a new attribute map with a single entry for the title using the given value
-func NewRoleAttribute(role interface{}) (*Attribute, error) {
-	role = Reduce(role)
-	if log.IsLevelEnabled(log.DebugLevel) {
-		log.Debugf("new role attribute: '%s'", spew.Sdump(role))
-	}
-	return &Attribute{
-		Key:   AttrRole,
-		Value: role,
-	}, nil
+func NewRoleAttribute(value interface{}) (*Attribute, error) {
+	return NewNamedAttribute(AttrRole, value)
 }
 
 type Roles []interface{} // more explicit than `[]interface{}`, and to bypass the `Reduce` func that would merge all roles into a single string :/
 
 // NewIDAttribute initializes a new attribute map with a single entry for the ID using the given value
-func NewIDAttribute(id interface{}) (*Attribute, error) {
-	return &Attribute{
-		Key:   AttrID,
-		Value: id,
-	}, nil
+func NewIDAttribute(value interface{}) (*Attribute, error) {
+	return NewNamedAttribute(AttrID, value)
 }
 
 // Set adds the given attribute to the current ones


### PR DESCRIPTION
parse attributes only once for escaped and unescaped text

store attributes in current state

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
