### PR TITLE
refactor(types): rename func to init AttributeReferences

### DIFF
--- a/pkg/parser/attribute_substitution_test.go
+++ b/pkg/parser/attribute_substitution_test.go
@@ -12,7 +12,7 @@ var _ = Describe("attribute substitutions", func() {
 
 	Context("in final documents", func() {
 
-		It("paragraph with attribute substitution", func() {
+		It("paragraph with attribute reference", func() {
 			source := `:author: Xavier
 
 a paragraph written by {author}.`
@@ -136,7 +136,7 @@ This journey continues`
 			Expect(ParseDocument(source)).To(MatchDocument(expected))
 		})
 
-		It("paragraph with attribute substitution from front-matter", func() {
+		It("paragraph with attribute reference from front-matter", func() {
 			source := `---
 author: Xavier
 ---
@@ -153,6 +153,78 @@ a paragraph written by {author}.`
 						Elements: []interface{}{
 							&types.StringElement{
 								Content: "a paragraph written by Xavier.",
+							},
+						},
+					},
+				},
+			}
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
+		})
+
+		It("link with attribute reference with hyphen", func() {
+			source := `:download-version: 1.0.0
+
+a link to https://example.com/version/v{download-version}[here]`
+
+			expected := &types.Document{
+				Elements: []interface{}{
+					&types.DocumentHeader{
+						Elements: []interface{}{
+							&types.AttributeDeclaration{
+								Name:  "download-version",
+								Value: "1.0.0",
+							},
+						},
+					},
+					&types.Paragraph{
+						Elements: []interface{}{
+							&types.StringElement{
+								Content: "a link to ",
+							},
+							&types.InlineLink{
+								Attributes: types.Attributes{
+									types.AttrInlineLinkText: "here",
+								},
+								Location: &types.Location{
+									Scheme: "https://",
+									Path:   "example.com/version/v1.0.0",
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(ParseDocument(source)).To(MatchDocument(expected))
+		})
+
+		It("link with unknown attribute reference in URL", func() {
+			source := `:version: 1.0.0
+
+a link to https://example.com/version/v{unknown}[here]`
+
+			expected := &types.Document{
+				Elements: []interface{}{
+					&types.DocumentHeader{
+						Elements: []interface{}{
+							&types.AttributeDeclaration{
+								Name:  "version",
+								Value: "1.0.0",
+							},
+						},
+					},
+					&types.Paragraph{
+						Elements: []interface{}{
+							&types.StringElement{
+								Content: "a link to ",
+							},
+							&types.InlineLink{
+								Attributes: types.Attributes{
+									types.AttrInlineLinkText: "here",
+								},
+								Location: &types.Location{
+									Scheme: "https://",
+									Path:   "example.com/version/v{unknown}",
+								},
 							},
 						},
 					},

--- a/pkg/parser/parser.peg
+++ b/pkg/parser/parser.peg
@@ -312,8 +312,8 @@ AttributeDeclaration <-
     }
 
 // AttributeName must be at least one character long, 
-// must begin with a word character (A-Z, a-z, 0-9 or _) and 
-// must only contain word Word and hyphens ("-").
+// must begin with a word character (A-Z, a-z, 0-9) or an underscore ("_") 
+// and must only contain word characters (A-Z, a-z, 0-9) and hyphens ("-").
 AttributeName <- [\pL0-9_] ([\pL0-9-])* {
         return string(c.text), nil
     }
@@ -651,7 +651,7 @@ AttributeReferenceValue <-
     /
     // unescaped
     "{" name:AttributeName "}" { 
-        return types.NewAttributeSubstitution(name.(string), string(c.text))
+        return types.NewAttributeReference(name.(string), string(c.text))
     }
     
 CounterReference <- CounterSubstitution1 / CounterSubstitution2

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -671,8 +671,8 @@ type AttributeReference struct {
 	rawText string
 }
 
-// NewAttributeSubstitution initializes a new Attribute Substitutions
-func NewAttributeSubstitution(name, rawText string) (interface{}, error) {
+// NewAttributeReference initializes a new Attribute Reference
+func NewAttributeReference(name, rawText string) (interface{}, error) {
 	if isPrefedinedAttribute(name) {
 		return &PredefinedAttribute{
 				Name:    name,


### PR DESCRIPTION
also, add test on attribute refs in links

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
