### PR TITLE
Typo fix in comment of configuration.go

### DIFF
--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -48,7 +48,7 @@ const (
 // Setting a setting to customize the configuration used during parsing and rendering of a document
 type Setting func(config *Configuration)
 
-// WithFigureCaption function to set the `fogure-caption` attribute
+// WithFigureCaption function to set the `figure-caption` attribute
 func WithFigureCaption(caption string) Setting {
 	return func(config *Configuration) {
 		config.Attributes[types.AttrFigureCaption] = caption


### PR DESCRIPTION
Simple, one-line change that fixes a single typo in configuration.go.