### PR TITLE
fix(parser): detect DocumentHeader when doc has FrontMatter

### DIFF
--- a/pkg/parser/document_processing_aggregate.go
+++ b/pkg/parser/document_processing_aggregate.go
@@ -162,11 +162,14 @@ func insertPreamble(doc *types.Document) {
 	// now, insert the preamble instead of the 'n' blocks that belong to the preamble
 	// and copy the other items
 	elements := make([]interface{}, len(doc.Elements)-len(preamble.Elements)+1)
-	if header := doc.Header(); header != nil {
+	if frontmatter := doc.FrontMatter(); frontmatter != nil {
+		elements[0] = frontmatter
+	}
+	if header, offset := doc.Header(); header != nil {
 		log.Debug("inserting preamble after header")
-		elements[0] = header
-		elements[1] = preamble
-		copy(elements[2:], doc.Elements[1+len(preamble.Elements):])
+		elements[0+offset] = header
+		elements[1+offset] = preamble
+		copy(elements[2+offset:], doc.Elements[1+len(preamble.Elements)+offset:])
 	} else {
 		log.Debug("inserting preamble at beginning of document")
 		elements[0] = preamble
@@ -176,7 +179,7 @@ func insertPreamble(doc *types.Document) {
 }
 
 func newPreamble(doc *types.Document) *types.Preamble {
-	if doc.Header() == nil {
+	if header, _ := doc.Header(); header == nil {
 		log.Debug("skipping preamble: no header in doc")
 		return nil
 	}
@@ -185,7 +188,7 @@ func newPreamble(doc *types.Document) *types.Preamble {
 	}
 	for _, e := range doc.Elements {
 		switch e.(type) {
-		case *types.DocumentHeader:
+		case *types.DocumentHeader, *types.FrontMatter:
 			continue
 		case *types.Section:
 			return preamble

--- a/pkg/parser/document_processing_insert_preamble_test.go
+++ b/pkg/parser/document_processing_insert_preamble_test.go
@@ -9,6 +9,11 @@ import (
 
 var _ = Describe("insert preambles", func() {
 
+	frontmatter := &types.FrontMatter{
+		Attributes: map[string]interface{}{
+			"draft": true,
+		},
+	}
 	header := &types.DocumentHeader{
 		Title: []interface{}{
 			&types.StringElement{
@@ -156,6 +161,38 @@ var _ = Describe("insert preambles", func() {
 						paragraph,
 						blankline,
 						anotherParagraph,
+						blankline,
+					},
+				},
+				sectionA,
+				sectionB,
+			},
+		}
+		// when
+		insertPreamble(doc)
+		// then
+		Expect(doc).To(Equal(expected))
+	})
+
+	It("should insert preamble with 1 paragraph and blankline when doc has frontmatter", func() {
+		// given
+		doc := &types.Document{
+			Elements: []interface{}{
+				frontmatter,
+				header,
+				paragraph,
+				blankline,
+				sectionA,
+				sectionB,
+			},
+		}
+		expected := &types.Document{
+			Elements: []interface{}{
+				frontmatter,
+				header,
+				&types.Preamble{
+					Elements: []interface{}{
+						paragraph,
 						blankline,
 					},
 				},

--- a/pkg/parser/document_processing_parse_fragments.go
+++ b/pkg/parser/document_processing_parse_fragments.go
@@ -220,8 +220,14 @@ func (c *current) isDocumentHeaderAllowed() bool {
 	return found && allowed && !c.isWithinDelimitedBlock()
 }
 
-func (c *current) disableDocumentHeaderRule() {
-	c.globalStore[documentHeaderKey] = false
+// disables the `DocumentHeader` grammar rule if the element is anything but a BlankLine or a FrontMatter
+func (c *current) disableDocumentHeaderRule(element interface{}) {
+	switch element.(type) {
+	case *types.BlankLine, *types.FrontMatter:
+		return
+	default:
+		c.globalStore[documentHeaderKey] = false
+	}
 }
 
 const blockAttributesKey = "block_attributes"

--- a/pkg/parser/parser.peg
+++ b/pkg/parser/parser.peg
@@ -255,7 +255,7 @@ DocumentFragment <-
     }
     {
         c.disableFrontMatterRule() // not allowed as soon as a single element is found
-        c.disableDocumentHeaderRule() // not allowed anymore, based on element that was found
+        c.disableDocumentHeaderRule(element) // not allowed anymore, based on element that was found
     
         if element, ok := element.(types.WithAttributes); ok && attributes != nil {
             element.AddAttributes(attributes.(types.Attributes))

--- a/pkg/parser/section_test.go
+++ b/pkg/parser/section_test.go
@@ -106,7 +106,7 @@ and a paragraph`
 				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
-			It("section 0, 1 and paragraph with bold quote", func() {
+			It("header, section 1 and paragraph with bold quote", func() {
 				source := `= a header
 				
 == section 1
@@ -1333,6 +1333,65 @@ a short preamble
 == Section 1`
 				expected := &types.Document{
 					Elements: []interface{}{
+						&types.DocumentHeader{
+							Title: []interface{}{
+								&types.StringElement{Content: "A Title"},
+							},
+						},
+						&types.Preamble{
+							Elements: []interface{}{
+								&types.Paragraph{
+									Elements: []interface{}{
+										&types.StringElement{Content: "a short preamble"},
+									},
+								},
+							},
+						},
+						&types.Section{
+							Attributes: types.Attributes{
+								types.AttrID: "_section_1",
+							},
+							Level: 1,
+							Title: []interface{}{
+								&types.StringElement{Content: "Section 1"},
+							},
+						},
+					},
+					ElementReferences: types.ElementReferences{
+						"_section_1": []interface{}{
+							&types.StringElement{Content: "Section 1"},
+						},
+					},
+					TableOfContents: &types.TableOfContents{
+						MaxDepth: 2,
+						Sections: []*types.ToCSection{
+							{
+								ID:    "_section_1",
+								Level: 1,
+							},
+						},
+					},
+				}
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
+			})
+
+			It("front-matter on top of header", func() {
+				source := `---
+draft: true
+---
+				
+= A Title
+
+a short preamble
+
+== Section 1`
+				expected := &types.Document{
+					Elements: []interface{}{
+						&types.FrontMatter{
+							Attributes: map[string]interface{}{
+								"draft": true,
+							},
+						},
 						&types.DocumentHeader{
 							Title: []interface{}{
 								&types.StringElement{Content: "A Title"},

--- a/pkg/renderer/context.go
+++ b/pkg/renderer/context.go
@@ -20,7 +20,7 @@ type Context struct {
 
 // NewContext returns a new rendering context for the given document.
 func NewContext(doc *types.Document, config *configuration.Configuration) *Context {
-	header := doc.Header()
+	header, _ := doc.Header()
 	ctx := &Context{
 		Config:            config,
 		counters:          make(map[string]int),

--- a/pkg/renderer/sgml/html5/section_test.go
+++ b/pkg/renderer/sgml/html5/section_test.go
@@ -202,27 +202,20 @@ var _ = Describe("sections", func() {
 			Expect(RenderHTML(source)).To(MatchHTML(expected))
 		})
 
-		It("with numbering disabled and enabled again", func() {
-			source := `= A title
+		It("with numbering disabled and enabled again - case 1", func() {
+			source := `= User Manual
+
 :sectnums!:
 
 == Disclaimer
 
+== Acknowledgments
+
 :sectnums:
 
-== Section A
+== Getting Started
 
-=== Section A.a
-
-=== Section A.b
-
-==== Section that shall not be in ToC
-
-== Section B
-
-=== Section B.a
-
-== Section C`
+=== Introduction`
 
 			expected := `<div class="sect1">
 <h2 id="_disclaimer">Disclaimer</h2>
@@ -230,35 +223,63 @@ var _ = Describe("sections", func() {
 </div>
 </div>
 <div class="sect1">
-<h2 id="_section_a">1. Section A</h2>
+<h2 id="_acknowledgments">Acknowledgments</h2>
 <div class="sectionbody">
-<div class="sect2">
-<h3 id="_section_a_a">1.1. Section A.a</h3>
-</div>
-<div class="sect2">
-<h3 id="_section_a_b">1.2. Section A.b</h3>
-<div class="sect3">
-<h4 id="_section_that_shall_not_be_in_toc">1.2.1. Section that shall not be in ToC</h4>
-</div>
-</div>
 </div>
 </div>
 <div class="sect1">
-<h2 id="_section_b">2. Section B</h2>
+<h2 id="_getting_started">1. Getting Started</h2>
 <div class="sectionbody">
 <div class="sect2">
-<h3 id="_section_b_a">2.1. Section B.a</h3>
+<h3 id="_introduction">1.1. Introduction</h3>
 </div>
-</div>
-</div>
-<div class="sect1">
-<h2 id="_section_c">3. Section C</h2>
-<div class="sectionbody">
 </div>
 </div>
 `
 			Expect(RenderHTML(source)).To(MatchHTML(expected))
 		})
+
+		It("with numbering disabled and enabled again - case 2", func() {
+			source := `---
+draft: true
+---
+			
+= User Manual
+
+:sectnums!:
+
+== Disclaimer
+
+== Acknowledgments
+
+:sectnums:
+
+== Getting Started
+
+=== Introduction`
+
+			expected := `<div class="sect1">
+<h2 id="_disclaimer">Disclaimer</h2>
+<div class="sectionbody">
+</div>
+</div>
+<div class="sect1">
+<h2 id="_acknowledgments">Acknowledgments</h2>
+<div class="sectionbody">
+</div>
+</div>
+<div class="sect1">
+<h2 id="_getting_started">1. Getting Started</h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_introduction">1.1. Introduction</h3>
+</div>
+</div>
+</div>
+`
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+		})
+
 	})
 
 	Context("with elements", func() {

--- a/pkg/renderer/sgml/renderer.go
+++ b/pkg/renderer/sgml/renderer.go
@@ -162,7 +162,7 @@ func (r *sgmlRenderer) Render(ctx *renderer.Context, doc *types.Document, output
 		renderedTitle = DefaultTitle
 	}
 	// process attribute declaration in the header
-	if header := doc.Header(); header != nil {
+	if header, _ := doc.Header(); header != nil {
 		for _, e := range header.Elements {
 			switch e := e.(type) {
 			case *types.AttributeDeclaration:
@@ -252,7 +252,8 @@ func (r *sgmlRenderer) splitAndRender(ctx *renderer.Context, doc *types.Document
 func (r *sgmlRenderer) splitAndRenderForArticle(ctx *renderer.Context, doc *types.Document) (string, string, error) {
 	log.Debugf("rendering article (within HTML/Body: %t)", ctx.Config.WrapInHTMLBodyElement)
 
-	renderedHeader, err := r.renderDocumentHeader(ctx, doc.Header())
+	header, _ := doc.Header()
+	renderedHeader, err := r.renderDocumentHeader(ctx, header)
 	if err != nil {
 		return "", "", err
 	}
@@ -270,7 +271,8 @@ func (r *sgmlRenderer) splitAndRenderForManpage(ctx *renderer.Context, doc *type
 	elements := doc.BodyElements()
 	nameSection := elements[0].(*types.Section) // TODO: enforce
 	if ctx.Config.WrapInHTMLBodyElement {
-		renderedHeader, err := r.renderManpageHeader(ctx, doc.Header(), nameSection)
+		header, _ := doc.Header()
+		renderedHeader, err := r.renderManpageHeader(ctx, header, nameSection)
 		if err != nil {
 			return "", "", err
 		}
@@ -296,14 +298,14 @@ func (r *sgmlRenderer) splitAndRenderForManpage(ctx *renderer.Context, doc *type
 }
 
 func (r *sgmlRenderer) renderDocumentRoles(ctx *renderer.Context, doc *types.Document) (string, error) {
-	if header := doc.Header(); header != nil {
+	if header, _ := doc.Header(); header != nil {
 		return r.renderElementRoles(ctx, header.Attributes)
 	}
 	return "", nil
 }
 
 func (r *sgmlRenderer) renderDocumentID(doc *types.Document) string {
-	if header := doc.Header(); header != nil {
+	if header, _ := doc.Header(); header != nil {
 		// if header.Attributes.Has(types.AttrCustomID) {
 		// We only want to emit a document body ID if one was explicitly set
 		return r.renderElementID(header.Attributes)
@@ -313,7 +315,7 @@ func (r *sgmlRenderer) renderDocumentID(doc *types.Document) string {
 }
 
 func (r *sgmlRenderer) renderAuthors(_ *renderer.Context, doc *types.Document) string { // TODO: pass header instead of doc
-	if header := doc.Header(); header != nil {
+	if header, _ := doc.Header(); header != nil {
 		if a := header.Authors(); a != nil {
 			authorStrs := make([]string, len(a))
 			for i, author := range a {
@@ -330,7 +332,7 @@ func (r *sgmlRenderer) renderAuthors(_ *renderer.Context, doc *types.Document) s
 const DefaultTitle = "Untitled"
 
 func (r *sgmlRenderer) renderDocumentTitle(ctx *renderer.Context, doc *types.Document) (string, bool, error) {
-	if header := doc.Header(); header != nil {
+	if header, _ := doc.Header(); header != nil {
 		// TODO: This feels wrong.  The title should not need markup.
 		title, err := r.renderPlainText(ctx, header.Title)
 		if err != nil {

--- a/pkg/types/section_numbering_test.go
+++ b/pkg/types/section_numbering_test.go
@@ -22,18 +22,18 @@ var _ = Describe("section numbering", func() {
 				},
 				&types.Section{
 					Attributes: types.Attributes{
-						types.AttrID: "_section_1",
+						types.AttrID: "_getting_started",
 					},
 					Elements: []interface{}{
 						&types.Section{
 							Attributes: types.Attributes{
-								types.AttrID: "_section_1a",
+								types.AttrID: "_introduction",
 							},
 							Elements: []interface{}{},
 						},
 						&types.Section{
 							Attributes: types.Attributes{
-								types.AttrID: "_section_1b",
+								types.AttrID: "_download_and_install",
 							},
 							Elements: []interface{}{},
 						},
@@ -46,9 +46,9 @@ var _ = Describe("section numbering", func() {
 
 		// then
 		Expect(err).NotTo(HaveOccurred())
-		Expect(n["_section_1"]).To(Equal("1"))
-		Expect(n["_section_1a"]).To(Equal("1.1"))
-		Expect(n["_section_1b"]).To(Equal("1.2"))
+		Expect(n["_getting_started"]).To(Equal("1"))
+		Expect(n["_introduction"]).To(Equal("1.1"))
+		Expect(n["_download_and_install"]).To(Equal("1.2"))
 	})
 
 	It("should always number sections - explicitly in document body", func() {
@@ -60,18 +60,18 @@ var _ = Describe("section numbering", func() {
 				},
 				&types.Section{
 					Attributes: types.Attributes{
-						types.AttrID: "_section_1",
+						types.AttrID: "_getting_started",
 					},
 					Elements: []interface{}{
 						&types.Section{
 							Attributes: types.Attributes{
-								types.AttrID: "_section_1a",
+								types.AttrID: "_introduction",
 							},
 							Elements: []interface{}{},
 						},
 						&types.Section{
 							Attributes: types.Attributes{
-								types.AttrID: "_section_1b",
+								types.AttrID: "_download_and_install",
 							},
 							Elements: []interface{}{},
 						},
@@ -84,9 +84,9 @@ var _ = Describe("section numbering", func() {
 
 		// then
 		Expect(err).NotTo(HaveOccurred())
-		Expect(n["_section_1"]).To(Equal("1"))
-		Expect(n["_section_1a"]).To(Equal("1.1"))
-		Expect(n["_section_1b"]).To(Equal("1.2"))
+		Expect(n["_getting_started"]).To(Equal("1"))
+		Expect(n["_introduction"]).To(Equal("1.1"))
+		Expect(n["_download_and_install"]).To(Equal("1.2"))
 	})
 
 	It("should never number sections - explicitly", func() {
@@ -98,18 +98,18 @@ var _ = Describe("section numbering", func() {
 				},
 				&types.Section{
 					Attributes: types.Attributes{
-						types.AttrID: "_section_1",
+						types.AttrID: "_getting_started",
 					},
 					Elements: []interface{}{
 						&types.Section{
 							Attributes: types.Attributes{
-								types.AttrID: "_section_1a",
+								types.AttrID: "_introduction",
 							},
 							Elements: []interface{}{},
 						},
 						&types.Section{
 							Attributes: types.Attributes{
-								types.AttrID: "_section_1b",
+								types.AttrID: "_download_and_install",
 							},
 							Elements: []interface{}{},
 						},
@@ -131,18 +131,18 @@ var _ = Describe("section numbering", func() {
 			Elements: []interface{}{
 				&types.Section{
 					Attributes: types.Attributes{
-						types.AttrID: "_section_1",
+						types.AttrID: "_getting_started",
 					},
 					Elements: []interface{}{
 						&types.Section{
 							Attributes: types.Attributes{
-								types.AttrID: "_section_1a",
+								types.AttrID: "_introduction",
 							},
 							Elements: []interface{}{},
 						},
 						&types.Section{
 							Attributes: types.Attributes{
-								types.AttrID: "_section_1b",
+								types.AttrID: "_download_and_install",
 							},
 							Elements: []interface{}{},
 						},
@@ -175,18 +175,18 @@ var _ = Describe("section numbering", func() {
 				},
 				&types.Section{
 					Attributes: types.Attributes{
-						types.AttrID: "_section_1",
+						types.AttrID: "_getting_started",
 					},
 					Elements: []interface{}{
 						&types.Section{
 							Attributes: types.Attributes{
-								types.AttrID: "_section_1a",
+								types.AttrID: "_introduction",
 							},
 							Elements: []interface{}{},
 						},
 						&types.Section{
 							Attributes: types.Attributes{
-								types.AttrID: "_section_1b",
+								types.AttrID: "_download_and_install",
 							},
 							Elements: []interface{}{},
 						},
@@ -200,8 +200,63 @@ var _ = Describe("section numbering", func() {
 		// then
 		Expect(err).NotTo(HaveOccurred())
 		Expect(n["_disclaimer"]).To(BeEmpty())
-		Expect(n["_section_1"]).To(Equal("1"))
-		Expect(n["_section_1a"]).To(Equal("1.1"))
-		Expect(n["_section_1b"]).To(Equal("1.2"))
+		Expect(n["_getting_started"]).To(Equal("1"))
+		Expect(n["_introduction"]).To(Equal("1.1"))
+		Expect(n["_download_and_install"]).To(Equal("1.2"))
+	})
+
+	It("should number sections when enabled - case 2", func() {
+		// given
+		doc := &types.Document{
+			Elements: []interface{}{
+				&types.FrontMatter{
+					Attributes: map[string]interface{}{
+						"draft": true,
+					},
+				},
+				&types.DocumentHeader{
+					Title: []interface{}{},
+				},
+				&types.AttributeReset{
+					Name: types.AttrSectionNumbering,
+				},
+				&types.Section{
+					Attributes: types.Attributes{
+						types.AttrID: "_disclaimer",
+					},
+				},
+				&types.AttributeDeclaration{
+					Name: types.AttrSectionNumbering,
+				},
+				&types.Section{
+					Attributes: types.Attributes{
+						types.AttrID: "_getting_started",
+					},
+					Elements: []interface{}{
+						&types.Section{
+							Attributes: types.Attributes{
+								types.AttrID: "_introduction",
+							},
+							Elements: []interface{}{},
+						},
+						&types.Section{
+							Attributes: types.Attributes{
+								types.AttrID: "_download_and_install",
+							},
+							Elements: []interface{}{},
+						},
+					},
+				},
+			},
+		}
+		// when
+		n, err := doc.SectionNumbers()
+
+		// then
+		Expect(err).NotTo(HaveOccurred())
+		Expect(n["_disclaimer"]).To(BeEmpty())
+		Expect(n["_getting_started"]).To(Equal("1"))
+		Expect(n["_introduction"]).To(Equal("1.1"))
+		Expect(n["_download_and_install"]).To(Equal("1.2"))
 	})
 })

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -42,7 +42,7 @@ const (
 func validateManpage(doc *types.Document) []Problem {
 	problems := []Problem{}
 	// checks the presence of a header
-	if doc.Header() == nil {
+	if header, _ := doc.Header(); header == nil {
 		problems = append(problems, Problem{
 			Severity: Error,
 			Message:  "manpage document is missing a header",


### PR DESCRIPTION
Only disable the 'DocumentHeader' rule if the element is not a FrontMatter (or a blankline)

Fixes #1041

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
