### PR TITLE
test(parser/renderer): verify quoted text case

### DIFF
--- a/pkg/parser/quoted_text_test.go
+++ b/pkg/parser/quoted_text_test.go
@@ -1662,6 +1662,34 @@ var _ = Describe("quoted texts", func() {
 				Expect(ParseDocument(source)).To(MatchDocument(expected))
 			})
 
+			It("unbalanced italic in bold", func() {
+				source := `*a_b* _c_`
+				expected := &types.Document{
+					Elements: []interface{}{
+						&types.Paragraph{
+							Elements: []interface{}{
+								&types.QuotedText{
+									Kind: types.SingleQuoteBold,
+									Elements: []interface{}{
+										&types.StringElement{Content: "a_b"},
+									},
+								},
+								&types.StringElement{
+									Content: " ",
+								},
+								&types.QuotedText{
+									Kind: types.SingleQuoteItalic,
+									Elements: []interface{}{
+										&types.StringElement{Content: "c"},
+									},
+								},
+							},
+						},
+					},
+				}
+				Expect(ParseDocument(source)).To(MatchDocument(expected))
+			})
+
 			It("unparsed bold in monospace", func() {
 				source := "`a*b*`"
 				expected := &types.Document{

--- a/pkg/renderer/sgml/html5/quoted_text_test.go
+++ b/pkg/renderer/sgml/html5/quoted_text_test.go
@@ -598,6 +598,15 @@ content</mark>.</p>
 			Expect(RenderHTML(source)).To(MatchHTML(expected))
 		})
 
+		It("unbalanced italic in bold", func() {
+			source := `*a_b* _c_`
+			expected := `<div class="paragraph">
+<p><strong>a_b</strong> <em>c</em></p>
+</div>
+`
+			Expect(RenderHTML(source)).To(MatchHTML(expected))
+		})
+
 		It("unparsed bold in monospace", func() {
 			source := "`a*b*`"
 			expected := `<div class="paragraph">


### PR DESCRIPTION
verifies that `*a_b* _c_` is parsed and renderer as expected
bug itself ws fixed in eecd0bb

Fixes #1078

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
