### PR TITLE
refactor(parser): simplify DocumentFragment rule

### DIFF
--- a/pkg/parser/document_processing_parse_fragments.go
+++ b/pkg/parser/document_processing_parse_fragments.go
@@ -160,7 +160,7 @@ func reparseDelimitedBlock(ctx *ParseContext, b *types.DelimitedBlock) error {
 	switch b.Kind {
 	case types.Example, types.Quote, types.Sidebar, types.Open:
 		log.Debugf("parsing elements of delimited block of kind '%s'", b.Kind)
-		opts := append(ctx.opts, Entrypoint("DelimitedBlockElements"), withinDelimitedBlock(true))
+		opts := append(ctx.opts, Entrypoint("DelimitedBlockElements"))
 		elements, err := reparseElements(b.Elements, opts...)
 		if err != nil {
 			return err
@@ -238,6 +238,6 @@ func (c *current) isWithinLiteralParagraph() bool {
 		log.Debugf("within literal paragraph: %t", attrs[types.AttrStyle] == types.Literal)
 		return attrs[types.AttrPositional1] == types.Literal || attrs[types.AttrStyle] == types.Literal
 	}
-	log.Debug("not within literal paragraph")
+	// log.Debug("not within literal paragraph")
 	return false
 }

--- a/pkg/parser/parser.peg
+++ b/pkg/parser/parser.peg
@@ -225,7 +225,6 @@ IncludedFileEndTag <- "end::" tag:(Alphanums {return string(c.text), nil}) "[]" 
 // Document Fragments
 // -------------------------------------------------------------------------------------
 DocumentFragment <-
-    !EOF
     attributes:(BlockAttributes)? 
     #{
         if attributes, ok := attributes.(types.Attributes); ok {
@@ -250,6 +249,10 @@ DocumentFragment <-
         / FrontMatter
         / Paragraph // must be the last one... 
     )? // allow attribute on empty/no element
+    &{
+        // there must be at least `attributes` or `element`
+        return attributes != nil || element != nil, nil
+    }
     {
         c.disableFrontMatterRule() // not allowed as soon as a single element is found
         c.disableDocumentHeaderRule() // not allowed anymore, based on element that was found
@@ -270,6 +273,10 @@ RawLine <-
 
 // reads all elements at once (for example, within a delimited block)
 DelimitedBlockElements <- 
+    #{
+    	c.globalStore[withinDelimitedBlockKey]=true
+        return nil
+    }
     elements:(
         ElementPlaceHolder // if there was a fileinclusion 
         / DocumentFragment

--- a/pkg/parser/parser_ext.go
+++ b/pkg/parser/parser_ext.go
@@ -181,10 +181,6 @@ func (c *current) isSectionEnabled() bool {
 
 const withinDelimitedBlockKey = "within_delimited_block"
 
-func withinDelimitedBlock(v bool) Option {
-	return GlobalStore(withinDelimitedBlockKey, v)
-}
-
 // state info to determine if parsing is happening within a delimited block (any kind),
 // in which case some grammar rules need to be disabled
 func (c *current) isWithinDelimitedBlock() bool {
@@ -206,39 +202,6 @@ func (c *current) setBlockDelimiterLength(length int) (bool, error) {
 // check if the length of the current block delimiters match
 func (c *current) matchBlockDelimiterLength(length int) (bool, error) {
 	return c.globalStore[blockDelimiterLengthKey] == length, nil
-}
-
-type blockDelimiterTracker struct {
-	stack []blockDelimiter
-}
-
-type blockDelimiter struct {
-	kind   string
-	length int
-}
-
-func newBlockDelimiterTracker() *blockDelimiterTracker {
-	return &blockDelimiterTracker{
-		stack: []blockDelimiter{},
-	}
-}
-
-func (t *blockDelimiterTracker) push(kind string, length int) {
-	switch {
-	case len(t.stack) > 0 && t.stack[len(t.stack)-1].kind == kind && t.stack[len(t.stack)-1].length == length:
-		// trim
-		t.stack = t.stack[:len(t.stack)-1]
-	default:
-		// append
-		t.stack = append(t.stack, blockDelimiter{
-			kind:   kind,
-			length: length,
-		})
-	}
-}
-
-func (t *blockDelimiterTracker) withinDelimitedBlock() bool {
-	return len(t.stack) > 0
 }
 
 const usermacrosKey = "user_macros"

--- a/pkg/parser/parser_ext_test.go
+++ b/pkg/parser/parser_ext_test.go
@@ -13,82 +13,82 @@ var _ = Describe("block delimiter tracker", func() {
 		// given
 		t := newBlockDelimiterTracker()
 		// then
-		Expect(t.withinDelimitedBlock()).To(BeFalse())
+		Expect(t.stack).To(BeEmpty())
 	})
 
 	It("should be within delimited block", func() {
 		// given
 		t := newBlockDelimiterTracker()
 		// when
-		t.push(types.Listing, 4) // entered block
+		t.track(types.Listing, 4) // entered block
 		// then
-		Expect(t.withinDelimitedBlock()).To(BeTrue())
+		Expect(t.stack).NotTo(BeEmpty())
 	})
 
 	It("should still be within delimited block - case 1", func() {
 		// given
 		t := newBlockDelimiterTracker()
 		// when
-		t.push(types.Listing, 4) // entered block
-		t.push(types.Comment, 4) // entered another block
+		t.track(types.Listing, 4) // entered block
+		t.track(types.Comment, 4) // entered another block
 		// then
-		Expect(t.withinDelimitedBlock()).To(BeTrue())
+		Expect(t.stack).NotTo(BeEmpty())
 	})
 
 	It("should still be within delimited block - case 2", func() {
 		// given
 		t := newBlockDelimiterTracker()
 		// when
-		t.push(types.Listing, 5) // entered first block
-		t.push(types.Listing, 4) // entered second block
+		t.track(types.Listing, 5) // entered first block
+		t.track(types.Listing, 4) // entered second block
 		// then
-		Expect(t.withinDelimitedBlock()).To(BeTrue())
+		Expect(t.stack).NotTo(BeEmpty())
 	})
 
 	It("should not be within delimited block anymore - case 1", func() {
 		// given
 		t := newBlockDelimiterTracker()
 		// when
-		t.push(types.Listing, 4) // entered block
-		t.push(types.Listing, 4) // exited block
+		t.track(types.Listing, 4) // entered block
+		t.track(types.Listing, 4) // exited block
 		// then
-		Expect(t.withinDelimitedBlock()).To(BeFalse())
+		Expect(t.stack).To(BeEmpty())
 	})
 
 	It("should not be within delimited block anymore - case 2", func() {
 		// given
 		t := newBlockDelimiterTracker()
 		// when
-		t.push(types.Listing, 4) // entered first block
-		t.push(types.Comment, 4) // entered second block
-		t.push(types.Comment, 4) // existed second block
-		t.push(types.Listing, 4) // exited first block
+		t.track(types.Listing, 4) // entered first block
+		t.track(types.Comment, 4) // entered second block
+		t.track(types.Comment, 4) // existed second block
+		t.track(types.Listing, 4) // exited first block
 		// then
-		Expect(t.withinDelimitedBlock()).To(BeFalse())
+		Expect(t.stack).To(BeEmpty())
 	})
 
 	It("should not be within delimited block anymore - case 3", func() {
 		// given
 		t := newBlockDelimiterTracker()
 		// when
-		t.push(types.Listing, 5) // entered first block
-		t.push(types.Listing, 4) // entered second block
-		t.push(types.Listing, 4) // exited second block
-		t.push(types.Listing, 5) // exited first block
+		t.track(types.Listing, 5) // entered first block
+		t.track(types.Listing, 4) // entered second block
+		t.track(types.Listing, 4) // exited second block
+		t.track(types.Listing, 5) // exited first block
 		// then
-		Expect(t.withinDelimitedBlock()).To(BeFalse())
+		Expect(t.stack).To(BeEmpty())
 	})
 
 	It("should not be within delimited block anymore - case 4", func() {
 		// given
 		t := newBlockDelimiterTracker()
 		// when
-		t.push(types.Listing, 4) // entered first block
-		t.push(types.Listing, 5) // entered second block
-		t.push(types.Listing, 5) // exited second block
-		t.push(types.Listing, 4) // exited first block
+		t.track(types.Listing, 4) // entered first block
+		t.track(types.Listing, 5) // entered second block
+		t.track(types.Listing, 5) // exited second block
+		t.track(types.Listing, 4) // exited first block
 		// then
-		Expect(t.withinDelimitedBlock()).To(BeFalse())
+		Expect(t.stack).To(BeEmpty())
 	})
 
 })


### PR DESCRIPTION
also, refactor block delimiter tracking in preprocessing

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
