### PR TITLE
refactor(parser): increase chan size in doc processing

### DIFF
--- a/pkg/parser/document_processing.go
+++ b/pkg/parser/document_processing.go
@@ -10,7 +10,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const bufferSize = 10
+const bufferSize = 100 // bigger buffer improves perfs on large documents
 
 // ParseDocument parses the content of the reader identitied by the filename and applies all the substitutions and arrangements
 func ParseDocument(r io.Reader, config *configuration.Configuration, opts ...Option) (*types.Document, error) {


### PR DESCRIPTION
increased size of chan between each step improves perfs on larger docs

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
