### PR TITLE
Add basename function to sgml FuncMap

### DIFF
--- a/pkg/renderer/sgml/sgml.go
+++ b/pkg/renderer/sgml/sgml.go
@@ -3,6 +3,7 @@ package sgml
 import (
 	"fmt"
 	"io"
+	"path/filepath"
 	"strings"
 	texttemplate "text/template"
 
@@ -19,6 +20,7 @@ func Render(doc *types.Document, config *configuration.Configuration, output io.
 		templates: tmpls,
 		// Establish some default function handlers.
 		functions: texttemplate.FuncMap{
+			"basename":           filepath.Base,
 			"escape":             escapeString,
 			"halign":             halign,
 			"lastInStrings":      lastInStrings,


### PR DESCRIPTION
This function is necessary to allow custom backends to only use the basename of an image in cases where images are stored as attachments.

```
blockImageTmpl = `<image ><attachment filename="{{ basename .Src }}" /></image>`
```