### PR TITLE
refactor(renderer): move context and switch/call to backends

### DIFF
--- a/code-gen/renderer-templates/main.go
+++ b/code-gen/renderer-templates/main.go
@@ -28,6 +28,25 @@ type sgmlRenderer struct {
 {{ end }}
 }
 
+type template func() (*texttemplate.Template, error)
+
+func (r *sgmlRenderer) newTemplate(name string, tmpl string, err error) (*texttemplate.Template, error) {
+	// NB: if the data is missing below, it will be an empty string.
+	if err != nil {
+		return nil, err
+	}
+	if len(tmpl) == 0 {
+		return nil, fmt.Errorf("empty template for '%s'", name)
+	}
+	t := texttemplate.New(name)
+	t.Funcs(r.functions)
+	if t, err = t.Parse(tmpl); err != nil {
+		log.Errorf("failed to initialize the '%s' template: %v", name, err)
+		return nil, err
+	}
+	return t, nil
+}
+
 {{ range  $i, $tmpl := . }}
 func (r *sgmlRenderer) {{ func $tmpl }} (*text.Template, error) {
 	var err error

--- a/libasciidoc.go
+++ b/libasciidoc.go
@@ -3,18 +3,14 @@
 package libasciidoc
 
 import (
-	"fmt"
 	"io"
 	"os"
 	"strings"
 	"time"
 
-	"github.com/bytesparadise/libasciidoc/pkg/renderer/sgml/xhtml5"
-
 	"github.com/bytesparadise/libasciidoc/pkg/configuration"
 	"github.com/bytesparadise/libasciidoc/pkg/parser"
 	"github.com/bytesparadise/libasciidoc/pkg/renderer"
-	"github.com/bytesparadise/libasciidoc/pkg/renderer/sgml/html5"
 	"github.com/bytesparadise/libasciidoc/pkg/types"
 	"github.com/bytesparadise/libasciidoc/pkg/validator"
 	"github.com/pkg/errors"
@@ -53,18 +49,6 @@ func ConvertFile(output io.Writer, config *configuration.Configuration) (types.M
 // Returns an error if a problem occurred. The default will be HTML5, but depends on the config.BackEnd value.
 func Convert(r io.Reader, output io.Writer, config *configuration.Configuration) (types.Metadata, error) {
 
-	var render func(*renderer.Context, *types.Document, io.Writer) (types.Metadata, error)
-	switch config.BackEnd {
-	case "html", "html5", "":
-		render = html5.Render
-		config.Attributes.Set("basebackend-html", true)
-	case "xhtml", "xhtml5":
-		render = xhtml5.Render
-		config.Attributes.Set("basebackend-html", true)
-	default:
-		return types.Metadata{}, fmt.Errorf("backend '%s' not supported", config.BackEnd)
-	}
-
 	start := time.Now()
 	defer func() {
 		duration := time.Since(start)
@@ -99,8 +83,7 @@ func Convert(r io.Reader, output io.Writer, config *configuration.Configuration)
 		}
 	}
 	// render
-	ctx := renderer.NewContext(doc, config)
-	metadata, err := render(ctx, doc, output)
+	metadata, err := renderer.Render(doc, config, output)
 	if err != nil {
 		return types.Metadata{}, err
 	}

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -10,8 +10,11 @@ import (
 // NewConfiguration returns a new configuration
 func NewConfiguration(settings ...Setting) *Configuration {
 	config := &Configuration{
-		Attributes: map[string]interface{}{},
-		Macros:     map[string]MacroTemplate{},
+		Attributes: map[string]interface{}{
+			"basebackend-html": true, // along with default backend, to support `ifdef::basebackend-html` conditionals out-of-the-box
+		},
+		BackEnd: "html5", // default backend
+		Macros:  map[string]MacroTemplate{},
 	}
 	for _, set := range settings {
 		set(config)
@@ -86,6 +89,12 @@ func WithBackEnd(backend string) Setting {
 	return func(config *Configuration) {
 		config.Attributes.Set("backend", backend)
 		config.BackEnd = backend
+		switch backend {
+		case "html", "html5", "xhtml", "xhtml5":
+			config.Attributes.Set("basebackend-html", true)
+		default:
+			config.Attributes.Unset("basebackend-html")
+		}
 	}
 }
 

--- a/pkg/renderer/renderer.go
+++ b/pkg/renderer/renderer.go
@@ -1,0 +1,22 @@
+package renderer
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/bytesparadise/libasciidoc/pkg/configuration"
+	"github.com/bytesparadise/libasciidoc/pkg/renderer/sgml/html5"
+	"github.com/bytesparadise/libasciidoc/pkg/renderer/sgml/xhtml5"
+	"github.com/bytesparadise/libasciidoc/pkg/types"
+)
+
+func Render(doc *types.Document, config *configuration.Configuration, output io.Writer) (types.Metadata, error) {
+	switch config.BackEnd {
+	case "html", "html5":
+		return html5.Render(doc, config, output)
+	case "xhtml", "xhtml5":
+		return xhtml5.Render(doc, config, output)
+	default:
+		return types.Metadata{}, fmt.Errorf("backend '%s' not supported", config.BackEnd)
+	}
+}

--- a/pkg/renderer/sgml/context.go
+++ b/pkg/renderer/sgml/context.go
@@ -1,79 +1,79 @@
-package renderer
+package sgml
 
 import (
 	"github.com/bytesparadise/libasciidoc/pkg/configuration"
 	"github.com/bytesparadise/libasciidoc/pkg/types"
 )
 
-// Context is a custom implementation of the standard golang context.Context interface,
+// context is a custom implementation of the standard golang context.context interface,
 // which carries the types.Document which is being processed
-type Context struct {
-	Config               *configuration.Configuration // TODO: use composition (remove the `Config` field)
-	WithinDelimitedBlock bool
-	WithinList           int
+type context struct {
+	config               *configuration.Configuration // TODO: use composition (remove the `Config` field)
+	withinDelimitedBlock bool
+	withinList           int
 	counters             map[string]int
-	Attributes           types.Attributes
-	ElementReferences    types.ElementReferences
-	HasHeader            bool
-	SectionNumbering     types.SectionNumbers
+	attributes           types.Attributes
+	elementReferences    types.ElementReferences
+	hasHeader            bool
+	sectionNumbering     types.SectionNumbers
 }
 
-// NewContext returns a new rendering context for the given document.
-func NewContext(doc *types.Document, config *configuration.Configuration) *Context {
+// newContext returns a new rendering context for the given document.
+func newContext(doc *types.Document, config *configuration.Configuration) *context {
 	header, _ := doc.Header()
-	ctx := &Context{
-		Config:            config,
+	ctx := &context{
+		config:            config,
 		counters:          make(map[string]int),
-		Attributes:        config.Attributes,
-		ElementReferences: doc.ElementReferences,
-		HasHeader:         header != nil,
+		attributes:        config.Attributes,
+		elementReferences: doc.ElementReferences,
+		hasHeader:         header != nil,
 	}
 	// TODO: add other attributes from https://docs.asciidoctor.org/asciidoc/latest/attributes/document-attributes-ref/#builtin-attributes-i18n
-	ctx.Attributes[types.AttrFigureCaption] = "Figure"
-	ctx.Attributes[types.AttrExampleCaption] = "Example"
-	ctx.Attributes[types.AttrTableCaption] = "Table"
-	ctx.Attributes[types.AttrVersionLabel] = "version"
+	ctx.attributes[types.AttrFigureCaption] = "Figure"
+	ctx.attributes[types.AttrExampleCaption] = "Example"
+	ctx.attributes[types.AttrTableCaption] = "Table"
+	ctx.attributes[types.AttrVersionLabel] = "version"
 	// also, expand authors and revision
 	if header != nil {
 		if authors := header.Authors(); authors != nil {
-			ctx.Attributes.AddAll(authors.Expand())
+			ctx.attributes.AddAll(authors.Expand())
 		}
 
 		if revision := header.Revision(); revision != nil {
-			ctx.Attributes.AddAll(revision.Expand())
+			ctx.attributes.AddAll(revision.Expand())
 
 		}
 	}
 	return ctx
 }
 
-func (ctx *Context) UseUnicode() bool {
-	return ctx.Attributes.GetAsBoolWithDefault(types.AttrUnicode, true)
+func (ctx *context) UseUnicode() bool {
+	return ctx.attributes.GetAsBoolWithDefault(types.AttrUnicode, true)
 }
 
 const tableCounter = "tableCounter"
 
 // GetAndIncrementTableCounter returns the current value for the table counter after internally incrementing it.
-func (ctx *Context) GetAndIncrementTableCounter() int {
+func (ctx *context) GetAndIncrementTableCounter() int {
 	return ctx.getAndIncrementCounter(tableCounter)
 }
 
 const imageCounter = "imageCounter"
 
 // GetAndIncrementImageCounter returns the current value for the image counter after internally incrementing it.
-func (ctx *Context) GetAndIncrementImageCounter() int {
+func (ctx *context) GetAndIncrementImageCounter() int {
 	return ctx.getAndIncrementCounter(imageCounter)
 }
 
 const exampleBlockCounter = "exampleBlockCounter"
 
 // GetAndIncrementExampleBlockCounter returns the current value for the example block counter after internally incrementing it.
-func (ctx *Context) GetAndIncrementExampleBlockCounter() int {
+func (ctx *context) GetAndIncrementExampleBlockCounter() int {
 	return ctx.getAndIncrementCounter(exampleBlockCounter)
 }
 
 // getAndIncrementCounter returns the current value for the  counter after internally incrementing it.
-func (ctx *Context) getAndIncrementCounter(name string) int {
+func (ctx *context) getAndIncrementCounter(name string) int {
 	if _, found := ctx.counters[name]; !found {
 		ctx.counters[name] = 1
 		return 1

--- a/pkg/renderer/sgml/cross_reference.go
+++ b/pkg/renderer/sgml/cross_reference.go
@@ -4,7 +4,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/bytesparadise/libasciidoc/pkg/renderer"
 	"github.com/bytesparadise/libasciidoc/pkg/types"
 
 	"github.com/davecgh/go-spew/spew"
@@ -12,7 +11,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func (r *sgmlRenderer) renderInternalCrossReference(ctx *renderer.Context, xref *types.InternalCrossReference) (string, error) {
+func (r *sgmlRenderer) renderInternalCrossReference(ctx *context, xref *types.InternalCrossReference) (string, error) {
 	if log.IsLevelEnabled(log.DebugLevel) {
 		log.Debugf("rendering cross reference with ID: %s", spew.Sdump(xref.ID))
 	}
@@ -23,7 +22,7 @@ func (r *sgmlRenderer) renderInternalCrossReference(ctx *renderer.Context, xref 
 	}
 	if xrefLabel, ok := xref.Label.(string); ok {
 		label = xrefLabel
-	} else if target, found := ctx.ElementReferences[xrefID]; found {
+	} else if target, found := ctx.elementReferences[xrefID]; found {
 		switch t := target.(type) {
 		case string:
 			label = t
@@ -62,7 +61,7 @@ func (r *sgmlRenderer) renderInternalCrossReference(ctx *renderer.Context, xref 
 	})
 }
 
-func (r *sgmlRenderer) renderExternalCrossReference(ctx *renderer.Context, xref *types.ExternalCrossReference) (string, error) {
+func (r *sgmlRenderer) renderExternalCrossReference(ctx *context, xref *types.ExternalCrossReference) (string, error) {
 	// log.Debugf("rendering cross reference with ID: %s", xref.Location)
 	var label string
 	var err error

--- a/pkg/renderer/sgml/delimited_block.go
+++ b/pkg/renderer/sgml/delimited_block.go
@@ -3,11 +3,10 @@ package sgml
 import (
 	"fmt"
 
-	"github.com/bytesparadise/libasciidoc/pkg/renderer"
 	"github.com/bytesparadise/libasciidoc/pkg/types"
 )
 
-func (r *sgmlRenderer) renderDelimitedBlock(ctx *renderer.Context, b *types.DelimitedBlock) (string, error) {
+func (r *sgmlRenderer) renderDelimitedBlock(ctx *context, b *types.DelimitedBlock) (string, error) {
 	switch b.Kind {
 	case types.Example:
 		if b.Attributes.Has(types.AttrStyle) {

--- a/pkg/renderer/sgml/delimited_block_admonition.go
+++ b/pkg/renderer/sgml/delimited_block_admonition.go
@@ -3,13 +3,12 @@ package sgml
 import (
 	"strings"
 
-	"github.com/bytesparadise/libasciidoc/pkg/renderer"
 	"github.com/bytesparadise/libasciidoc/pkg/types"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
 
-func (r *sgmlRenderer) renderAdmonitionBlock(ctx *renderer.Context, b *types.DelimitedBlock) (string, error) {
+func (r *sgmlRenderer) renderAdmonitionBlock(ctx *context, b *types.DelimitedBlock) (string, error) {
 	kind, _, err := b.Attributes.GetAsString(types.AttrStyle)
 	if err != nil {
 		return "", err
@@ -33,7 +32,7 @@ func (r *sgmlRenderer) renderAdmonitionBlock(ctx *renderer.Context, b *types.Del
 		return "", errors.Wrap(err, "unable to render admonition block title")
 	}
 	return r.execute(r.admonitionBlock, struct {
-		Context *renderer.Context
+		Context *context
 		ID      string
 		Title   string
 		Kind    string
@@ -51,7 +50,7 @@ func (r *sgmlRenderer) renderAdmonitionBlock(ctx *renderer.Context, b *types.Del
 	})
 }
 
-func (r *sgmlRenderer) renderAdmonitionParagraph(ctx *renderer.Context, p *types.Paragraph) (string, error) {
+func (r *sgmlRenderer) renderAdmonitionParagraph(ctx *context, p *types.Paragraph) (string, error) {
 	log.Debug("rendering admonition paragraph...")
 	kind, ok, err := p.Attributes.GetAsString(types.AttrStyle)
 	if err != nil {
@@ -78,7 +77,7 @@ func (r *sgmlRenderer) renderAdmonitionParagraph(ctx *renderer.Context, p *types
 		return "", err
 	}
 	return r.execute(r.admonitionParagraph, struct {
-		Context *renderer.Context
+		Context *context
 		ID      string
 		Title   string
 		Roles   string

--- a/pkg/renderer/sgml/delimited_block_example.go
+++ b/pkg/renderer/sgml/delimited_block_example.go
@@ -5,13 +5,12 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/bytesparadise/libasciidoc/pkg/renderer"
 	"github.com/bytesparadise/libasciidoc/pkg/types"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
 
-func (r *sgmlRenderer) renderExampleBlock(ctx *renderer.Context, b *types.DelimitedBlock) (string, error) {
+func (r *sgmlRenderer) renderExampleBlock(ctx *context, b *types.DelimitedBlock) (string, error) {
 	// default, example block
 	number := 0
 	content, err := r.renderElements(ctx, b.Elements)
@@ -27,7 +26,7 @@ func (r *sgmlRenderer) renderExampleBlock(ctx *renderer.Context, b *types.Delimi
 		return "", errors.Wrap(err, "unable to render example block caption")
 	}
 	if !found {
-		c, found, err = ctx.Attributes.GetAsString(types.AttrExampleCaption)
+		c, found, err = ctx.attributes.GetAsString(types.AttrExampleCaption)
 		if err != nil {
 			return "", errors.Wrap(err, "unable to render example block caption")
 		}
@@ -47,7 +46,7 @@ func (r *sgmlRenderer) renderExampleBlock(ctx *renderer.Context, b *types.Delimi
 	caption := &strings.Builder{}
 	caption.WriteString(c)
 	return r.execute(r.exampleBlock, struct {
-		Context       *renderer.Context
+		Context       *context
 		ID            string
 		Title         string
 		Caption       string
@@ -65,7 +64,7 @@ func (r *sgmlRenderer) renderExampleBlock(ctx *renderer.Context, b *types.Delimi
 	})
 }
 
-func (r *sgmlRenderer) renderExampleParagraph(ctx *renderer.Context, p *types.Paragraph) (string, error) {
+func (r *sgmlRenderer) renderExampleParagraph(ctx *context, p *types.Paragraph) (string, error) {
 	log.Debug("rendering example paragraph...")
 	content, err := r.renderElements(ctx, p.Elements)
 	if err != nil {
@@ -80,7 +79,7 @@ func (r *sgmlRenderer) renderExampleParagraph(ctx *renderer.Context, p *types.Pa
 		return "", errors.Wrap(err, "unable to render example paragraph title")
 	}
 	return r.execute(r.exampleBlock, struct {
-		Context       *renderer.Context
+		Context       *context
 		ID            string
 		Title         string
 		Caption       string
@@ -96,7 +95,7 @@ func (r *sgmlRenderer) renderExampleParagraph(ctx *renderer.Context, p *types.Pa
 	})
 }
 
-func (r *sgmlRenderer) renderLiteralParagraph(ctx *renderer.Context, p *types.Paragraph) (string, error) {
+func (r *sgmlRenderer) renderLiteralParagraph(ctx *context, p *types.Paragraph) (string, error) {
 	log.Debugf("rendering literal paragraph")
 	content, err := r.renderElements(ctx, p.Elements)
 	if err != nil {
@@ -115,7 +114,7 @@ func (r *sgmlRenderer) renderLiteralParagraph(ctx *renderer.Context, p *types.Pa
 		return "", errors.Wrap(err, "unable to render literal block roles")
 	}
 	return r.execute(r.literalBlock, struct {
-		Context *renderer.Context
+		Context *context
 		ID      string
 		Title   string
 		Roles   string

--- a/pkg/renderer/sgml/delimited_block_fenced.go
+++ b/pkg/renderer/sgml/delimited_block_fenced.go
@@ -3,17 +3,16 @@ package sgml
 import (
 	"strings"
 
-	"github.com/bytesparadise/libasciidoc/pkg/renderer"
 	"github.com/bytesparadise/libasciidoc/pkg/types"
 	"github.com/pkg/errors"
 )
 
-func (r *sgmlRenderer) renderFencedBlock(ctx *renderer.Context, b *types.DelimitedBlock) (string, error) {
-	previousWithinDelimitedBlock := ctx.WithinDelimitedBlock
+func (r *sgmlRenderer) renderFencedBlock(ctx *context, b *types.DelimitedBlock) (string, error) {
+	previousWithinDelimitedBlock := ctx.withinDelimitedBlock
 	defer func() {
-		ctx.WithinDelimitedBlock = previousWithinDelimitedBlock
+		ctx.withinDelimitedBlock = previousWithinDelimitedBlock
 	}()
-	ctx.WithinDelimitedBlock = true
+	ctx.withinDelimitedBlock = true
 	content, err := r.renderElements(ctx, b.Elements)
 	if err != nil {
 		return "", errors.Wrap(err, "unable to render fenced block content")
@@ -27,7 +26,7 @@ func (r *sgmlRenderer) renderFencedBlock(ctx *renderer.Context, b *types.Delimit
 		return "", errors.Wrap(err, "unable to render fenced block roles")
 	}
 	return r.execute(r.fencedBlock, struct {
-		Context *renderer.Context
+		Context *context
 		ID      string
 		Title   string
 		Roles   string

--- a/pkg/renderer/sgml/delimited_block_listing.go
+++ b/pkg/renderer/sgml/delimited_block_listing.go
@@ -3,20 +3,19 @@ package sgml
 import (
 	"strings"
 
-	"github.com/bytesparadise/libasciidoc/pkg/renderer"
 	"github.com/bytesparadise/libasciidoc/pkg/types"
 	"github.com/pkg/errors"
 )
 
-func (r *sgmlRenderer) renderListingBlock(ctx *renderer.Context, b *types.DelimitedBlock) (string, error) {
+func (r *sgmlRenderer) renderListingBlock(ctx *context, b *types.DelimitedBlock) (string, error) {
 	if k, found := b.Attributes[types.AttrStyle]; found && k == types.Source {
 		return r.renderSourceBlock(ctx, b)
 	}
-	previousWithinDelimitedBlock := ctx.WithinDelimitedBlock
+	previousWithinDelimitedBlock := ctx.withinDelimitedBlock
 	defer func() {
-		ctx.WithinDelimitedBlock = previousWithinDelimitedBlock
+		ctx.withinDelimitedBlock = previousWithinDelimitedBlock
 	}()
-	ctx.WithinDelimitedBlock = true
+	ctx.withinDelimitedBlock = true
 	content, err := r.renderElements(ctx, b.Elements)
 	if err != nil {
 		return "", errors.Wrap(err, "unable to render listing block content")
@@ -30,7 +29,7 @@ func (r *sgmlRenderer) renderListingBlock(ctx *renderer.Context, b *types.Delimi
 		return "", errors.Wrap(err, "unable to render listing block title")
 	}
 	return r.execute(r.listingBlock, struct {
-		Context *renderer.Context
+		Context *context
 		ID      string
 		Title   string
 		Roles   string
@@ -44,7 +43,7 @@ func (r *sgmlRenderer) renderListingBlock(ctx *renderer.Context, b *types.Delimi
 	})
 }
 
-func (r *sgmlRenderer) renderListingParagraph(ctx *renderer.Context, p *types.Paragraph) (string, error) {
+func (r *sgmlRenderer) renderListingParagraph(ctx *context, p *types.Paragraph) (string, error) {
 	content, err := r.renderElements(ctx, p.Elements)
 	if err != nil {
 		return "", errors.Wrap(err, "unable to render listing block content")
@@ -58,7 +57,7 @@ func (r *sgmlRenderer) renderListingParagraph(ctx *renderer.Context, p *types.Pa
 		return "", errors.Wrap(err, "unable to render listing paragraph roles")
 	}
 	return r.execute(r.listingBlock, struct {
-		Context *renderer.Context
+		Context *context
 		ID      string
 		Title   string
 		Roles   string

--- a/pkg/renderer/sgml/delimited_block_markdown_quote.go
+++ b/pkg/renderer/sgml/delimited_block_markdown_quote.go
@@ -3,12 +3,11 @@ package sgml
 import (
 	"strings"
 
-	"github.com/bytesparadise/libasciidoc/pkg/renderer"
 	"github.com/bytesparadise/libasciidoc/pkg/types"
 	"github.com/pkg/errors"
 )
 
-func (r *sgmlRenderer) renderMarkdownQuoteBlock(ctx *renderer.Context, b *types.DelimitedBlock) (string, error) {
+func (r *sgmlRenderer) renderMarkdownQuoteBlock(ctx *context, b *types.DelimitedBlock) (string, error) {
 	content, err := r.renderElements(ctx, b.Elements)
 	if err != nil {
 		return "", errors.Wrap(err, "unable to render markdown quote block content")
@@ -26,7 +25,7 @@ func (r *sgmlRenderer) renderMarkdownQuoteBlock(ctx *renderer.Context, b *types.
 		return "", errors.Wrap(err, "unable to render markdown quote block title")
 	}
 	return r.execute(r.markdownQuoteBlock, struct {
-		Context     *renderer.Context
+		Context     *context
 		ID          string
 		Title       string
 		Roles       string

--- a/pkg/renderer/sgml/delimited_block_open.go
+++ b/pkg/renderer/sgml/delimited_block_open.go
@@ -1,12 +1,11 @@
 package sgml
 
 import (
-	"github.com/bytesparadise/libasciidoc/pkg/renderer"
 	"github.com/bytesparadise/libasciidoc/pkg/types"
 	"github.com/pkg/errors"
 )
 
-func (r *sgmlRenderer) renderOpenBlock(ctx *renderer.Context, b *types.DelimitedBlock) (string, error) {
+func (r *sgmlRenderer) renderOpenBlock(ctx *context, b *types.DelimitedBlock) (string, error) {
 	blocks := discardBlankLines(b.Elements)
 	content, err := r.renderElements(ctx, blocks)
 	if err != nil {
@@ -21,7 +20,7 @@ func (r *sgmlRenderer) renderOpenBlock(ctx *renderer.Context, b *types.Delimited
 		return "", errors.Wrap(err, "unable to render open block title")
 	}
 	return r.execute(r.openBlock, struct {
-		Context *renderer.Context
+		Context *context
 		ID      string
 		Title   string
 		Roles   string

--- a/pkg/renderer/sgml/delimited_block_passthrough.go
+++ b/pkg/renderer/sgml/delimited_block_passthrough.go
@@ -3,17 +3,16 @@ package sgml
 import (
 	"strings"
 
-	"github.com/bytesparadise/libasciidoc/pkg/renderer"
 	"github.com/bytesparadise/libasciidoc/pkg/types"
 	"github.com/pkg/errors"
 )
 
-func (r *sgmlRenderer) renderPassthroughBlock(ctx *renderer.Context, b *types.DelimitedBlock) (string, error) {
-	previousWithinDelimitedBlock := ctx.WithinDelimitedBlock
+func (r *sgmlRenderer) renderPassthroughBlock(ctx *context, b *types.DelimitedBlock) (string, error) {
+	previousWithinDelimitedBlock := ctx.withinDelimitedBlock
 	defer func() {
-		ctx.WithinDelimitedBlock = previousWithinDelimitedBlock
+		ctx.withinDelimitedBlock = previousWithinDelimitedBlock
 	}()
-	ctx.WithinDelimitedBlock = true
+	ctx.withinDelimitedBlock = true
 	content, err := r.renderElements(ctx, b.Elements)
 	if err != nil {
 		return "", errors.Wrap(err, "unable to render passthrough block content")
@@ -23,7 +22,7 @@ func (r *sgmlRenderer) renderPassthroughBlock(ctx *renderer.Context, b *types.De
 		return "", errors.Wrap(err, "unable to render passthrough block roles")
 	}
 	return r.execute(r.passthroughBlock, struct {
-		Context *renderer.Context
+		Context *context
 		ID      string
 		Roles   string
 		Content string

--- a/pkg/renderer/sgml/delimited_block_quote.go
+++ b/pkg/renderer/sgml/delimited_block_quote.go
@@ -1,13 +1,12 @@
 package sgml
 
 import (
-	"github.com/bytesparadise/libasciidoc/pkg/renderer"
 	"github.com/bytesparadise/libasciidoc/pkg/types"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
 
-func (r *sgmlRenderer) renderQuoteBlock(ctx *renderer.Context, b *types.DelimitedBlock) (string, error) {
+func (r *sgmlRenderer) renderQuoteBlock(ctx *context, b *types.DelimitedBlock) (string, error) {
 	content, err := r.renderElements(ctx, b.Elements)
 	if err != nil {
 		return "", errors.Wrap(err, "unable to render quote block content")
@@ -25,7 +24,7 @@ func (r *sgmlRenderer) renderQuoteBlock(ctx *renderer.Context, b *types.Delimite
 		return "", errors.Wrap(err, "unable to render quote block title")
 	}
 	return r.execute(r.quoteBlock, struct {
-		Context     *renderer.Context
+		Context     *context
 		ID          string
 		Title       string
 		Roles       string
@@ -41,7 +40,7 @@ func (r *sgmlRenderer) renderQuoteBlock(ctx *renderer.Context, b *types.Delimite
 	})
 }
 
-func (r *sgmlRenderer) renderQuoteParagraph(ctx *renderer.Context, p *types.Paragraph) (string, error) {
+func (r *sgmlRenderer) renderQuoteParagraph(ctx *context, p *types.Paragraph) (string, error) {
 	log.Debug("rendering quote paragraph...")
 	content, err := r.renderParagraphElements(ctx, p)
 	if err != nil {
@@ -56,7 +55,7 @@ func (r *sgmlRenderer) renderQuoteParagraph(ctx *renderer.Context, p *types.Para
 		return "", errors.Wrap(err, "unable to render callout list roles")
 	}
 	return r.execute(r.quoteParagraph, struct {
-		Context     *renderer.Context
+		Context     *context
 		ID          string
 		Title       string
 		Attribution Attribution

--- a/pkg/renderer/sgml/delimited_block_sidebar.go
+++ b/pkg/renderer/sgml/delimited_block_sidebar.go
@@ -1,12 +1,11 @@
 package sgml
 
 import (
-	"github.com/bytesparadise/libasciidoc/pkg/renderer"
 	"github.com/bytesparadise/libasciidoc/pkg/types"
 	"github.com/pkg/errors"
 )
 
-func (r *sgmlRenderer) renderSidebarBlock(ctx *renderer.Context, b *types.DelimitedBlock) (string, error) {
+func (r *sgmlRenderer) renderSidebarBlock(ctx *context, b *types.DelimitedBlock) (string, error) {
 	blocks := discardBlankLines(b.Elements)
 	content, err := r.renderElements(ctx, blocks)
 	if err != nil {
@@ -21,7 +20,7 @@ func (r *sgmlRenderer) renderSidebarBlock(ctx *renderer.Context, b *types.Delimi
 		return "", errors.Wrap(err, "unable to render sidebar block title")
 	}
 	return r.execute(r.sidebarBlock, struct {
-		Context *renderer.Context
+		Context *context
 		ID      string
 		Title   string
 		Roles   string

--- a/pkg/renderer/sgml/delimited_block_verse.go
+++ b/pkg/renderer/sgml/delimited_block_verse.go
@@ -3,22 +3,21 @@ package sgml
 import (
 	"strings"
 
-	"github.com/bytesparadise/libasciidoc/pkg/renderer"
 	"github.com/bytesparadise/libasciidoc/pkg/types"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
 
-func (r *sgmlRenderer) renderVerseBlock(ctx *renderer.Context, b *types.DelimitedBlock) (string, error) {
+func (r *sgmlRenderer) renderVerseBlock(ctx *context, b *types.DelimitedBlock) (string, error) {
 	roles, err := r.renderElementRoles(ctx, b.Attributes)
 	if err != nil {
 		return "", errors.Wrap(err, "unable to render verser block roles")
 	}
-	previousWithinDelimitedBlock := ctx.WithinDelimitedBlock
+	previousWithinDelimitedBlock := ctx.withinDelimitedBlock
 	defer func() {
-		ctx.WithinDelimitedBlock = previousWithinDelimitedBlock
+		ctx.withinDelimitedBlock = previousWithinDelimitedBlock
 	}()
-	ctx.WithinDelimitedBlock = true
+	ctx.withinDelimitedBlock = true
 	content, err := r.renderElements(ctx, b.Elements)
 	if err != nil {
 		return "", errors.Wrap(err, "unable to render verse block content")
@@ -32,7 +31,7 @@ func (r *sgmlRenderer) renderVerseBlock(ctx *renderer.Context, b *types.Delimite
 		return "", errors.Wrap(err, "unable to render verse block title")
 	}
 	return r.execute(r.verseBlock, struct {
-		Context     *renderer.Context
+		Context     *context
 		ID          string
 		Title       string
 		Roles       string
@@ -48,7 +47,7 @@ func (r *sgmlRenderer) renderVerseBlock(ctx *renderer.Context, b *types.Delimite
 	})
 }
 
-func (r *sgmlRenderer) renderVerseParagraph(ctx *renderer.Context, p *types.Paragraph) (string, error) {
+func (r *sgmlRenderer) renderVerseParagraph(ctx *context, p *types.Paragraph) (string, error) {
 	log.Debug("rendering verse paragraph...")
 	content, err := r.renderParagraphElements(ctx, p, withRenderer(r.renderPlainText))
 	if err != nil {
@@ -63,7 +62,7 @@ func (r *sgmlRenderer) renderVerseParagraph(ctx *renderer.Context, p *types.Para
 		return "", errors.Wrap(err, "unable to render callout list roles")
 	}
 	return r.execute(r.verseParagraph, struct {
-		Context     *renderer.Context
+		Context     *context
 		ID          string
 		Title       string
 		Attribution Attribution

--- a/pkg/renderer/sgml/document_details.go
+++ b/pkg/renderer/sgml/document_details.go
@@ -5,13 +5,12 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/bytesparadise/libasciidoc/pkg/renderer"
 	"github.com/bytesparadise/libasciidoc/pkg/types"
 	"github.com/pkg/errors"
 )
 
-func (r *sgmlRenderer) renderDocumentDetails(ctx *renderer.Context) (string, error) {
-	if !ctx.Attributes.Has(types.AttrAuthors) {
+func (r *sgmlRenderer) renderDocumentDetails(ctx *context) (string, error) {
+	if !ctx.attributes.Has(types.AttrAuthors) {
 		return "", nil
 	}
 	authors, err := r.renderDocumentAuthorsDetails(ctx)
@@ -19,19 +18,19 @@ func (r *sgmlRenderer) renderDocumentDetails(ctx *renderer.Context) (string, err
 		return "", errors.Wrap(err, "error while rendering the document details")
 	}
 	documentDetailsBuff := &bytes.Buffer{}
-	revLabel, _, err := ctx.Attributes.GetAsString(types.AttrVersionLabel)
+	revLabel, _, err := ctx.attributes.GetAsString(types.AttrVersionLabel)
 	if err != nil {
 		return "", errors.Wrap(err, "error while rendering the document details")
 	}
-	revNumber, _, err := ctx.Attributes.GetAsString("revnumber")
+	revNumber, _, err := ctx.attributes.GetAsString("revnumber")
 	if err != nil {
 		return "", errors.Wrap(err, "error while rendering the document details")
 	}
-	revDate, _, err := ctx.Attributes.GetAsString("revdate")
+	revDate, _, err := ctx.attributes.GetAsString("revdate")
 	if err != nil {
 		return "", errors.Wrap(err, "error while rendering the document details")
 	}
-	revRemark, _, err := ctx.Attributes.GetAsString("revremark")
+	revRemark, _, err := ctx.attributes.GetAsString("revremark")
 	if err != nil {
 		return "", errors.Wrap(err, "error while rendering the document details")
 	}
@@ -57,7 +56,7 @@ func (r *sgmlRenderer) renderDocumentDetails(ctx *renderer.Context) (string, err
 	return documentDetailsBuff.String(), nil
 }
 
-func (r *sgmlRenderer) renderDocumentAuthorsDetails(ctx *renderer.Context) (string, error) { // TODO: use  `types.DocumentAuthor` attribute in context
+func (r *sgmlRenderer) renderDocumentAuthorsDetails(ctx *context) (string, error) { // TODO: use  `types.DocumentAuthor` attribute in context
 	authorsDetailsBuff := &strings.Builder{}
 	i := 1
 	for {
@@ -74,13 +73,13 @@ func (r *sgmlRenderer) renderDocumentAuthorsDetails(ctx *renderer.Context) (stri
 			emailKey = "email_" + index
 		}
 		// having at least one author is the minimal requirement for document details
-		if author, ok, err := ctx.Attributes.GetAsString(authorKey); err != nil {
+		if author, ok, err := ctx.attributes.GetAsString(authorKey); err != nil {
 			return "", errors.Wrap(err, "error while rendering the document authors")
 		} else if ok {
 			if i > 1 {
 				authorsDetailsBuff.WriteString("\n")
 			}
-			email, _, err := ctx.Attributes.GetAsString(emailKey)
+			email, _, err := ctx.attributes.GetAsString(emailKey)
 			if err != nil {
 				return "", errors.Wrap(err, "error while rendering the document authors")
 			}

--- a/pkg/renderer/sgml/element_role.go
+++ b/pkg/renderer/sgml/element_role.go
@@ -4,11 +4,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/bytesparadise/libasciidoc/pkg/renderer"
 	"github.com/bytesparadise/libasciidoc/pkg/types"
 )
 
-func (r *sgmlRenderer) renderElementRoles(ctx *renderer.Context, attrs types.Attributes) (string, error) {
+func (r *sgmlRenderer) renderElementRoles(ctx *context, attrs types.Attributes) (string, error) {
 	if roles, ok := attrs[types.AttrRoles].(types.Roles); ok {
 		result := make([]string, len(roles))
 		for i, e := range roles {
@@ -24,7 +23,7 @@ func (r *sgmlRenderer) renderElementRoles(ctx *renderer.Context, attrs types.Att
 }
 
 // Image roles add float and alignment attributes -- we turn these into roles.
-func (r *sgmlRenderer) renderImageRoles(ctx *renderer.Context, attrs types.Attributes) (string, error) {
+func (r *sgmlRenderer) renderImageRoles(ctx *context, attrs types.Attributes) (string, error) {
 	var result []string
 	if val, ok, err := attrs.GetAsString(types.AttrFloat); err != nil {
 		return "", err
@@ -49,7 +48,7 @@ func (r *sgmlRenderer) renderImageRoles(ctx *renderer.Context, attrs types.Attri
 	return strings.Join(result, " "), nil
 }
 
-func (r *sgmlRenderer) renderElementRole(ctx *renderer.Context, role interface{}) (string, error) {
+func (r *sgmlRenderer) renderElementRole(ctx *context, role interface{}) (string, error) {
 	result := strings.Builder{}
 	switch role := role.(type) {
 	case string:

--- a/pkg/renderer/sgml/footnote_reference.go
+++ b/pkg/renderer/sgml/footnote_reference.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/bytesparadise/libasciidoc/pkg/renderer"
 	"github.com/bytesparadise/libasciidoc/pkg/types"
 	"github.com/pkg/errors"
 )
@@ -72,7 +71,7 @@ func (r *sgmlRenderer) renderFootnoteReferencePlainText(note *types.FootnoteRefe
 	return "", fmt.Errorf("unable to render missing footnote")
 }
 
-func (r *sgmlRenderer) renderFootnotes(ctx *renderer.Context, notes []*types.Footnote) (string, error) {
+func (r *sgmlRenderer) renderFootnotes(ctx *context, notes []*types.Footnote) (string, error) {
 	// skip if there's no foot note in the doc
 	if len(notes) == 0 {
 		return "", nil
@@ -86,7 +85,7 @@ func (r *sgmlRenderer) renderFootnotes(ctx *renderer.Context, notes []*types.Foo
 		content.WriteString(renderedNote)
 	}
 	return r.execute(r.footnotes, struct {
-		Context   *renderer.Context
+		Context   *context
 		Content   string
 		Footnotes []*types.Footnote
 	}{
@@ -96,7 +95,7 @@ func (r *sgmlRenderer) renderFootnotes(ctx *renderer.Context, notes []*types.Foo
 	})
 }
 
-func (r *sgmlRenderer) renderFootnoteElement(ctx *renderer.Context, note *types.Footnote) (string, error) {
+func (r *sgmlRenderer) renderFootnoteElement(ctx *context, note *types.Footnote) (string, error) {
 	content, err := r.renderInlineElements(ctx, note.Elements)
 	if err != nil {
 		return "", errors.Wrapf(err, "unable to render foot note content")
@@ -105,7 +104,7 @@ func (r *sgmlRenderer) renderFootnoteElement(ctx *renderer.Context, note *types.
 	// Note: Asciidoctor will render the footnote content on a single line
 	content = strings.ReplaceAll(content, "\n", " ")
 	return r.execute(r.footnoteElement, struct {
-		Context *renderer.Context
+		Context *context
 		ID      int
 		Ref     string
 		Content string

--- a/pkg/renderer/sgml/html5/article.go
+++ b/pkg/renderer/sgml/html5/article.go
@@ -1,0 +1,33 @@
+package html5
+
+const (
+	articleTmpl = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+{{ if .Generator }}<meta name="generator" content="{{ .Generator }}">
+{{ end }}{{ if .Description }}<meta name="description" content="{{ .Description }}">
+{{ end }}{{ if .Authors }}<meta name="author" content="{{ .Authors }}">
+{{ end }}{{ range $css := .CSS }}<link type="text/css" rel="stylesheet" href="{{ $css }}">
+{{ end }}<title>{{ .Title }}</title>
+</head>
+<body{{ if .ID }} id="{{ .ID }}"{{ end }} class="{{ .Doctype }}{{ if .Roles }} {{ .Roles }}{{ end }}">
+{{ if .IncludeHTMLBodyHeader }}{{ .Header }}{{ end }}<div id="content">
+{{ .Content }}</div>
+{{ if .IncludeHTMLBodyFooter }}<div id="footer">
+<div id="footer-text">
+{{ if .RevNumber }}Version {{ .RevNumber }}<br>
+{{ end }}Last updated {{ .LastUpdated }}
+</div>
+</div>
+{{ end }}</body>
+</html>
+`
+
+	articleHeaderTmpl = `<div id="header">
+<h1>{{ .Header }}</h1>
+{{ if.Details }}{{ .Details }}{{ end }}</div>
+`
+)

--- a/pkg/renderer/sgml/html5/html5.go
+++ b/pkg/renderer/sgml/html5/html5.go
@@ -1,41 +1,15 @@
 package html5
 
-const (
-	articleTmpl = `<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="UTF-8">
-<meta http-equiv="X-UA-Compatible" content="IE=edge">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-{{ if .Generator }}<meta name="generator" content="{{ .Generator }}">
-{{ end }}{{ if .Description }}<meta name="description" content="{{ .Description }}">
-{{ end }}{{ if .Authors }}<meta name="author" content="{{ .Authors }}">
-{{ end }}{{ range $css := .CSS }}<link type="text/css" rel="stylesheet" href="{{ $css }}">
-{{ end }}<title>{{ .Title }}</title>
-</head>
-<body{{ if .ID }} id="{{ .ID }}"{{ end }} class="{{ .Doctype }}{{ if .Roles }} {{ .Roles }}{{ end }}">
-{{ if .IncludeHTMLBodyHeader }}{{ .Header }}{{ end }}<div id="content">
-{{ .Content }}</div>
-{{ if .IncludeHTMLBodyFooter }}<div id="footer">
-<div id="footer-text">
-{{ if .RevNumber }}Version {{ .RevNumber }}<br>
-{{ end }}Last updated {{ .LastUpdated }}
-</div>
-</div>
-{{ end }}</body>
-</html>
-`
+import (
+	"io"
 
-	articleHeaderTmpl = `<div id="header">
-<h1>{{ .Header }}</h1>
-{{ if.Details }}{{ .Details }}{{ end }}</div>
-`
-
-	manpageHeaderTmpl = `{{ if.IncludeH1 }}<div id="header">
-<h1>{{ .Header }} Manual Page</h1>
-{{ end }}<h2 id="_name">{{ .Name }}</h2>
-<div class="sectionbody">
-{{ .Content }}</div>
-{{ if .IncludeH1 }}</div>
-{{ end }}`
+	"github.com/bytesparadise/libasciidoc/pkg/configuration"
+	"github.com/bytesparadise/libasciidoc/pkg/renderer/sgml"
+	"github.com/bytesparadise/libasciidoc/pkg/types"
 )
+
+// Render renders the document to the output, using a default instance
+// of the renderer, with default templates.
+func Render(doc *types.Document, config *configuration.Configuration, output io.Writer) (types.Metadata, error) {
+	return sgml.Render(doc, config, output, templates)
+}

--- a/pkg/renderer/sgml/html5/manpage.go
+++ b/pkg/renderer/sgml/html5/manpage.go
@@ -1,0 +1,9 @@
+package html5
+
+const manpageHeaderTmpl = `{{ if.IncludeH1 }}<div id="header">
+<h1>{{ .Header }} Manual Page</h1>
+{{ end }}<h2 id="_name">{{ .Name }}</h2>
+<div class="sectionbody">
+{{ .Content }}</div>
+{{ if .IncludeH1 }}</div>
+{{ end }}`

--- a/pkg/renderer/sgml/html5/templates.go
+++ b/pkg/renderer/sgml/html5/templates.go
@@ -1,12 +1,14 @@
 package html5
 
 import (
-	"io"
-
-	"github.com/bytesparadise/libasciidoc/pkg/renderer"
 	"github.com/bytesparadise/libasciidoc/pkg/renderer/sgml"
-	"github.com/bytesparadise/libasciidoc/pkg/types"
 )
+
+// Templates returns the default Templates use for HTML5.  It may be useful
+// for derived implementations.
+func Templates() sgml.Templates {
+	return templates
+}
 
 var templates = sgml.Templates{
 	AdmonitionBlock:              admonitionBlockTmpl,
@@ -85,23 +87,4 @@ var templates = sgml.Templates{
 	UnorderedListElement:         unorderedListElementTmpl,
 	VerseBlock:                   verseBlockTmpl,
 	VerseParagraph:               verseParagraphTmpl,
-}
-
-var defaultRenderer sgml.Renderer
-
-func init() {
-	// NB: This is fast, and doesn't including parsing.
-	defaultRenderer = sgml.NewRenderer(templates)
-}
-
-// Render renders the document to the output, using a default instance
-// of the renderer, with default templates.
-func Render(ctx *renderer.Context, doc *types.Document, output io.Writer) (types.Metadata, error) {
-	return defaultRenderer.Render(ctx, doc, output)
-}
-
-// Templates returns the default Templates use for HTML5.  It may be useful
-// for derived implementations.
-func Templates() sgml.Templates {
-	return templates
 }

--- a/pkg/renderer/sgml/icon.go
+++ b/pkg/renderer/sgml/icon.go
@@ -6,12 +6,11 @@ import (
 	"strings"
 	texttemplate "text/template"
 
-	"github.com/bytesparadise/libasciidoc/pkg/renderer"
 	"github.com/bytesparadise/libasciidoc/pkg/types"
 	"github.com/pkg/errors"
 )
 
-func (r *sgmlRenderer) renderInlineIcon(ctx *renderer.Context, icon *types.Icon) (string, error) {
+func (r *sgmlRenderer) renderInlineIcon(ctx *context, icon *types.Icon) (string, error) {
 	iconStr, err := r.renderIcon(ctx, types.Icon{
 		Class:      icon.Class,
 		Attributes: icon.Attributes,
@@ -44,8 +43,8 @@ var defaultIconClasses = map[string]string{
 	types.AttrWarningCaption:   "Warning",
 }
 
-func (r *sgmlRenderer) renderIcon(ctx *renderer.Context, icon types.Icon, admonition bool) (string, error) {
-	icons := ctx.Attributes.GetAsStringWithDefault("icons", "text")
+func (r *sgmlRenderer) renderIcon(ctx *context, icon types.Icon, admonition bool) (string, error) {
+	icons := ctx.attributes.GetAsStringWithDefault("icons", "text")
 	var tmpl *texttemplate.Template
 	var err error
 	font := false
@@ -72,7 +71,7 @@ func (r *sgmlRenderer) renderIcon(ctx *renderer.Context, icon types.Icon, admoni
 		// Admonition uses title on block instead of the icon, and the alt text is
 		// taken from the caption.  However, in admonitions using the font, the alt
 		// is used as the title element instead.  Go figure.
-		alt = ctx.Attributes.GetAsStringWithDefault(icon.Class+"-caption", defaultIconClasses[icon.Class+"-caption"])
+		alt = ctx.attributes.GetAsStringWithDefault(icon.Class+"-caption", defaultIconClasses[icon.Class+"-caption"])
 		alt = icon.Attributes.GetAsStringWithDefault(types.AttrCaption, alt)
 		if font {
 			title = alt
@@ -117,12 +116,12 @@ func (r *sgmlRenderer) renderIcon(ctx *renderer.Context, icon types.Icon, admoni
 	return string(s.String()), nil
 }
 
-func renderIconPath(ctx *renderer.Context, name string) string {
+func renderIconPath(ctx *context, name string) string {
 	// Icon files by default are in {imagesdir}/icons, where {imagesdir} defaults to "./images"
-	dir := ctx.Attributes.GetAsStringWithDefault("iconsdir",
-		path.Join(ctx.Attributes.GetAsStringWithDefault(types.AttrImagesDir, "./images"), "icons"))
+	dir := ctx.attributes.GetAsStringWithDefault("iconsdir",
+		path.Join(ctx.attributes.GetAsStringWithDefault(types.AttrImagesDir, "./images"), "icons"))
 	// TODO: perform attribute substitutions here!
-	ext := ctx.Attributes.GetAsStringWithDefault("icontype", "png")
+	ext := ctx.attributes.GetAsStringWithDefault("icontype", "png")
 
 	return path.Join(dir, name+"."+ext)
 }

--- a/pkg/renderer/sgml/image.go
+++ b/pkg/renderer/sgml/image.go
@@ -8,13 +8,12 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/bytesparadise/libasciidoc/pkg/renderer"
 	"github.com/bytesparadise/libasciidoc/pkg/types"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
 
-func (r *sgmlRenderer) renderImageBlock(ctx *renderer.Context, img *types.ImageBlock) (string, error) {
+func (r *sgmlRenderer) renderImageBlock(ctx *context, img *types.ImageBlock) (string, error) {
 	title, err := r.renderElementTitle(ctx, img.Attributes)
 	if err != nil {
 		return "", errors.Wrap(err, "unable to render image")
@@ -30,7 +29,7 @@ func (r *sgmlRenderer) renderImageBlock(ctx *renderer.Context, img *types.ImageB
 		if err != nil {
 			return "", errors.Wrap(err, "unable to render image")
 		} else if !found {
-			c, found, err = ctx.Attributes.GetAsString(types.AttrFigureCaption)
+			c, found, err = ctx.attributes.GetAsString(types.AttrFigureCaption)
 			if err != nil {
 				return "", errors.Wrap(err, "unable to render image")
 			}
@@ -81,7 +80,7 @@ func (r *sgmlRenderer) renderImageBlock(ctx *renderer.Context, img *types.ImageB
 	})
 }
 
-func (r *sgmlRenderer) renderInlineImage(ctx *renderer.Context, img *types.InlineImage) (string, error) {
+func (r *sgmlRenderer) renderInlineImage(ctx *context, img *types.InlineImage) (string, error) {
 	roles, err := r.renderImageRoles(ctx, img.Attributes)
 	if err != nil {
 		return "", errors.Wrap(err, "unable to render inline image")
@@ -115,17 +114,17 @@ func (r *sgmlRenderer) renderInlineImage(ctx *renderer.Context, img *types.Inlin
 	})
 }
 
-func (r *sgmlRenderer) getImageSrc(ctx *renderer.Context, location *types.Location) string {
-	if imagesdir, found, err := ctx.Attributes.GetAsString(types.AttrImagesDir); err == nil && found {
+func (r *sgmlRenderer) getImageSrc(ctx *context, location *types.Location) string {
+	if imagesdir, found, err := ctx.attributes.GetAsString(types.AttrImagesDir); err == nil && found {
 		location.SetPathPrefix(imagesdir)
 	}
 	src := location.ToString()
 
 	// if Data URI is enables, then include the content of the file in the `src` attribute of the `<img>` tag
-	if !ctx.Attributes.Has("data-uri") {
+	if !ctx.attributes.Has("data-uri") {
 		return src
 	}
-	dir := filepath.Dir(ctx.Config.Filename)
+	dir := filepath.Dir(ctx.config.Filename)
 	src = filepath.Join(dir, src)
 	result := "data:image/" + strings.TrimPrefix(filepath.Ext(src), ".") + ";base64,"
 	data, err := ioutil.ReadFile(src)

--- a/pkg/renderer/sgml/index_term.go
+++ b/pkg/renderer/sgml/index_term.go
@@ -1,11 +1,10 @@
 package sgml
 
 import (
-	"github.com/bytesparadise/libasciidoc/pkg/renderer"
 	"github.com/bytesparadise/libasciidoc/pkg/types"
 )
 
-func (r *sgmlRenderer) renderIndexTerm(ctx *renderer.Context, t *types.IndexTerm) (string, error) {
+func (r *sgmlRenderer) renderIndexTerm(ctx *context, t *types.IndexTerm) (string, error) {
 	return r.renderInlineElements(ctx, t.Term)
 }
 

--- a/pkg/renderer/sgml/inline_elements.go
+++ b/pkg/renderer/sgml/inline_elements.go
@@ -3,11 +3,10 @@ package sgml
 import (
 	"strings"
 
-	"github.com/bytesparadise/libasciidoc/pkg/renderer"
 	"github.com/bytesparadise/libasciidoc/pkg/types"
 )
 
-func (r *sgmlRenderer) renderInlineElements(ctx *renderer.Context, elements []interface{}, options ...lineRendererOption) (string, error) {
+func (r *sgmlRenderer) renderInlineElements(ctx *context, elements []interface{}, options ...lineRendererOption) (string, error) {
 	if len(elements) == 0 {
 		return "", nil
 	}
@@ -37,4 +36,4 @@ func (r *sgmlRenderer) renderInlineElements(ctx *renderer.Context, elements []in
 	return buf.String(), nil
 }
 
-type renderFunc func(*renderer.Context, interface{}) (string, error)
+type renderFunc func(*context, interface{}) (string, error)

--- a/pkg/renderer/sgml/link.go
+++ b/pkg/renderer/sgml/link.go
@@ -4,12 +4,11 @@ import (
 	"html"
 	"strings"
 
-	"github.com/bytesparadise/libasciidoc/pkg/renderer"
 	"github.com/bytesparadise/libasciidoc/pkg/types"
 	"github.com/pkg/errors"
 )
 
-func (r *sgmlRenderer) renderLink(ctx *renderer.Context, l *types.InlineLink) (string, error) {
+func (r *sgmlRenderer) renderLink(ctx *context, l *types.InlineLink) (string, error) {
 	location := l.Location.ToString()
 	text := ""
 	class := ""

--- a/pkg/renderer/sgml/literal_blocks.go
+++ b/pkg/renderer/sgml/literal_blocks.go
@@ -3,13 +3,12 @@ package sgml
 import (
 	"strings"
 
-	"github.com/bytesparadise/libasciidoc/pkg/renderer"
 	"github.com/bytesparadise/libasciidoc/pkg/types"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
 
-func (r *sgmlRenderer) renderLiteralBlock(ctx *renderer.Context, b *types.DelimitedBlock) (string, error) {
+func (r *sgmlRenderer) renderLiteralBlock(ctx *context, b *types.DelimitedBlock) (string, error) {
 	log.Debugf("rendering literal block")
 	content, err := r.renderElements(ctx, b.Elements)
 	if err != nil {
@@ -25,7 +24,7 @@ func (r *sgmlRenderer) renderLiteralBlock(ctx *renderer.Context, b *types.Delimi
 	}
 
 	return r.execute(r.literalBlock, struct {
-		Context *renderer.Context
+		Context *context
 		ID      string
 		Title   string
 		Roles   string

--- a/pkg/renderer/sgml/passthrough.go
+++ b/pkg/renderer/sgml/passthrough.go
@@ -4,12 +4,11 @@ import (
 	htmltemplate "html/template"
 	"strings"
 
-	"github.com/bytesparadise/libasciidoc/pkg/renderer"
 	"github.com/bytesparadise/libasciidoc/pkg/types"
 	"github.com/pkg/errors"
 )
 
-func (r *sgmlRenderer) renderPassthroughParagraph(ctx *renderer.Context, p *types.Paragraph) (string, error) {
+func (r *sgmlRenderer) renderPassthroughParagraph(ctx *context, p *types.Paragraph) (string, error) {
 	content, err := r.renderPassthroughContent(ctx, p.Elements)
 	if err != nil {
 		return "", err
@@ -17,7 +16,7 @@ func (r *sgmlRenderer) renderPassthroughParagraph(ctx *renderer.Context, p *type
 	return content + "\n", nil
 }
 
-func (r *sgmlRenderer) renderInlinePassthrough(ctx *renderer.Context, p *types.InlinePassthrough) (string, error) {
+func (r *sgmlRenderer) renderInlinePassthrough(ctx *context, p *types.InlinePassthrough) (string, error) {
 	renderedContent, err := r.renderPassthroughContent(ctx, p.Elements)
 	if err != nil {
 		return "", errors.Wrap(err, "unable to render passthrough")
@@ -34,7 +33,7 @@ func (r *sgmlRenderer) renderInlinePassthrough(ctx *renderer.Context, p *types.I
 }
 
 // renderPassthroughMacro renders the passthrough content in its raw from
-func (r *sgmlRenderer) renderPassthroughContent(ctx *renderer.Context, elements []interface{}) (string, error) {
+func (r *sgmlRenderer) renderPassthroughContent(ctx *context, elements []interface{}) (string, error) {
 	result := &strings.Builder{}
 	for _, element := range elements {
 		switch element := element.(type) {

--- a/pkg/renderer/sgml/preamble.go
+++ b/pkg/renderer/sgml/preamble.go
@@ -1,12 +1,11 @@
 package sgml
 
 import (
-	"github.com/bytesparadise/libasciidoc/pkg/renderer"
 	"github.com/bytesparadise/libasciidoc/pkg/types"
 	"github.com/pkg/errors"
 )
 
-func (r *sgmlRenderer) renderPreamble(ctx *renderer.Context, p *types.Preamble) (string, error) {
+func (r *sgmlRenderer) renderPreamble(ctx *context, p *types.Preamble) (string, error) {
 	// log.Debugf("rendering preamble...")
 	// the <div id="preamble"> wrapper is only necessary
 	// if the document has a section 0
@@ -20,13 +19,13 @@ func (r *sgmlRenderer) renderPreamble(ctx *renderer.Context, p *types.Preamble) 
 		return "", errors.Wrap(err, "error rendering preamble elements")
 	}
 	return r.execute(r.preamble, struct {
-		Context *renderer.Context
+		Context *context
 		Wrapper bool
 		Content string
 		ToC     string
 	}{
 		Context: ctx,
-		Wrapper: ctx.HasHeader,
+		Wrapper: ctx.hasHeader,
 		Content: string(content),
 		ToC:     string(toc),
 	})

--- a/pkg/renderer/sgml/quoted_text.go
+++ b/pkg/renderer/sgml/quoted_text.go
@@ -4,14 +4,13 @@ import (
 	"strings"
 	texttemplate "text/template"
 
-	"github.com/bytesparadise/libasciidoc/pkg/renderer"
 	"github.com/bytesparadise/libasciidoc/pkg/types"
 	"github.com/pkg/errors"
 )
 
 // TODO: The bold, italic, and monospace items should be refactored to support semantic tags instead.
 
-func (r *sgmlRenderer) renderQuotedText(ctx *renderer.Context, t *types.QuotedText) (string, error) {
+func (r *sgmlRenderer) renderQuotedText(ctx *context, t *types.QuotedText) (string, error) {
 	elementsBuffer := &strings.Builder{}
 	for _, element := range t.Elements {
 		b, err := r.renderElement(ctx, element)

--- a/pkg/renderer/sgml/section.go
+++ b/pkg/renderer/sgml/section.go
@@ -3,14 +3,13 @@ package sgml
 import (
 	"strings"
 
-	"github.com/bytesparadise/libasciidoc/pkg/renderer"
 	"github.com/bytesparadise/libasciidoc/pkg/types"
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
 
-func (r *sgmlRenderer) renderSection(ctx *renderer.Context, s *types.Section) (string, error) {
+func (r *sgmlRenderer) renderSection(ctx *context, s *types.Section) (string, error) {
 	// log.Debugf("rendering section level %d", s.Level)
 	title, err := r.renderSectionTitle(ctx, s)
 	if err != nil {
@@ -26,7 +25,7 @@ func (r *sgmlRenderer) renderSection(ctx *renderer.Context, s *types.Section) (s
 		return "", errors.Wrap(err, "unable to render section roles")
 	}
 	return r.execute(r.sectionContent, struct {
-		Context  *renderer.Context
+		Context  *context
 		Header   string
 		Content  string
 		Elements []interface{}
@@ -44,20 +43,20 @@ func (r *sgmlRenderer) renderSection(ctx *renderer.Context, s *types.Section) (s
 	})
 }
 
-func (r *sgmlRenderer) renderSectionTitle(ctx *renderer.Context, s *types.Section) (string, error) {
+func (r *sgmlRenderer) renderSectionTitle(ctx *context, s *types.Section) (string, error) {
 	renderedContent, err := r.renderInlineElements(ctx, s.Title)
 	if err != nil {
 		return "", errors.Wrap(err, "error while rendering section title")
 	}
 	renderedContentStr := strings.TrimSpace(renderedContent)
 	var number string
-	if ctx.SectionNumbering != nil {
+	if ctx.sectionNumbering != nil {
 		id, err := s.GetID()
 		if err != nil {
 			return "", errors.Wrap(err, "error while rendering section title")
 		}
 		log.Debugf("number for section '%s': '%s'", id, number)
-		number = ctx.SectionNumbering[id]
+		number = ctx.sectionNumbering[id]
 	}
 	return r.execute(r.sectionTitle, struct {
 		Level        int

--- a/pkg/renderer/sgml/sgml_renderer.go
+++ b/pkg/renderer/sgml/sgml_renderer.go
@@ -1,11 +1,13 @@
 package sgml
 
 import (
+	"fmt"
 	"strings"
 	"sync"
 	texttemplate "text/template"
 
 	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 )
 
 type sgmlRenderer struct {
@@ -242,6 +244,23 @@ type sgmlRenderer struct {
 }
 
 type template func() (*texttemplate.Template, error)
+
+func (r *sgmlRenderer) newTemplate(name string, tmpl string, err error) (*texttemplate.Template, error) {
+	// NB: if the data is missing below, it will be an empty string.
+	if err != nil {
+		return nil, err
+	}
+	if len(tmpl) == 0 {
+		return nil, fmt.Errorf("empty template for '%s'", name)
+	}
+	t := texttemplate.New(name)
+	t.Funcs(r.functions)
+	if t, err = t.Parse(tmpl); err != nil {
+		log.Errorf("failed to initialize the '%s' template: %v", name, err)
+		return nil, err
+	}
+	return t, nil
+}
 
 func (s *sgmlRenderer) execute(loadTmpl template, data interface{}) (string, error) {
 	tmpl, err := loadTmpl()

--- a/pkg/renderer/sgml/string.go
+++ b/pkg/renderer/sgml/string.go
@@ -5,11 +5,10 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/bytesparadise/libasciidoc/pkg/renderer"
 	"github.com/bytesparadise/libasciidoc/pkg/types"
 )
 
-func (r *sgmlRenderer) renderStringElement(ctx *renderer.Context, str *types.StringElement) (string, error) {
+func (r *sgmlRenderer) renderStringElement(ctx *context, str *types.StringElement) (string, error) {
 	// NB: For all SGML flavors we are aware of, the numeric entities from
 	// Unicode are supported.  We generally avoid named entities.
 	result := str.Content

--- a/pkg/renderer/sgml/table.go
+++ b/pkg/renderer/sgml/table.go
@@ -5,13 +5,12 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/bytesparadise/libasciidoc/pkg/renderer"
 	"github.com/bytesparadise/libasciidoc/pkg/types"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
 
-func (r *sgmlRenderer) renderTable(ctx *renderer.Context, t *types.Table) (string, error) {
+func (r *sgmlRenderer) renderTable(ctx *context, t *types.Table) (string, error) {
 	caption := &strings.Builder{}
 	number := 0
 	fit := "stretch"
@@ -45,7 +44,7 @@ func (r *sgmlRenderer) renderTable(ctx *renderer.Context, t *types.Table) (strin
 		if err != nil {
 			return "", err
 		} else if !found {
-			c, found, err = ctx.Attributes.GetAsString(types.AttrTableCaption)
+			c, found, err = ctx.attributes.GetAsString(types.AttrTableCaption)
 			if err != nil {
 				return "", errors.Wrap(err, "unable to render table")
 			}
@@ -90,7 +89,7 @@ func (r *sgmlRenderer) renderTable(ctx *renderer.Context, t *types.Table) (strin
 		return "", errors.Wrap(err, "unable to render table title")
 	}
 	return r.execute(r.table, struct {
-		Context     *renderer.Context
+		Context     *context
 		ID          string
 		Title       string
 		Columns     []*types.TableColumn
@@ -126,7 +125,7 @@ func (r *sgmlRenderer) renderTable(ctx *renderer.Context, t *types.Table) (strin
 	})
 }
 
-func (r *sgmlRenderer) renderTableHeader(ctx *renderer.Context, h *types.TableRow, cols []*types.TableColumn) (string, error) {
+func (r *sgmlRenderer) renderTableHeader(ctx *context, h *types.TableRow, cols []*types.TableColumn) (string, error) {
 	if h == nil {
 		return "", nil
 	}
@@ -147,7 +146,7 @@ func (r *sgmlRenderer) renderTableHeader(ctx *renderer.Context, h *types.TableRo
 	})
 }
 
-func (r *sgmlRenderer) renderTableHeaderCell(ctx *renderer.Context, c *types.TableCell, col *types.TableColumn) (string, error) {
+func (r *sgmlRenderer) renderTableHeaderCell(ctx *context, c *types.TableCell, col *types.TableColumn) (string, error) {
 	// assume that elements to render are within the first element of the cell, which should be a paragraph
 	if len(c.Elements) == 1 {
 		if p, ok := c.Elements[0].(*types.Paragraph); ok {
@@ -169,7 +168,7 @@ func (r *sgmlRenderer) renderTableHeaderCell(ctx *renderer.Context, c *types.Tab
 	return "", fmt.Errorf("invalid header content (expected a single paragraph)")
 }
 
-func (r *sgmlRenderer) renderTableFooter(ctx *renderer.Context, f *types.TableRow, cols []*types.TableColumn) (string, error) {
+func (r *sgmlRenderer) renderTableFooter(ctx *context, f *types.TableRow, cols []*types.TableColumn) (string, error) {
 	if f == nil {
 		return "", nil
 	}
@@ -184,7 +183,7 @@ func (r *sgmlRenderer) renderTableFooter(ctx *renderer.Context, f *types.TableRo
 		content.WriteString(c)
 	}
 	return r.execute(r.tableFooter, struct {
-		Context *renderer.Context
+		Context *context
 		Content string
 		Cells   []*types.TableCell
 	}{
@@ -194,7 +193,7 @@ func (r *sgmlRenderer) renderTableFooter(ctx *renderer.Context, f *types.TableRo
 	})
 }
 
-func (r *sgmlRenderer) renderTableFooterCell(ctx *renderer.Context, c *types.TableCell, col *types.TableColumn) (string, error) {
+func (r *sgmlRenderer) renderTableFooterCell(ctx *context, c *types.TableCell, col *types.TableColumn) (string, error) {
 	// assume that elements to render are within the first element of the cell, which should be a paragraph
 	if len(c.Elements) == 1 {
 		if p, ok := c.Elements[0].(*types.Paragraph); ok {
@@ -216,7 +215,7 @@ func (r *sgmlRenderer) renderTableFooterCell(ctx *renderer.Context, c *types.Tab
 	return "", fmt.Errorf("invalid footer content (expected a single paragraph)")
 }
 
-func (r *sgmlRenderer) renderTableBody(ctx *renderer.Context, rows []*types.TableRow, columns []*types.TableColumn) (string, error) {
+func (r *sgmlRenderer) renderTableBody(ctx *context, rows []*types.TableRow, columns []*types.TableColumn) (string, error) {
 	content := &strings.Builder{}
 	for _, row := range rows {
 		c, err := r.renderTableRow(ctx, row, columns)
@@ -226,7 +225,7 @@ func (r *sgmlRenderer) renderTableBody(ctx *renderer.Context, rows []*types.Tabl
 		content.WriteString(c)
 	}
 	return r.execute(r.tableBody, struct {
-		Context *renderer.Context
+		Context *context
 		Content string
 		Rows    []*types.TableRow
 		Columns []*types.TableColumn
@@ -238,7 +237,7 @@ func (r *sgmlRenderer) renderTableBody(ctx *renderer.Context, rows []*types.Tabl
 	})
 }
 
-func (r *sgmlRenderer) renderTableRow(ctx *renderer.Context, l *types.TableRow, cols []*types.TableColumn) (string, error) {
+func (r *sgmlRenderer) renderTableRow(ctx *context, l *types.TableRow, cols []*types.TableColumn) (string, error) {
 	content := &strings.Builder{}
 	for i, cell := range l.Cells {
 		c, err := r.renderTableCell(ctx, cell, cols[i])
@@ -248,7 +247,7 @@ func (r *sgmlRenderer) renderTableRow(ctx *renderer.Context, l *types.TableRow, 
 		content.WriteString(c)
 	}
 	return r.execute(r.tableRow, struct {
-		Context *renderer.Context
+		Context *context
 		Content string
 		Cells   []*types.TableCell
 	}{
@@ -258,7 +257,7 @@ func (r *sgmlRenderer) renderTableRow(ctx *renderer.Context, l *types.TableRow, 
 	})
 }
 
-func (r *sgmlRenderer) renderTableCell(ctx *renderer.Context, cell *types.TableCell, col *types.TableColumn) (string, error) {
+func (r *sgmlRenderer) renderTableCell(ctx *context, cell *types.TableCell, col *types.TableColumn) (string, error) {
 	buff := &strings.Builder{}
 	for _, element := range cell.Elements {
 		renderedElement, err := r.renderTableCellBlock(ctx, element)
@@ -268,7 +267,7 @@ func (r *sgmlRenderer) renderTableCell(ctx *renderer.Context, cell *types.TableC
 		buff.WriteString(renderedElement)
 	}
 	return r.execute(r.tableCell, struct {
-		Context *renderer.Context
+		Context *context
 		Content string
 		Cell    *types.TableCell
 		HAlign  types.HAlign
@@ -282,7 +281,7 @@ func (r *sgmlRenderer) renderTableCell(ctx *renderer.Context, cell *types.TableC
 	})
 }
 
-func (r *sgmlRenderer) renderTableCellBlock(ctx *renderer.Context, element interface{}) (string, error) {
+func (r *sgmlRenderer) renderTableCellBlock(ctx *context, element interface{}) (string, error) {
 	switch e := element.(type) {
 	case *types.Paragraph:
 		log.Debug("rendering paragraph within table cell")
@@ -295,7 +294,7 @@ func (r *sgmlRenderer) renderTableCellBlock(ctx *renderer.Context, element inter
 			return "", errors.Wrap(err, "unable to render table cell paragraph content")
 		}
 		result, err := r.execute(r.embeddedParagraph, struct {
-			Context    *renderer.Context
+			Context    *context
 			ID         string // TODO: not used in template?
 			Title      string // TODO: not used in template?
 			CheckStyle string

--- a/pkg/renderer/sgml/table_of_contents.go
+++ b/pkg/renderer/sgml/table_of_contents.go
@@ -4,12 +4,11 @@ import (
 	"strings"
 
 	"github.com/bytesparadise/libasciidoc/pkg/parser"
-	"github.com/bytesparadise/libasciidoc/pkg/renderer"
 	"github.com/bytesparadise/libasciidoc/pkg/types"
 	"github.com/pkg/errors"
 )
 
-func (r *sgmlRenderer) prerenderTableOfContents(ctx *renderer.Context, toc *types.TableOfContents) error {
+func (r *sgmlRenderer) prerenderTableOfContents(ctx *context, toc *types.TableOfContents) error {
 	if toc == nil || toc.Sections == nil {
 		return nil
 	}
@@ -26,7 +25,7 @@ func (r *sgmlRenderer) prerenderTableOfContents(ctx *renderer.Context, toc *type
 	return nil
 }
 
-func (r *sgmlRenderer) prerenderTableOfContentsSections(ctx *renderer.Context, sections []*types.ToCSection) error {
+func (r *sgmlRenderer) prerenderTableOfContentsSections(ctx *context, sections []*types.ToCSection) error {
 	for _, entry := range sections {
 		if err := r.prerenderTableOfContentsEntry(ctx, entry); err != nil {
 			return errors.Wrap(err, "unable to render table of contents section")
@@ -36,14 +35,14 @@ func (r *sgmlRenderer) prerenderTableOfContentsSections(ctx *renderer.Context, s
 	return nil
 }
 
-func (r *sgmlRenderer) prerenderTableOfContentsEntry(ctx *renderer.Context, entry *types.ToCSection) error {
+func (r *sgmlRenderer) prerenderTableOfContentsEntry(ctx *context, entry *types.ToCSection) error {
 	if err := r.prerenderTableOfContentsSections(ctx, entry.Children); err != nil {
 		return errors.Wrap(err, "unable to render table of contents entry children")
 	}
-	if ctx.SectionNumbering != nil {
-		entry.Number = ctx.SectionNumbering[entry.ID]
+	if ctx.sectionNumbering != nil {
+		entry.Number = ctx.sectionNumbering[entry.ID]
 	}
-	s, found := ctx.ElementReferences[entry.ID]
+	s, found := ctx.elementReferences[entry.ID]
 	if !found {
 		return errors.New("unable to render table of contents entry title (missing element reference")
 	}
@@ -55,7 +54,7 @@ func (r *sgmlRenderer) prerenderTableOfContentsEntry(ctx *renderer.Context, entr
 	return nil
 }
 
-func (r *sgmlRenderer) renderTableOfContents(ctx *renderer.Context, toc *types.TableOfContents) (string, error) {
+func (r *sgmlRenderer) renderTableOfContents(ctx *context, toc *types.TableOfContents) (string, error) {
 	if toc == nil || toc.Sections == nil {
 		return "", nil
 	}
@@ -85,8 +84,8 @@ func (r *sgmlRenderer) renderTableOfContents(ctx *renderer.Context, toc *types.T
 	})
 }
 
-func (r *sgmlRenderer) renderTableOfContentsTitle(ctx *renderer.Context) (string, error) {
-	title, found, err := ctx.Attributes.GetAsString(types.AttrTableOfContentsTitle)
+func (r *sgmlRenderer) renderTableOfContentsTitle(ctx *context) (string, error) {
+	title, found, err := ctx.attributes.GetAsString(types.AttrTableOfContentsTitle)
 	if err != nil {
 		return "", errors.Wrap(err, "error while rendering table of contents")
 	}
@@ -102,7 +101,7 @@ func (r *sgmlRenderer) renderTableOfContentsTitle(ctx *renderer.Context) (string
 
 }
 
-func (r *sgmlRenderer) renderTableOfContentsSections(ctx *renderer.Context, sections []*types.ToCSection) (string, error) {
+func (r *sgmlRenderer) renderTableOfContentsSections(ctx *context, sections []*types.ToCSection) (string, error) {
 	if len(sections) == 0 {
 		return "", nil
 	}
@@ -123,7 +122,7 @@ func (r *sgmlRenderer) renderTableOfContentsSections(ctx *renderer.Context, sect
 	})
 }
 
-func (r *sgmlRenderer) renderTableOfContentsEntry(ctx *renderer.Context, entry *types.ToCSection) (string, error) {
+func (r *sgmlRenderer) renderTableOfContentsEntry(ctx *context, entry *types.ToCSection) (string, error) {
 	content, err := r.renderTableOfContentsSections(ctx, entry.Children)
 	if err != nil {
 		return "", errors.Wrap(err, "unable to render table of contents entry children")

--- a/pkg/renderer/sgml/user_macro.go
+++ b/pkg/renderer/sgml/user_macro.go
@@ -3,13 +3,12 @@ package sgml
 import (
 	"strings"
 
-	"github.com/bytesparadise/libasciidoc/pkg/renderer"
 	"github.com/bytesparadise/libasciidoc/pkg/types"
 )
 
-func (r *sgmlRenderer) renderUserMacro(ctx *renderer.Context, m *types.UserMacro) (string, error) {
+func (r *sgmlRenderer) renderUserMacro(ctx *context, m *types.UserMacro) (string, error) {
 	buf := &strings.Builder{}
-	macro, ok := ctx.Config.Macros[m.Name]
+	macro, ok := ctx.config.Macros[m.Name]
 	if !ok {
 		if m.Kind == types.BlockMacro {
 			// fallback to paragraph

--- a/pkg/renderer/sgml/xhtml5/templates.go
+++ b/pkg/renderer/sgml/xhtml5/templates.go
@@ -3,19 +3,16 @@ package xhtml5
 import (
 	"io"
 
-	"github.com/bytesparadise/libasciidoc/pkg/renderer"
+	"github.com/bytesparadise/libasciidoc/pkg/configuration"
 	"github.com/bytesparadise/libasciidoc/pkg/renderer/sgml"
 	"github.com/bytesparadise/libasciidoc/pkg/renderer/sgml/html5"
 	"github.com/bytesparadise/libasciidoc/pkg/types"
 )
 
-var templates = html5.Templates()
-
-var defaultRenderer sgml.Renderer
-
-func init() {
-	templates = html5.Templates()
-
+// Render renders the document to the output, using a default instance
+// of the renderer, with default templates.
+func Render(doc *types.Document, config *configuration.Configuration, output io.Writer) (types.Metadata, error) {
+	templates := html5.Templates()
 	// XHTML5 overrides of HTML5.
 	templates.Article = articleTmpl
 	templates.BlockImage = blockImageTmpl
@@ -33,18 +30,5 @@ func init() {
 	templates.VerseBlock = verseBlockTmpl
 	templates.VerseParagraph = verseParagraphTmpl
 
-	// NB: This is fast, and doesn't including parsing.
-	defaultRenderer = sgml.NewRenderer(templates)
-}
-
-// Render renders the document to the output, using a default instance
-// of the renderer, with default templates.
-func Render(ctx *renderer.Context, doc *types.Document, output io.Writer) (types.Metadata, error) {
-	return defaultRenderer.Render(ctx, doc, output)
-}
-
-// Templates returns the default Templates use for HTML5.  It may be useful
-// for derived implementations.
-func Templates() sgml.Templates {
-	return templates
+	return sgml.Render(doc, config, output, templates)
 }

--- a/pkg/types/attributes.go
+++ b/pkg/types/attributes.go
@@ -435,6 +435,10 @@ func (a Attributes) Set(key string, value interface{}) Attributes {
 	return a
 }
 
+func (a Attributes) Unset(key string) {
+	delete(a, key)
+}
+
 // SetAll adds the given attributes to the current ones
 func (a Attributes) SetAll(attr interface{}) Attributes {
 	switch attr := attr.(type) {


### PR DESCRIPTION
move `Context` from `pkg/renderer` into `pkg/renderer/sgml` and make
it unexported, and refactor the way to run the renderer on the doc:
```
html5.Render(doc, config, out)
```

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
